### PR TITLE
Adjust styling of the authentication page WD-3436

### DIFF
--- a/src/pages/certificates/BrowserImport.tsx
+++ b/src/pages/certificates/BrowserImport.tsx
@@ -22,7 +22,7 @@ const BrowserImport: FC = () => {
 
         {activeTab === FIREFOX && (
           <div tabIndex={0} role="tabpanel" aria-label="firefox">
-            <ul className="p-list--divided">
+            <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste this link into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
@@ -40,7 +40,8 @@ const BrowserImport: FC = () => {
                 <code>Import</code>.
               </li>
               <li className="p-list__item">
-                Select the <code>lxd-ui.pfx</code> file you just downloaded
+                Select the <code>lxd-ui.pfx</code> file you just downloaded.
+                Confirm an empty password.
               </li>
             </ul>
           </div>
@@ -48,7 +49,7 @@ const BrowserImport: FC = () => {
 
         {activeTab === CHROME_LINUX && (
           <div tabIndex={1} role="tabpanel" aria-label="chrome linux">
-            <ul className="p-list--divided">
+            <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
@@ -59,8 +60,9 @@ const BrowserImport: FC = () => {
               </li>
 
               <li className="p-list__item">
-                Click the blue <code>Import</code> button and select the{" "}
-                <code>lxd-ui.pfx</code> file you just downloaded
+                Click the <code>Import</code> button and select the{" "}
+                <code>lxd-ui.pfx</code> file you just downloaded. Confirm an
+                empty password.
               </li>
             </ul>
           </div>
@@ -68,7 +70,7 @@ const BrowserImport: FC = () => {
 
         {activeTab === CHROME_WINDOWS && (
           <div tabIndex={1} role="tabpanel" aria-label="chrome windows">
-            <ul className="p-list--divided">
+            <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
@@ -83,7 +85,8 @@ const BrowserImport: FC = () => {
               </li>
               <li className="p-list__item">
                 Click the <code>Import</code> button and select the{" "}
-                <code>lxd-ui.pfx</code> file you just downloaded
+                <code>lxd-ui.pfx</code> file you just downloaded. Confirm an
+                empty password.
               </li>
             </ul>
           </div>

--- a/src/pages/certificates/CertificateGenerate.tsx
+++ b/src/pages/certificates/CertificateGenerate.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState } from "react";
 import { generateCert } from "util/certificate";
 import { Button, Col, Icon, Row } from "@canonical/react-components";
-import BaseLayout from "components/BaseLayout";
 import BrowserImport from "pages/certificates/BrowserImport";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "context/auth";
@@ -55,97 +54,123 @@ const CertificateGenerate: FC = () => {
   };
 
   return (
-    <BaseLayout title="Certificate generation">
-      <Row className="p-certificate-generate">
-        <ol className="p-stepped-list">
-          <li className="p-stepped-list__item">
-            <Row>
-              <Col size={8}>
-                <h3 className="p-stepped-list__title">Generate</h3>
-                <div className="p-stepped-list__content">
-                  <p>Click generate to create a new certificate</p>
-                </div>
-              </Col>
-              <Col size={4}>
-                <Button
-                  className="u-certificate-button"
-                  onClick={createCert}
-                  appearance="positive"
-                  disabled={isGenerating || certs !== null}
-                  hasIcon={isGenerating}
-                  aria-label={`${
-                    isGenerating ? "Generating" : "Generate"
-                  } certificate`}
-                >
-                  {isGenerating && (
-                    <Icon
-                      className="is-light u-animation--spin"
-                      name="spinner"
-                    />
-                  )}
-                  <span>{isGenerating ? "Generating" : "Generate"}</span>
-                </Button>
-              </Col>
-            </Row>
-          </li>
-          <li className="p-stepped-list__item">
-            <Row>
-              <Col size={8}>
-                <h3 className="p-stepped-list__title">Trust</h3>
-                <div className="p-stepped-list__content">
-                  Download <code>lxd-ui.crt</code> and add it to the LXD trust
-                  store
-                  <div className="p-code-snippet">
-                    <pre className="p-code-snippet__block--icon">
-                      <code>lxc config trust add Downloads/lxd-ui.crt</code>{" "}
-                    </pre>
-                  </div>
-                </div>
-              </Col>
-              <Col size={4}>
-                {certs && (
-                  <Button
-                    className="u-certificate-button"
-                    onClick={() => downloadText("lxd-ui.crt", certs.crt)}
-                  >
-                    Download crt
-                  </Button>
-                )}
-              </Col>
-            </Row>
-          </li>
-          <li className="p-stepped-list__item">
-            <Row>
-              <Col size={8}>
-                <h3 className="p-stepped-list__title">Import</h3>
-                <div className="p-stepped-list__content">
-                  <p>
-                    Download <code>lxd-ui.pfx</code> and import it into your
-                    browser.
-                  </p>
-                  <BrowserImport />
-                </div>
-              </Col>
-              <Col size={4}>
-                {certs && (
-                  <Button
-                    className="u-certificate-button"
-                    onClick={() => downloadBase64("lxd-ui.pfx", certs.pfx)}
-                  >
-                    Download pfx
-                  </Button>
-                )}
-              </Col>
-            </Row>
-          </li>
-          <li className="p-stepped-list__item">
-            <h3 className="p-stepped-list__title">
-              All done <Icon name="success" />
-            </h3>
-          </li>
-        </ol>
-      </Row>
-    </BaseLayout>
+    <main className="l-main certificate-generate">
+      <div className="p-panel">
+        <div className="p-panel__header is-sticky">
+          <h1 className="p-panel__title">Setup LXD UI</h1>
+        </div>
+        <div className="p-panel__content">
+          <Row className="u-no-margin--left">
+            <Col size={12}>
+              <ol className="p-stepped-list--detailed">
+                <li className="p-stepped-list__item">
+                  <Row>
+                    <Col size={3}>
+                      <h3 className="p-stepped-list__title">Generate</h3>
+                    </Col>
+                    <Col size={6}>
+                      <div className="p-stepped-list__content">
+                        <p>Create a new certificate</p>
+                      </div>
+                    </Col>
+                    <Col size={3}>
+                      <Button
+                        onClick={createCert}
+                        appearance="positive"
+                        disabled={isGenerating || certs !== null}
+                        hasIcon={isGenerating}
+                        aria-label={`${
+                          isGenerating ? "Generating" : "Generate"
+                        } certificate`}
+                      >
+                        {isGenerating && (
+                          <Icon
+                            className="is-light u-animation--spin"
+                            name="spinner"
+                          />
+                        )}
+                        <span>{isGenerating ? "Generating" : "Generate"}</span>
+                      </Button>
+                      {certs !== null && <Icon name="success" />}
+                    </Col>
+                  </Row>
+                </li>
+                <li className="p-stepped-list__item">
+                  <Row>
+                    <Col size={3}>
+                      <h3 className="p-stepped-list__title">Trust</h3>
+                    </Col>
+                    <Col size={6}>
+                      <div className="p-stepped-list__content">
+                        <p>
+                          Download <code>lxd-ui.crt</code> and add it to the LXD
+                          trust store
+                        </p>
+                        <div className="p-code-snippet">
+                          <pre className="p-code-snippet__block--icon">
+                            <code>
+                              lxc config trust add Downloads/lxd-ui.crt
+                            </code>
+                          </pre>
+                        </div>
+                      </div>
+                    </Col>
+                    {certs && (
+                      <Col size={3}>
+                        <Button
+                          onClick={() => downloadText("lxd-ui.crt", certs.crt)}
+                        >
+                          Download crt
+                        </Button>
+                      </Col>
+                    )}
+                  </Row>
+                </li>
+                <li className="p-stepped-list__item">
+                  <Row>
+                    <Col size={3}>
+                      <h3 className="p-stepped-list__title">Import</h3>
+                    </Col>
+                    <Col size={6}>
+                      <div className="p-stepped-list__content">
+                        <p>
+                          Download <code>lxd-ui.pfx</code> and import it into
+                          your browser.
+                        </p>
+                        <BrowserImport />
+                      </div>
+                    </Col>
+                    {certs && (
+                      <Col size={3}>
+                        <Button
+                          onClick={() =>
+                            downloadBase64("lxd-ui.pfx", certs.pfx)
+                          }
+                        >
+                          Download pfx
+                        </Button>
+                      </Col>
+                    )}
+                  </Row>
+                </li>
+                <li className="p-stepped-list__item u-no-margin--bottom">
+                  <Row>
+                    <Col size={3}>
+                      <h3 className="p-stepped-list__title">Done</h3>
+                    </Col>
+                    <Col size={6}>
+                      <div className="p-stepped-list__content">
+                        <p>Enjoy LXD UI.</p>
+                      </div>
+                    </Col>
+                  </Row>
+                </li>
+              </ol>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </main>
   );
 };
 

--- a/src/pages/certificates/CertificateMain.tsx
+++ b/src/pages/certificates/CertificateMain.tsx
@@ -1,8 +1,10 @@
 import React, { FC } from "react";
-import { Row, Col, Button } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
 import { Navigate, useNavigate } from "react-router-dom";
 import { useAuth } from "context/auth";
 import Loader from "components/Loader";
+import BaseLayout from "components/BaseLayout";
+import EmptyState from "components/EmptyState";
 
 const CertificateMain: FC = () => {
   const { isAuthenticated, isAuthLoading } = useAuth();
@@ -17,24 +19,21 @@ const CertificateMain: FC = () => {
   }
 
   return (
-    <main className="l-main">
-      <div className="p-strip">
-        <Row className="certificate-main">
-          <Col size={12}>
-            <h1>LXD UI</h1>
-            <p>
-              A valid certificate is needed to access the UI from your browser.
-            </p>
-            <Button
-              appearance="positive"
-              onClick={() => navigate("/ui/certificates/generate")}
-            >
-              Setup certificates
-            </Button>
-          </Col>
-        </Row>
-      </div>
-    </main>
+    <BaseLayout title="">
+      <EmptyState
+        iconName="containers"
+        iconClass="lxd-icon"
+        title="LXD UI"
+        message="To access the user interface, create a certificate."
+      >
+        <Button
+          appearance="positive"
+          onClick={() => navigate("/ui/certificates/generate")}
+        >
+          Setup
+        </Button>
+      </EmptyState>
+    </BaseLayout>
   );
 };
 

--- a/src/sass/_certificates.scss
+++ b/src/sass/_certificates.scss
@@ -1,0 +1,19 @@
+.certificate-generate {
+  .p-panel__header {
+    background: white;
+    z-index: 10;
+  }
+
+  .p-panel__content {
+    max-width: 65rem !important;
+    padding-bottom: 0;
+
+    .p-list__item:first-child {
+      box-shadow: none;
+    }
+
+    .p-stepped-list__item:first-child::after {
+      display: none;
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -45,6 +45,7 @@
 
 $border-thin: 1px solid $color-mid-light !default;
 
+@import "certificates";
 @import "configuration_table";
 @import "empty_state";
 @import "file_row";
@@ -94,18 +95,6 @@ $border-thin: 1px solid $color-mid-light !default;
   margin: $sp-large;
 }
 
-.certificate-main {
-  padding-left: 2rem;
-
-  @include large {
-    padding-left: 4rem;
-  }
-}
-
-.p-certificate-generate {
-  max-width: 57rem !important;
-}
-
 .p-bottom-controls {
   background-color: white;
   bottom: 0;
@@ -136,6 +125,10 @@ $border-thin: 1px solid $color-mid-light !default;
   @include vf-icon-pods($color-mid-light);
 }
 
+.lxd-icon {
+  background-image: url("data:image/svg+xml,%0A%3Csvg width='38' height='38' viewBox='0 0 38 38' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M28.5311 15.7998V5.71128L18.6554 0L8.77977 5.71128V15.7998L0 20.8683V32.2887L9.87566 38L18.6554 32.9083L27.4352 37.9768L37.3108 32.2655V20.8451L28.5311 15.7998ZM18.6554 2.57113L26.3182 6.99684V15.7998L18.6554 20.2487L10.9694 15.823V7.02002L18.6554 2.57113ZM9.87566 35.431L2.21286 31.0053V22.1538L9.85037 17.7513L17.5595 22.2002V31.0032L9.87355 35.4289L9.87566 35.431ZM35.098 31.0053L27.4352 35.431L19.7724 31.0053V22.2023L27.4816 17.7534L35.1191 22.156V31.0074H35.0959L35.098 31.0053Z' fill='%23D9D9D9'/%3E%3Cpath d='M28.1978 31.9072L32.4085 29.4099V24.4594L28.1978 26.9357V31.9072Z' fill='%23D9D9D9'/%3E%3Cpath d='M27.4119 20.7966L23.2012 23.2223L27.4372 25.627L31.648 23.1507L27.4119 20.7966Z' fill='%23D9D9D9'/%3E%3Cpath d='M22.4635 29.4816L26.6995 31.9558V26.9357L22.415 24.5311L22.4635 29.4816Z' fill='%23D9D9D9'/%3E%3Cpath d='M9.85235 20.7966L5.6416 23.2223L9.87553 25.627L14.0884 23.1507L9.85235 20.7966Z' fill='%23D9D9D9'/%3E%3Cpath d='M4.90371 29.4816L9.13764 31.9558V26.9357L4.87842 24.5311L4.90371 29.4816Z' fill='%23D9D9D9'/%3E%3Cpath d='M10.6387 31.9072L14.8726 29.4099V24.4594L10.6387 26.9357V31.9072Z' fill='%23D9D9D9'/%3E%3Cpath d='M22.8455 7.97052L18.6326 5.63965L14.4219 8.06536L18.6326 10.4447L22.8455 7.97052Z' fill='%23D9D9D9'/%3E%3Cpath d='M17.8946 16.7755V11.7534L13.6606 9.35083L13.6838 14.3245L17.8946 16.7755Z' fill='%23D9D9D9'/%3E%3Cpath d='M19.3955 16.7503L23.6294 14.2529V9.2561L19.3955 11.7535V16.7503Z' fill='%23D9D9D9'/%3E%3C/svg%3E%0A");
+}
+
 .clear-selection-icon {
   @include vf-icon-close($color-link);
 }
@@ -158,12 +151,6 @@ $border-thin: 1px solid $color-mid-light !default;
 
   & > *:last-child {
     border-right: none;
-  }
-}
-
-@include mobile-and-tablet {
-  .u-certificate-button {
-    margin-left: 2.5rem;
   }
 }
 


### PR DESCRIPTION
## Done

- adjusted layout of the certificate generation page

Fixes [WD-3436](https://warthogs.atlassian.net/browse/WD-3436)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check the certificate generation page

[WD-3436]: https://warthogs.atlassian.net/browse/WD-3436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ