### PR TITLE
Disable create button when an invalid name is entered [WD-1874]

### DIFF
--- a/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
@@ -103,6 +103,7 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
       expirationDate: null,
       expirationTime: null,
     },
+    validateOnMount: true,
     validationSchema: SnapshotSchema,
     onSubmit: (values) => {
       notify.clear();
@@ -146,7 +147,7 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
           </Button>
           <SubmitButton
             isSubmitting={formik.isSubmitting}
-            isDisabled={false}
+            isDisabled={!formik.isValid}
             buttonLabel="Create"
             onClick={submitForm}
           />


### PR DESCRIPTION
## Done

- The create button in the snapshot modal is now enabled only when the value entered in the name field is valid.

Fixes [WD-1874](https://warthogs.atlassian.net/browse/WD-1874)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Try to create a snapshot with an invalid name
    - Check that the button is disabled opportunely

[WD-1874]: https://warthogs.atlassian.net/browse/WD-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ