### PR TITLE
Profile list overhaul [WD-2673]

### DIFF
--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -91,7 +91,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
         <>
           Name
           <br />
-          <div className="created-header--collapsed">Date created</div>
+          <div className="header-second-row">Date created</div>
         </>
       ) : (
         "Name"

--- a/src/pages/profiles/ProfileDetail.tsx
+++ b/src/pages/profiles/ProfileDetail.tsx
@@ -18,7 +18,11 @@ const TABS: string[] = ["Overview", "Configuration"];
 const ProfileDetail: FC = () => {
   const navigate = useNavigate();
   const notify = useNotify();
-  const { name, project, activeTab } = useParams<{
+  const {
+    name,
+    project: projectName,
+    activeTab,
+  } = useParams<{
     name: string;
     project: string;
     activeTab?: string;
@@ -27,7 +31,7 @@ const ProfileDetail: FC = () => {
   if (!name) {
     return <>Missing name</>;
   }
-  if (!project) {
+  if (!projectName) {
     return <>Missing project</>;
   }
 
@@ -37,16 +41,16 @@ const ProfileDetail: FC = () => {
     isLoading: isProfileLoading,
   } = useQuery({
     queryKey: [queryKeys.profiles, "detail", name],
-    queryFn: () => fetchProfile(name, project),
+    queryFn: () => fetchProfile(name, projectName),
   });
 
   const {
-    data: projectObj,
+    data: project,
     error: projectError,
     isLoading: isProjectLoading,
   } = useQuery({
-    queryKey: [queryKeys.projects, project],
-    queryFn: () => fetchProject(project),
+    queryKey: [queryKeys.projects, projectName],
+    queryFn: () => fetchProject(projectName),
   });
 
   if (error) {
@@ -58,14 +62,14 @@ const ProfileDetail: FC = () => {
   }
   const isLoading = isProfileLoading || isProjectLoading;
 
-  const featuresProfiles = projectObj?.config["features.profiles"] === "true";
+  const featuresProfiles = project?.config["features.profiles"] === "true";
 
   const handleTabChange = (newTab: string) => {
     notify.clear();
     if (newTab === "overview") {
-      navigate(`/ui/${project}/profiles/detail/${name}`);
+      navigate(`/ui/${projectName}/profiles/detail/${name}`);
     } else {
-      navigate(`/ui/${project}/profiles/detail/${name}/${newTab}`);
+      navigate(`/ui/${projectName}/profiles/detail/${name}/${newTab}`);
     }
   };
 
@@ -75,7 +79,7 @@ const ProfileDetail: FC = () => {
         <ProfileDetailHeader
           name={name}
           profile={profile}
-          project={project}
+          project={projectName}
           featuresProfiles={featuresProfiles}
         />
         <div className="p-panel__content">

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -209,7 +209,7 @@ const ProfileList: FC = () => {
           <NotificationRow />
           <Row className="no-grid-gap">
             <Col size={12}>
-              {!featuresProfiles && (
+              {!isLoading && !featuresProfiles && (
                 <Notification severity="caution" title="Profiles disabled">
                   The feature has been disabled on a project level. All the
                   available profiles are inherited from the default project.

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -28,30 +28,30 @@ const ProfileList: FC = () => {
   const navigate = useNavigate();
   const notify = useNotify();
   const panelParams = usePanelParams();
-  const { project } = useParams<{ project: string }>();
+  const { project: projectName } = useParams<{ project: string }>();
   const [query, setQuery] = useState<string>("");
 
-  if (!project) {
+  if (!projectName) {
     return <>Missing project</>;
   }
-  const isDefaultProject = project === "default";
+  const isDefaultProject = projectName === "default";
 
   const {
     data: profiles = [],
     error,
     isLoading: isProfilesLoading,
   } = useQuery({
-    queryKey: [queryKeys.profiles, project],
-    queryFn: () => fetchProfiles(project),
+    queryKey: [queryKeys.profiles, projectName],
+    queryFn: () => fetchProfiles(projectName),
   });
 
   const {
-    data: projectObj,
+    data: project,
     error: projectError,
     isLoading: isProjectLoading,
   } = useQuery({
-    queryKey: [queryKeys.projects, project],
-    queryFn: () => fetchProject(project),
+    queryKey: [queryKeys.projects, projectName],
+    queryFn: () => fetchProject(projectName),
   });
 
   if (error) {
@@ -63,18 +63,19 @@ const ProfileList: FC = () => {
   }
   const isLoading = isProfilesLoading || isProjectLoading;
 
-  const featuresProfiles = projectObj?.config["features.profiles"] === "true";
+  const featuresProfiles = project?.config["features.profiles"] === "true";
 
   const instanceCountMap = profiles.map((profile) => {
     const usedByInstances = getProfileInstances(
-      project,
+      projectName,
       isDefaultProject,
       profile.used_by
     );
     return {
       name: profile.name,
-      count: usedByInstances.filter((instance) => instance.project === project)
-        .length,
+      count: usedByInstances.filter(
+        (instance) => instance.project === projectName
+      ).length,
       total: usedByInstances.length,
     };
   });
@@ -96,15 +97,7 @@ const ProfileList: FC = () => {
     { content: "Name", sortKey: "name" },
     { content: "Description", sortKey: "description" },
     {
-      content: isDefaultProject ? (
-        <>
-          Total instances
-          <br />
-          <div className="header-second-row">Used by</div>
-        </>
-      ) : (
-        "Used by"
-      ),
+      content: "Used by",
       sortKey: "used_by",
     },
   ];
@@ -120,7 +113,7 @@ const ProfileList: FC = () => {
         {
           content: (
             <div className="u-truncate" title={profile.name}>
-              <Link to={`/ui/${project}/profiles/detail/${profile.name}`}>
+              <Link to={`/ui/${projectName}/profiles/detail/${profile.name}`}>
                 <ItemName item={profile} />
               </Link>
             </div>
@@ -140,17 +133,15 @@ const ProfileList: FC = () => {
         {
           content: (
             <>
+              {usedBy} {usedBy === 1 ? "instance" : "instances"}
               {isDefaultProject && (
                 <>
-                  {total} in all projects
-                  <br />
+                  <div className="u-text--muted">{total} in all projects</div>
                 </>
               )}
-              {usedBy} instances
             </>
           ),
           role: "rowheader",
-          className: "u-text--muted",
           "aria-label": "Used by",
         },
       ],
@@ -183,27 +174,29 @@ const ProfileList: FC = () => {
         })}
       >
         <div className="p-panel__header profile-list-header">
-          <h1 className="p-heading--4 u-no-margin--bottom">Profiles</h1>
-          <SearchBox
-            className="search-box margin-right u-no-margin--bottom"
-            name="search-profile"
-            type="text"
-            onChange={(value) => {
-              setQuery(value);
-            }}
-            placeholder="Search"
-            value={query}
-            aria-label="Search"
-          />
-          <Button
-            appearance="positive"
-            className={classnames("u-no-margin--bottom", {
-              "profiles-disabled": !featuresProfiles,
-            })}
-            onClick={() => navigate(`/ui/${project}/profiles/create`)}
-          >
-            Create profile
-          </Button>
+          <div className="profile-header-left">
+            <h1 className="p-heading--4 u-no-margin--bottom">Profiles</h1>
+            <SearchBox
+              className="search-box margin-right u-no-margin--bottom"
+              name="search-profile"
+              type="text"
+              onChange={(value) => {
+                setQuery(value);
+              }}
+              placeholder="Search"
+              value={query}
+              aria-label="Search"
+            />
+          </div>
+          {featuresProfiles && (
+            <Button
+              appearance="positive"
+              className="u-no-margin--bottom"
+              onClick={() => navigate(`/ui/${projectName}/profiles/create`)}
+            >
+              Create profile
+            </Button>
+          )}
         </div>
         <div className="p-panel__content profile-content">
           <NotificationRow />

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -48,7 +48,7 @@
     th,
     td {
       display: table-cell;
-      vertical-align: middle;
+      vertical-align: top;
     }
 
     th:last-child {

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -86,11 +86,6 @@
       }
     }
 
-    .created-header--collapsed {
-      display: inline-block;
-      padding-top: 1px;
-    }
-
     .name {
       min-width: 170px;
     }

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -163,34 +163,34 @@
   .p-panel {
     min-height: auto;
   }
-}
 
-.table-column-select-list {
-  min-width: 12rem;
+  .table-column-select-list {
+    min-width: 12rem;
 
-  label {
-    margin-left: 1rem;
-  }
-}
-
-// hide filters on small screens
-@media screen and (max-width: $breakpoint-large) {
-  .filter-state,
-  .filter-type,
-  .search-box {
-    display: none;
+    label {
+      margin-left: 1rem;
+    }
   }
 
-  .instance-list-header {
-    margin-bottom: 0 !important;
-  }
-}
-@media screen and (max-width: 1500px) {
-  .has-side-panel {
+  // hide filters on small screens
+  @media screen and (max-width: $breakpoint-large) {
     .filter-state,
     .filter-type,
     .search-box {
       display: none;
+    }
+
+    .instance-list-header {
+      margin-bottom: 0 !important;
+    }
+  }
+  @media screen and (max-width: 1500px) {
+    .has-side-panel {
+      .filter-state,
+      .filter-type,
+      .search-box {
+        display: none;
+      }
     }
   }
 }

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -27,8 +27,11 @@
   }
 
   .instance-content {
+    margin-top: -$spv--large;
     padding-bottom: 0;
-    padding-top: $spv--large;
+    @media screen and (max-width: $breakpoint-large) {
+      margin-top: 0;
+    }
 
     .p-notification--positive,
     .p-notification--negative {

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -164,14 +164,6 @@
     min-height: auto;
   }
 
-  .table-column-select-list {
-    min-width: 12rem;
-
-    label {
-      margin-left: 1rem;
-    }
-  }
-
   // hide filters on small screens
   @media screen and (max-width: $breakpoint-large) {
     .filter-state,
@@ -211,5 +203,13 @@
         display: none;
       }
     }
+  }
+}
+
+.table-column-select-list {
+  min-width: 12rem;
+
+  label {
+    margin-left: 1rem;
   }
 }

--- a/src/sass/_profile_list.scss
+++ b/src/sass/_profile_list.scss
@@ -16,11 +16,23 @@
     .margin-right {
       margin-right: $sph--large;
     }
+
+    .profiles-disabled {
+      visibility: hidden;
+    }
   }
 
   .profile-content {
     padding-bottom: 0;
     padding-top: $spv--large;
+
+    .p-notification--caution {
+      background-image: none;
+      border: 0;
+      margin-bottom: $spv--small;
+      margin-top: -$spv--small;
+      padding-left: $spv--large;
+    }
 
     .p-notification--positive,
     .p-notification--negative {
@@ -31,9 +43,21 @@
   .profile-table {
     margin-bottom: 0;
 
+    th,
+    td {
+      display: table-cell;
+      vertical-align: middle;
+    }
+
     td:last-child {
       padding-bottom: 0;
       padding-right: $sph--large;
+    }
+
+    th::before {
+      content: "";
+      display: inline-block;
+      height: 1rem;
     }
 
     thead,

--- a/src/sass/_profile_list.scss
+++ b/src/sass/_profile_list.scss
@@ -1,0 +1,84 @@
+.profile-list {
+  .profile-list-header {
+    display: flex;
+    justify-content: space-between;
+    margin: $spv--x-small 0 $spv--large 0;
+
+    h1 {
+      margin-right: 2rem;
+    }
+
+    .search-box {
+      max-width: 20rem;
+      width: 100%;
+    }
+
+    .margin-right {
+      margin-right: $sph--large;
+    }
+  }
+
+  .profile-content {
+    padding-bottom: 0;
+    padding-top: $spv--large;
+
+    .p-notification--positive,
+    .p-notification--negative {
+      margin-bottom: $spv--large;
+    }
+  }
+
+  .profile-table {
+    margin-bottom: 0;
+
+    td:last-child {
+      padding-bottom: 0;
+      padding-right: $sph--large;
+    }
+
+    thead,
+    tbody {
+      display: block;
+      overflow-y: auto;
+      scrollbar-gutter: stable;
+    }
+
+    tbody {
+      height: calc(100vh - 323px);
+    }
+
+    thead tr,
+    tbody tr {
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+    }
+  }
+
+  .p-pagination__items {
+    justify-content: flex-end;
+  }
+
+  .p-panel {
+    min-height: auto;
+  }
+
+  // hide search box on small screens
+  @media screen and (max-width: 860px) {
+    .search-box {
+      display: none;
+    }
+
+    .profile-list-header {
+      margin-bottom: 0 !important;
+    }
+  }
+}
+
+.l-navigation.is-collapsed + .profile-list {
+  @media screen and (min-width: 685px) {
+    .search-box {
+      display: flex;
+    }
+  }
+}

--- a/src/sass/_profile_list.scss
+++ b/src/sass/_profile_list.scss
@@ -4,10 +4,6 @@
     justify-content: space-between;
     margin: $spv--x-small 0 $spv--large 0;
 
-    h1 {
-      margin-right: 2rem;
-    }
-
     .search-box {
       max-width: 20rem;
       width: 100%;
@@ -46,7 +42,7 @@
     th,
     td {
       display: table-cell;
-      vertical-align: middle;
+      vertical-align: top;
     }
 
     td:last-child {

--- a/src/sass/_profile_list.scss
+++ b/src/sass/_profile_list.scss
@@ -4,29 +4,36 @@
     justify-content: space-between;
     margin: $spv--x-small 0 $spv--large 0;
 
-    .search-box {
-      max-width: 20rem;
-      width: 100%;
+    .profile-header-left {
+      display: flex;
+      flex-grow: 1;
+
+      h1 {
+        margin-right: 2rem;
+      }
+
+      .search-box {
+        max-width: 20rem;
+        width: 100%;
+      }
     }
 
     .margin-right {
       margin-right: $sph--large;
     }
-
-    .profiles-disabled {
-      visibility: hidden;
-    }
   }
 
   .profile-content {
+    margin-top: -$spv--large;
     padding-bottom: 0;
-    padding-top: $spv--large;
+    @media screen and (max-width: 860px) {
+      margin-top: 0;
+    }
 
     .p-notification--caution {
       background-image: none;
       border: 0;
       margin-bottom: $spv--small;
-      margin-top: -$spv--small;
       padding-left: $spv--large;
     }
 
@@ -38,17 +45,6 @@
 
   .profile-table {
     margin-bottom: 0;
-
-    th,
-    td {
-      display: table-cell;
-      vertical-align: top;
-    }
-
-    td:last-child {
-      padding-bottom: 0;
-      padding-right: $sph--large;
-    }
 
     th::before {
       content: "";

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -208,3 +208,8 @@ $border-thin: 1px solid $color-mid-light !default;
 .item-name {
   overflow-wrap: anywhere;
 }
+
+.header-second-row {
+  display: inline-block;
+  padding-top: 1px;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -62,6 +62,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "pattern_terminal";
 @import "profile_detail_overview";
 @import "profile_detail_page";
+@import "profile_list";
 @import "project_select";
 @import "selectable_main_table";
 


### PR DESCRIPTION
## Done

- Updated profile list page to match the look and feel of the instance list page
- Handled the peculiar UI differences for the default project and for projects with inherited profiles

Fixes [WD-2673](https://warthogs.atlassian.net/browse/WD-2673)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check the profile list page for the default project
    - Check the profile list page for a project with profiles enabled
    - Check the profile list page for a project with profiles disabled

[WD-2673]: https://warthogs.atlassian.net/browse/WD-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ