### PR TITLE
Improve empty states of instances, networks, storages [WD-2915]

### DIFF
--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -84,7 +84,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
       {isGraphic && !isRunning && (
         <EmptyState
           iconName="containers"
-          iconClass="p-empty-instances"
+          iconClass="empty-instances-icon"
           title="Instance stopped"
           message="Start the instance to access the graphic console."
         >

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -333,7 +333,7 @@ const InstanceList: FC = () => {
         <div className="p-panel__header instance-list-header">
           <div className="instance-header-left">
             <h1 className="p-heading--4 u-no-margin--bottom">Instances</h1>
-            {selectedNames.length > 0 ? (
+            {selectedNames.length > 0 && (
               <>
                 <InstanceBulkActions
                   instances={instances.filter((instance) =>
@@ -351,7 +351,8 @@ const InstanceList: FC = () => {
                   <Icon name="close" className="clear-selection-icon" />
                 </Button>
               </>
-            ) : (
+            )}
+            {hasInstances && selectedNames.length === 0 && (
               <>
                 <SearchBox
                   className="search-box margin-right u-no-margin--bottom"
@@ -476,7 +477,7 @@ const InstanceList: FC = () => {
               {!hasInstances && (
                 <EmptyState
                   iconName="containers"
-                  iconClass="p-empty-instances"
+                  iconClass="empty-instances-icon"
                   title="No instances found"
                   message="There are no instances in this project. Spin up your first instance!"
                 >

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -303,7 +303,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
       ) : (
         <EmptyState
           iconName="containers"
-          iconClass="p-empty-instances"
+          iconClass="empty-instances-icon"
           title="No snapshots found"
           message={
             snapshotsDisabled ? (

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -222,7 +222,7 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
       {!isRunning && (
         <EmptyState
           iconName="containers"
-          iconClass="p-empty-instances"
+          iconClass="empty-instances-icon"
           title="Instance stopped"
           message="Start the instance to access the terminal."
         >

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Button, MainTable, Row } from "@canonical/react-components";
+import { Button, Icon, MainTable, Row } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import { fetchNetworks } from "api/networks";
 import BaseLayout from "components/BaseLayout";
@@ -8,6 +8,7 @@ import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import { useNavigate, useParams } from "react-router-dom";
 import { useNotify } from "context/notify";
+import EmptyState from "components/EmptyState";
 
 const NetworkList: FC = () => {
   const navigate = useNavigate();
@@ -30,6 +31,8 @@ const NetworkList: FC = () => {
   if (error) {
     notify.failure("Loading networks failed", error);
   }
+
+  const hasNetworks = networks.length > 0;
 
   const headers = [
     { content: "Name", sortKey: "name" },
@@ -111,31 +114,57 @@ const NetworkList: FC = () => {
       <BaseLayout
         title="Networks"
         controls={
-          <Button
-            className="u-no-margin--bottom"
-            onClick={() => navigate(`/ui/${project}/networks/map`)}
-          >
-            See map
-          </Button>
+          hasNetworks && (
+            <Button
+              className="u-no-margin--bottom"
+              onClick={() => navigate(`/ui/${project}/networks/map`)}
+            >
+              See map
+            </Button>
+          )
         }
       >
         <NotificationRow />
         <Row>
-          <MainTable
-            headers={headers}
-            rows={rows}
-            paginate={30}
-            responsive
-            sortable
-            className="u-table-layout--auto"
-            emptyStateMsg={
-              isLoading ? (
-                <Loader text="Loading networks..." />
-              ) : (
-                "No data to display"
-              )
-            }
-          />
+          {hasNetworks && (
+            <MainTable
+              headers={headers}
+              rows={rows}
+              paginate={30}
+              responsive
+              sortable
+              className="u-table-layout--auto"
+              emptyStateMsg={
+                isLoading ? (
+                  <Loader text="Loading networks..." />
+                ) : (
+                  "No data to display"
+                )
+              }
+            />
+          )}
+          {!isLoading && !hasNetworks && (
+            <EmptyState
+              iconName="connected"
+              iconClass="empty-networks-icon"
+              title="No networks found"
+              message="There are no networks in this project."
+            >
+              <>
+                <p>
+                  <a
+                    className="p-link--external"
+                    href="https://linuxcontainers.org/lxd/docs/latest/explanation/networks/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn more about networks
+                    <Icon className="external-link-icon" name="external-link" />
+                  </a>
+                </p>
+              </>
+            </EmptyState>
+          )}
         </Row>
       </BaseLayout>
     </>

--- a/src/pages/storages/StorageList.tsx
+++ b/src/pages/storages/StorageList.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { MainTable, Row } from "@canonical/react-components";
+import { Icon, MainTable, Row } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import { fetchStorages } from "api/storages";
 import BaseLayout from "components/BaseLayout";
@@ -11,6 +11,7 @@ import { Link, useParams } from "react-router-dom";
 import AddStorageBtn from "pages/storages/actions/AddStorageBtn";
 import DeleteStorageBtn from "pages/storages/actions/DeleteStorageBtn";
 import StorageSize from "pages/storages/StorageSize";
+import EmptyState from "components/EmptyState";
 
 const StorageList: FC = () => {
   const notify = useNotify();
@@ -32,6 +33,8 @@ const StorageList: FC = () => {
   if (error) {
     notify.failure("Loading storage pools failed", error);
   }
+
+  const hasStorages = storages.length > 0;
 
   const headers = [
     { content: "Name", sortKey: "name" },
@@ -102,25 +105,57 @@ const StorageList: FC = () => {
     <>
       <BaseLayout
         title="Storages"
-        controls={<AddStorageBtn project={project} />}
+        controls={
+          hasStorages && (
+            <AddStorageBtn project={project} className="u-no-margin--bottom" />
+          )
+        }
       >
         <NotificationRow />
         <Row>
-          <MainTable
-            headers={headers}
-            rows={rows}
-            paginate={30}
-            responsive
-            sortable
-            className="u-table-layout--auto"
-            emptyStateMsg={
-              isLoading ? (
-                <Loader text="Loading storages..." />
-              ) : (
-                "No data to display"
-              )
-            }
-          />
+          {hasStorages && (
+            <MainTable
+              headers={headers}
+              rows={rows}
+              paginate={30}
+              responsive
+              sortable
+              className="u-table-layout--auto"
+              emptyStateMsg={
+                isLoading ? (
+                  <Loader text="Loading storages..." />
+                ) : (
+                  "No data to display"
+                )
+              }
+            />
+          )}
+          {!isLoading && !hasStorages && (
+            <EmptyState
+              iconName="pods"
+              iconClass="empty-storages-icon"
+              title="No storages found"
+              message="There are no storages in this project."
+            >
+              <>
+                <p>
+                  <a
+                    className="p-link--external"
+                    href="https://linuxcontainers.org/lxd/docs/latest/explanation/storage/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn more about storages
+                    <Icon className="external-link-icon" name="external-link" />
+                  </a>
+                </p>
+                <AddStorageBtn
+                  project={project}
+                  className="empty-state-button"
+                />
+              </>
+            </EmptyState>
+          )}
         </Row>
       </BaseLayout>
     </>

--- a/src/pages/storages/actions/AddStorageBtn.tsx
+++ b/src/pages/storages/actions/AddStorageBtn.tsx
@@ -4,15 +4,16 @@ import usePanelParams from "util/usePanelParams";
 
 interface Props {
   project: string;
+  className?: string;
 }
 
-const AddStorageBtn: FC<Props> = ({ project }) => {
+const AddStorageBtn: FC<Props> = ({ project, className }) => {
   const panelParams = usePanelParams();
 
   return (
     <Button
       appearance="positive"
-      className="u-no-margin--bottom"
+      className={className}
       hasIcon
       onClick={() => panelParams.openStorageForm(project)}
     >

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -124,8 +124,16 @@ $border-thin: 1px solid $color-mid-light !default;
   @include vf-icon-external-link($color-link);
 }
 
-.p-empty-instances {
+.empty-instances-icon {
   @include vf-icon-containers($color-mid-light);
+}
+
+.empty-networks-icon {
+  @include vf-icon-connected($color-mid-light);
+}
+
+.empty-storages-icon {
+  @include vf-icon-pods($color-mid-light);
 }
 
 .clear-selection-icon {


### PR DESCRIPTION
## Done

- Removed search box and filters from instance list when there are no instances
- Added empty states for networks and storages lists

Fixes [WD-2915](https://warthogs.atlassian.net/browse/WD-2915)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check the empty states for instances, networks and storages list pages

[WD-2915]: https://warthogs.atlassian.net/browse/WD-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ