### PR TITLE
Fix label for bulk delete snaphots button [WD-3151]

### DIFF
--- a/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotBulkDelete.tsx
@@ -52,7 +52,8 @@ const SnapshotBulkDelete: FC<Props> = ({
       isLoading={isLoading}
       icon={isLoading ? "spinner" : undefined}
       title="Confirm delete"
-      toggleCaption="Delete"
+      toggleCaption="Delete snapshots"
+      onHoverText="Delete snapshots"
       confirmMessage={
         snapshotNames.length === 1 ? (
           <>


### PR DESCRIPTION
## Done

- Updated the label of the "Delete" button for snapshots bulk delete, to clarify its function, since there is another delete button, in the top-right of the page, to delete the instance.

Fixes [WD-3151](https://warthogs.atlassian.net/browse/WD-3151)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit the snapshot tab of an instance with snapshots
    - Select one or more snapshots
    - Check the label of the delete button (for bulk delete of snapshots)

[WD-3151]: https://warthogs.atlassian.net/browse/WD-3151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ