### PR TITLE
Removed the instance count from the instance page header [WD-2937]

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -300,11 +300,7 @@ const InstanceList: FC = () => {
         >
           <div className="p-panel__header instance-list-header">
             <div className="instance-header-left">
-              <h1 className="p-heading--4">
-                {instances.length}
-                &nbsp;
-                {instances.length === 1 ? "Instance" : "Instances"}
-              </h1>
+              <h1 className="p-heading--4">Instances</h1>
               <SearchBox
                 className="search-box margin-right"
                 name="search-instance"

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -167,7 +167,7 @@
 }
 
 // hide filters on small screens
-@media screen and (max-width: 1110px) {
+@media screen and (max-width: $breakpoint-large) {
   .filter-state,
   .filter-type,
   .search-box {


### PR DESCRIPTION
## Done

- Removed the instance count from the instance page header

Fixes [WD-2937](https://warthogs.atlassian.net/browse/WD-2937)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check the header of the instance page - the count is not there anymore

[WD-2937]: https://warthogs.atlassian.net/browse/WD-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ