### PR TITLE
Table sorting across multiple pages, sort snapshots by recency

### DIFF
--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -87,7 +87,7 @@ const ClusterList: FC = () => {
         },
       ],
       sortData: {
-        name: member.server_name,
+        name: member.server_name.toLowerCase(),
       },
     };
   });

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -212,9 +212,9 @@ const ImageSelector: FC<Props> = ({ onClose, onSelect }) => {
           },
         ],
         sortData: {
-          os: item.os,
-          release: item.release,
-          variant: item.variant,
+          os: item.os.toLowerCase(),
+          release: item.release.toLowerCase(),
+          variant: item.variant?.toLowerCase(),
           type: itemType,
           alias: item.aliases,
         },

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -159,7 +159,11 @@ const InstanceList: FC = () => {
         sortKey: "snapshots",
         className: "u-align--right snapshots",
       },
-      { content: STATUS, sortKey: "status", className: "status-header status" },
+      {
+        content: <span>{STATUS}</span>,
+        sortKey: "status",
+        className: "status-header status",
+      },
       {
         "aria-label": "Actions",
         className: classnames("actions", { "u-hide": panelParams.instance }),
@@ -278,7 +282,8 @@ const InstanceList: FC = () => {
           },
         ].filter((item) => !hiddenCols.includes(item["aria-label"])),
         sortData: {
-          name: instance.name,
+          name: instance.name.toLowerCase(),
+          description: instance.description.toLowerCase(),
           status: instance.status,
           type: instance.type,
           snapshots: instance.snapshots?.length ?? 0,
@@ -393,6 +398,7 @@ const InstanceList: FC = () => {
                           <>No instance found matching this search</>
                         )
                       }
+                      onUpdateSort={pagination.updateSort}
                     />
                     <Pagination
                       {...pagination}

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -88,7 +88,7 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
           },
         ],
         sortData: {
-          name: network.name,
+          name: network.name.toLowerCase(),
           type: network.type,
           managed: network.managed,
           interfaceName: interfaceNames.join(" "),

--- a/src/pages/instances/InstanceOverviewProfiles.tsx
+++ b/src/pages/instances/InstanceOverviewProfiles.tsx
@@ -65,8 +65,8 @@ const InstanceOverviewProfiles: FC<Props> = ({ instance, onFailure }) => {
         },
       ],
       sortData: {
-        name: profile,
-        description: description,
+        name: profile.toLowerCase(),
+        description: description.toLowerCase(),
       },
     };
   });

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -91,12 +91,12 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
         <>
           Name
           <br />
-          Date created
+          <div className="created-header--collapsed">Date created</div>
         </>
       ) : (
         "Name"
       ),
-      sortKey: "name",
+      sortKey: isSmallScreen ? "created_at" : undefined,
       className: "name",
     },
     ...(isSmallScreen
@@ -178,7 +178,6 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
         },
       ],
       sortData: {
-        name: snapshot.name,
         created_at: snapshot.created_at,
         expires_at: snapshot.expires_at,
         stateful: snapshot.stateful,
@@ -186,7 +185,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
     };
   });
 
-  const pagination = usePagination(rows);
+  const pagination = usePagination(rows, "created_at", "descending");
 
   const resize = () => {
     updateTBodyHeight("snapshots-table-wrapper");
@@ -287,6 +286,9 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
             allNames={
               instance.snapshots?.map((snapshot) => snapshot.name) ?? []
             }
+            onUpdateSort={pagination.updateSort}
+            defaultSort="created_at"
+            defaultSortDirection="descending"
           />
           <Pagination
             {...pagination}

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -96,10 +96,10 @@ const NetworkList: FC = () => {
         },
       ],
       sortData: {
-        name: network.name,
+        name: network.name.toLowerCase(),
         type: network.type,
         managed: network.managed,
-        description: network.description,
+        description: network.description.toLowerCase(),
         state: network.status,
         usedBy: network.used_by?.length ?? 0,
       },

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -72,8 +72,8 @@ const ProfileList: FC = () => {
         },
       ],
       sortData: {
-        name: profile.name,
-        description: profile.description,
+        name: profile.name.toLowerCase(),
+        description: profile.description.toLowerCase(),
         used_by: profile.used_by,
       },
     };

--- a/src/pages/storages/StorageList.tsx
+++ b/src/pages/storages/StorageList.tsx
@@ -89,9 +89,9 @@ const StorageList: FC = () => {
         },
       ],
       sortData: {
-        name: storage.name,
+        name: storage.name.toLowerCase(),
         driver: storage.driver,
-        description: storage.description,
+        description: storage.description.toLowerCase(),
         state: storage.status,
         usedBy: storage.used_by?.length ?? 0,
       },

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -84,11 +84,11 @@ const WarningList: FC = () => {
       ],
       sortData: {
         type: warning.type,
-        lastMessage: warning.last_message,
+        lastMessage: warning.last_message.toLowerCase(),
         status: warning.status,
         severity: warning.severity,
         count: warning.count,
-        project: warning.project,
+        project: warning.project.toLowerCase(),
         firstSeen: warning.first_seen_at,
         lastSeen: warning.last_seen_at,
       },

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -86,6 +86,11 @@
       }
     }
 
+    .created-header--collapsed {
+      display: inline-block;
+      padding-top: 1px;
+    }
+
     .name {
       min-width: 170px;
     }
@@ -99,7 +104,7 @@
     }
 
     .stateful {
-      width: 95px;
+      width: 105px;
     }
 
     .actions {

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -87,6 +87,17 @@
 
     .status-header {
       padding-left: 3.33rem;
+      pointer-events: none;
+
+      > * {
+        pointer-events: all;
+      }
+    }
+
+    th::before {
+      content: "";
+      display: inline-block;
+      height: 1rem;
     }
 
     thead,
@@ -132,7 +143,7 @@
     }
 
     .snapshots {
-      width: 100px;
+      width: 110px;
     }
 
     .actions {

--- a/src/util/pagination.tsx
+++ b/src/util/pagination.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { usePagination as _usePagination } from "@canonical/react-components";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { SortDirection } from "@canonical/react-components/dist/types";
 
 export const paginationOptions = [
   {
@@ -17,17 +18,47 @@ export const paginationOptions = [
   },
 ];
 
-export const usePagination = (
-  data: MainTableRow[]
-): {
+export interface Pagination {
   pageData: MainTableRow[];
   currentPage: number;
   paginate: (pageNumber: number) => void;
   pageSize: number;
   setPageSize: (newSize: number) => void;
   totalPages: number;
-} => {
+  updateSort: (sort?: string | null) => void;
+}
+
+export const usePagination = (
+  data: MainTableRow[],
+  defaultSort?: string,
+  defaultSortDirection: SortDirection = "ascending"
+): Pagination => {
   const [_pageSize, _setPageSize] = useState(paginationOptions[0].value);
+  const [sort, setSort] = useState<string | null | undefined>(defaultSort);
+  const [sortDirection, setSortDirection] = useState(defaultSortDirection);
+
+  if (sort) {
+    data.sort((a, b) => {
+      const aVal = a.sortData ? (a.sortData[sort] as string) : "";
+      const bVal = b.sortData ? (b.sortData[sort] as string) : "";
+      if (aVal > bVal) {
+        return sortDirection === "ascending" ? 1 : -1;
+      }
+      if (aVal < bVal) {
+        return sortDirection === "ascending" ? -1 : 1;
+      }
+      return 0;
+    });
+  }
+
+  const updateSort = (newSort?: string | null) => {
+    if (newSort === sort) {
+      setSortDirection("descending");
+    } else {
+      setSortDirection("ascending");
+    }
+    setSort(newSort);
+  };
 
   const usePagination = _usePagination(data, {
     itemsPerPage: _pageSize,
@@ -44,5 +75,6 @@ export const usePagination = (
     pageSize: _pageSize,
     setPageSize,
     totalPages: Math.ceil(data.length / _pageSize),
+    updateSort,
   };
 };


### PR DESCRIPTION
## Done

- fix instance and snapshot table sorting, when more than one page is available
- order snapshot table by recency

Fixes WD-3052

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - sort instances and snapshots when more than one page of items exists