### PR TITLE
Prevent TypeError when image.description is undefined

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -153,7 +153,7 @@ const InstanceList: FC = () => {
         !item.status.toLowerCase().includes(q) &&
         !item.type.toLowerCase().includes(q) &&
         !item.description.toLowerCase().includes(q) &&
-        !item.config["image.description"].toLowerCase().includes(q)
+        !item.config["image.description"]?.toLowerCase().includes(q)
       ) {
         return false;
       }


### PR DESCRIPTION
The field `config["image.description"]` of an instance can be undefined. In such case, this can cause a `TypeError` when searching the instance list:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```