### PR TITLE
Specific message for stateful help in CreateSnapshotForm

### DIFF
--- a/static/js/modals/CreateSnapshotForm.tsx
+++ b/static/js/modals/CreateSnapshotForm.tsx
@@ -19,15 +19,23 @@ type Props = {
 const CreateSnapshotForm: FC<Props> = ({ instance, close, notify }) => {
   const queryClient = useQueryClient();
 
-  const statefulHelp = (
-    <p>
-      To create a stateful snapshot, the instance must be running and needs the{" "}
-      <code>migration.stateful</code> config set to true
-    </p>
-  );
+  const isRunning = instance.status === "Running";
+  const isStateful = instance.config["migration.stateful"];
 
-  const canBeStateful =
-    instance.config["migration.stateful"] && instance.status === "Running";
+  const getStatefulHelp = () => {
+    if (isStateful && isRunning) {
+      return "";
+    }
+    if (isStateful) {
+      return <p>To create a stateful snapshot, the instance must be running</p>;
+    }
+    return (
+      <p>
+        To create a stateful snapshot, the instance needs the{" "}
+        <code>migration.stateful</code> config set to true
+      </p>
+    );
+  };
 
   const SnapshotSchema = Yup.object().shape({
     name: Yup.string().required("This field is required"),
@@ -106,8 +114,8 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, notify }) => {
           type="checkbox"
           label="Stateful"
           wrapperClassName="row"
-          help={canBeStateful ? "" : statefulHelp}
-          disabled={!canBeStateful}
+          help={getStatefulHelp()}
+          disabled={!isStateful || !isRunning}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
         />


### PR DESCRIPTION
The previous help message was too generic, because it just informed the user of the 2 reasons why they could not create a stateful snapshot, without telling them the _exact_ one for their particular case. This PR addresses that.

- If the instance is stateful but not running, the user will be informed that the instance needs to be running in order to create the snapshot.
- If the instance is not stateful, regardless of its status, the user will be informed that the instance needs to have the stateful config set to true in order to create the snapshot.