### PR TITLE
wrap cert main page in a l-main container to fix layout for mobile

### DIFF
--- a/static/js/pages/certificates/CertificateMain.tsx
+++ b/static/js/pages/certificates/CertificateMain.tsx
@@ -17,22 +17,24 @@ const CertificateMain: FC = () => {
   }
 
   return (
-    <div className="p-strip">
-      <Row>
-        <Col size={12}>
-          <h1>LXD UI</h1>
-          <p>
-            A valid certificate is needed to access the UI from your browser.
-          </p>
-          <Button
-            appearance="positive"
-            onClick={() => navigate("/ui/certificates/generate")}
-          >
-            Setup certificates
-          </Button>
-        </Col>
-      </Row>
-    </div>
+    <main className="l-main">
+      <div className="p-strip">
+        <Row>
+          <Col size={12}>
+            <h1>LXD UI</h1>
+            <p>
+              A valid certificate is needed to access the UI from your browser.
+            </p>
+            <Button
+              appearance="positive"
+              onClick={() => navigate("/ui/certificates/generate")}
+            >
+              Setup certificates
+            </Button>
+          </Col>
+        </Row>
+      </div>
+    </main>
   );
 };
 


### PR DESCRIPTION
before this change the layout of the main page was broken on mobile (see screen)
![Screenshot_20230206-210943](https://user-images.githubusercontent.com/1155472/217171886-b6fcbc03-15cd-45d3-a438-0afbe3632830.png)
