### PR TITLE
Change copy to expiry

### DIFF
--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -49,7 +49,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
     { content: "Name", sortKey: "name", className: "name" },
     { content: "Date created", sortKey: "created_at", className: "created" },
     {
-      content: "Expiration date",
+      content: "Expiry date",
       sortKey: "expires_at",
       className: "expiration",
     },

--- a/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
@@ -174,7 +174,7 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
               id="expirationDate"
               name="expirationDate"
               type="date"
-              label="Expiration date"
+              label="Expiry date"
               min={getTomorrow()}
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
@@ -185,7 +185,7 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
               id="expirationTime"
               name="expirationTime"
               type="time"
-              label="Expiration time"
+              label="Expiry time"
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
             />

--- a/src/pages/instances/forms/SnapshotsForm.tsx
+++ b/src/pages/instances/forms/SnapshotsForm.tsx
@@ -76,7 +76,7 @@ const SnapshotsForm: FC<Props> = ({ formik }) => {
           defaultValue: "",
           children: (
             <Input
-              placeholder="Enter expiration expression"
+              placeholder="Enter expiry expression"
               help="Controls when snapshots are to be deleted (expects an expression like 1M 2H 3d 4w 5m 6y)"
               type="text"
             />


### PR DESCRIPTION
## Done

- use expiry instead of expiration in all the snapshot part of the application.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check the snapshot parts for the expiry copy, no trace of expiration should be left