### PR TITLE
Make default project and profile be always first in list [WD-3190]

### DIFF
--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -23,6 +23,7 @@ import { updateTBodyHeight } from "util/updateTBodyHeight";
 import Pagination from "components/Pagination";
 import NotificationRow from "components/NotificationRow";
 import { fetchProject } from "api/projects";
+import { defaultFirst } from "util/helpers";
 
 const ProfileList: FC = () => {
   const navigate = useNavigate();
@@ -65,9 +66,7 @@ const ProfileList: FC = () => {
 
   const featuresProfiles = project?.config["features.profiles"] === "true";
 
-  profiles.sort((p1, p2) =>
-    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
-  );
+  profiles.sort(defaultFirst);
 
   const instanceCountMap = profiles.map((profile) => {
     const usedByInstances = getProfileInstances(

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -65,6 +65,10 @@ const ProfileList: FC = () => {
 
   const featuresProfiles = project?.config["features.profiles"] === "true";
 
+  profiles.sort((p1, p2) =>
+    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
+  );
+
   const instanceCountMap = profiles.map((profile) => {
     const usedByInstances = getProfileInstances(
       projectName,

--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -45,6 +45,10 @@ const ProfileSelector: FC<Props> = ({
     notify.failure("Loading profiles failed", error);
   }
 
+  profiles.sort((p1, p2) =>
+    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
+  );
+
   const unselected = profiles.filter(
     (profile) => !selected.includes(profile.name)
   );

--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -12,6 +12,7 @@ import { queryKeys } from "util/queryKeys";
 import { fetchProfiles } from "api/profiles";
 import Loader from "components/Loader";
 import { useNotify } from "context/notify";
+import { defaultFirst } from "util/helpers";
 
 interface Props {
   project: string;
@@ -45,9 +46,7 @@ const ProfileSelector: FC<Props> = ({
     notify.failure("Loading profiles failed", error);
   }
 
-  profiles.sort((p1, p2) =>
-    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
-  );
+  profiles.sort(defaultFirst);
 
   const unselected = profiles.filter(
     (profile) => !selected.includes(profile.name)

--- a/src/pages/projects/ProjectSelector.tsx
+++ b/src/pages/projects/ProjectSelector.tsx
@@ -10,6 +10,7 @@ import { queryKeys } from "util/queryKeys";
 import { fetchProjects } from "api/projects";
 import { useNavigate } from "react-router-dom";
 import ProjectSelectorList from "pages/projects/ProjectSelectorList";
+import { defaultFirst } from "util/helpers";
 
 interface Props {
   activeProject: string;
@@ -24,9 +25,7 @@ const ProjectSelector: FC<Props> = ({ activeProject }): JSX.Element => {
     queryFn: () => fetchProjects(1),
   });
 
-  projects.sort((p1, p2) =>
-    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
-  );
+  projects.sort(defaultFirst);
 
   let updateQuery = (_val: string) => {
     /**/

--- a/src/pages/projects/ProjectSelector.tsx
+++ b/src/pages/projects/ProjectSelector.tsx
@@ -24,6 +24,10 @@ const ProjectSelector: FC<Props> = ({ activeProject }): JSX.Element => {
     queryFn: () => fetchProjects(1),
   });
 
+  projects.sort((p1, p2) =>
+    p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0
+  );
+
   let updateQuery = (_val: string) => {
     /**/
   };

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -155,3 +155,6 @@ export const getUrlParam = (paramName: string, url?: string): string | null => {
 
   return browserUrl.searchParams.get(paramName);
 };
+
+export const defaultFirst = (p1: { name: string }, p2: { name: string }) =>
+  p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0;


### PR DESCRIPTION
## Done

- Made default project and profile appear as the first item of their respective lists.

Fixes [WD-3190](https://warthogs.atlassian.net/browse/WD-3190)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open the project selector
    - Check that the default project is at the top of the list
    - Open the profiles list
    - Check that the default profile is at the top of the list (with default table sorting)
    - Open the profile selector in instance creation/edit form (dropdown)
    - Check that the default profile is at the top of the dropdown list

[WD-3190]: https://warthogs.atlassian.net/browse/WD-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ