### PR TITLE
Add loading state and show error on configure snapshots

### DIFF
--- a/src/components/SubmitButton.tsx
+++ b/src/components/SubmitButton.tsx
@@ -10,6 +10,7 @@ interface Props {
   processingText?: string;
   onClick?: () => void;
   dense?: boolean;
+  className?: string;
 }
 
 const SubmitButton: FC<Props> = ({
@@ -20,6 +21,7 @@ const SubmitButton: FC<Props> = ({
   processingText = "Processing...",
   onClick,
   dense,
+  className,
 }) => {
   return isSubmitting ? (
     <Button
@@ -28,6 +30,7 @@ const SubmitButton: FC<Props> = ({
       hasIcon
       disabled
       dense={dense}
+      className={className}
     >
       <Icon
         name="spinner"
@@ -44,6 +47,7 @@ const SubmitButton: FC<Props> = ({
       disabled={isDisabled}
       onClick={onClick}
       dense={dense}
+      className={className}
     >
       {buttonLabel}
     </Button>

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -10,7 +10,7 @@ import { isNicDevice } from "util/devices";
 
 interface Props {
   instance: LxdInstance;
-  onFailure: (message: string, e: unknown) => void;
+  onFailure: (title: string, e: unknown) => void;
 }
 
 const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {

--- a/src/pages/instances/InstanceOverviewProfiles.tsx
+++ b/src/pages/instances/InstanceOverviewProfiles.tsx
@@ -9,7 +9,7 @@ import { fetchProfiles } from "api/profiles";
 
 interface Props {
   instance: LxdInstance;
-  onFailure: (message: string, e: unknown) => void;
+  onFailure: (title: string, e: unknown) => void;
 }
 
 const InstanceOverviewProfiles: FC<Props> = ({ instance, onFailure }) => {

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -196,6 +196,8 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
               <ConfigureSnapshotsBtn
                 instance={instance}
                 className="u-no-margin--right"
+                onSuccess={onSuccess}
+                onFailure={onFailure}
               />
               <Button
                 appearance="positive"
@@ -292,6 +294,8 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
             <ConfigureSnapshotsBtn
               instance={instance}
               isDisabled={snapshotsDisabled}
+              onSuccess={onSuccess}
+              onFailure={onFailure}
             />
             <Button
               className="empty-state-button"

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
@@ -14,6 +14,7 @@ import {
   getInstancePayload,
   InstanceEditSchema,
 } from "util/instanceEdit";
+import SubmitButton from "components/SubmitButton";
 
 interface Props {
   instance: LxdInstance;
@@ -37,12 +38,12 @@ const ConfigureSnapshotModal: FC<Props> = ({ instance, close }) => {
       updateInstance(instancePayload, project ?? "")
         .then(() => {
           notify.success("Configuration updated.");
-          close();
         })
         .catch((e: Error) => {
           notify.failure("Configuration update failed", e);
         })
         .finally(() => {
+          close();
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.instances],
           });
@@ -87,13 +88,13 @@ const ConfigureSnapshotModal: FC<Props> = ({ instance, close }) => {
             >
               Cancel
             </Button>
-            <Button
-              appearance="positive"
+            <SubmitButton
+              buttonLabel="Save"
               className="u-no-margin--bottom"
+              isSubmitting={formik.isSubmitting}
+              isDisabled={formik.isSubmitting}
               onClick={() => void formik.submitForm()}
-            >
-              Save
-            </Button>
+            />
           </>
         )
       }

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, KeyboardEvent } from "react";
+import React, { FC, KeyboardEvent, ReactNode } from "react";
 import { Button, Modal } from "@canonical/react-components";
 import { LxdInstance } from "types/instance";
 import { useFormik } from "formik";
@@ -6,7 +6,6 @@ import { updateInstance } from "api/instances";
 import { queryKeys } from "util/queryKeys";
 import { EditInstanceFormValues } from "pages/instances/EditInstanceForm";
 import { useQueryClient } from "@tanstack/react-query";
-import { useNotify } from "context/notify";
 import SnapshotsForm from "pages/instances/forms/SnapshotsForm";
 import { useParams } from "react-router-dom";
 import {
@@ -19,10 +18,16 @@ import SubmitButton from "components/SubmitButton";
 interface Props {
   instance: LxdInstance;
   close: () => void;
+  onSuccess: (message: ReactNode) => void;
+  onFailure: (title: string, e: unknown) => void;
 }
 
-const ConfigureSnapshotModal: FC<Props> = ({ instance, close }) => {
-  const notify = useNotify();
+const ConfigureSnapshotModal: FC<Props> = ({
+  instance,
+  close,
+  onSuccess,
+  onFailure,
+}) => {
   const { project } = useParams<{ project: string }>();
   const queryClient = useQueryClient();
 
@@ -37,10 +42,10 @@ const ConfigureSnapshotModal: FC<Props> = ({ instance, close }) => {
 
       updateInstance(instancePayload, project ?? "")
         .then(() => {
-          notify.success("Configuration updated.");
+          onSuccess("Configuration updated.");
         })
         .catch((e: Error) => {
-          notify.failure("Configuration update failed", e);
+          onFailure("Configuration update failed", e);
         })
         .finally(() => {
           close();

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotsBtn.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, ReactNode, useState } from "react";
 import { Button } from "@canonical/react-components";
 import ConfigureSnapshotModal from "pages/instances/actions/snapshots/ConfigureSnapshotModal";
 import { LxdInstance } from "types/instance";
@@ -7,12 +7,16 @@ interface Props {
   instance: LxdInstance;
   className?: string;
   isDisabled?: boolean;
+  onSuccess: (message: ReactNode) => void;
+  onFailure: (title: string, e: unknown) => void;
 }
 
 const ConfigureSnapshotsBtn: FC<Props> = ({
   instance,
   className,
   isDisabled = false,
+  onSuccess,
+  onFailure,
 }) => {
   const [isModal, setModal] = useState(false);
 
@@ -27,7 +31,12 @@ const ConfigureSnapshotsBtn: FC<Props> = ({
   return (
     <>
       {isModal && (
-        <ConfigureSnapshotModal close={closeModal} instance={instance} />
+        <ConfigureSnapshotModal
+          close={closeModal}
+          instance={instance}
+          onSuccess={onSuccess}
+          onFailure={onFailure}
+        />
       )}
       <Button onClick={openModal} className={className} disabled={isDisabled}>
         See configuration


### PR DESCRIPTION
## Done

- added loading state to configure snapshots
- make error visible when snapshot config update failed

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - update snapshot configuration from snapshot tab of instance detail