### PR TITLE
Fix navigation toggle and logo are sticky WD-2987

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -218,19 +218,21 @@ const Navigation: FC = () => {
                     </a>
                   </li>
                 </ul>
-                <Button
-                  appearance="base"
-                  aria-label={`${
-                    menuCollapsed ? "expand" : "collapse"
-                  } main navigation`}
-                  hasIcon
-                  dense
-                  className="sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle u-hide--small"
-                  onClick={hardToggleMenu}
-                >
-                  <Icon light name="sidebar-toggle" />
-                </Button>
               </div>
+            </div>
+            <div className="sidenav-toggle-wrapper">
+              <Button
+                appearance="base"
+                aria-label={`${
+                  menuCollapsed ? "expand" : "collapse"
+                } main navigation`}
+                hasIcon
+                dense
+                className="sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle u-hide--small"
+                onClick={hardToggleMenu}
+              >
+                <Icon light name="sidebar-toggle" />
+              </Button>
             </div>
           </div>
         </div>

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -64,6 +64,10 @@
   }
 }
 
+.l-navigation .p-panel__header {
+  z-index: 1001;
+}
+
 .sidenav-top-ul::after {
   display: none;
 }

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -76,29 +76,38 @@
   width: 15rem;
 }
 
-.sidenav-toggle {
-  background-color: #444 !important;
-  left: 12rem;
-  position: relative;
+.sidenav-toggle-wrapper {
+  background: $colors--dark-theme--background-default;
+  bottom: 0;
+  padding: $spv--small $sph--x-large $sp-medium $sp-medium;
+  position: sticky;
+  text-align: right;
+
+  .sidenav-toggle {
+    background-color: #444 !important;
+  }
 }
 
-@media screen and (min-height: 720px) {
+.l-navigation.is-collapsed .sidenav-toggle-wrapper {
+  text-align: left;
+
+  .sidenav-toggle {
+    rotate: 180deg;
+  }
+}
+
+@media screen and (max-width: $breakpoint-x-large) and (min-height: 600px),
+  screen and (min-width: $breakpoint-x-large) and (min-height: 720px) {
   .sidenav-bottom-ul {
     bottom: $spv--x-large;
     position: absolute;
   }
 
-  .sidenav-toggle {
-    bottom: $spv--large;
-    left: inherit;
+  .sidenav-toggle-wrapper {
+    bottom: 0;
     position: absolute;
-    right: $sph--large;
+    width: 100%;
   }
-}
-
-.l-navigation.is-collapsed .sidenav-toggle {
-  left: $sph--large;
-  rotate: 180deg;
 }
 
 .p-side-navigation__item--title {


### PR DESCRIPTION
## Done

- fix navigation on small height screens
- avoid overlaying the logo with the project selector
- make the navigation toggle at the bottom sticky

Fixes WD-2987

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - test navigation on all possible screen dimensions