### PR TITLE
Update profiles icon [WD-2911]

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -104,7 +104,7 @@ const Navigation: FC = () => {
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
-                            name="profile"
+                            name="units"
                           />{" "}
                           Profiles
                         </NavLink>

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -28,7 +28,6 @@
 @include vf-p-icon-pods;
 @include vf-p-icon-power-off;
 @include vf-p-icon-priority-low;
-@include vf-p-icon-profile;
 @include vf-p-icon-restart;
 @include vf-p-icon-security;
 @include vf-p-icon-settings;
@@ -40,6 +39,7 @@
 @include vf-p-icon-stop;
 @include vf-p-icon-switcher-environments;
 @include vf-p-icon-task-outstanding;
+@include vf-p-icon-units;
 @include vf-p-icon-video-play;
 @include vf-p-icon-warning-grey;
 


### PR DESCRIPTION
## Done

- Updated profiles icon in the side navigation

Fixes [WD-2911](https://warthogs.atlassian.net/browse/WD-2911)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check the new icon for the "Profiles" entry in the side navigation

[WD-2911]: https://warthogs.atlassian.net/browse/WD-2911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ