### PR TITLE
Add snapshot configuration WD-3026

### DIFF
--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -18,6 +18,7 @@ import Pagination from "components/Pagination";
 import { paginationOptions } from "util/paginationOptions";
 import { updateTBodyHeight } from "util/updateTBodyHeight";
 import ItemName from "components/ItemName";
+import ConfigureSnapshotsBtn from "pages/instances/actions/snapshots/ConfigureSnapshotsBtn";
 
 interface Props {
   instance: LxdInstance;
@@ -159,6 +160,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
               aria-label="Search for snapshots"
             />
           </div>
+          <ConfigureSnapshotsBtn instance={instance} />
           <Button
             appearance="positive"
             className="u-float-right"

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
@@ -1,0 +1,107 @@
+import React, { FC, KeyboardEvent } from "react";
+import { Button, Modal } from "@canonical/react-components";
+import { LxdInstance } from "types/instance";
+import { useFormik } from "formik";
+import { updateInstance } from "api/instances";
+import { queryKeys } from "util/queryKeys";
+import { EditInstanceFormValues } from "pages/instances/EditInstanceForm";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNotify } from "context/notify";
+import SnapshotsForm from "pages/instances/forms/SnapshotsForm";
+import { useParams } from "react-router-dom";
+import {
+  getInstanceEditValues,
+  getInstancePayload,
+  InstanceEditSchema,
+} from "util/instanceEdit";
+
+interface Props {
+  instance: LxdInstance;
+  close: () => void;
+}
+
+const ConfigureSnapshotModal: FC<Props> = ({ instance, close }) => {
+  const notify = useNotify();
+  const { project } = useParams<{ project: string }>();
+  const queryClient = useQueryClient();
+
+  const formik = useFormik<EditInstanceFormValues>({
+    initialValues: getInstanceEditValues(instance),
+    validationSchema: InstanceEditSchema,
+    onSubmit: (values) => {
+      const instancePayload = getInstancePayload(
+        instance,
+        values
+      ) as LxdInstance;
+
+      updateInstance(instancePayload, project ?? "")
+        .then(() => {
+          notify.success("Snapshot configuration updated.");
+          close();
+        })
+        .catch((e: Error) => {
+          notify.failure("Snapshot configuration update failed", e);
+        })
+        .finally(() => {
+          void queryClient.invalidateQueries({
+            queryKey: [queryKeys.instances],
+          });
+        });
+    },
+  });
+
+  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Escape") {
+      close();
+    }
+  };
+
+  return (
+    <Modal
+      close={close}
+      className="edit-snapshot-config"
+      title="Snapshot configuration"
+      buttonRow={
+        formik.values.readOnly ? (
+          <div className="u-space-between u-flex-row-reverse">
+            <Button
+              className="u-no-margin--bottom u-no-margin--right"
+              onClick={close}
+            >
+              Close
+            </Button>
+            <Button
+              className="u-no-margin--bottom"
+              type="button"
+              onClick={() => formik.setFieldValue("readOnly", false)}
+            >
+              Edit configuration
+            </Button>
+          </div>
+        ) : (
+          <>
+            <Button
+              className="u-no-margin--bottom"
+              type="button"
+              onClick={close}
+            >
+              Cancel
+            </Button>
+            <Button
+              appearance="positive"
+              className="u-no-margin--bottom"
+              onClick={() => void formik.submitForm()}
+            >
+              Save
+            </Button>
+          </>
+        )
+      }
+      onKeyDown={handleEscKey}
+    >
+      <SnapshotsForm formik={formik} />
+    </Modal>
+  );
+};
+
+export default ConfigureSnapshotModal;

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
@@ -1,0 +1,33 @@
+import React, { FC, useState } from "react";
+import { Button } from "@canonical/react-components";
+import ConfigureSnapshotModal from "pages/instances/actions/snapshots/ConfigureSnapshotModal";
+import { LxdInstance } from "types/instance";
+
+interface Props {
+  instance: LxdInstance;
+}
+
+const ConfigureSnapshotsBtn: FC<Props> = ({ instance }) => {
+  const [isModal, setModal] = useState(false);
+
+  const closeModal = () => {
+    setModal(false);
+  };
+
+  const openModal = () => {
+    setModal(true);
+  };
+
+  return (
+    <>
+      {isModal && (
+        <ConfigureSnapshotModal close={closeModal} instance={instance} />
+      )}
+      <Button onClick={openModal} className="u-no-margin--right">
+        See configuration
+      </Button>
+    </>
+  );
+};
+
+export default ConfigureSnapshotsBtn;

--- a/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
@@ -21,8 +21,7 @@ import SubmitButton from "components/SubmitButton";
 import { useNotify } from "context/notify";
 import NotificationRow from "components/NotificationRow";
 import ItemName from "components/ItemName";
-
-const TOOLTIP_OVER_MODAL_ZINDEX = 150;
+import { TOOLTIP_OVER_MODAL_ZINDEX } from "util/zIndex";
 
 interface Props {
   instance: LxdInstance;

--- a/src/pages/instances/forms/ConfigurationTable.tsx
+++ b/src/pages/instances/forms/ConfigurationTable.tsx
@@ -10,6 +10,7 @@ import { SharedFormikTypes } from "pages/instances/forms/sharedFormTypes";
 import useEventListener from "@use-it/event-listener";
 import { updateTBodyHeight } from "util/updateTBodyHeight";
 import { useNotify } from "context/notify";
+import { TOOLTIP_OVER_MODAL_ZINDEX } from "util/zIndex";
 
 interface Props {
   formik: SharedFormikTypes;
@@ -86,7 +87,10 @@ const ConfigurationTable: FC<Props> = ({
   const headers = [
     {
       content: isSmallScreen ? (
-        <Tooltip message="Select configuration to override">
+        <Tooltip
+          message="Select configuration to override"
+          zIndex={TOOLTIP_OVER_MODAL_ZINDEX}
+        >
           <Icon name="information" />
         </Tooltip>
       ) : (

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -55,7 +55,7 @@ import ProfileDetailsForm, {
 } from "pages/profiles/forms/ProfileDetailsForm";
 import { getUnhandledKeyValues } from "util/formFields";
 import { getProfileConfigKeys } from "util/instanceConfigFields";
-import { getProfileEdit } from "util/instanceEdit";
+import { getProfileEditValues } from "util/instanceEdit";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -90,14 +90,8 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
     name: Yup.string().required("Name is required"),
   });
 
-  const initialValues = {
-    type: "profile",
-    readOnly: true,
-    ...getProfileEdit(profile),
-  };
-
   const formik = useFormik<EditProfileFormValues>({
-    initialValues: initialValues,
+    initialValues: getProfileEditValues(profile),
     validationSchema: ProfileSchema,
     onSubmit: (values) => {
       const profilePayload = (
@@ -231,7 +225,11 @@ const EditProfileForm: FC<Props> = ({ profile }) => {
               </Button>
             ) : (
               <>
-                <Button onClick={() => formik.setValues(initialValues)}>
+                <Button
+                  onClick={() =>
+                    formik.setValues(getProfileEditValues(profile))
+                  }
+                >
                   Cancel
                 </Button>
                 <SubmitButton

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -3,7 +3,8 @@
 .create-profile,
 .edit-profile,
 .create-project,
-.edit-project {
+.edit-project,
+.edit-snapshot-config {
   padding-bottom: 0;
 
   .p-notification--caution {

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -112,4 +112,11 @@
   .p-pagination__items {
     justify-content: flex-end;
   }
+
+  .edit-snapshot-config {
+    tbody {
+      height: inherit !important;
+      min-height: inherit !important;
+    }
+  }
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -156,6 +156,10 @@ $border-thin: 1px solid $color-mid-light !default;
   justify-content: space-between;
 }
 
+.u-flex-row-reverse {
+  flex-direction: row-reverse;
+}
+
 .item-name {
   overflow-wrap: anywhere;
 }

--- a/src/util/zIndex.tsx
+++ b/src/util/zIndex.tsx
@@ -1,0 +1,1 @@
+export const TOOLTIP_OVER_MODAL_ZINDEX = 150;


### PR DESCRIPTION
## Done

- added configuration button to instance snapshot tab
- added modal to configure automatic snapshots for the above button

Fixes WD-3026
## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - go to the snapshots tab for an instance
    - see configuration, change it and save it