### PR TITLE
Remove handler for Esc key from ConfirmationModal (not needed anymore)

### DIFF
--- a/static/js/modals/ConfirmationModal.tsx
+++ b/static/js/modals/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, KeyboardEvent } from "react";
+import React, { FC } from "react";
 import { Button, Modal } from "@canonical/react-components";
 
 interface Props {
@@ -18,13 +18,6 @@ const ConfirmationModal: FC<Props> = ({
   posButtonLabel,
   onConfirm,
 }) => {
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      onClose();
-    }
-  };
-
   return (
     <Modal
       close={onClose}
@@ -43,7 +36,6 @@ const ConfirmationModal: FC<Props> = ({
           </Button>
         </>
       }
-      onKeyDown={handleEscKey}
     >
       <p style={{ textAlign: "start", whiteSpace: "pre-line" }}>
         {confirmationMessage}

--- a/static/js/modals/CreateSnapshotForm.tsx
+++ b/static/js/modals/CreateSnapshotForm.tsx
@@ -36,9 +36,9 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, notify }) => {
       </>
     );
   };
+  // TODO: remove on next react-components update
   const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
     if (e.key === "Escape") {
-      e.stopPropagation();
       close();
     }
   };
@@ -82,6 +82,7 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, notify }) => {
     <Form onSubmit={formik.handleSubmit}>
       <Modal
         title={`Create snapshot for ${instance.name}`}
+        // TODO: put back the close prop on next react-components update
         buttonRow={
           <>
             <Button


### PR DESCRIPTION
The snapshot actions have been moved out of the side panel, so we don't need to handle the Esc key in `ConfirmationModal` anymore.