### PR TITLE
Add bulk select and delete for snapshots WD-3025

### DIFF
--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -163,7 +163,7 @@ const SelectableMainTable: FC<Props> = ({
               ) : (
                 <>
                   <b>{selectedNames.length}</b> {itemName}
-                  {selectedNames.length > 1 && "s"} selected{" "}
+                  {selectedNames.length > 1 && "s"} selected.{" "}
                   <Button
                     appearance="link"
                     className="u-no-margin--bottom u-no-padding--top"

--- a/src/pages/instances/actions/snapshots/SnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotActions.tsx
@@ -21,11 +21,12 @@ const SnapshotActions: FC<Props> = ({
   onSuccess,
   onFailure,
 }) => {
-  const [isLoading, setLoading] = useState(false);
+  const [isDeleting, setDeleting] = useState(false);
+  const [isRestoring, setRestoring] = useState(false);
   const queryClient = useQueryClient();
 
   const handleDelete = () => {
-    setLoading(true);
+    setDeleting(true);
     deleteSnapshot(instance, snapshot)
       .then(() =>
         onSuccess(
@@ -36,7 +37,7 @@ const SnapshotActions: FC<Props> = ({
       )
       .catch((e) => onFailure("Error on snapshot delete.", e))
       .finally(() => {
-        setLoading(false);
+        setDeleting(false);
         void queryClient.invalidateQueries({
           predicate: (query) => query.queryKey[0] === queryKeys.instances,
         });
@@ -44,7 +45,7 @@ const SnapshotActions: FC<Props> = ({
   };
 
   const handleRestore = () => {
-    setLoading(true);
+    setRestoring(true);
     restoreSnapshot(instance, snapshot)
       .then(() =>
         onSuccess(
@@ -55,7 +56,7 @@ const SnapshotActions: FC<Props> = ({
       )
       .catch((e) => onFailure("Error on snapshot restore.", e))
       .finally(() => {
-        setLoading(false);
+        setRestoring(false);
         void queryClient.invalidateQueries({
           predicate: (query) => query.queryKey[0] === queryKeys.instances,
         });
@@ -66,12 +67,13 @@ const SnapshotActions: FC<Props> = ({
     <List
       inline
       className={classnames("u-no-margin--bottom", {
-        "u-snapshot-actions": !isLoading,
+        "u-snapshot-actions": !isDeleting && !isRestoring,
       })}
       items={[
         <ConfirmationButton
           key="delete"
-          isLoading={isLoading}
+          isLoading={isDeleting}
+          icon={isDeleting ? "spinner" : undefined}
           title="Confirm delete"
           toggleCaption="Delete"
           confirmationMessage={
@@ -83,11 +85,12 @@ const SnapshotActions: FC<Props> = ({
           }
           posButtonLabel="Delete"
           onConfirm={handleDelete}
-          isDisabled={isLoading}
+          isDisabled={isDeleting || isRestoring}
         />,
         <ConfirmationButton
           key="restore"
-          isLoading={isLoading}
+          isLoading={isRestoring}
+          icon={isRestoring ? "spinner" : undefined}
           title="Confirm restore"
           toggleCaption="Restore"
           confirmationMessage={
@@ -99,7 +102,7 @@ const SnapshotActions: FC<Props> = ({
           }
           posButtonLabel="Restore"
           onConfirm={handleRestore}
-          isDisabled={isLoading}
+          isDisabled={isDeleting || isRestoring}
         />,
       ]}
     />

--- a/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
@@ -1,0 +1,76 @@
+import React, { FC, ReactNode, useState } from "react";
+import { LxdInstance } from "types/instance";
+import { deleteSnapshotBulk } from "api/snapshots";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import ConfirmationButton from "components/ConfirmationButton";
+
+interface Props {
+  instance: LxdInstance;
+  snapshotNames: string[];
+  onStart: () => void;
+  onFinish: () => void;
+  onSuccess: (message: ReactNode) => void;
+  onFailure: (message: ReactNode, e: unknown) => void;
+}
+
+const SnapshotBulkDelete: FC<Props> = ({
+  instance,
+  snapshotNames,
+  onStart,
+  onFinish,
+  onSuccess,
+  onFailure,
+}) => {
+  const [isLoading, setLoading] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleDelete = () => {
+    setLoading(true);
+    onStart();
+    deleteSnapshotBulk(instance, snapshotNames)
+      .then(() =>
+        onSuccess(
+          <>
+            <b>{snapshotNames.length}</b> snapshot
+            {snapshotNames.length > 1 && "s"} deleted.
+          </>
+        )
+      )
+      .catch((e) => onFailure("Error on snapshot delete.", e))
+      .finally(() => {
+        setLoading(false);
+        onFinish();
+        void queryClient.invalidateQueries({
+          predicate: (query) => query.queryKey[0] === queryKeys.instances,
+        });
+      });
+  };
+
+  return (
+    <ConfirmationButton
+      isLoading={isLoading}
+      icon={isLoading ? "spinner" : undefined}
+      title="Confirm delete"
+      toggleCaption="Delete"
+      confirmationMessage={
+        snapshotNames.length === 1 ? (
+          <>
+            <b>1</b> snapshot selected.{"\n"}Are you sure you want to delete it?
+          </>
+        ) : (
+          <>
+            <b>{snapshotNames.length}</b> snapshots selected.{"\n"}Are you sure
+            you want to delete them?
+          </>
+        )
+      }
+      posButtonLabel="Delete"
+      onConfirm={handleDelete}
+      isDisabled={isLoading}
+      isDense={false}
+    />
+  );
+};
+
+export default SnapshotBulkDelete;

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -45,6 +45,15 @@
   .snapshots-table {
     margin-bottom: 0;
 
+    th,
+    td {
+      display: table-cell;
+    }
+
+    th:last-child {
+      display: none;
+    }
+
     td:last-child {
       padding-right: $sph--large;
     }
@@ -67,24 +76,33 @@
       width: 100%;
     }
 
+    .select {
+      padding-right: 0;
+      width: 70px;
+
+      button {
+        margin-left: -15px;
+      }
+    }
+
     .name {
-      width: 170px;
+      min-width: 170px;
     }
 
     .created {
-      width: 200px;
+      min-width: 200px;
     }
 
     .expiration {
-      width: 200px;
+      min-width: 200px;
     }
 
     .stateful {
-      width: 80px;
+      width: 105px;
     }
 
     .actions {
-      width: 220px;
+      width: 240px;
 
       .p-inline-list__item:not(:last-of-type) {
         margin-right: $sph--small;

--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -1,0 +1,27 @@
+.select-header {
+  padding-bottom: 0;
+  padding-top: 4px;
+
+  .multiselect-checkbox {
+    display: inline-block;
+  }
+}
+
+.select-notification {
+  background: white;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.selected-row {
+  background-color: #e6f2ff;
+}
+
+.processing-row {
+  opacity: 0.5;
+
+  .actions > * {
+    display: none;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -61,6 +61,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "pattern_navigation";
 @import "pattern_terminal";
 @import "project_select";
+@import "selectable_main_table";
 
 .l-main .row {
   max-width: none;
@@ -120,6 +121,10 @@ $border-thin: 1px solid $color-mid-light !default;
 
 .p-empty-snapshots {
   @include vf-icon-settings($color-mid-light);
+}
+
+.clear-selection-icon {
+  @include vf-icon-close($color-link);
 }
 
 .actions-list {


### PR DESCRIPTION
## Done

- added bulk selection for snapshots
- allow deletion of multiple snapshots
- added a reusable component `SelectableMainTable` that adds checkboxes to all rows.

Fixes [WD-3025](https://warthogs.atlassian.net/browse/WD-3025)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Select instance snapshots (all on page, all on instance)
    - Browse snapshot pages and search while/before selecting
    - Delete multiple selected snapshots


[WD-3025]: https://warthogs.atlassian.net/browse/WD-3025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ