### PR TITLE
Align table headings with navigation WD-2936

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -313,9 +313,9 @@ const InstanceList: FC = () => {
         >
           <div className="p-panel__header instance-list-header">
             <div className="instance-header-left">
-              <h1 className="p-heading--4">Instances</h1>
+              <h1 className="p-heading--4 u-no-margin--bottom">Instances</h1>
               <SearchBox
-                className="search-box margin-right"
+                className="search-box margin-right u-no-margin--bottom"
                 name="search-instance"
                 type="text"
                 onChange={(value) => {
@@ -326,6 +326,7 @@ const InstanceList: FC = () => {
                 aria-label="Search"
               />
               <Select
+                className="u-no-margin--bottom"
                 wrapperClassName="margin-right filter-state"
                 onChange={(v) => {
                   setStatus(v.target.value);
@@ -341,6 +342,7 @@ const InstanceList: FC = () => {
                 aria-label="Filter status"
               />
               <Select
+                className="u-no-margin--bottom"
                 wrapperClassName="margin-right filter-type"
                 onChange={(v) => {
                   setType(v.target.value);
@@ -359,6 +361,7 @@ const InstanceList: FC = () => {
             {hasInstances && (
               <Button
                 appearance="positive"
+                className="u-no-margin--bottom"
                 onClick={() => navigate(`/ui/${project}/instances/create`)}
               >
                 Create instance

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -169,6 +169,10 @@
   .search-box {
     display: none;
   }
+
+  .instance-list-header {
+    margin-bottom: 0 !important;
+  }
 }
 @media screen and (max-width: 1500px) {
   .has-side-panel {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -162,6 +162,10 @@ $border-thin: 1px solid $color-mid-light !default;
   padding-top: $spv--x-small;
 }
 
+.p-panel__title {
+  padding-bottom: $spv--medium;
+}
+
 .p-breadcrumbs {
   margin-bottom: 0;
   width: inherit;


### PR DESCRIPTION
## Done

- Align table headings with navigation

Fixes [WD-2936](https://warthogs.atlassian.net/browse/WD-2936)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check the tables in different screen sizes, the headings should align with the "project" string in the navigaiton

[WD-2936]: https://warthogs.atlassian.net/browse/WD-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ