### PR TITLE
Add version in main navigation WD-3409

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,7 @@ import classnames from "classnames";
 import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
 import { getProjectFromUrl } from "util/projects";
+import ServerVersion from "components/ServerVersion";
 
 const isSmallScreen = () => {
   // using the max from both, because there is a bug in chrome, causing a 0 outerWidth for
@@ -254,6 +255,7 @@ const Navigation: FC = () => {
                       Report a bug
                     </a>
                   </li>
+                  <ServerVersion />
                 </ul>
               </div>
             </div>

--- a/src/components/ServerVersion.tsx
+++ b/src/components/ServerVersion.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from "react";
+import { Icon, Tooltip } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchSettings } from "api/server";
+
+const ServerVersion: FC = () => {
+  const { data: settings } = useQuery({
+    queryKey: [queryKeys.settings],
+    queryFn: fetchSettings,
+  });
+
+  const version = settings?.environment?.server_version;
+  if (!version) {
+    return null;
+  }
+
+  const major = version.includes(".") ? version.split(".")[0] : undefined;
+  const recentMajor = 5;
+  const isOutdated = major ? parseInt(major) < recentMajor : false;
+
+  return (
+    <>
+      <hr className="p-side-navigation__list is-dark navigation-hr" />
+      <li className="p-side-navigation__link server-version">
+        {isOutdated && (
+          <Tooltip
+            message="You are using an outdated version.
+Update your LXD server to benefit from the latest features."
+            tooltipClassName="version-warning"
+            zIndex={1000}
+          >
+            <Icon name="warning" className="p-side-navigation__icon" />
+          </Tooltip>
+        )}
+        Server {version}
+      </li>
+    </>
+  );
+};
+
+export default ServerVersion;

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -68,6 +68,26 @@
   z-index: 1001;
 }
 
+.l-navigation .server-version {
+  color: $color-mid-light;
+}
+
+.l-navigation .server-version:hover {
+  background: $colors--dark-theme--background-default !important;
+  color: $color-mid-light !important;
+}
+
+.version-warning .p-tooltip__message {
+  bottom: 1rem;
+  left: -3rem;
+}
+
+@include desktop {
+  .version-warning .p-tooltip__message {
+    left: -3.5rem;
+  }
+}
+
 .sidenav-top-ul::after {
   display: none;
 }

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -5,5 +5,6 @@ export interface LxdSettings {
   config: LxdConfigPair;
   environment?: {
     architectures: string[];
+    server_version: ?string;
   };
 }


### PR DESCRIPTION
## Done

- added server version to main navigation
- added warning next to main nav in case version is too old

Fixes WD-3409

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check version is displayed correctly in the navigation