### PR TITLE
Refactor names of confirm and cancel props for the ConfirmationButton

### DIFF
--- a/src/components/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton.tsx
@@ -14,7 +14,7 @@ interface Props {
   onHoverText?: string;
   confirmationExtra?: ReactNode;
   confirmationMessage: string | ReactNode;
-  posButtonLabel: string;
+  confirmButtonLabel: string;
   onCancel?: () => void;
   onConfirm: () => void;
   isDense?: boolean;
@@ -32,7 +32,7 @@ const ConfirmationButton: FC<Props> = ({
   onHoverText,
   confirmationExtra,
   confirmationMessage,
-  posButtonLabel,
+  confirmButtonLabel,
   onCancel,
   onConfirm,
   isDense = true,
@@ -72,7 +72,7 @@ const ConfirmationButton: FC<Props> = ({
             onClose={handleCancelModal}
             confirmationExtra={confirmationExtra}
             confirmationMessage={confirmationMessage}
-            posButtonLabel={posButtonLabel}
+            confirmButtonLabel={confirmButtonLabel}
             onConfirm={handleConfirmModal}
             hasShiftHint={hasShiftHint}
           />
@@ -85,8 +85,8 @@ const ConfirmationButton: FC<Props> = ({
         dense={isDense}
         disabled={isDisabled}
         onClick={handleShiftClick}
-        aria-label={posButtonLabel}
-        title={onHoverText ?? posButtonLabel}
+        aria-label={confirmButtonLabel}
+        title={onHoverText ?? confirmButtonLabel}
         type="button"
       >
         {iconName && (

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -6,8 +6,8 @@ interface Props {
   onClose: () => void;
   confirmationExtra?: ReactNode;
   confirmationMessage: string | ReactNode;
-  negButtonLabel?: string;
-  posButtonLabel: string;
+  cancelButtonLabel?: string;
+  confirmButtonLabel: string;
   onConfirm: (e: MouseEvent<HTMLElement>) => void;
   hasShiftHint?: boolean;
 }
@@ -17,8 +17,8 @@ const ConfirmationModal: FC<Props> = ({
   onClose,
   confirmationExtra,
   confirmationMessage,
-  negButtonLabel = "Cancel",
-  posButtonLabel,
+  cancelButtonLabel = "Cancel",
+  confirmButtonLabel,
   onConfirm,
   hasShiftHint = true,
 }) => {
@@ -30,14 +30,14 @@ const ConfirmationModal: FC<Props> = ({
         <>
           {confirmationExtra}
           <Button className="u-no-margin--bottom" onClick={onClose}>
-            {negButtonLabel}
+            {cancelButtonLabel}
           </Button>
           <Button
             appearance="negative"
             className="u-no-margin--bottom"
             onClick={onConfirm}
           >
-            {posButtonLabel}
+            {confirmButtonLabel}
           </Button>
         </>
       }

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -37,7 +37,7 @@ const DeleteImageBtn: FC<Props> = ({ image }) => {
       icon="delete"
       title="Confirm delete"
       confirmationMessage={`Are you sure you want to delete image "${image.properties.description}"?\nThis action cannot be undone, and can result in data loss.`}
-      posButtonLabel="Delete"
+      confirmButtonLabel="Delete"
       onConfirm={handleDelete}
       isDisabled={isLoading}
     />

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -53,7 +53,7 @@ const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
           and can result in data loss.
         </>
       }
-      posButtonLabel="Delete"
+      confirmButtonLabel="Delete"
       onConfirm={handleDelete}
       isDisabled={isDisabled}
       isDense

--- a/src/pages/instances/actions/PauseInstanceBtn.tsx
+++ b/src/pages/instances/actions/PauseInstanceBtn.tsx
@@ -62,7 +62,7 @@ const PauseInstanceBtn: FC<Props> = ({ instance }) => {
           <ItemName item={instance} bold />?
         </>
       }
-      posButtonLabel="Pause"
+      confirmButtonLabel="Pause"
       onConfirm={handlePause}
       isDense={true}
       isDisabled={isDisabled}

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -68,7 +68,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
       confirmationExtra={
         <ConfirmationForce label="Force restart" force={[isForce, setForce]} />
       }
-      posButtonLabel="Restart"
+      confirmButtonLabel="Restart"
       onCancel={() => setForce(false)}
       onConfirm={handleRestart}
       isDense={true}

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -65,7 +65,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
       confirmationExtra={
         <ConfirmationForce label="Force stop" force={[isForce, setForce]} />
       }
-      posButtonLabel="Stop"
+      confirmButtonLabel="Stop"
       onCancel={() => setForce(false)}
       onConfirm={handleStop}
       isDense={true}

--- a/src/pages/instances/actions/snapshots/SnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotActions.tsx
@@ -83,7 +83,7 @@ const SnapshotActions: FC<Props> = ({
               undone, and can result in data loss.
             </>
           }
-          posButtonLabel="Delete"
+          confirmButtonLabel="Delete"
           onConfirm={handleDelete}
           isDisabled={isDeleting || isRestoring}
         />,
@@ -100,7 +100,7 @@ const SnapshotActions: FC<Props> = ({
               undone, and can result in data loss.
             </>
           }
-          posButtonLabel="Restore"
+          confirmButtonLabel="Restore"
           onConfirm={handleRestore}
           isDisabled={isDeleting || isRestoring}
         />,

--- a/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
@@ -65,7 +65,7 @@ const SnapshotBulkDelete: FC<Props> = ({
           </>
         )
       }
-      posButtonLabel="Delete"
+      confirmButtonLabel="Delete"
       onConfirm={handleDelete}
       isDisabled={isLoading}
       isDense={false}

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -50,7 +50,7 @@ const DeleteProfileBtn: FC<Props> = ({
           and can result in data loss.
         </>
       }
-      posButtonLabel="Delete"
+      confirmButtonLabel="Delete"
       onConfirm={handleDelete}
       isDisabled={profile.name === "default" || !featuresProfiles}
       isDense

--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -52,7 +52,7 @@ const DeleteProjectBtn: FC<Props> = ({ project }) => {
           and can result in data loss.
         </>
       }
-      posButtonLabel={
+      confirmButtonLabel={
         project.name === "default"
           ? "The default project can't be deleted"
           : "Delete"

--- a/src/pages/storages/actions/DeleteStorageBtn.tsx
+++ b/src/pages/storages/actions/DeleteStorageBtn.tsx
@@ -51,7 +51,7 @@ const DeleteStorageBtn: FC<Props> = ({ storage, project }) => {
           and can result in data loss.
         </>
       }
-      posButtonLabel="Delete"
+      confirmButtonLabel="Delete"
       onConfirm={handleDelete}
       isDense={true}
     />


### PR DESCRIPTION
## Done

- Prop names for cancel/confirm buttons were prefixed with `negButton` and `posButton`, which was conceptually wrong and confusing - especially given that the so-called `posButton` had a negative appearance most of the time. This PR fixes this by using `cancelButton` and `confirmButton` prefixes instead.