### PR TITLE
Ensure creation form sections are active, simplify section…

### DIFF
--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -229,7 +229,7 @@ const CreateInstanceForm: FC = () => {
   };
 
   const updateSection = (newItem: string) => {
-    if (section === YAML_CONFIGURATION && newItem !== YAML_CONFIGURATION) {
+    if (Boolean(formik.values.yaml) && newItem !== YAML_CONFIGURATION) {
       void formik.setFieldValue("yaml", undefined);
     }
     setSection(newItem);

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -117,21 +117,14 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
   });
 
   const updateSection = (newSection: string) => {
-    if (
-      activeSection === slugify(YAML_CONFIGURATION) &&
-      newSection !== slugify(YAML_CONFIGURATION)
-    ) {
+    if (Boolean(formik.values.yaml) && newSection !== YAML_CONFIGURATION) {
       void formik.setFieldValue("yaml", undefined);
     }
-    if (newSection === slugify(INSTANCE_DETAILS)) {
-      navigate(
-        `/ui/${project}/instances/detail/${instance.name}/configuration`
-      );
-    } else {
-      navigate(
-        `/ui/${project}/instances/detail/${instance.name}/configuration/${newSection}`
-      );
-    }
+
+    const baseUrl = `/ui/${project}/instances/detail/${instance.name}/configuration`;
+    newSection === INSTANCE_DETAILS
+      ? navigate(baseUrl)
+      : navigate(`${baseUrl}/${slugify(newSection)}`);
   };
 
   const toggleMenu = () => {
@@ -160,7 +153,7 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
       <Form onSubmit={() => void formik.submitForm()} stacked className="form">
         <InstanceFormMenu
           active={activeSection ?? slugify(INSTANCE_DETAILS)}
-          setActive={(val) => updateSection(slugify(val))}
+          setActive={updateSection}
           isConfigDisabled={false}
           isConfigOpen={isConfigOpen}
           toggleConfigOpen={toggleMenu}

--- a/src/pages/instances/forms/FormMenuItem.tsx
+++ b/src/pages/instances/forms/FormMenuItem.tsx
@@ -13,7 +13,7 @@ const FormMenuItem: FC<Props> = ({ active, setActive, label }) => {
       <a
         className="p-side-navigation__link"
         onClick={() => setActive(label)}
-        aria-current={slugify(label) === active ? "page" : undefined}
+        aria-current={slugify(label) === slugify(active) ? "page" : undefined}
       >
         {label}
       </a>

--- a/src/pages/instances/forms/ResourceLimitsForm.tsx
+++ b/src/pages/instances/forms/ResourceLimitsForm.tsx
@@ -74,7 +74,7 @@ const ResourceLimitsForm: FC<Props> = ({ formik }) => {
           label: "Memory limit",
           defaultValue: DEFAULT_MEM_LIMIT,
           readOnlyRenderer: (val) =>
-            memoryLimitToPayload(val as MemoryLimit | undefined),
+            memoryLimitToPayload(val as MemoryLimit | undefined) ?? "-",
           children: (
             <MemoryLimitSelector
               memoryLimit={formik.values.limits_memory}

--- a/src/pages/profiles/CreateProfileForm.tsx
+++ b/src/pages/profiles/CreateProfileForm.tsx
@@ -34,7 +34,6 @@ import ResourceLimitsForm, {
   ResourceLimitsFormValues,
   resourceLimitsPayload,
 } from "pages/instances/forms/ResourceLimitsForm";
-import { DEFAULT_CPU_LIMIT, DEFAULT_MEM_LIMIT } from "util/defaults";
 import YamlForm, { YamlFormValues } from "pages/instances/forms/YamlForm";
 import { createProfile } from "api/profiles";
 import ProfileFormMenu, {
@@ -95,8 +94,6 @@ const CreateProfileForm: FC = () => {
     initialValues: {
       name: "",
       devices: [{ type: "nic", name: "" }],
-      limits_cpu: DEFAULT_CPU_LIMIT,
-      limits_memory: DEFAULT_MEM_LIMIT,
       readOnly: false,
       type: "profile",
     },
@@ -139,7 +136,7 @@ const CreateProfileForm: FC = () => {
   };
 
   const updateSection = (newItem: string) => {
-    if (section === YAML_CONFIGURATION && newItem !== YAML_CONFIGURATION) {
+    if (Boolean(formik.values.yaml) && newItem !== YAML_CONFIGURATION) {
       void formik.setFieldValue("yaml", undefined);
     }
     setSection(newItem);

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -142,19 +142,14 @@ const EditProfileForm: FC<Props> = ({ profile, featuresProfiles }) => {
   };
 
   const updateSection = (newSection: string) => {
-    if (
-      activeSection === slugify(YAML_CONFIGURATION) &&
-      newSection !== slugify(YAML_CONFIGURATION)
-    ) {
+    if (Boolean(formik.values.yaml) && newSection !== YAML_CONFIGURATION) {
       void formik.setFieldValue("yaml", undefined);
     }
-    if (newSection === slugify(PROFILE_DETAILS)) {
-      navigate(`/ui/${project}/profiles/detail/${profile.name}/configuration`);
-    } else {
-      navigate(
-        `/ui/${project}/profiles/detail/${profile.name}/configuration/${newSection}`
-      );
-    }
+
+    const baseUrl = `/ui/${project}/profiles/detail/${profile.name}/configuration`;
+    newSection === PROFILE_DETAILS
+      ? navigate(baseUrl)
+      : navigate(`${baseUrl}/${slugify(newSection)}`);
   };
 
   const toggleMenu = () => {
@@ -181,7 +176,7 @@ const EditProfileForm: FC<Props> = ({ profile, featuresProfiles }) => {
       <Form onSubmit={() => void formik.submitForm()} stacked className="form">
         <ProfileFormMenu
           active={activeSection ?? slugify(PROFILE_DETAILS)}
-          setActive={(val) => updateSection(slugify(val))}
+          setActive={updateSection}
           isConfigOpen={isConfigOpen}
           toggleConfigOpen={toggleMenu}
         />


### PR DESCRIPTION
## Done

- fixed profile and instance creation forms: active sections should be active
- simplify state handling in the forms
- fixed memory/cpu limits in creation (should not be overridded initially)
- fixed read only output of memory limits

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check profile/instance create and edit