### PR TITLE
Change defaults for the instance terminal, raise state so it is persisted when reconnecting multiple times

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -1,7 +1,7 @@
 import { watchOperation } from "./operations";
 import { handleResponse, handleTextResponse } from "util/helpers";
 import { LxdInstance } from "types/instance";
-import { LxdTerminal, LxdTerminalPayload } from "types/terminal";
+import { LxdTerminal, TerminalConnectPayload } from "types/terminal";
 import { LxdApiResponse } from "types/apiResponse";
 import { LxdOperation } from "types/operation";
 
@@ -168,12 +168,23 @@ export const deleteInstance = (instance: LxdInstance) => {
 export const connectInstanceExec = (
   name: string,
   project: string,
-  payload: LxdTerminalPayload
+  payload: TerminalConnectPayload
 ): Promise<LxdTerminal> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/instances/${name}/exec?project=${project}&wait=10`, {
       method: "POST",
-      body: JSON.stringify(payload),
+      body: JSON.stringify({
+        command: [payload.command],
+        "record-output": true,
+        "wait-for-websocket": true,
+        environment: payload.environment.reduce(
+          (a, v) => ({ ...a, [v.key]: v.value }),
+          {}
+        ),
+        interactive: true,
+        group: payload.group,
+        user: payload.user,
+      }),
     })
       .then(handleResponse)
       .then((data: LxdTerminal) => resolve(data))

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -63,13 +63,19 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
       {isGraphic ? (
         <div className="spice-wrapper">
           <InstanceGraphicConsole
+            instance={instance}
             onMount={onChildMount}
             onFailure={onFailure}
             inTabNotification={inTabNotification}
+            clearNotification={() => setInTabNotification(null)}
           />
         </div>
       ) : (
-        <InstanceTextConsole instance={instance} onFailure={onFailure} />
+        <InstanceTextConsole
+          instance={instance}
+          onFailure={onFailure}
+          clearNotification={() => setInTabNotification(null)}
+        />
       )}
     </div>
   );

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -127,7 +127,7 @@ const InstanceDetail: FC = () => {
 
               {activeTab === "terminal" && (
                 <div role="tabpanel" aria-labelledby="terminal">
-                  <InstanceTerminal />
+                  <InstanceTerminal instance={instance} />
                 </div>
               )}
 

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -8,6 +8,7 @@ import Loader from "components/Loader";
 import { useNotify } from "context/notify";
 import { Notification } from "types/notification";
 import { updateMaxHeight } from "util/updateMaxHeight";
+import { LxdInstance } from "types/instance";
 
 declare global {
   // eslint-disable-next-line no-unused-vars
@@ -17,15 +18,19 @@ declare global {
 }
 
 interface Props {
+  instance: LxdInstance;
   onMount: (handler: () => void) => void;
   onFailure: (message: string, e: unknown) => void;
   inTabNotification: Notification | null;
+  clearNotification: () => void;
 }
 
 const InstanceGraphicConsole: FC<Props> = ({
+  instance,
   onMount,
   onFailure,
   inTabNotification,
+  clearNotification,
 }) => {
   const { name, project } = useParams<{
     name: string;
@@ -108,6 +113,7 @@ const InstanceGraphicConsole: FC<Props> = ({
   ]);
 
   useEffect(() => {
+    clearNotification();
     const websocketPromise = openVgaConsole();
     return () => {
       try {
@@ -117,7 +123,7 @@ const InstanceGraphicConsole: FC<Props> = ({
       }
       void websocketPromise.then((websocket) => websocket?.close());
     };
-  }, []);
+  }, [instance.status]);
 
   const handleFullScreen = () => {
     const container = spiceRef.current;

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -13,6 +13,7 @@ import { Notification } from "types/notification";
 import NotificationRowLegacy from "components/NotificationRowLegacy";
 import { failure } from "context/notify";
 import { updateMaxHeight } from "util/updateMaxHeight";
+import { LxdInstance } from "types/instance";
 
 const XTERM_OPTIONS = {
   theme: {
@@ -33,7 +34,11 @@ const defaultPayload = {
   user: 0,
 };
 
-const InstanceTerminal: FC = () => {
+interface Props {
+  instance: LxdInstance;
+}
+
+const InstanceTerminal: FC<Props> = ({ instance }) => {
   const { name, project } = useParams<{
     name: string;
     project: string;
@@ -52,8 +57,6 @@ const InstanceTerminal: FC = () => {
   const [fitAddon] = useState<FitAddon>(new FitAddon());
 
   const handleReconnect = (payload: LxdTerminalPayload) => {
-    xtermRef.current?.terminal.clear();
-    setInTabNotification(null);
     setPayload(payload);
   };
 
@@ -141,13 +144,15 @@ const InstanceTerminal: FC = () => {
     if (!payload) {
       return;
     }
+    xtermRef.current?.terminal.clear();
+    setInTabNotification(null);
     const websocketPromise = openWebsockets(payload);
     return () => {
       void websocketPromise.then((websockets) => {
         websockets?.map((websocket) => websocket.close());
       });
     };
-  }, [payload]);
+  }, [payload, instance.status]);
 
   const handleResize = () => {
     if (controlWs?.readyState === WebSocket.CLOSED) {

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -26,10 +26,11 @@ const defaultPayload = {
   "wait-for-websocket": true,
   environment: {
     TERM: "xterm-256color",
+    HOME: "/root",
   },
   interactive: true,
-  group: 1000,
-  user: 1000,
+  group: 0,
+  user: 0,
 };
 
 const InstanceTerminal: FC = () => {

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -7,7 +7,7 @@ import { connectInstanceExec } from "api/instances";
 import { getWsErrorMsg } from "util/helpers";
 import useEventListener from "@use-it/event-listener";
 import ReconnectTerminalBtn from "./actions/ReconnectTerminalBtn";
-import { LxdTerminalPayload } from "types/terminal";
+import { TerminalConnectPayload } from "types/terminal";
 import Loader from "components/Loader";
 import { Notification } from "types/notification";
 import NotificationRowLegacy from "components/NotificationRowLegacy";
@@ -21,17 +21,20 @@ const XTERM_OPTIONS = {
   },
 };
 
-const defaultPayload = {
-  command: ["bash"],
-  "record-output": true,
-  "wait-for-websocket": true,
-  environment: {
-    TERM: "xterm-256color",
-    HOME: "/root",
-  },
-  interactive: true,
-  group: 0,
+export const defaultPayload: TerminalConnectPayload = {
+  command: "bash",
+  environment: [
+    {
+      key: "TERM",
+      value: "xterm-256color",
+    },
+    {
+      key: "HOME",
+      value: "/root",
+    },
+  ],
   user: 0,
+  group: 0,
 };
 
 interface Props {
@@ -47,20 +50,13 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   const textEncoder = new TextEncoder();
   const [inTabNotification, setInTabNotification] =
     useState<Notification | null>(null);
-  const [isLoading, setLoading] = useState<boolean>(false);
+  const [isLoading, setLoading] = useState(false);
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
-  const [payload, setPayload] = useState<LxdTerminalPayload | null>(
-    defaultPayload
-  );
-
+  const [payload, setPayload] = useState(defaultPayload);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
 
-  const handleReconnect = (payload: LxdTerminalPayload) => {
-    setPayload(payload);
-  };
-
-  const openWebsockets = async (payload: LxdTerminalPayload) => {
+  const openWebsockets = async (payload: TerminalConnectPayload) => {
     if (!name) {
       setInTabNotification(failure("Missing name", new Error()));
       return;
@@ -197,7 +193,7 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   return (
     <div className="instance-terminal-tab">
       <div className="p-panel__controls">
-        <ReconnectTerminalBtn onFinish={handleReconnect} />
+        <ReconnectTerminalBtn reconnect={setPayload} payload={payload} />
       </div>
       <NotificationRowLegacy
         notification={inTabNotification}

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -16,9 +16,14 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 interface Props {
   instance: LxdInstance;
   onFailure: (message: string, e: unknown) => void;
+  clearNotification: () => void;
 }
 
-const InstanceTextConsole: FC<Props> = ({ instance, onFailure }) => {
+const InstanceTextConsole: FC<Props> = ({
+  instance,
+  onFailure,
+  clearNotification,
+}) => {
   const { name, project } = useParams<{
     name: string;
     project: string;
@@ -109,6 +114,7 @@ const InstanceTextConsole: FC<Props> = ({ instance, onFailure }) => {
     if (dataWs) {
       return;
     }
+    clearNotification();
     const websocketPromise = openWebsockets();
     return () => {
       void websocketPromise.then((websockets) => {

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -1,71 +1,37 @@
 import React, { FC, KeyboardEvent, useEffect, useRef } from "react";
 import { Button, Form, Icon, Input, Modal } from "@canonical/react-components";
-import * as Yup from "yup";
-import { useFormik } from "formik";
-import { LxdTerminalPayload } from "types/terminal";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
+import { FormikProps } from "formik/dist/types";
+
+export interface TerminalPayloadFormValues {
+  command: string;
+  environment: {
+    key: string;
+    value: string;
+  }[];
+  user: number;
+  group: number;
+}
 
 interface Props {
   close: () => void;
-  onFinish: (data: LxdTerminalPayload) => void;
+  formik: FormikProps<TerminalPayloadFormValues>;
 }
 
-const TerminalPayloadForm: FC<Props> = ({ close, onFinish }) => {
+const TerminalPayloadForm: FC<Props> = ({ close, formik }) => {
   const ref = useRef<HTMLDivElement>(null);
-
-  const TerminalSchema = Yup.object().shape({
-    command: Yup.string().required("This field is required"),
-    environment: Yup.array().of(
-      Yup.object().shape({
-        key: Yup.string(),
-        value: Yup.string(),
-      })
-    ),
-    user: Yup.number(),
-    group: Yup.number(),
-  });
-
-  const formik = useFormik({
-    initialValues: {
-      command: "bash",
-      environment: [
-        {
-          key: "TERM",
-          value: "xterm-256color",
-        },
-      ],
-      user: 1000,
-      group: 1000,
-    },
-    validationSchema: TerminalSchema,
-    onSubmit: (values) => {
-      const result = {
-        command: [values.command],
-        "record-output": true,
-        "wait-for-websocket": true,
-        environment: values.environment.reduce(
-          (a, v) => ({ ...a, [v.key]: v.value }),
-          {}
-        ),
-        interactive: true,
-        group: values.group,
-        user: values.user,
-      };
-      onFinish(result);
-    },
-  });
 
   const addEnvironmentRow = () => {
     const copy = [...formik.values.environment];
     copy.push({ key: "", value: "" });
-    void formik.setFieldValue("environment", copy);
+    formik.setFieldValue("environment", copy);
   };
 
   const removeEnvironmentRow = (index: number) => {
     const copy = [...formik.values.environment];
     copy.splice(index, 1);
-    void formik.setFieldValue("environment", copy);
+    formik.setFieldValue("environment", copy);
   };
 
   const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -43,6 +43,9 @@ const TerminalPayloadForm: FC<Props> = ({ close, formik }) => {
   const updateContentHeight = () => {
     updateMaxHeight("content-wrapper", "p-modal__footer", 64, "max-height");
   };
+  useEventListener("resize", updateContentHeight);
+  useEffect(updateContentHeight, []);
+
   useEffect(() => {
     ref.current?.scrollIntoView({
       behavior: "smooth",
@@ -51,7 +54,6 @@ const TerminalPayloadForm: FC<Props> = ({ close, formik }) => {
     });
     window.dispatchEvent(new Event("resize"));
   }, [formik.values.environment]);
-  useEventListener("resize", updateContentHeight);
 
   return (
     <Modal

--- a/src/pages/instances/actions/ReconnectTerminalBtn.tsx
+++ b/src/pages/instances/actions/ReconnectTerminalBtn.tsx
@@ -1,15 +1,14 @@
 import React, { FC, useState } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { LxdTerminalPayload } from "types/terminal";
+import { TerminalConnectPayload } from "types/terminal";
 import TerminalPayloadForm from "../TerminalPayloadForm";
-import * as Yup from "yup";
-import { useFormik } from "formik";
 
 interface Props {
-  onFinish: (data: LxdTerminalPayload) => void;
+  payload: TerminalConnectPayload;
+  reconnect: (data: TerminalConnectPayload) => void;
 }
 
-const ReconnectTerminalBtn: FC<Props> = ({ onFinish }) => {
+const ReconnectTerminalBtn: FC<Props> = ({ payload, reconnect }) => {
   const [isModal, setModal] = useState(false);
 
   const closeModal = () => {
@@ -20,56 +19,20 @@ const ReconnectTerminalBtn: FC<Props> = ({ onFinish }) => {
     setModal(true);
   };
 
-  const TerminalSchema = Yup.object().shape({
-    command: Yup.string().required("This field is required"),
-    environment: Yup.array().of(
-      Yup.object().shape({
-        key: Yup.string(),
-        value: Yup.string(),
-      })
-    ),
-    user: Yup.number(),
-    group: Yup.number(),
-  });
-
-  const formik = useFormik({
-    initialValues: {
-      command: "bash",
-      environment: [
-        {
-          key: "TERM",
-          value: "xterm-256color",
-        },
-        {
-          key: "HOME",
-          value: "/root",
-        },
-      ],
-      user: 0,
-      group: 0,
-    },
-    validationSchema: TerminalSchema,
-    onSubmit: (values) => {
-      const result = {
-        command: [values.command],
-        "record-output": true,
-        "wait-for-websocket": true,
-        environment: values.environment.reduce(
-          (a, v) => ({ ...a, [v.key]: v.value }),
-          {}
-        ),
-        interactive: true,
-        group: values.group,
-        user: values.user,
-      };
-      onFinish(result);
-      closeModal();
-    },
-  });
+  const handleReconnect = (payload: TerminalConnectPayload) => {
+    closeModal();
+    reconnect(payload);
+  };
 
   return (
     <>
-      {isModal && <TerminalPayloadForm close={closeModal} formik={formik} />}
+      {isModal && (
+        <TerminalPayloadForm
+          close={closeModal}
+          reconnect={handleReconnect}
+          payload={payload}
+        />
+      )}
       <Button className="u-no-margin--bottom" hasIcon onClick={openModal}>
         <Icon name="connected" />
         <span>Reconnect</span>

--- a/src/types/terminal.d.ts
+++ b/src/types/terminal.d.ts
@@ -10,12 +10,12 @@ export interface LxdTerminal {
   };
 }
 
-export interface LxdTerminalPayload {
-  command: string[];
-  "record-output": boolean;
-  "wait-for-websocket": boolean;
-  interactive: boolean;
-  environment: Record<string, string>;
-  user?: number;
-  group?: number;
+export interface TerminalConnectPayload {
+  command: string;
+  environment: {
+    key: string;
+    value: string;
+  }[];
+  user: number;
+  group: number;
 }


### PR DESCRIPTION
## Done

- change defaults when opening a terminal to use uid/gid 0, with /root as home
- raise the state for the terminal reconnect button, so it is persisted when reconnecting multiple times
- reconnect terminal and graphic/text console on starting of an instance, close error notifications before reconnecting

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - open terminal
    - reconnect terminal multiple times
    - start/stop instance when displaying terminal, and graphic/text console. They should reconnect on start and close the error notification.