### PR TITLE
Overhaul instance detail header [WD-2550]

### DIFF
--- a/src/components/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton.tsx
@@ -1,13 +1,13 @@
 import React, { FC, MouseEvent, ReactNode } from "react";
-import { Button } from "@canonical/react-components";
+import { Button, Icon, ICONS, ValueOf } from "@canonical/react-components";
 import usePortal from "react-useportal";
 import ConfirmationModal from "./ConfirmationModal";
+import classnames from "classnames";
 
 interface Props {
   className?: string;
   isLoading?: boolean;
-  iconClass?: string;
-  iconDescription?: string;
+  icon?: ValueOf<typeof ICONS> | string;
   title: string;
   toggleAppearance?: string;
   toggleCaption?: string;
@@ -23,8 +23,7 @@ interface Props {
 const ConfirmationButton: FC<Props> = ({
   className,
   isLoading = false,
-  iconClass = null,
-  iconDescription = null,
+  icon = null,
   title,
   toggleAppearance = "",
   toggleCaption,
@@ -58,11 +57,7 @@ const ConfirmationButton: FC<Props> = ({
     }
   };
 
-  const visibleIcon = iconClass
-    ? isLoading
-      ? "p-icon--spinner u-animation--spin"
-      : iconClass
-    : undefined;
+  const iconName = icon ? (isLoading ? "spinner" : icon) : undefined;
 
   return (
     <>
@@ -80,7 +75,7 @@ const ConfirmationButton: FC<Props> = ({
       )}
       <Button
         appearance={toggleAppearance}
-        hasIcon={!!visibleIcon}
+        hasIcon={!!iconName}
         className={className}
         dense={isDense}
         disabled={isDisabled}
@@ -89,7 +84,12 @@ const ConfirmationButton: FC<Props> = ({
         title={posButtonLabel}
         type="button"
       >
-        {visibleIcon && <i className={visibleIcon}>{iconDescription}</i>}
+        {iconName && (
+          <Icon
+            className={classnames({ "u-animation--spin": isLoading })}
+            name={iconName}
+          />
+        )}
         {toggleCaption && <span>{toggleCaption}</span>}
       </Button>
     </>

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -34,8 +34,7 @@ const DeleteImageBtn: FC<Props> = ({ image }) => {
   return (
     <ConfirmationButton
       isLoading={isLoading}
-      iconClass="p-icon--delete"
-      iconDescription="Delete"
+      icon="delete"
       title="Confirm delete"
       confirmationMessage={`Are you sure you want to delete image "${image.properties.description}"? This action cannot be undone, and can result in data loss.`}
       posButtonLabel="Delete"

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
-import { List, Row, Tabs } from "@canonical/react-components";
+import { Row, Tabs } from "@canonical/react-components";
 import InstanceOverview from "./InstanceOverview";
 import InstanceTerminal from "./InstanceTerminal";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import InstanceSnapshots from "./InstanceSnapshots";
 import NotificationRow from "components/NotificationRow";
 import { useNotify } from "context/notify";
@@ -71,18 +71,31 @@ const InstanceDetail: FC = () => {
     <main className="l-main">
       <div className="p-panel instance-detail-page">
         <div className="p-panel__header">
+          <h1 className="u-off-screen">{name}</h1>
           {instance ? (
-            <List
-              className="p-panel__title"
-              inline
-              items={[
-                <span key="name">{name}</span>,
-                <i key="status" className="p-text--small">
-                  {instance.status}
-                </i>,
-                <InstanceStateActions key="state" instance={instance} />,
-              ]}
-            />
+            <div className="p-panel__title">
+              <nav
+                key="breadcrumbs"
+                className="p-breadcrumbs"
+                aria-label="Breadcrumbs"
+              >
+                <ol className="p-breadcrumbs__items">
+                  <li className="p-breadcrumbs__item">
+                    <Link to={`/ui/${project}/instances`}>Instances</Link>
+                  </li>
+                  <li
+                    className="p-breadcrumbs__item instance-name u-truncate"
+                    title={name}
+                  >
+                    {name}
+                  </li>
+                </ol>
+              </nav>
+              <div>
+                <i className="u-text--muted">({instance.status})</i>
+                <InstanceStateActions key="state" instance={instance} />
+              </div>
+            </div>
           ) : (
             <h4 className="p-panel__title">{name}</h4>
           )}

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -159,7 +159,7 @@ const InstanceList: FC = () => {
       { content: STATUS, sortKey: "status", className: "status-header status" },
       {
         "aria-label": "Actions",
-        className: "actions",
+        className: classnames("actions", { "u-hide": panelParams.instance }),
       },
     ].filter(
       (item) =>
@@ -256,8 +256,10 @@ const InstanceList: FC = () => {
               />
             ),
             role: "rowheader",
-            className: "u-align--right actions",
-            "aria-label": "Details",
+            className: classnames("u-align--right actions", {
+              "u-hide": panelParams.instance,
+            }),
+            "aria-label": "Actions",
           },
         ].filter((item) => !hiddenCols.includes(item["aria-label"])),
         sortData: {

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from "react";
 import { deleteInstance } from "api/instances";
 import { LxdInstance } from "types/instance";
 import ConfirmationButton from "components/ConfirmationButton";
-import { Tooltip } from "@canonical/react-components";
 import { useNavigate } from "react-router-dom";
 import { useNotify } from "context/notify";
 
@@ -34,24 +33,18 @@ const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
   const isDisabled = isLoading || instance.status !== "Stopped";
 
   return (
-    <Tooltip
-      message={isDisabled ? "Instance must be stopped" : undefined}
-      position="btm-center"
-    >
-      <ConfirmationButton
-        className="u-no-margin--bottom"
-        isLoading={isLoading}
-        iconClass="p-icon--delete"
-        iconDescription="Delete"
-        title="Confirm delete"
-        toggleCaption="Delete"
-        confirmationMessage={`Are you sure you want to delete instance "${instance.name}"? This action cannot be undone, and can result in data loss.`}
-        posButtonLabel="Delete"
-        onConfirm={handleDelete}
-        isDense={false}
-        isDisabled={isDisabled}
-      />
-    </Tooltip>
+    <ConfirmationButton
+      toggleAppearance="base"
+      className="delete-instance-btn"
+      isLoading={isLoading}
+      icon="delete"
+      title="Confirm delete"
+      confirmationMessage={`Are you sure you want to delete instance "${instance.name}"? This action cannot be undone, and can result in data loss.`}
+      posButtonLabel="Delete"
+      onConfirm={handleDelete}
+      isDense={true}
+      isDisabled={isDisabled}
+    />
   );
 };
 

--- a/src/pages/instances/actions/PauseInstanceBtn.tsx
+++ b/src/pages/instances/actions/PauseInstanceBtn.tsx
@@ -52,7 +52,7 @@ const PauseInstanceBtn: FC<Props> = ({ instance }) => {
     <ConfirmationButton
       toggleAppearance="base"
       isLoading={isLoading}
-      iconClass="p-icon--pause-instance"
+      icon="pause"
       title="Confirm pause"
       confirmationMessage={`Are you sure you want to pause instance "${instance.name}"?`}
       posButtonLabel="Pause"

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -55,7 +55,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
     <ConfirmationButton
       toggleAppearance="base"
       isLoading={isLoading}
-      iconClass="p-icon--restart-instance"
+      icon="restart"
       title="Confirm restart"
       confirmationMessage={`Are you sure you want to restart instance "${instance.name}"?`}
       confirmationExtra={

--- a/src/pages/instances/actions/StartInstanceBtn.tsx
+++ b/src/pages/instances/actions/StartInstanceBtn.tsx
@@ -3,10 +3,11 @@ import { LxdInstance } from "types/instance";
 import { useQueryClient } from "@tanstack/react-query";
 import { startInstance, unfreezeInstance } from "api/instances";
 import { queryKeys } from "util/queryKeys";
-import { Button } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 import { useNotify } from "context/notify";
 import { useInstanceLoading } from "context/instanceLoading";
 import InstanceLink from "pages/instances/InstanceLink";
+import classnames from "classnames";
 
 interface Props {
   instance: LxdInstance;
@@ -62,12 +63,9 @@ const StartInstanceBtn: FC<Props> = ({ instance }) => {
       aria-label={isLoading ? "Starting" : "Start"}
       title="Start"
     >
-      <i
-        className={
-          isLoading
-            ? "p-icon--spinner u-animation--spin"
-            : "p-icon--start-instance"
-        }
+      <Icon
+        className={classnames({ "u-animation--spin": isLoading })}
+        name={isLoading ? "spinner" : "play"}
       />
     </Button>
   );

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -52,7 +52,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
     <ConfirmationButton
       toggleAppearance="base"
       isLoading={isLoading}
-      iconClass="p-icon--stop-instance"
+      icon="stop"
       title="Confirm stop"
       confirmationMessage={`Are you sure you want to stop instance "${instance.name}"?`}
       confirmationExtra={

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -35,8 +35,7 @@ const DeleteProfileBtn: FC<Props> = ({ profile, project }) => {
     <ConfirmationButton
       className="u-no-margin--bottom"
       isLoading={isLoading}
-      iconClass="p-icon--delete"
-      iconDescription="Delete"
+      icon="delete"
       title="Confirm delete"
       toggleCaption="Delete"
       confirmationMessage={`Are you sure you want to delete profile "${profile.name}"? This action cannot be undone, and can result in data loss.`}

--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -41,8 +41,7 @@ const DeleteProjectBtn: FC<Props> = ({ project }) => {
     <ConfirmationButton
       className="u-no-margin--bottom"
       isLoading={isLoading}
-      iconClass="p-icon--delete"
-      iconDescription="Delete"
+      icon="delete"
       title="Confirm delete"
       toggleCaption="Delete"
       confirmationMessage={`Are you sure you want to delete the project "${project.name}"? This action cannot be undone, and can result in data loss.`}

--- a/src/pages/storages/actions/DeleteStorageBtn.tsx
+++ b/src/pages/storages/actions/DeleteStorageBtn.tsx
@@ -37,8 +37,7 @@ const DeleteStorageBtn: FC<Props> = ({ storage, project }) => {
       toggleAppearance="base"
       className="u-no-margin--bottom"
       isLoading={isLoading}
-      iconClass="p-icon--delete"
-      iconDescription="Delete"
+      icon="delete"
       title="Confirm delete"
       confirmationMessage={`Are you sure you want to delete storage "${storage.name}"? This action cannot be undone, and can result in data loss.`}
       posButtonLabel="Delete"

--- a/src/sass/_instance_detail_page.scss
+++ b/src/sass/_instance_detail_page.scss
@@ -1,10 +1,62 @@
 .instance-detail-page {
+  .p-panel__title {
+    display: flex;
+    flex-direction: column;
+    max-width: none;
+
+    @include large {
+      align-items: center;
+      flex-direction: row;
+    }
+
+    .p-breadcrumbs {
+      margin-bottom: 0;
+      width: inherit;
+
+      .p-breadcrumbs__items {
+        margin-bottom: 0;
+      }
+
+      .p-breadcrumbs__item {
+        font-size: #{map.get($font-sizes, h4-mobile)}rem;
+        line-height: 2rem;
+        margin-bottom: 0;
+        margin-top: 0;
+        padding-top: 0;
+      }
+
+      .p-breadcrumbs__item:first-of-type {
+        margin-right: $sp-x-small;
+      }
+    }
+
+    .instance-name {
+      margin-right: $sph--x-small;
+      max-width: 33vw;
+      overflow: clip !important;
+    }
+
+    .actions-list {
+      margin: 0 $sph--large;
+    }
+  }
+
+  .p-panel__controls {
+    margin-top: 0.2rem;
+
+    .delete-instance-btn {
+      margin: 0;
+      padding-left: $sph--x-large;
+      padding-right: $sph--x-large;
+    }
+  }
+
   .p-tabs__list {
     margin-bottom: $spv--large !important;
   }
 
   .p-panel__content {
+    margin-top: -$spv--medium;
     padding-bottom: 0;
-    padding-top: $spv--large;
   }
 }

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -140,7 +140,7 @@
     }
 
     .actions {
-      width: 160px;
+      width: 210px;
     }
   }
 

--- a/src/sass/_pattern_icon.scss
+++ b/src/sass/_pattern_icon.scss
@@ -8,35 +8,3 @@
     @include lxdui-icon-sidebar-collapse;
   }
 }
-
-.p-icon--start-instance {
-  background-image: url("https://assets.ubuntu.com/v1/169dd804-state=start.svg");
-  background-position: center;
-  display: inline-block;
-  min-height: 1rem;
-  min-width: 1rem;
-}
-
-.p-icon--stop-instance {
-  background-image: url("https://assets.ubuntu.com/v1/651b51a3-state=stop.svg");
-  background-position: center;
-  display: inline-block;
-  min-height: 1rem;
-  min-width: 1rem;
-}
-
-.p-icon--pause-instance {
-  background-image: url("https://assets.ubuntu.com/v1/24df595c-state=pause.svg");
-  background-position: center;
-  display: inline-block;
-  min-height: 1rem;
-  min-width: 1rem;
-}
-
-.p-icon--restart-instance {
-  background-image: url("https://assets.ubuntu.com/v1/d205cd5a-state=state4.svg");
-  background-position: center;
-  display: inline-block;
-  min-height: 1rem;
-  min-width: 1rem;
-}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -22,6 +22,8 @@
 @include vf-p-icon-import;
 @include vf-p-icon-machines;
 @include vf-p-icon-open-terminal;
+@include vf-p-icon-pause;
+@include vf-p-icon-play;
 @include vf-p-icon-pods;
 @include vf-p-icon-power-off;
 @include vf-p-icon-priority-low;
@@ -34,6 +36,7 @@
 @include vf-p-icon-status-queued-small;
 @include vf-p-icon-status-succeeded-small;
 @include vf-p-icon-status-waiting-small;
+@include vf-p-icon-stop;
 @include vf-p-icon-switcher-environments;
 @include vf-p-icon-task-outstanding;
 @include vf-p-icon-video-play;
@@ -121,10 +124,14 @@ $border-thin: 1px solid $color-mid-light !default;
 
 .actions-list {
   display: inline-block;
+  min-width: 8.5rem;
 
   * {
     border-right: $border-thin;
     margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+    width: 44px;
   }
 
   *:last-child {


### PR DESCRIPTION
## Done

- Adjusted the header of the instance detail page.

Fixes [WD-2550](https://warthogs.atlassian.net/browse/WD-2550)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit any instance detail page ([example](https://lxd-ui-260.demos.haus/ui/default/instances/detail/alex-is-testing)), and check the appearance of the header.

[WD-2550]: https://warthogs.atlassian.net/browse/WD-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ