### PR TITLE
simplify dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Install HAProxy
 
     apt install haproxy
 
+Generate a certificate for the proxy
+
+    sudo openssl req -nodes -x509 -newkey rsa:2048 -keyout /etc/ssl/private/lxd-ui.key -out /etc/ssl/private/lxd-ui.crt -days 3000
+    sudo cat /etc/ssl/private/lxd-ui.key /etc/ssl/private/lxd-ui.crt | sudo tee -a /etc/ssl/private/lxd-ui.pem
+
 Configure HAProxy with below content in /etc/haproxy/haproxy.cfg
 
     global
@@ -27,8 +32,7 @@ Configure HAProxy with below content in /etc/haproxy/haproxy.cfg
       mode  http
 
     frontend lxd_frontend
-      bind *:9000
-      mode http
+      bind *:9443 ssl crt /etc/ssl/private/lxd-ui.pem
       acl is_upgrade hdr(Connection) -i upgrade
       acl is_websocket hdr(Upgrade) -i websocket
       acl is_lxd_core path_beg /1.0

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-scss": "stylelint 'static/**/*.scss'",
     "lint-js": "eslint 'static/js/**/*.{js,json,jsx,tsx}' && prettier 'static/js/**/*.{js,json,jsx,tsx}' --check",
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch' 'yarn serve'",
-    "serve": "serve --single --no-clipboard build && echo 'available on to http://0.0.0.0:9000'"
+    "serve": "serve --single --no-clipboard build && echo 'available on to https://0.0.0.0:9443'"
   },
   "dependencies": {
     "@canonical/react-components": "0.37.7",

--- a/static/js/InstanceTerminal.tsx
+++ b/static/js/InstanceTerminal.tsx
@@ -28,13 +28,10 @@ const InstanceTerminal: FC = () => {
       return;
     }
 
-    // todo: need to open https://0.0.0.0:8443/ once per browser session,
-    // todo: so the secure websockets connect with the self-signed certificate
-
     const result = await fetchInstanceExec(name);
 
-    const dataUrl = `wss://0.0.0.0:8443${result.operation}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
-    const controlUrl = `wss://0.0.0.0:8443${result.operation}/websocket?secret=${result.metadata.metadata.fds["control"]}`;
+    const dataUrl = `wss://${location.host}${result.operation}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
+    const controlUrl = `wss://${location.host}${result.operation}/websocket?secret=${result.metadata.metadata.fds["control"]}`;
 
     const data = new WebSocket(dataUrl);
     const control = new WebSocket(controlUrl);

--- a/static/js/InstanceVga.tsx
+++ b/static/js/InstanceVga.tsx
@@ -40,9 +40,6 @@ const InstanceVga: FC = () => {
       return;
     }
 
-    // todo: need to open https://0.0.0.0:8443/ once per browser session,
-    // todo: so the secure websockets connect with the self-signed certificate
-
     const result = await fetchInstanceVga(name).catch((e) => {
       setNotification({
         message: e.message,
@@ -53,8 +50,8 @@ const InstanceVga: FC = () => {
       return;
     }
 
-    const dataUrl = `wss://0.0.0.0:8443${result.operation}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
-    const controlUrl = `wss://0.0.0.0:8443${result.operation}/websocket?secret=${result.metadata.metadata.fds.control}`;
+    const dataUrl = `wss://${location.host}${result.operation}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
+    const controlUrl = `wss://${location.host}${result.operation}/websocket?secret=${result.metadata.metadata.fds.control}`;
 
     const control = new WebSocket(controlUrl);
 


### PR DESCRIPTION
simplify dev setup to use ssl cert, so we can use a generic hostname for the terminal and vga websockets