### PR TITLE
Set a ConfirmationButton for all delete actions

### DIFF
--- a/static/js/buttons/ConfirmationButton.tsx
+++ b/static/js/buttons/ConfirmationButton.tsx
@@ -9,6 +9,7 @@ type Props = {
   confirmationMessage: string;
   posButtonLabel: string;
   onPositive: () => void;
+  isDisabled?: boolean;
 };
 
 const ConfirmationButton: FC<Props> = ({
@@ -18,6 +19,7 @@ const ConfirmationButton: FC<Props> = ({
   confirmationMessage,
   posButtonLabel,
   onPositive,
+  isDisabled = false,
 }) => {
   const [isOpen, setOpen] = useState(false);
 
@@ -45,7 +47,7 @@ const ConfirmationButton: FC<Props> = ({
           onPositive={onPositiveCloseModal}
         />
       )}
-      <Button dense onClick={handleShiftClick}>
+      <Button dense disabled={isDisabled} onClick={handleShiftClick}>
         <i
           className={
             isLoading ? "p-icon--spinner u-animation--spin" : iconClass

--- a/static/js/buttons/images/DeleteImageBtn.tsx
+++ b/static/js/buttons/images/DeleteImageBtn.tsx
@@ -4,7 +4,7 @@ import { LxdImage } from "../../types/image";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../util/queryKeys";
 import { NotificationHelper } from "../../types/notification";
-import { Button } from "@canonical/react-components";
+import ConfirmationButton from "../ConfirmationButton";
 
 type Props = {
   image: LxdImage;
@@ -32,15 +32,16 @@ const DeleteImageBtn: FC<Props> = ({ image, notify }) => {
   };
 
   return (
-    <Button dense onClick={handleDelete} disabled={isLoading}>
-      <i
-        className={
-          isLoading ? "p-icon--spinner u-animation--spin" : "p-icon--delete"
-        }
-      >
-        Delete
-      </i>
-    </Button>
+    <ConfirmationButton
+      isLoading={isLoading}
+      iconClass="p-icon--delete"
+      title="Confirm delete"
+      confirmationMessage={`Are you sure you want to delete image "${image.properties.description}"?
+                            This action cannot be undone, and can result in data loss.`}
+      posButtonLabel="Delete"
+      onPositive={handleDelete}
+      isDisabled={isLoading}
+    />
   );
 };
 

--- a/static/js/buttons/instances/DeleteInstanceBtn.tsx
+++ b/static/js/buttons/instances/DeleteInstanceBtn.tsx
@@ -4,7 +4,7 @@ import { LxdInstance } from "../../types/instance";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../util/queryKeys";
 import { NotificationHelper } from "../../types/notification";
-import { Button } from "@canonical/react-components";
+import ConfirmationButton from "../ConfirmationButton";
 
 type Props = {
   instance: LxdInstance;
@@ -32,19 +32,16 @@ const DeleteInstanceBtn: FC<Props> = ({ instance, notify }) => {
   };
 
   return (
-    <Button
-      dense
-      onClick={handleDelete}
-      disabled={isLoading || instance.status !== "Stopped"}
-    >
-      <i
-        className={
-          isLoading ? "p-icon--spinner u-animation--spin" : "p-icon--delete"
-        }
-      >
-        Delete
-      </i>
-    </Button>
+    <ConfirmationButton
+      isLoading={isLoading}
+      iconClass="p-icon--delete"
+      title="Confirm delete"
+      confirmationMessage={`Are you sure you want to delete instance "${instance.name}"?
+                            This action cannot be undone, and can result in data loss.`}
+      posButtonLabel="Delete"
+      onPositive={handleDelete}
+      isDisabled={isLoading || instance.status !== "Stopped"}
+    />
   );
 };
 


### PR DESCRIPTION
Extend the use of `ConfirmationButton` to delete instance and delete image actions.