### PR TITLE
Improve snapshots section in instance side panel [WD-2710]

### DIFF
--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -201,32 +201,53 @@ const InstanceDetailPanel: FC = () => {
                         <Link
                           to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
                         >
-                          Recent snapshots
+                          Snapshots
                         </Link>
                       </h3>
                       {instance.snapshots?.length ? (
-                        <List
-                          items={instance.snapshots
-                            .reverse()
-                            .slice(0, RECENT_SNAPSHOT_LIMIT)
-                            .map((snapshot) => (
-                              <Row key={snapshot.name} className="no-grid-gap">
-                                <Col
-                                  size={4}
-                                  className="u-truncate"
-                                  title={snapshot.name}
+                        <>
+                          <List
+                            className="u-no-margin--bottom"
+                            items={instance.snapshots
+                              .slice()
+                              .sort((snap1, snap2) => {
+                                const a = snap1.created_at;
+                                const b = snap2.created_at;
+                                return a > b ? -1 : a < b ? 1 : 0;
+                              })
+                              .slice(0, RECENT_SNAPSHOT_LIMIT)
+                              .map((snapshot) => (
+                                <Row
+                                  key={snapshot.name}
+                                  className="no-grid-gap"
                                 >
-                                  <ItemName item={snapshot} />
-                                </Col>
-                                <Col
-                                  size={8}
-                                  className="p-snapshot-creation u-align--right u-text--muted u-no-margin--bottom"
-                                >
-                                  <i>{isoTimeToString(snapshot.created_at)}</i>
-                                </Col>
-                              </Row>
-                            ))}
-                        />
+                                  <Col
+                                    size={4}
+                                    className="u-truncate"
+                                    title={snapshot.name}
+                                  >
+                                    <ItemName item={snapshot} />
+                                  </Col>
+                                  <Col
+                                    size={8}
+                                    className="p-snapshot-creation u-align--right u-text--muted u-no-margin--bottom"
+                                  >
+                                    <i>
+                                      {isoTimeToString(snapshot.created_at)}
+                                    </i>
+                                  </Col>
+                                </Row>
+                              ))}
+                          />
+                          {instance.snapshots.length >
+                            RECENT_SNAPSHOT_LIMIT && (
+                            <Link
+                              to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
+                            >
+                              {`View all (${instance.snapshots.length})`}
+                            </Link>
+                          )}
+                        </>
                       ) : (
                         <p>
                           No snapshots found.

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import OpenTerminalBtn from "./actions/OpenTerminalBtn";
 import OpenConsoleBtn from "./actions/OpenConsoleBtn";
-import { Button, Col, Icon, List, Row } from "@canonical/react-components";
+import { Button, Icon, List } from "@canonical/react-components";
 import { isoTimeToString } from "util/helpers";
 import { isNicDevice } from "util/devices";
 import { Link } from "react-router-dom";
@@ -195,8 +195,8 @@ const InstanceDetailPanel: FC = () => {
                       />
                     </td>
                   </tr>
-                  <tr>
-                    <td colSpan={2}>
+                  <tr className="u-no-border">
+                    <th colSpan={2} className="snapshots-header">
                       <h3 className="p-muted-heading p-heading--5">
                         <Link
                           to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
@@ -204,52 +204,47 @@ const InstanceDetailPanel: FC = () => {
                           Snapshots
                         </Link>
                       </h3>
-                      {instance.snapshots?.length ? (
-                        <>
-                          <List
-                            className="u-no-margin--bottom"
-                            items={instance.snapshots
-                              .slice()
-                              .sort((snap1, snap2) => {
-                                const a = snap1.created_at;
-                                const b = snap2.created_at;
-                                return a > b ? -1 : a < b ? 1 : 0;
-                              })
-                              .slice(0, RECENT_SNAPSHOT_LIMIT)
-                              .map((snapshot) => (
-                                <Row
-                                  key={snapshot.name}
-                                  className="no-grid-gap"
-                                >
-                                  <Col
-                                    size={4}
-                                    className="u-truncate"
-                                    title={snapshot.name}
-                                  >
-                                    <ItemName item={snapshot} />
-                                  </Col>
-                                  <Col
-                                    size={8}
-                                    className="p-snapshot-creation u-align--right u-text--muted u-no-margin--bottom"
-                                  >
-                                    <i>
-                                      {isoTimeToString(snapshot.created_at)}
-                                    </i>
-                                  </Col>
-                                </Row>
-                              ))}
-                          />
-                          {instance.snapshots.length >
-                            RECENT_SNAPSHOT_LIMIT && (
+                    </th>
+                  </tr>
+                  {instance.snapshots?.length ? (
+                    <>
+                      {instance.snapshots
+                        .slice()
+                        .sort((snap1, snap2) => {
+                          const a = snap1.created_at;
+                          const b = snap2.created_at;
+                          return a > b ? -1 : a < b ? 1 : 0;
+                        })
+                        .slice(0, RECENT_SNAPSHOT_LIMIT)
+                        .map((snapshot) => (
+                          <tr key={snapshot.name} className="u-no-border">
+                            <th
+                              title={snapshot.name}
+                              className="snapshot-name u-truncate"
+                            >
+                              <ItemName item={snapshot} />
+                            </th>
+                            <td className="u-text--muted">
+                              <i>{isoTimeToString(snapshot.created_at)}</i>
+                            </td>
+                          </tr>
+                        ))}
+                      {instance.snapshots.length > RECENT_SNAPSHOT_LIMIT && (
+                        <tr>
+                          <td colSpan={2}>
                             <Link
                               to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
                             >
                               {`View all (${instance.snapshots.length})`}
                             </Link>
-                          )}
-                        </>
-                      ) : (
-                        <p>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  ) : (
+                    <tr>
+                      <td colSpan={2}>
+                        <p className="no-snapshots">
                           No snapshots found.
                           <br />
                           Create one in{" "}
@@ -260,9 +255,9 @@ const InstanceDetailPanel: FC = () => {
                           </Link>
                           .
                         </p>
-                      )}
-                    </td>
-                  </tr>
+                      </td>
+                    </tr>
+                  )}
                 </tbody>
               </table>
             </div>

--- a/src/sass/_instance_detail_panel.scss
+++ b/src/sass/_instance_detail_panel.scss
@@ -36,12 +36,12 @@
   }
 
   th {
-    padding: $sp-x-small !important;
+    padding: $sp-x-small $sp-x-small $sp-x-small 0 !important;
     width: 9rem;
   }
 
   td {
-    padding: $sp-x-small !important;
+    padding: $sp-x-small $sp-x-small $sp-x-small 0 !important;
   }
 
   tr {
@@ -51,6 +51,18 @@
 
   tr:last-child {
     border: 0;
+  }
+
+  .snapshots-header {
+    padding-bottom: 0 !important;
+  }
+
+  .snapshot-name {
+    display: inline-block;
+  }
+
+  .no-snapshots {
+    padding-top: 0;
   }
 
   .content-scroll {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -164,6 +164,10 @@ $border-thin: 1px solid $color-mid-light !default;
   flex-direction: row-reverse;
 }
 
+.u-no-border {
+  border: none !important;
+}
+
 .item-name {
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Done

- Changed heading of the snapshots section to "Snapshots"
- Added local sort logic to sort the snapshots from the most recent, so that we do not rely on the BE implementation for the order
- Added a "View all (N)" link below the most 5 recent snapshots (if N > 5)

Fixes [WD-2710](https://warthogs.atlassian.net/browse/WD-2710)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open an instance side panel and check the snapshots section

[WD-2710]: https://warthogs.atlassian.net/browse/WD-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ