### PR TITLE
Set dark theme for YAML editor [WD-2549]

### DIFF
--- a/src/pages/instances/forms/YamlForm.tsx
+++ b/src/pages/instances/forms/YamlForm.tsx
@@ -48,6 +48,7 @@ const YamlForm: FC<Props> = ({
         <Editor
           defaultValue={yaml}
           language="yaml"
+          theme="vs-dark"
           onChange={(value) => value && setYaml(value)}
           options={{
             fontSize: 18,


### PR DESCRIPTION
Thanks to @xlmnxp we now have a much better YAML Editor, which also has a nice dark theme. Could you please have a look at it @al-bakalova?

![image](https://user-images.githubusercontent.com/56583786/226690197-b420380e-1ff6-4c42-a52b-f038cea05b6c.png)