### PR TITLE
Use react-component's Icon consistently [WD-2712]

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -36,7 +36,7 @@ const EmptyState: FC<Props> = ({
             rel="noreferrer"
           >
             {linkMessage}
-            <i className="p-icon--external-link external-link-icon"></i>
+            <Icon className="external-link-icon" name="external-link" />
           </a>
         </p>
         <Button

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -66,6 +66,7 @@ const Navigation: FC = () => {
                   hasIcon
                   className="u-no-margin"
                   aria-label="close navigation"
+                  onClick={hardToggleMenu}
                 >
                   <Icon name="close" />
                 </Button>
@@ -88,7 +89,10 @@ const Navigation: FC = () => {
                           to={`/ui/${project}/instances`}
                           title={`Instances (${project})`}
                         >
-                          <i className="p-icon--containers is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="containers"
+                          />{" "}
                           Instances
                         </NavLink>
                       </li>
@@ -98,7 +102,10 @@ const Navigation: FC = () => {
                           to={`/ui/${project}/profiles`}
                           title={`Profiles (${project})`}
                         >
-                          <i className="p-icon--profile is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="profile"
+                          />{" "}
                           Profiles
                         </NavLink>
                       </li>
@@ -108,7 +115,10 @@ const Navigation: FC = () => {
                           to={`/ui/${project}/networks`}
                           title={`Networks (${project})`}
                         >
-                          <i className="p-icon--connected is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="connected"
+                          />{" "}
                           Networks
                         </NavLink>
                       </li>
@@ -118,7 +128,10 @@ const Navigation: FC = () => {
                           to={`/ui/${project}/storages`}
                           title={`Storages (${project})`}
                         >
-                          <i className="p-icon--pods is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="pods"
+                          />{" "}
                           Storages
                         </NavLink>
                       </li>
@@ -128,7 +141,10 @@ const Navigation: FC = () => {
                           to={`/ui/${project}/configuration`}
                           title={`Configuration (${project})`}
                         >
-                          <i className="p-icon--switcher-environments is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="switcher-environments"
+                          />{" "}
                           Configuration
                         </NavLink>
                       </li>
@@ -139,7 +155,10 @@ const Navigation: FC = () => {
                           to="/ui/cluster"
                           title="Cluster"
                         >
-                          <i className="p-icon--machines is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="machines"
+                          />{" "}
                           Cluster
                         </NavLink>
                       </li>
@@ -149,7 +168,10 @@ const Navigation: FC = () => {
                           to="/ui/warnings"
                           title="Warnings"
                         >
-                          <i className="p-icon--warning-grey is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="warning-grey"
+                          />{" "}
                           Warnings
                         </NavLink>
                       </li>
@@ -159,7 +181,10 @@ const Navigation: FC = () => {
                           to="/ui/settings"
                           title="Settings"
                         >
-                          <i className="p-icon--settings is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="settings"
+                          />{" "}
                           Settings
                         </NavLink>
                       </li>
@@ -173,7 +198,10 @@ const Navigation: FC = () => {
                           to="/ui/certificates/generate"
                           title="Authentication"
                         >
-                          <i className="p-icon--security is-light p-side-navigation__icon"></i>{" "}
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="security"
+                          />{" "}
                           Authentication
                         </NavLink>
                       </li>
@@ -189,7 +217,10 @@ const Navigation: FC = () => {
                       rel="noreferrer"
                       title="Documentation"
                     >
-                      <i className="p-icon--information is-light p-side-navigation__icon"></i>{" "}
+                      <Icon
+                        className="is-light p-side-navigation__icon"
+                        name="information"
+                      />{" "}
                       Documentation
                     </a>
                   </li>
@@ -201,7 +232,10 @@ const Navigation: FC = () => {
                       rel="noreferrer"
                       title="Discussion"
                     >
-                      <i className="p-icon--share is-light p-side-navigation__icon"></i>{" "}
+                      <Icon
+                        className="is-light p-side-navigation__icon"
+                        name="share"
+                      />{" "}
                       Discussion
                     </a>
                   </li>
@@ -213,7 +247,10 @@ const Navigation: FC = () => {
                       rel="noreferrer"
                       title="Report a bug"
                     >
-                      <i className="p-icon--code is-light p-side-navigation__icon"></i>{" "}
+                      <Icon
+                        className="is-light p-side-navigation__icon"
+                        name="code"
+                      />{" "}
                       Report a bug
                     </a>
                   </li>

--- a/src/components/PanelHeader.tsx
+++ b/src/components/PanelHeader.tsx
@@ -1,6 +1,6 @@
 import React, { FC, MouseEvent, ReactNode } from "react";
 import usePanelParams from "util/usePanelParams";
-import { Button } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 
 interface Props {
   title: ReactNode;
@@ -20,7 +20,7 @@ const PanelHeader: FC<Props> = ({ title, onClose }: Props) => {
           onClick={onClose ?? panelParams.clear}
           aria-label="close panel"
         >
-          <i className="p-icon--close"></i>
+          <Icon name="close" />
         </Button>
       </div>
     </div>

--- a/src/components/SubmitButton.tsx
+++ b/src/components/SubmitButton.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
-import { Button } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
+import classnames from "classnames";
 
 interface Props {
   isSubmitting: boolean;
@@ -20,13 +21,12 @@ const SubmitButton: FC<Props> = ({
 }) => {
   return isSubmitting ? (
     <Button appearance={appearance} type="submit" hasIcon disabled>
-      <i
-        className={
-          appearance === "positive"
-            ? "p-icon--spinner is-light u-animation--spin"
-            : "p-icon--spinner u-animation--spin"
-        }
-      ></i>{" "}
+      <Icon
+        name="spinner"
+        className={classnames("u-animation--spin", {
+          "is-light": appearance === "positive",
+        })}
+      />{" "}
       <span>{processingText}</span>
     </Button>
   ) : (

--- a/src/pages/certificates/CertificateGenerate.tsx
+++ b/src/pages/certificates/CertificateGenerate.tsx
@@ -73,9 +73,15 @@ const CertificateGenerate: FC = () => {
                   appearance="positive"
                   disabled={isGenerating || certs !== null}
                   hasIcon={isGenerating}
+                  aria-label={`${
+                    isGenerating ? "Generating" : "Generate"
+                  } certificate`}
                 >
                   {isGenerating && (
-                    <i className="p-icon--spinner is-light u-animation--spin"></i>
+                    <Icon
+                      className="is-light u-animation--spin"
+                      name="spinner"
+                    />
                   )}
                   <span>{isGenerating ? "Generating" : "Generate"}</span>
                 </Button>

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import OpenTerminalBtn from "./actions/OpenTerminalBtn";
 import OpenConsoleBtn from "./actions/OpenConsoleBtn";
-import { Button, Col, List, Row } from "@canonical/react-components";
+import { Button, Col, Icon, List, Row } from "@canonical/react-components";
 import { isoTimeToString } from "util/helpers";
 import { isNicDevice } from "util/devices";
 import { Link } from "react-router-dom";
@@ -58,8 +58,9 @@ const InstanceDetailPanel: FC = () => {
                 className="u-no-margin--bottom"
                 hasIcon
                 onClick={panelParams.clear}
+                aria-label="Close"
               >
-                <i className="p-icon--close">Close</i>
+                <Icon name="close" />
               </Button>
             </div>
           </div>

--- a/src/pages/instances/InstanceStatusIcon.tsx
+++ b/src/pages/instances/InstanceStatusIcon.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { LxdInstance } from "types/instance";
 import classnames from "classnames";
 import { useInstanceLoading } from "context/instanceLoading";
+import { Icon } from "@canonical/react-components";
 
 interface Props {
   instance: LxdInstance;
@@ -11,30 +12,32 @@ const InstanceStatusIcon: FC<Props> = ({ instance }) => {
   const instanceLoading = useInstanceLoading();
   const loadingState = instanceLoading.getType(instance);
 
-  const getIconClassForStatus = (status: string) => {
-    return {
-      Error: "p-icon--status-failed-small",
-      Frozen: "p-icon--status-in-progress-small",
-      Freezing: "p-icon--spinner u-animation--spin",
-      Ready: "p-icon--status-waiting-small",
-      Running: "p-icon--status-succeeded-small",
-      Stopped: "p-icon--status-queued-small",
-    }[status];
+  const getIconNameForStatus = (status: string) => {
+    return (
+      {
+        Error: "status-failed-small",
+        Frozen: "status-in-progress-small",
+        Freezing: "spinner",
+        Ready: "status-waiting-small",
+        Running: "status-succeeded-small",
+        Stopped: "status-queued-small",
+      }[status] ?? ""
+    );
   };
 
   return loadingState ? (
     <>
-      <i className="p-icon--spinner u-animation--spin status-icon" />
+      <Icon className="u-animation--spin status-icon" name="spinner" />
       <i>{loadingState}</i>
     </>
   ) : (
     <>
-      <i
-        className={classnames(
-          getIconClassForStatus(instance.status),
-          "status-icon"
-        )}
-      ></i>
+      <Icon
+        name={getIconNameForStatus(instance.status)}
+        className={classnames("status-icon", {
+          "u-animation--spin": instance.status === "Freezing",
+        })}
+      />
       {instance.status}
     </>
   );

--- a/src/pages/instances/actions/OpenTerminalBtn.tsx
+++ b/src/pages/instances/actions/OpenTerminalBtn.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { useNavigate } from "react-router-dom";
 import { LxdInstance } from "types/instance";
-import { Button } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 
 interface Props {
   instance: LxdInstance;
@@ -26,8 +26,9 @@ const OpenTerminalBtn: FC<Props> = ({ instance }) => {
       onClick={handleOpen}
       disabled={isDisabled}
       title="Terminal"
+      aria-label="Open Terminal"
     >
-      <i className="p-icon--code">Open Terminal</i>
+      <Icon name="code" />
     </Button>
   );
 };


### PR DESCRIPTION
## Done

- Replaced `<i>` elements scattered here and there with react-component's `<Icon />`, for consistency.

Fixes [WD-2712](https://warthogs.atlassian.net/browse/WD-2712)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check that icons are displaying and behaving correctly throughout the app.

[WD-2712]: https://warthogs.atlassian.net/browse/WD-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ