### PR TITLE
Redesign the Reconnect terminal modal [WD-2772]

### DIFF
--- a/src/sass/_instance_detail_terminal.scss
+++ b/src/sass/_instance_detail_terminal.scss
@@ -5,4 +5,36 @@
     margin-bottom: $spv--large;
     padding-top: 0;
   }
+
+  .p-modal__dialog {
+    overflow: hidden;
+    padding-right: 0;
+
+    @include large {
+      width: 35rem;
+    }
+
+    .p-modal__header {
+      margin-bottom: 0;
+    }
+
+    .content-wrapper {
+      overflow: auto;
+      padding-right: $sph--large;
+    }
+
+    .p-modal__header,
+    .p-modal__footer {
+      margin-right: $sph--large;
+    }
+  }
+
+  .env-variables {
+    display: flex;
+    gap: $sph--large;
+
+    .p-form__group {
+      flex-grow: 1;
+    }
+  }
 }

--- a/src/util/updateMaxHeight.tsx
+++ b/src/util/updateMaxHeight.tsx
@@ -1,7 +1,10 @@
+type HeightProperty = "height" | "max-height" | "min-height";
+
 export const updateMaxHeight = (
   targetClass: string,
   bottomClass?: string,
-  additionalOffset = 0
+  additionalOffset = 0,
+  targetProperty: HeightProperty = "height"
 ) => {
   const elements = document.getElementsByClassName(targetClass);
   const belowElements = bottomClass
@@ -15,6 +18,6 @@ export const updateMaxHeight = (
     ? belowElements[0].getBoundingClientRect().height + 1
     : 0;
   const offset = Math.ceil(above + below + additionalOffset);
-  const style = `height: calc(100vh - ${offset}px)`;
+  const style = `${targetProperty}: calc(100vh - ${offset}px)`;
   elements[0].setAttribute("style", style);
 };


### PR DESCRIPTION
## Done

- Redesigned the "Reconnect terminal" modal.

Fixes [WD-2772](https://warthogs.atlassian.net/browse/WD-2772)

## QA

- Perform the following QA steps:
  - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
  - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development)

1. Browse an instance detail page, [terminal tab](https://lxd-ui-256.demos.haus/ui/default/instances/detail/alex-is-testing/terminal), and click on the "Reconnect" button.
2. Check the new design of the modal.

[WD-2772]: https://warthogs.atlassian.net/browse/WD-2772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ