### PR TITLE
Hide vertical scrollbars during rerender

### DIFF
--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -103,6 +103,7 @@
     thead,
     tbody {
       display: block;
+      overflow-x: hidden;
       overflow-y: auto;
       scrollbar-gutter: stable;
     }


### PR DESCRIPTION
## Done

- hidden vertical scrollbars in the instance list, to avoid flicker when opening the side panel

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - test opening and closing of the side panel of the instance list in various screen sizes