### PR TITLE
Remove unnecessary check for an always truthy payload in InstanceTerminal

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -137,9 +137,6 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   };
 
   useEffect(() => {
-    if (!payload) {
-      return;
-    }
     xtermRef.current?.terminal.clear();
     setInTabNotification(null);
     const websocketPromise = openWebsockets(payload);


### PR DESCRIPTION
## Done

- Removed an unnecessary check for the payload in `InstanceTerminal`, which is always truthy.