### PR TITLE
Fixed crash happening on detail page/panel for instances without networks

### DIFF
--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -212,9 +212,8 @@ const InstanceDetailPanel: FC = () => {
                           <Link
                             to={`/ui/${instance.project}/instances/detail/${instance.name}/configuration/networks`}
                           >
-                            Configure
-                          </Link>{" "}
-                          instance networks.
+                            Configure instance networks
+                          </Link>
                         </p>
                       </td>
                     </tr>
@@ -274,9 +273,8 @@ const InstanceDetailPanel: FC = () => {
                           <Link
                             to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
                           >
-                            Manage
-                          </Link>{" "}
-                          instance snapshots.
+                            Manage instance snapshots
+                          </Link>
                         </p>
                       </td>
                     </tr>

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -44,6 +44,10 @@ const InstanceDetailPanel: FC = () => {
   const ip4Addresses = getIpAddresses("inet", instance);
   const ip6Addresses = getIpAddresses("inet6", instance);
 
+  const networkDevices = Object.values(instance?.expanded_devices ?? {}).filter(
+    isNicDevice
+  );
+
   return (
     <Aside width="narrow" pinned className="u-hide--medium u-hide--small">
       {isLoading && <Loader />}
@@ -179,11 +183,10 @@ const InstanceDetailPanel: FC = () => {
                       <h3 className="p-muted-heading p-heading--5">Networks</h3>
                     </th>
                     <td>
-                      <List
-                        className="list"
-                        items={Object.values(instance.expanded_devices)
-                          .filter(isNicDevice)
-                          .map((item) => (
+                      {networkDevices.length > 0 ? (
+                        <List
+                          className="list"
+                          items={networkDevices.map((item) => (
                             // TODO: fix this link to point to the network detail page
                             <Link
                               key={item.network}
@@ -192,7 +195,10 @@ const InstanceDetailPanel: FC = () => {
                               {item.network}
                             </Link>
                           ))}
-                      />
+                        />
+                      ) : (
+                        <>-</>
+                      )}
                     </td>
                   </tr>
                   <tr className="u-no-border">

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -178,12 +178,14 @@ const InstanceDetailPanel: FC = () => {
                       />
                     </td>
                   </tr>
-                  <tr>
-                    <th>
-                      <h3 className="p-muted-heading p-heading--5">Networks</h3>
-                    </th>
-                    <td>
-                      {networkDevices.length > 0 ? (
+                  {networkDevices.length > 0 ? (
+                    <tr>
+                      <th>
+                        <h3 className="p-muted-heading p-heading--5">
+                          Networks
+                        </h3>
+                      </th>
+                      <td>
                         <List
                           className="list"
                           items={networkDevices.map((item) => (
@@ -196,11 +198,27 @@ const InstanceDetailPanel: FC = () => {
                             </Link>
                           ))}
                         />
-                      ) : (
-                        <>-</>
-                      )}
-                    </td>
-                  </tr>
+                      </td>
+                    </tr>
+                  ) : (
+                    <tr>
+                      <td colSpan={2}>
+                        <h3 className="p-muted-heading p-heading--5">
+                          Networks
+                        </h3>
+                        <p>
+                          No networks found.
+                          <br />
+                          <Link
+                            to={`/ui/${instance.project}/instances/detail/${instance.name}/configuration/networks`}
+                          >
+                            Configure
+                          </Link>{" "}
+                          instance networks.
+                        </p>
+                      </td>
+                    </tr>
+                  )}
                   <tr className="u-no-border">
                     <th colSpan={2} className="snapshots-header">
                       <h3 className="p-muted-heading p-heading--5">

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -49,7 +49,7 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
   const networksRows = networks
     .filter((network) => instanceNetworks.includes(network.name))
     .map((network) => {
-      const interfaceNames = Object.entries(instance.expanded_devices)
+      const interfaceNames = Object.entries(instance.expanded_devices ?? {})
         .filter(
           ([_key, value]) =>
             value.type === "nic" && value.network === network.name

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -27,7 +27,7 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
     onFailure("Loading networks failed", error);
   }
 
-  const instanceNetworks = Object.values(instance.expanded_devices)
+  const instanceNetworks = Object.values(instance.expanded_devices ?? {})
     .filter(isNicDevice)
     .map((network) => network.network);
 
@@ -101,7 +101,12 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
       {isLoading ? (
         <Loader text="Loading networks..." />
       ) : (
-        <MainTable headers={networksHeaders} rows={networksRows} sortable />
+        <MainTable
+          headers={networksHeaders}
+          rows={networksRows}
+          sortable
+          emptyStateMsg="No data to display"
+        />
       )}
     </>
   );

--- a/src/pages/networks/NetworkMap.tsx
+++ b/src/pages/networks/NetworkMap.tsx
@@ -113,7 +113,7 @@ const NetworkMap: FC = () => {
 
   const edges: EdgeDefinition[] = [];
   instances.map((instance) =>
-    Object.values(instance.expanded_devices)
+    Object.values(instance.expanded_devices ?? {})
       .filter(isNicDevice)
       .map((network) => {
         edges.push({

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -87,7 +87,7 @@ export interface LxdInstance {
   devices: LxdDevices;
   ephemeral: boolean;
   expanded_config: LxdConfigPair;
-  expanded_devices: LxdDevices;
+  expanded_devices?: LxdDevices;
   last_used_at: string;
   location: string;
   name: string;


### PR DESCRIPTION
## Done

- An instance can have zero network devices. The app wasn't currently able to handle this case correctly, and was crashing when opening the side panel or the detail page of instances with no networks. This PR fixes this bug.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open the [side panel](https://lxd-ui-304.demos.haus/ui/default/instances?panel=instance-summary&instance=test-no-network&project=default) or [detail page](https://lxd-ui-304.demos.haus/ui/default/instances/detail/test-no-network) of an instance without networks.
    - Confirm that the "no networks" case is correctly handled.