### PR TITLE
fix(navigation) avoid breaking the back button when redirecting pages

### DIFF
--- a/static/js/App.tsx
+++ b/static/js/App.tsx
@@ -19,8 +19,14 @@ import ProtectedRoute from "components/ProtectedRoute";
 const App: FC = () => {
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/ui/default/instances" />} />
-      <Route path="/ui" element={<Navigate to="/ui/default/instances" />} />
+      <Route
+        path="/"
+        element={<Navigate to="/ui/default/instances" replace={true} />}
+      />
+      <Route
+        path="/ui"
+        element={<Navigate to="/ui/default/instances" replace={true} />}
+      />
       <Route
         path="/ui/:project/instances"
         element={<ProtectedRoute outlet={<InstanceList />} />}

--- a/static/js/components/ProtectedRoute.tsx
+++ b/static/js/components/ProtectedRoute.tsx
@@ -15,7 +15,7 @@ const ProtectedRoute = ({ outlet }: Props) => {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/ui/certificates" />;
+    return <Navigate to="/ui/certificates" replace={true} />;
   }
 
   return outlet;

--- a/static/js/pages/certificates/CertificateGenerate.tsx
+++ b/static/js/pages/certificates/CertificateGenerate.tsx
@@ -22,7 +22,7 @@ const CertificateGenerate: FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/ui" />;
+    return <Navigate to="/ui" replace={true} />;
   }
 
   const createCert = () => {

--- a/static/js/pages/certificates/CertificateMain.tsx
+++ b/static/js/pages/certificates/CertificateMain.tsx
@@ -13,7 +13,7 @@ const CertificateMain: FC = () => {
   }
 
   if (isAuthenticated) {
-    return <Navigate to="/ui" />;
+    return <Navigate to="/ui" replace={true} />;
   }
 
   return (


### PR DESCRIPTION
* changed the redirect logic to replace the page in history, the old behaviour broke the back button as on go back we would immediately redirect forward