### PR TITLE
Fx some issues with a11y

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -20,7 +20,7 @@ const EmptyState: FC<Props> = ({
     <Row className="empty-state">
       <Col size={6} className="col-start-large-4">
         <Icon name={iconName} className={`empty-state-icon ${iconClass}`} />
-        <h4>{title}</h4>
+        <h2 className="p-heading--4">{title}</h2>
         <p>{message}</p>
         {children}
       </Col>

--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -59,12 +59,11 @@ const SelectableMainTable: FC<Props> = ({
       content: (
         <>
           <CheckboxInput
-            label=""
+            label={<div className="u-off-screen">Select all</div>}
             labelClassName="multiselect-checkbox"
             checked={isAllSelected}
             indeterminate={isSomeSelected && !isAllSelected}
             onChange={isSomeSelected ? selectNone : selectPage}
-            aria-label="Select all"
           />
           <ContextualMenu
             position="left"
@@ -108,12 +107,13 @@ const SelectableMainTable: FC<Props> = ({
       {
         content: (
           <CheckboxInput
-            label=""
+            label={
+              <div className="u-off-screen">Select {row.name ?? "row"}</div>
+            }
             labelClassName="u-no-margin--bottom"
             checked={isRowSelected}
             onChange={toggleRow}
             disabled={isRowProcessing}
-            aria-label={`Select ${row.name ?? ""}`}
           />
         ),
         role: "rowheader",

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -114,7 +114,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
       className: "expiration",
     },
     { content: "Stateful", sortKey: "stateful", className: "stateful" },
-    { content: "", className: "actions" },
+    { "aria-label": "Actions", className: "actions" },
   ];
 
   const rows = filteredSnapshots.map((snapshot) => {


### PR DESCRIPTION
## Done

- fixed a11y issue with labels for selectable table
- fixed heading hierarchy for empty state
- fixed column heading for snapshots table

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - test the changed pages are still good.