### PR TITLE
Ensure to invalidate instances cache after an instance is created and started

### DIFF
--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -167,6 +167,11 @@ const CreateInstanceForm: FC = () => {
             })
             .catch((e: Error) => {
               notifyCreatedButStartFailed(instanceLink, e);
+            })
+            .finally(() => {
+              void queryClient.invalidateQueries({
+                queryKey: [queryKeys.instances],
+              });
             });
         } else {
           notifyLaunched(instanceLink);

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -22,7 +22,11 @@ interface Props {
   inTabNotification: Notification | null;
 }
 
-const InstanceGraphicConsole: FC<Props> = ({ onMount, onFailure, inTabNotification }) => {
+const InstanceGraphicConsole: FC<Props> = ({
+  onMount,
+  onFailure,
+  inTabNotification,
+}) => {
   const { name, project } = useParams<{
     name: string;
     project: string;


### PR DESCRIPTION
* fix a caching bug. we were invalidating the instance cache after creation, but not after starting it right after creation