### PR TITLE
Fix cert redirect

### DIFF
--- a/static/js/pages/certificates/CertificateGenerate.tsx
+++ b/static/js/pages/certificates/CertificateGenerate.tsx
@@ -22,7 +22,7 @@ const CertificateGenerate: FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/" />;
+    return <Navigate to="/ui" />;
   }
 
   const createCert = () => {

--- a/static/js/pages/certificates/CertificateMain.tsx
+++ b/static/js/pages/certificates/CertificateMain.tsx
@@ -13,7 +13,7 @@ const CertificateMain: FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/" />;
+    return <Navigate to="/ui" />;
   }
 
   return (


### PR DESCRIPTION
* we should always rediriect to /ui, because the / part is the api without the ui.