### PR TITLE
New design and features for snapshot empty state [WD-3030]

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, ReactNode } from "react";
 import { Button, Col, Icon, Row } from "@canonical/react-components";
 
 interface Props {
@@ -10,6 +10,8 @@ interface Props {
   linkURL: string;
   buttonLabel: string;
   buttonAction: () => void;
+  isDisabled?: boolean;
+  extraButton?: ReactNode;
 }
 
 const EmptyState: FC<Props> = ({
@@ -21,6 +23,8 @@ const EmptyState: FC<Props> = ({
   linkURL,
   buttonLabel,
   buttonAction,
+  isDisabled = false,
+  extraButton,
 }) => {
   return (
     <Row className="empty-state">
@@ -39,10 +43,12 @@ const EmptyState: FC<Props> = ({
             <Icon className="external-link-icon" name="external-link" />
           </a>
         </p>
+        {extraButton}
         <Button
           className="empty-state-button"
           appearance="positive"
           onClick={buttonAction}
+          disabled={isDisabled}
         >
           {buttonLabel}
         </Button>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,17 +1,12 @@
 import React, { FC, ReactNode } from "react";
-import { Button, Col, Icon, Row } from "@canonical/react-components";
+import { Col, Icon, Row } from "@canonical/react-components";
 
 interface Props {
   iconName: string;
   iconClass: string;
   title: string;
   message: string | ReactNode;
-  linkMessage?: string;
-  linkURL?: string;
-  buttonLabel?: string;
-  buttonAction?: () => void;
-  isDisabled?: boolean;
-  customButton?: ReactNode;
+  children: ReactNode;
 }
 
 const EmptyState: FC<Props> = ({
@@ -19,12 +14,7 @@ const EmptyState: FC<Props> = ({
   iconClass,
   title,
   message,
-  linkMessage,
-  linkURL,
-  buttonLabel,
-  buttonAction,
-  isDisabled = false,
-  customButton,
+  children,
 }) => {
   return (
     <Row className="empty-state">
@@ -32,30 +22,7 @@ const EmptyState: FC<Props> = ({
         <Icon name={iconName} className={`empty-state-icon ${iconClass}`} />
         <h4>{title}</h4>
         <p>{message}</p>
-        {linkMessage && linkURL && (
-          <p>
-            <a
-              className="p-link--external"
-              href={linkURL}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {linkMessage}
-              <Icon className="external-link-icon" name="external-link" />
-            </a>
-          </p>
-        )}
-        {customButton}
-        {buttonLabel && buttonAction && (
-          <Button
-            className="empty-state-button"
-            appearance="positive"
-            onClick={buttonAction}
-            disabled={isDisabled}
-          >
-            {buttonLabel}
-          </Button>
-        )}
+        {children}
       </Col>
     </Row>
   );

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -5,13 +5,13 @@ interface Props {
   iconName: string;
   iconClass: string;
   title: string;
-  message: string;
-  linkMessage: string;
-  linkURL: string;
-  buttonLabel: string;
-  buttonAction: () => void;
+  message: string | ReactNode;
+  linkMessage?: string;
+  linkURL?: string;
+  buttonLabel?: string;
+  buttonAction?: () => void;
   isDisabled?: boolean;
-  extraButton?: ReactNode;
+  customButton?: ReactNode;
 }
 
 const EmptyState: FC<Props> = ({
@@ -24,7 +24,7 @@ const EmptyState: FC<Props> = ({
   buttonLabel,
   buttonAction,
   isDisabled = false,
-  extraButton,
+  customButton,
 }) => {
   return (
     <Row className="empty-state">
@@ -32,26 +32,30 @@ const EmptyState: FC<Props> = ({
         <Icon name={iconName} className={`empty-state-icon ${iconClass}`} />
         <h4>{title}</h4>
         <p>{message}</p>
-        <p>
-          <a
-            className="p-link--external"
-            href={linkURL}
-            target="_blank"
-            rel="noreferrer"
+        {linkMessage && linkURL && (
+          <p>
+            <a
+              className="p-link--external"
+              href={linkURL}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {linkMessage}
+              <Icon className="external-link-icon" name="external-link" />
+            </a>
+          </p>
+        )}
+        {customButton}
+        {buttonLabel && buttonAction && (
+          <Button
+            className="empty-state-button"
+            appearance="positive"
+            onClick={buttonAction}
+            disabled={isDisabled}
           >
-            {linkMessage}
-            <Icon className="external-link-icon" name="external-link" />
-          </a>
-        </p>
-        {extraButton}
-        <Button
-          className="empty-state-button"
-          appearance="positive"
-          onClick={buttonAction}
-          disabled={isDisabled}
-        >
-          {buttonLabel}
-        </Button>
+            {buttonLabel}
+          </Button>
+        )}
       </Col>
     </Row>
   );

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Col,
+  Icon,
   MainTable,
   Row,
   SearchBox,
@@ -406,13 +407,33 @@ const InstanceList: FC = () => {
                     iconClass="p-empty-instances"
                     title="No instances found"
                     message="There are no instances in this project. Spin up your first instance!"
-                    linkMessage="How to create instances"
-                    linkURL="https://linuxcontainers.org/lxd/docs/latest/howto/instances_create/"
-                    buttonLabel="Create instance"
-                    buttonAction={() =>
-                      navigate(`/ui/${project}/instances/create`)
-                    }
-                  />
+                  >
+                    <>
+                      <p>
+                        <a
+                          className="p-link--external"
+                          href="https://linuxcontainers.org/lxd/docs/latest/howto/instances_create/"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          How to create instances
+                          <Icon
+                            className="external-link-icon"
+                            name="external-link"
+                          />
+                        </a>
+                      </p>
+                      <Button
+                        className="empty-state-button"
+                        appearance="positive"
+                        onClick={() =>
+                          navigate(`/ui/${project}/instances/create`)
+                        }
+                      >
+                        Create instance
+                      </Button>
+                    </>
+                  </EmptyState>
                 )}
               </Col>
             </Row>

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -54,6 +54,8 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
     onFailure("Loading project failed", error);
   }
 
+  const snapshotsDisabled = project?.config["restricted.snapshots"] === "block";
+
   useEffect(() => {
     const validNames = new Set(
       instance.snapshots?.map((snapshot) => snapshot.name)
@@ -262,15 +264,29 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
       ) : (
         <EmptyState
           iconName="containers"
-          iconClass="p-empty-snapshots"
+          iconClass="p-empty-instances"
           title="No snapshots found"
-          message="There are no snapshots of this instance."
+          message={
+            snapshotsDisabled ? (
+              <>
+                Snapshots are disabled for project{" "}
+                <ItemName item={project} bold />.
+              </>
+            ) : (
+              "There are no snapshots of this instance."
+            )
+          }
           linkMessage="Learn more about snapshots"
           linkURL="https://linuxcontainers.org/lxd/docs/latest/howto/storage_backup_volume/#storage-backup-snapshots"
           buttonLabel="Create snapshot"
           buttonAction={() => setModalOpen(true)}
-          isDisabled={project?.config["restricted.snapshots"] === "block"}
-          extraButton={<ConfigureSnapshotsBtn instance={instance} />}
+          isDisabled={snapshotsDisabled}
+          customButton={
+            <ConfigureSnapshotsBtn
+              instance={instance}
+              isDisabled={snapshotsDisabled}
+            />
+          }
         />
       )}
     </div>

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -276,18 +276,33 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
               "There are no snapshots of this instance."
             )
           }
-          linkMessage="Learn more about snapshots"
-          linkURL="https://linuxcontainers.org/lxd/docs/latest/howto/storage_backup_volume/#storage-backup-snapshots"
-          buttonLabel="Create snapshot"
-          buttonAction={() => setModalOpen(true)}
-          isDisabled={snapshotsDisabled}
-          customButton={
+        >
+          <>
+            <p>
+              <a
+                className="p-link--external"
+                href="https://linuxcontainers.org/lxd/docs/latest/howto/storage_backup_volume/#storage-backup-snapshots"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more about snapshots
+                <Icon className="external-link-icon" name="external-link" />
+              </a>
+            </p>
             <ConfigureSnapshotsBtn
               instance={instance}
               isDisabled={snapshotsDisabled}
             />
-          }
-        />
+            <Button
+              className="empty-state-button"
+              appearance="positive"
+              onClick={() => setModalOpen(true)}
+              disabled={snapshotsDisabled}
+            >
+              Create snapshot
+            </Button>
+          </>
+        </EmptyState>
       )}
     </div>
   );

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
@@ -6,9 +6,14 @@ import { LxdInstance } from "types/instance";
 interface Props {
   instance: LxdInstance;
   className?: string;
+  isDisabled?: boolean;
 }
 
-const ConfigureSnapshotsBtn: FC<Props> = ({ instance, className }) => {
+const ConfigureSnapshotsBtn: FC<Props> = ({
+  instance,
+  className,
+  isDisabled = false,
+}) => {
   const [isModal, setModal] = useState(false);
 
   const closeModal = () => {
@@ -24,7 +29,7 @@ const ConfigureSnapshotsBtn: FC<Props> = ({ instance, className }) => {
       {isModal && (
         <ConfigureSnapshotModal close={closeModal} instance={instance} />
       )}
-      <Button onClick={openModal} className={className}>
+      <Button onClick={openModal} className={className} disabled={isDisabled}>
         See configuration
       </Button>
     </>

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
@@ -5,9 +5,10 @@ import { LxdInstance } from "types/instance";
 
 interface Props {
   instance: LxdInstance;
+  className?: string;
 }
 
-const ConfigureSnapshotsBtn: FC<Props> = ({ instance }) => {
+const ConfigureSnapshotsBtn: FC<Props> = ({ instance, className }) => {
   const [isModal, setModal] = useState(false);
 
   const closeModal = () => {
@@ -23,7 +24,7 @@ const ConfigureSnapshotsBtn: FC<Props> = ({ instance }) => {
       {isModal && (
         <ConfigureSnapshotModal close={closeModal} instance={instance} />
       )}
-      <Button onClick={openModal} className="u-no-margin--right">
+      <Button onClick={openModal} className={className}>
         See configuration
       </Button>
     </>

--- a/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
@@ -11,7 +11,7 @@ interface Props {
   onStart: () => void;
   onFinish: () => void;
   onSuccess: (message: ReactNode) => void;
-  onFailure: (message: ReactNode, e: unknown) => void;
+  onFailure: (title: string, e: unknown) => void;
 }
 
 const SnapshotBulkDelete: FC<Props> = ({
@@ -37,7 +37,7 @@ const SnapshotBulkDelete: FC<Props> = ({
           </>
         )
       )
-      .catch((e) => onFailure("Error on snapshot delete.", e))
+      .catch((e) => onFailure("Snapshot deletion failed.", e))
       .finally(() => {
         setLoading(false);
         onFinish();

--- a/src/sass/_empty_state.scss
+++ b/src/sass/_empty_state.scss
@@ -1,9 +1,19 @@
 .empty-state {
+  margin-top: min(5vh, $spv--strip-regular);
+
   .empty-state-icon {
     height: $sp-xx-large;
     margin-bottom: $spv--large;
     margin-top: $spv--x-large;
     width: $sp-xx-large;
+  }
+
+  h4 {
+    margin-bottom: $spv--x-small;
+  }
+
+  p {
+    margin-bottom: $spv--medium;
   }
 
   .empty-state-button {

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -36,10 +36,6 @@
     }
   }
 
-  .p-empty-instances {
-    @include vf-icon-containers($color-mid-light);
-  }
-
   .u-row:hover,
   .u-row-selected {
     background-color: $colors--light-theme--background-hover;

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -121,7 +121,7 @@ $border-thin: 1px solid $color-mid-light !default;
 }
 
 .p-empty-snapshots {
-  @include vf-icon-settings($color-mid-light);
+  @include vf-icon-containers($color-mid-light);
 }
 
 .clear-selection-icon {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -120,7 +120,7 @@ $border-thin: 1px solid $color-mid-light !default;
   @include vf-icon-external-link($color-link);
 }
 
-.p-empty-snapshots {
+.p-empty-instances {
   @include vf-icon-containers($color-mid-light);
 }
 


### PR DESCRIPTION
## Done

- Updated design of snapshot empty state
- Added "See configuration" button to the empty state
- Disabled "Create snapshot" button when snapshots are disabled in the current project

Fixes [WD-3030](https://warthogs.atlassian.net/browse/WD-3030)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open the snapshots tab of an instance with no snapshots
    - Check that the empty state looks and behaves as expected
    - Check also that the "Create snapshot" button is disabled when the snapshot feature is disabled in the current project

[WD-3030]: https://warthogs.atlassian.net/browse/WD-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ