### PR TITLE
Add .eslintignore to exclude external libraries (in src/lib) from eslint checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# Ignore external libraries (spice, ...)
+
+src/lib/*


### PR DESCRIPTION
Switching to vite has caused the external libraries, that are now placed in `src/lib`, to be included in the eslint checks. With this PR they are excluded from the checks.