### PR TITLE
Add empty placeholder when there are no networks in the instance overview [WD-3317]

### DIFF
--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -31,6 +31,8 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
     .filter(isNicDevice)
     .map((network) => network.network);
 
+  const hasNetworks = instanceNetworks.length > 0;
+
   const networksHeaders = [
     { content: "Name", sortKey: "name", className: "p-muted-heading" },
     {
@@ -98,16 +100,11 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
 
   return (
     <>
-      {isLoading ? (
-        <Loader text="Loading networks..." />
-      ) : (
-        <MainTable
-          headers={networksHeaders}
-          rows={networksRows}
-          sortable
-          emptyStateMsg="No data to display"
-        />
+      {isLoading && <Loader text="Loading networks..." />}
+      {!isLoading && hasNetworks && (
+        <MainTable headers={networksHeaders} rows={networksRows} sortable />
       )}
+      {!isLoading && !hasNetworks && <>-</>}
     </>
   );
 };


### PR DESCRIPTION
## Done

- Replaced the table with the empty state message with the "-" placeholder in the instance overview tab, "Networks" section.

Fixes [WD-3317](https://warthogs.atlassian.net/browse/WD-3317)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open the instance overview of an instance with no networks, e.g. [this](https://lxd-ui-311.demos.haus/ui/default/instances/detail/test-no-network) one.
    - In the "Networks" section, check the new empty state with the "-" placeholder instead of the empty table.

[WD-3317]: https://warthogs.atlassian.net/browse/WD-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ