### PR TITLE
Use capitalised labels for instance types [WD-2877]

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -17,6 +17,7 @@ import { isContainerOnlyImage, isVmOnlyImage } from "util/images";
 import Loader from "components/Loader";
 import { fetchSettings } from "api/server";
 import { getArchitectureAliases } from "util/architectures";
+import { instanceCreationTypes } from "util/instanceOptions";
 
 interface Props {
   onClose: () => void;
@@ -321,14 +322,7 @@ const ImageSelector: FC<Props> = ({ onClose, onSelect }) => {
                   label: "Any",
                   value: ANY,
                 },
-                {
-                  label: "container",
-                  value: CONTAINER,
-                },
-                {
-                  label: "virtual-machine",
-                  value: VM,
-                },
+                ...instanceCreationTypes,
               ]}
               value={type}
             />

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -15,7 +15,11 @@ import { useNotify } from "context/notify";
 import usePanelParams from "util/usePanelParams";
 import { useNavigate, useParams } from "react-router-dom";
 import Loader from "components/Loader";
-import { instanceStatuses, instanceListTypes } from "util/instanceOptions";
+import {
+  instanceStatuses,
+  instanceListTypes,
+  instanceCreationTypes,
+} from "util/instanceOptions";
 import InstanceStatusIcon from "./InstanceStatusIcon";
 import TableColumnsSelect from "components/TableColumnsSelect";
 import useEventListener from "@use-it/event-listener";
@@ -199,7 +203,15 @@ const InstanceList: FC = () => {
             "aria-label": NAME,
           },
           {
-            content: instance.type,
+            content: (
+              <>
+                {
+                  instanceCreationTypes.find(
+                    (item) => item.value === instance.type
+                  )?.label
+                }
+              </>
+            ),
             role: "rowheader",
             "aria-label": TYPE,
             onClick: openSummary,

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -15,7 +15,7 @@ export const instanceCreationTypes = [
     value: "container",
   },
   {
-    label: "Virtual Machine",
+    label: "VM",
     value: "virtual-machine",
   },
 ];


### PR DESCRIPTION
## Done

- Set capitalised labels for instance types throughout the app

Fixes [WD-2877](https://warthogs.atlassian.net/browse/WD-2877)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check labels for instance types in: instance list, instance side panel, instance detail page (overview), instance creation page (dropdown)

[WD-2877]: https://warthogs.atlassian.net/browse/WD-2877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ