### PR TITLE
Responsive snapshot list in instance detail page

### DIFF
--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -48,6 +48,7 @@
     th,
     td {
       display: table-cell;
+      vertical-align: middle;
     }
 
     th:last-child {
@@ -98,7 +99,7 @@
     }
 
     .stateful {
-      width: 105px;
+      width: 95px;
     }
 
     .actions {
@@ -113,8 +114,8 @@
       background-color: $colors--light-theme--background-hover;
     }
 
-    // show actions only on hover for desktop sized screens
-    @media screen and (min-width: 800px) {
+    // show actions only on hover if a pointing device is used
+    @media screen and (pointer: fine) {
       .u-snapshot-actions {
         visibility: hidden;
       }

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -53,8 +53,8 @@
     margin-bottom: -3px;
   }
 
-  // show actions only on hover for desktop sized screens
-  @media screen and (min-width: 800px) {
+  // show actions only on hover if a pointing device is used
+  @media screen and (pointer: fine) {
     .instance-actions {
       visibility: hidden;
     }

--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -18,6 +18,10 @@
   background-color: #e6f2ff;
 }
 
+.select label {
+  padding-top: 0.2rem !important;
+}
+
 .processing-row {
   opacity: 0.5;
 


### PR DESCRIPTION
## Done

- collapsing columns in the snapshot table for smaller screens
- always show buttons of snapshot table on smaller screens
- align content vertically in snapshot table

Fixes [WD-3031](https://warthogs.atlassian.net/browse/WD-3031)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check instance snapshots on various screen sizes

[WD-3031]: https://warthogs.atlassian.net/browse/WD-3031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ