### PR TITLE
Instance and profile edit fixes

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -1,4 +1,4 @@
-import { watchOperation } from "./operations";
+import { TIMEOUT_300, watchOperation } from "./operations";
 import { handleResponse } from "util/helpers";
 import { ImportImage, LxdImage } from "types/image";
 import { LxdApiResponse } from "types/apiResponse";
@@ -55,7 +55,7 @@ export const importImage = (remoteImage: ImportImage) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 300).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_300).then(resolve).catch(reject);
       })
       .catch(reject);
   });

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -1,5 +1,9 @@
 import { watchOperation } from "./operations";
-import { handleResponse, handleTextResponse } from "util/helpers";
+import {
+  handleEtagResponse,
+  handleResponse,
+  handleTextResponse,
+} from "util/helpers";
 import { LxdInstance } from "types/instance";
 import { LxdTerminal, TerminalConnectPayload } from "types/terminal";
 import { LxdApiResponse } from "types/apiResponse";
@@ -12,16 +16,8 @@ export const fetchInstance = (
 ): Promise<LxdInstance> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/instances/${name}?project=${project}&recursion=${recursion}`)
-      .then((response) => {
-        return handleResponse(response)
-          .then((data: LxdApiResponse<LxdInstance>) => {
-            const result = data.metadata;
-            result.etag =
-              response.headers.get("etag")?.replace("W/", "") ?? undefined;
-            resolve(result);
-          })
-          .catch(reject);
-      })
+      .then(handleEtagResponse)
+      .then((data) => resolve(data as LxdInstance))
       .catch(reject);
   });
 };

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -87,7 +87,9 @@ export const renameInstance = (
       }),
     })
       .then(handleResponse)
-      .then(resolve)
+      .then((data: LxdOperation) => {
+        watchOperation(data.operation, 120).then(resolve).catch(reject);
+      })
       .catch(reject);
   });
 };

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -48,18 +48,13 @@ export const createInstance = (
   });
 };
 
-export const updateInstance = (
-  body: string,
-  project: string,
-  etag?: string
-) => {
-  const instance = JSON.parse(body) as LxdInstance;
+export const updateInstance = (instance: LxdInstance, project: string) => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/instances/${instance.name}?project=${project}`, {
       method: "PUT",
-      body: body,
+      body: JSON.stringify(instance),
       headers: {
-        "If-Match": etag ?? "invalid-etag",
+        "If-Match": instance.etag ?? "invalid-etag",
       },
     })
       .then(handleResponse)

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -74,6 +74,24 @@ export const updateInstance = (
   });
 };
 
+export const renameInstance = (
+  oldName: string,
+  newName: string,
+  project: string
+) => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/instances/${oldName}?project=${project}`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: newName,
+      }),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
 export const startInstance = (instance: LxdInstance) => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/instances/${instance.name}/state?project=${instance.project}`, {

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -1,4 +1,4 @@
-import { watchOperation } from "./operations";
+import { TIMEOUT_120, TIMEOUT_60, watchOperation } from "./operations";
 import {
   handleEtagResponse,
   handleResponse,
@@ -42,7 +42,7 @@ export const createInstance = (
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 120).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_120).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -59,7 +59,7 @@ export const updateInstance = (instance: LxdInstance, project: string) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 120).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_120).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -79,7 +79,7 @@ export const renameInstance = (
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 120).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_120).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -93,7 +93,7 @@ export const startInstance = (instance: LxdInstance) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -110,7 +110,7 @@ export const stopInstance = (instance: LxdInstance, isForce: boolean) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -126,7 +126,7 @@ export const freezeInstance = (instance: LxdInstance) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -140,7 +140,7 @@ export const unfreezeInstance = (instance: LxdInstance) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });
@@ -157,7 +157,7 @@ export const restartInstance = (instance: LxdInstance, isForce: boolean) => {
     })
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });

--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -1,9 +1,14 @@
 import { handleResponse } from "util/helpers";
 import { LxdOperation } from "types/operation";
 
+export const TIMEOUT_300 = 300;
+export const TIMEOUT_120 = 120;
+export const TIMEOUT_60 = 60;
+export const TIMEOUT_10 = 10;
+
 export const watchOperation = (
   operationUrl: string,
-  timeout = 10
+  timeout = TIMEOUT_10
 ): Promise<LxdOperation> => {
   return new Promise((resolve, reject) => {
     fetch(`${operationUrl}/wait?timeout=${timeout}`)

--- a/src/api/profiles.tsx
+++ b/src/api/profiles.tsx
@@ -35,14 +35,13 @@ export const createProfile = (body: string, project: string) => {
   });
 };
 
-export const updateProfile = (body: string, project: string, etag?: string) => {
-  const profile = JSON.parse(body) as LxdProfile;
+export const updateProfile = (profile: LxdProfile, project: string) => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/profiles/${profile.name}?project=${project}`, {
       method: "PUT",
-      body: body,
+      body: JSON.stringify(profile),
       headers: {
-        "If-Match": etag ?? "invalid-etag",
+        "If-Match": profile.etag ?? "invalid-etag",
       },
     })
       .then(handleResponse)

--- a/src/api/profiles.tsx
+++ b/src/api/profiles.tsx
@@ -1,4 +1,4 @@
-import { handleResponse } from "util/helpers";
+import { handleEtagResponse, handleResponse } from "util/helpers";
 import { LxdProfile } from "types/profile";
 import { LxdApiResponse } from "types/apiResponse";
 
@@ -8,8 +8,8 @@ export const fetchProfile = (
 ): Promise<LxdProfile> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/profiles/${name}?project=${project}&recursion=1`)
-      .then(handleResponse)
-      .then((data: LxdApiResponse<LxdProfile>) => resolve(data.metadata))
+      .then(handleEtagResponse)
+      .then((data) => resolve(data as LxdProfile))
       .catch(reject);
   });
 };
@@ -35,12 +35,15 @@ export const createProfile = (body: string, project: string) => {
   });
 };
 
-export const updateProfile = (body: string, project: string) => {
+export const updateProfile = (body: string, project: string, etag?: string) => {
   const profile = JSON.parse(body) as LxdProfile;
   return new Promise((resolve, reject) => {
     fetch(`/1.0/profiles/${profile.name}?project=${project}`, {
       method: "PUT",
       body: body,
+      headers: {
+        "If-Match": etag ?? "invalid-etag",
+      },
     })
       .then(handleResponse)
       .then(resolve)

--- a/src/api/profiles.tsx
+++ b/src/api/profiles.tsx
@@ -48,6 +48,24 @@ export const updateProfile = (body: string, project: string) => {
   });
 };
 
+export const renameProfile = (
+  oldName: string,
+  newName: string,
+  project: string
+) => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/profiles/${oldName}?project=${project}`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: newName,
+      }),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
 export const deleteProfile = (name: string, project: string) => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/profiles/${name}?project=${project}`, {

--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -32,14 +32,13 @@ export const createProject = (body: string) => {
   });
 };
 
-export const updateProject = (body: string, etag?: string) => {
-  const project = JSON.parse(body) as LxdProject;
+export const updateProject = (project: LxdProject) => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/projects/${project.name}`, {
       method: "PUT",
-      body: body,
+      body: JSON.stringify(project),
       headers: {
-        "If-Match": etag ?? "invalid-etag",
+        "If-Match": project.etag ?? "invalid-etag",
       },
     })
       .then(handleResponse)

--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -1,4 +1,4 @@
-import { handleResponse } from "util/helpers";
+import { handleEtagResponse, handleResponse } from "util/helpers";
 import { LxdProject } from "types/project";
 import { LxdApiResponse } from "types/apiResponse";
 
@@ -14,8 +14,8 @@ export const fetchProjects = (recursion: number): Promise<LxdProject[]> => {
 export const fetchProject = (name: string): Promise<LxdProject> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/projects/${name}`)
-      .then(handleResponse)
-      .then((data: LxdApiResponse<LxdProject>) => resolve(data.metadata))
+      .then(handleEtagResponse)
+      .then((data) => resolve(data as LxdProject))
       .catch(reject);
   });
 };
@@ -32,12 +32,15 @@ export const createProject = (body: string) => {
   });
 };
 
-export const updateProject = (body: string) => {
+export const updateProject = (body: string, etag?: string) => {
   const project = JSON.parse(body) as LxdProject;
   return new Promise((resolve, reject) => {
     fetch(`/1.0/projects/${project.name}`, {
       method: "PUT",
       body: body,
+      headers: {
+        "If-Match": etag ?? "invalid-etag",
+      },
     })
       .then(handleResponse)
       .then((data) => resolve(data))

--- a/src/api/snapshots.tsx
+++ b/src/api/snapshots.tsx
@@ -1,4 +1,4 @@
-import { watchOperation } from "./operations";
+import { TIMEOUT_60, watchOperation } from "./operations";
 import { handleResponse } from "util/helpers";
 import { LxdInstance, LxdSnapshot } from "types/instance";
 import { LxdOperation } from "types/operation";
@@ -23,7 +23,7 @@ export const createSnapshot = (
     )
       .then(handleResponse)
       .then((data: LxdOperation) => {
-        watchOperation(data.operation, 60).then(resolve).catch(reject);
+        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
       })
       .catch(reject);
   });

--- a/src/context/notify.tsx
+++ b/src/context/notify.tsx
@@ -22,7 +22,8 @@ const queue = (notification: Notification): QueuedNotification => {
 export const failure = (
   message: string | ReactNode,
   error: unknown,
-  actions?: NotificationAction[]
+  actions?: NotificationAction[],
+  title?: string
 ): Notification => {
   return {
     actions,
@@ -34,6 +35,7 @@ export const failure = (
       ) : (
         message
       ),
+    title,
     type: "negative",
   };
 };
@@ -95,8 +97,8 @@ export const NotifyProvider: FC<NotifyProviderProps> = ({ children }) => {
     notification,
     clear: () => notification !== null && setNotification(null),
     queue,
-    failure: (message, error, actions) =>
-      setDeduplicated(failure(message, error, actions)),
+    failure: (message, error, actions, title) =>
+      setDeduplicated(failure(message, error, actions, title)),
     info: (message, title) => setDeduplicated(info(message, title)),
     success: (message) => setDeduplicated(success(message)),
   };

--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -21,10 +21,10 @@ import { yamlToObject } from "util/yaml";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { LxdInstance } from "types/instance";
 import { Location } from "history";
-import InstanceDetailsForm, {
+import InstanceCreateDetailsForm, {
   instanceDetailPayload,
   InstanceDetailsFormValues,
-} from "pages/instances/forms/InstanceDetailsForm";
+} from "pages/instances/forms/InstanceCreateDetailsForm";
 import { useNotify } from "context/notify";
 import { formDeviceToPayload, FormDeviceValues } from "util/formDevices";
 import SecurityPoliciesForm, {
@@ -266,7 +266,7 @@ const CreateInstanceForm: FC = () => {
               <Col size={12}>
                 <NotificationRow />
                 {section === INSTANCE_DETAILS && (
-                  <InstanceDetailsForm
+                  <InstanceCreateDetailsForm
                     formik={formik}
                     project={project}
                     onSelectImage={handleSelectImage}

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -120,22 +120,19 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
               .then(() => {
                 navigate(
                   `/ui/${instance.project}/instances/detail/${newName}/configuration`,
-                  notify.queue(notify.success("Configuration updated."))
+                  notify.queue(notify.success("Instance updated."))
                 );
               })
               .catch((e: Error) => {
-                notify.failure(
-                  `Saved changes, but could not rename the instance ${oldName}.`,
-                  e
-                );
+                notify.failure(`Failed to rename the instance ${oldName}`, e);
               });
           } else {
-            notify.success("Configuration updated.");
+            notify.success("Instance updated.");
             void formik.setFieldValue("readOnly", true);
           }
         })
         .catch((e: Error) => {
-          notify.failure("Could not save", e);
+          notify.failure("", e, undefined, "Instance update failed");
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -114,9 +114,9 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
       instancePayload.name = oldName;
 
       updateInstance(JSON.stringify(instancePayload), project, instance.etag)
-        .then(() => {
+        .then(async () => {
           if (newName !== oldName) {
-            renameInstance(oldName, newName, project)
+            await renameInstance(oldName, newName, project)
               .then(() => {
                 navigate(
                   `/ui/${instance.project}/instances/detail/${newName}/configuration`,

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -53,7 +53,11 @@ import useEventListener from "@use-it/event-listener";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import RootStorageForm from "pages/instances/forms/RootStorageForm";
 import NetworkForm from "pages/instances/forms/NetworkForm";
-import { getEditValues, getSupportedConfigKeys } from "util/formFields";
+import {
+  getEditValues,
+  getHandledConfigKeys,
+  getUnhandledKeyValues,
+} from "util/formFields";
 
 export type EditInstanceFormValues = InstanceEditDetailsFormValues &
   FormDeviceValues &
@@ -126,14 +130,8 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
   });
 
   const getPayload = (values: EditInstanceFormValues) => {
-    const supportedConfigKeys = getSupportedConfigKeys();
-    const additionalConfigKeys = Object.fromEntries(
-      Object.entries(instance.config).filter(
-        ([key]) => !supportedConfigKeys.has(key)
-      )
-    );
-
-    const supportedMainKeys = new Set([
+    const handledConfigKeys = getHandledConfigKeys();
+    const handledKeys = new Set([
       "name",
       "description",
       "type",
@@ -141,9 +139,6 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
       "devices",
       "config",
     ]);
-    const additionalMainKeys = Object.fromEntries(
-      Object.entries(instance).filter(([key]) => !supportedMainKeys.has(key))
-    );
 
     return {
       ...instanceEditDetailPayload(values),
@@ -153,9 +148,9 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
         ...securityPoliciesPayload(values),
         ...snapshotsPayload(values),
         ...cloudInitPayload(values),
-        ...additionalConfigKeys,
+        ...getUnhandledKeyValues(instance.config, handledConfigKeys),
       },
-      ...additionalMainKeys,
+      ...getUnhandledKeyValues(instance, handledKeys),
     };
   };
 

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -112,8 +112,9 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
       // rename will be a second request
       // keep the old name for the first request persisting other changes
       instancePayload.name = oldName;
+      instancePayload.etag = instance.etag;
 
-      updateInstance(JSON.stringify(instancePayload), project, instance.etag)
+      updateInstance(instancePayload, project)
         .then(async () => {
           if (newName !== oldName) {
             await renameInstance(oldName, newName, project)

--- a/src/pages/instances/forms/CloudInitForm.tsx
+++ b/src/pages/instances/forms/CloudInitForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "pages/instances/forms/sharedFormTypes";
 import { getConfigurationRow } from "pages/instances/forms/ConfigurationRow";
 import ConfigurationTable from "pages/instances/forms/ConfigurationTable";
+import { getPayloadKey } from "util/formFields";
 
 export interface CloudInitFormValues {
   cloud_init_network_config?: string;
@@ -16,9 +17,10 @@ export interface CloudInitFormValues {
 
 export const cloudInitPayload = (values: SharedFormTypes) => {
   return {
-    ["cloud-init.network-config"]: values.cloud_init_network_config,
-    ["cloud-init.user-data"]: values.cloud_init_user_data,
-    ["cloud-init.vendor-data"]: values.cloud_init_vendor_data,
+    [getPayloadKey("cloud_init_network_config")]:
+      values.cloud_init_network_config,
+    [getPayloadKey("cloud_init_user_data")]: values.cloud_init_user_data,
+    [getPayloadKey("cloud_init_vendor_data")]: values.cloud_init_vendor_data,
   };
 };
 

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -39,7 +39,11 @@ interface Props {
   project: string;
 }
 
-const InstanceDetailsForm: FC<Props> = ({ formik, onSelectImage, project }) => {
+const InstanceCreateDetailsForm: FC<Props> = ({
+  formik,
+  onSelectImage,
+  project,
+}) => {
   function figureBaseImageName() {
     const image = formik.values.image;
     return image
@@ -126,6 +130,7 @@ const InstanceDetailsForm: FC<Props> = ({ formik, onSelectImage, project }) => {
             project={project}
             selected={formik.values.profiles}
             setSelected={(value) => formik.setFieldValue("profiles", value)}
+            isReadOnly={false}
           />
         </>
       )}
@@ -133,4 +138,4 @@ const InstanceDetailsForm: FC<Props> = ({ formik, onSelectImage, project }) => {
   );
 };
 
-export default InstanceDetailsForm;
+export default InstanceCreateDetailsForm;

--- a/src/pages/instances/forms/InstanceEditDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceEditDetailsForm.tsx
@@ -37,13 +37,14 @@ const InstanceEditDetailsForm: FC<Props> = ({ formik, project }) => {
           <Input
             id="name"
             name="name"
-            label="Instance name"
-            placeholder="Enter name"
             type="text"
+            label="Profile name"
+            placeholder="Enter name"
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             value={formik.values.name}
-            disabled
+            error={formik.touched.name ? formik.errors.name : null}
+            required
           />
           <Textarea
             id="description"

--- a/src/pages/instances/forms/InstanceEditDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceEditDetailsForm.tsx
@@ -45,6 +45,7 @@ const InstanceEditDetailsForm: FC<Props> = ({ formik, project }) => {
             value={formik.values.name}
             error={formik.touched.name ? formik.errors.name : null}
             required
+            disabled={isReadOnly}
           />
           <Textarea
             id="description"

--- a/src/pages/instances/forms/InstanceEditDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceEditDetailsForm.tsx
@@ -38,7 +38,7 @@ const InstanceEditDetailsForm: FC<Props> = ({ formik, project }) => {
             id="name"
             name="name"
             type="text"
-            label="Profile name"
+            label="Instance name"
             placeholder="Enter name"
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}

--- a/src/pages/instances/forms/ResourceLimitsForm.tsx
+++ b/src/pages/instances/forms/ResourceLimitsForm.tsx
@@ -13,7 +13,7 @@ import {
 import { DEFAULT_CPU_LIMIT, DEFAULT_MEM_LIMIT } from "util/defaults";
 import { getConfigurationRow } from "pages/instances/forms/ConfigurationRow";
 import ConfigurationTable from "pages/instances/forms/ConfigurationTable";
-import { boolRenderer } from "util/formFields";
+import { boolRenderer, getPayloadKey } from "util/formFields";
 
 export interface ResourceLimitsFormValues {
   limits_cpu?: CpuLimit;
@@ -25,11 +25,14 @@ export interface ResourceLimitsFormValues {
 
 export const resourceLimitsPayload = (values: SharedFormTypes) => {
   return {
-    ["limits.cpu"]: cpuLimitToPayload(values.limits_cpu),
-    ["limits.memory"]: memoryLimitToPayload(values.limits_memory),
-    ["limits.memory.swap"]: values.limits_memory_swap,
-    ["limits.disk.priority"]: values.limits_disk_priority?.toString(),
-    ["limits.processes"]: values.limits_processes?.toString(),
+    [getPayloadKey("limits_cpu")]: cpuLimitToPayload(values.limits_cpu),
+    [getPayloadKey("limits_memory")]: memoryLimitToPayload(
+      values.limits_memory
+    ),
+    [getPayloadKey("limits_memory_swap")]: values.limits_memory_swap,
+    [getPayloadKey("limits_disk_priority")]:
+      values.limits_disk_priority?.toString(),
+    [getPayloadKey("limits_processes")]: values.limits_processes?.toString(),
   };
 };
 

--- a/src/pages/instances/forms/SecurityPoliciesForm.tsx
+++ b/src/pages/instances/forms/SecurityPoliciesForm.tsx
@@ -13,7 +13,7 @@ import {
 } from "pages/instances/forms/sharedFormTypes";
 import { getConfigurationRow } from "pages/instances/forms/ConfigurationRow";
 import ConfigurationTable from "pages/instances/forms/ConfigurationTable";
-import { boolRenderer } from "util/formFields";
+import { boolRenderer, getPayloadKey } from "util/formFields";
 
 export interface SecurityPoliciesFormValues {
   security_protection_delete?: string;
@@ -29,15 +29,18 @@ export interface SecurityPoliciesFormValues {
 
 export const securityPoliciesPayload = (values: SharedFormTypes) => {
   return {
-    ["security.protection.delete"]: values.security_protection_delete,
-    ["security.privileged"]: values.security_privileged,
-    ["security.protection.shift"]: values.security_protection_shift,
-    ["security.idmap.base"]: values.security_idmap_base,
-    ["security.idmap.size"]: values.security_idmap_size?.toString(),
-    ["security.idmap.isolated"]: values.security_idmap_isolated,
-    ["security.devlxd"]: values.security_devlxd,
-    ["security.devlxd.images"]: values.security_devlxd_images,
-    ["security.secureboot"]: values.security_secureboot,
+    [getPayloadKey("security_protection_delete")]:
+      values.security_protection_delete,
+    [getPayloadKey("security_privileged")]: values.security_privileged,
+    [getPayloadKey("security_protection_shift")]:
+      values.security_protection_shift,
+    [getPayloadKey("security_idmap_base")]: values.security_idmap_base,
+    [getPayloadKey("security_idmap_size")]:
+      values.security_idmap_size?.toString(),
+    [getPayloadKey("security_idmap_isolated")]: values.security_idmap_isolated,
+    [getPayloadKey("security_devlxd")]: values.security_devlxd,
+    [getPayloadKey("security_devlxd_images")]: values.security_devlxd_images,
+    [getPayloadKey("security_secureboot")]: values.security_secureboot,
   };
 };
 

--- a/src/pages/instances/forms/SnapshotsForm.tsx
+++ b/src/pages/instances/forms/SnapshotsForm.tsx
@@ -8,7 +8,7 @@ import {
 import { getConfigurationRow } from "pages/instances/forms/ConfigurationRow";
 import ConfigurationTable from "pages/instances/forms/ConfigurationTable";
 import { snapshotOptions } from "util/snapshotOptions";
-import { boolRenderer } from "util/formFields";
+import { boolRenderer, getPayloadKey } from "util/formFields";
 
 export interface SnapshotFormValues {
   snapshots_pattern?: string;
@@ -19,10 +19,11 @@ export interface SnapshotFormValues {
 
 export const snapshotsPayload = (values: SharedFormTypes) => {
   return {
-    ["snapshots.pattern"]: values.snapshots_pattern,
-    ["snapshots.schedule.stopped"]: values.snapshots_schedule_stopped,
-    ["snapshots.schedule"]: values.snapshots_schedule,
-    ["snapshots.expiry"]: values.snapshots_expiry,
+    [getPayloadKey("snapshots_pattern")]: values.snapshots_pattern,
+    [getPayloadKey("snapshots_schedule_stopped")]:
+      values.snapshots_schedule_stopped,
+    [getPayloadKey("snapshots_schedule")]: values.snapshots_schedule,
+    [getPayloadKey("snapshots_expiry")]: values.snapshots_expiry,
   };
 };
 

--- a/src/pages/profiles/CreateProfileForm.tsx
+++ b/src/pages/profiles/CreateProfileForm.tsx
@@ -97,6 +97,7 @@ const CreateProfileForm: FC = () => {
       devices: [{ type: "nic", name: "" }],
       limits_cpu: DEFAULT_CPU_LIMIT,
       limits_memory: DEFAULT_MEM_LIMIT,
+      readOnly: false,
       type: "profile",
     },
     validationSchema: ProfileSchema,

--- a/src/pages/profiles/CreateProfileForm.tsx
+++ b/src/pages/profiles/CreateProfileForm.tsx
@@ -175,7 +175,7 @@ const CreateProfileForm: FC = () => {
               <Col size={12}>
                 <NotificationRow />
                 {section === PROFILE_DETAILS && (
-                  <ProfileDetailsForm formik={formik} isCreateMode={true} />
+                  <ProfileDetailsForm formik={formik} />
                 )}
 
                 {section === STORAGE && (

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -109,8 +109,9 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
       // rename will be a second request
       // keep the old name for the first request persisting other changes
       profilePayload.name = oldName;
+      profilePayload.etag = profile.etag;
 
-      updateProfile(JSON.stringify(profilePayload), project, profile.etag)
+      updateProfile(profilePayload, project)
         .then(async () => {
           if (newName !== oldName) {
             await renameProfile(oldName, newName, project)

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -110,7 +110,7 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
       // keep the old name for the first request persisting other changes
       profilePayload.name = oldName;
 
-      updateProfile(JSON.stringify(profilePayload), project)
+      updateProfile(JSON.stringify(profilePayload), project, profile.etag)
         .then(async () => {
           if (newName !== oldName) {
             await renameProfile(oldName, newName, project)

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -53,7 +53,11 @@ import ProfileDetailsForm, {
   profileDetailPayload,
   ProfileDetailsFormValues,
 } from "pages/profiles/forms/ProfileDetailsForm";
-import { getEditValues, getSupportedConfigKeys } from "util/formFields";
+import {
+  getEditValues,
+  getHandledConfigKeys,
+  getUnhandledKeyValues,
+} from "util/formFields";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -123,22 +127,8 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
   });
 
   const getPayload = (values: EditProfileFormValues) => {
-    const supportedConfigKeys = getSupportedConfigKeys();
-    const additionalConfigKeys = Object.fromEntries(
-      Object.entries(profile.config).filter(
-        ([key]) => !supportedConfigKeys.has(key)
-      )
-    );
-
-    const supportedMainKeys = new Set([
-      "name",
-      "description",
-      "devices",
-      "config",
-    ]);
-    const additionalMainKeys = Object.fromEntries(
-      Object.entries(profile).filter(([key]) => !supportedMainKeys.has(key))
-    );
+    const handledConfigKeys = getHandledConfigKeys();
+    const handledKeys = new Set(["name", "description", "devices", "config"]);
 
     return {
       ...profileDetailPayload(values),
@@ -148,9 +138,9 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
         ...securityPoliciesPayload(values),
         ...snapshotsPayload(values),
         ...cloudInitPayload(values),
-        ...additionalConfigKeys,
+        ...getUnhandledKeyValues(profile.config, handledConfigKeys),
       },
-      ...additionalMainKeys,
+      ...getUnhandledKeyValues(profile, handledKeys),
     };
   };
 

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -111,9 +111,9 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
       profilePayload.name = oldName;
 
       updateProfile(JSON.stringify(profilePayload), project)
-        .then(() => {
+        .then(async () => {
           if (newName !== oldName) {
-            renameProfile(oldName, newName, project)
+            await renameProfile(oldName, newName, project)
               .then(() => {
                 navigate(
                   `/ui/${project}/profiles/detail/${newName}/configuration`,

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -121,13 +121,11 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
                 );
               })
               .catch((e: Error) => {
-                notify.failure(
-                  `Saved changes, but could not rename the profile ${oldName}.`,
-                  e
-                );
+                notify.failure(`Failed to rename the profile ${oldName}`, e);
               });
           } else {
             notify.success("Profile updated.");
+            void formik.setFieldValue("readOnly", true);
           }
         })
         .catch((e: Error) => {

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -117,7 +117,7 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
               .then(() => {
                 navigate(
                   `/ui/${project}/profiles/detail/${newName}/configuration`,
-                  notify.queue(notify.success("Configuration updated."))
+                  notify.queue(notify.success("Profile updated."))
                 );
               })
               .catch((e: Error) => {
@@ -127,11 +127,11 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
                 );
               });
           } else {
-            notify.success("Configuration updated.");
+            notify.success("Profile updated.");
           }
         })
         .catch((e: Error) => {
-          notify.failure("Could not save", e);
+          notify.failure("", e, undefined, "Profile update failed");
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/profiles/forms/ProfileDetailsForm.tsx
+++ b/src/pages/profiles/forms/ProfileDetailsForm.tsx
@@ -19,12 +19,10 @@ export const profileDetailPayload = (values: CreateProfileFormValues) => {
 
 interface Props {
   formik: FormikProps<CreateProfileFormValues>;
-  isCreateMode: boolean;
 }
 
-const ProfileDetailsForm: FC<Props> = ({ formik, isCreateMode }) => {
+const ProfileDetailsForm: FC<Props> = ({ formik }) => {
   const isReadOnly = formik.values.readOnly;
-
   return (
     <div className="details">
       <Row>
@@ -40,7 +38,7 @@ const ProfileDetailsForm: FC<Props> = ({ formik, isCreateMode }) => {
             value={formik.values.name}
             error={formik.touched.name ? formik.errors.name : null}
             required
-            disabled={!isCreateMode}
+            disabled={formik.values.name === "default"}
           />
           <Textarea
             id="description"

--- a/src/pages/profiles/forms/ProfileDetailsForm.tsx
+++ b/src/pages/profiles/forms/ProfileDetailsForm.tsx
@@ -38,7 +38,7 @@ const ProfileDetailsForm: FC<Props> = ({ formik }) => {
             value={formik.values.name}
             error={formik.touched.name ? formik.errors.name : null}
             required
-            disabled={formik.values.name === "default"}
+            disabled={formik.values.name === "default" || isReadOnly}
           />
           <Textarea
             id="description"

--- a/src/pages/projects/EditProjectForm.tsx
+++ b/src/pages/projects/EditProjectForm.tsx
@@ -47,10 +47,13 @@ const EditProjectForm: FC<Props> = ({ project }) => {
     },
     validationSchema: ProjectSchema,
     onSubmit: (values) => {
-      const projectPayload = JSON.stringify({
+      const projectPayload = {
         ...projectDetailPayload(values),
-      });
-      updateProject(projectPayload, project.etag)
+      } as LxdProject;
+
+      projectPayload.etag = project.etag;
+
+      updateProject(projectPayload)
         .then(() => {
           notify.success(`Project ${values.name} saved.`);
         })

--- a/src/pages/projects/EditProjectForm.tsx
+++ b/src/pages/projects/EditProjectForm.tsx
@@ -47,11 +47,10 @@ const EditProjectForm: FC<Props> = ({ project }) => {
     },
     validationSchema: ProjectSchema,
     onSubmit: (values) => {
-      updateProject(
-        JSON.stringify({
-          ...projectDetailPayload(values),
-        })
-      )
+      const projectPayload = JSON.stringify({
+        ...projectDetailPayload(values),
+      });
+      updateProject(projectPayload, project.etag)
         .then(() => {
           notify.success(`Project ${values.name} saved.`);
         })

--- a/src/pages/projects/EditProjectForm.tsx
+++ b/src/pages/projects/EditProjectForm.tsx
@@ -55,10 +55,11 @@ const EditProjectForm: FC<Props> = ({ project }) => {
 
       updateProject(projectPayload)
         .then(() => {
-          notify.success(`Project ${values.name} saved.`);
+          notify.success(`Project updated.`);
+          void formik.setFieldValue("readOnly", true);
         })
         .catch((e: Error) => {
-          notify.failure("Could not save project", e);
+          notify.failure("", e, undefined, "Project update failed");
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/types/notification.d.ts
+++ b/src/types/notification.d.ts
@@ -27,7 +27,8 @@ export interface NotificationHelper {
   failure: (
     message: string | ReactNode,
     error: unknown,
-    actions?: NotificationAction[]
+    actions?: NotificationAction[],
+    title?: string
   ) => Notification;
   info: (message: string | ReactNode, title?: string) => Notification;
   success: (message: string | ReactNode) => Notification;

--- a/src/types/profile.d.ts
+++ b/src/types/profile.d.ts
@@ -7,4 +7,5 @@ export interface LxdProfile {
   devices: LxdDevices;
   name: string;
   used_by?: string[];
+  etag?: string;
 }

--- a/src/types/project.d.ts
+++ b/src/types/project.d.ts
@@ -8,4 +8,5 @@ export interface LxdProject {
   };
   description: string;
   used_by?: string[];
+  etag?: string;
 }

--- a/src/util/formFields.tsx
+++ b/src/util/formFields.tsx
@@ -8,6 +8,7 @@ import { LxdInstance } from "types/instance";
 import { parseDevices } from "util/formDevices";
 import { parseCpuLimit, parseMemoryLimit } from "util/limits";
 import { OptionHTMLAttributes } from "react";
+import { LxdConfigPair } from "types/config";
 
 const formFieldsToPayloadFields: Record<string, string> = {
   rootStorage: "",
@@ -41,8 +42,17 @@ export const getPayloadKey = (formField: string) => {
   return formFieldsToPayloadFields[formField];
 };
 
-export const getSupportedConfigKeys = () => {
+export const getHandledConfigKeys = () => {
   return new Set(Object.values(formFieldsToPayloadFields));
+};
+
+export const getUnhandledKeyValues = (
+  item: LxdInstance | LxdProfile | LxdConfigPair,
+  handledKeys: Set<string>
+) => {
+  return Object.fromEntries(
+    Object.entries(item).filter(([key]) => !handledKeys.has(key))
+  );
 };
 
 export const figureInheritedValue = (

--- a/src/util/formFields.tsx
+++ b/src/util/formFields.tsx
@@ -34,13 +34,24 @@ const formFieldsToPayloadFields: Record<string, string> = {
   cloud_init_vendor_data: "cloud-init.vendor-data",
 };
 
+export const getPayloadKey = (formField: string) => {
+  if (!(formField in formFieldsToPayloadFields)) {
+    throw new Error(`Could not find ${formField} in formFieldsToPayloadFields`);
+  }
+  return formFieldsToPayloadFields[formField];
+};
+
+export const getSupportedConfigKeys = () => {
+  return new Set(Object.values(formFieldsToPayloadFields));
+};
+
 export const figureInheritedValue = (
   values: SharedFormTypes,
   formField: string,
   profiles: LxdProfile[]
 ): [string, string] => {
   if (Object.prototype.hasOwnProperty.call(values, "profiles")) {
-    const payloadField = formFieldsToPayloadFields[formField];
+    const payloadField = getPayloadKey(formField);
     const appliedProfiles = [
       ...(values as CreateInstanceFormValues | EditInstanceFormValues).profiles,
     ].reverse();

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -1,4 +1,8 @@
 import React from "react";
+import { LxdApiResponse } from "types/apiResponse";
+import { LxdInstance } from "types/instance";
+import { LxdProject } from "types/project";
+import { LxdProfile } from "types/profile";
 
 export const isoTimeToString = (isoTime: string) => {
   if (isoTime.startsWith("0001-01-01T00")) {
@@ -41,6 +45,15 @@ export const handleResponse = async (response: Response) => {
     throw Error(result.error);
   }
   return response.json();
+};
+
+export const handleEtagResponse = async (response: Response) => {
+  const data = (await handleResponse(response)) as LxdApiResponse<
+    LxdInstance | LxdProject | LxdProfile
+  >;
+  const result = data.metadata;
+  result.etag = response.headers.get("etag")?.replace("W/", "") ?? undefined;
+  return result;
 };
 
 export const handleTextResponse = async (response: Response) => {


### PR DESCRIPTION
## Done

- ensure all fields from the instance and profile are kept, even if they are not supported by the UI
- simplify edit code
- added rename API functions for instances and profiles (unused atm, but we'll need it shortly)
- this is taken from https://github.com/canonical/lxd-ui/pull/253 but avoiding any visible UI changes.
- adjusted error and success notifications on edit

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - edit instances and a profiles