### PR TITLE
404 page overhaul [WD-3149]

### DIFF
--- a/src/components/NoMatch.tsx
+++ b/src/components/NoMatch.tsx
@@ -1,12 +1,29 @@
 import React, { FC } from "react";
-import { Strip } from "@canonical/react-components";
+import { Row, Col } from "@canonical/react-components";
 
 const NoMatch: FC = () => {
   return (
-    <Strip>
-      <h1>Page not found</h1>
-      <p className="p-heading--4">Sorry, we could not find that page</p>
-    </Strip>
+    <main className="l-main no-match">
+      <Row>
+        <Col size={6} className="col-start-large-4">
+          <h1 className="p-heading--4">404 Page not found</h1>
+          <p>
+            Sorry, we cannot find the page that you are looking for.
+            <br />
+            If you think this is an error in our product, please{" "}
+            <a
+              href="https://github.com/canonical/lxd-ui/issues/new"
+              target="_blank"
+              rel="noreferrer"
+              title="Report a bug"
+            >
+              Report a bug
+            </a>
+            .
+          </p>
+        </Col>
+      </Row>
+    </main>
   );
 };
 

--- a/src/sass/_no_match.scss
+++ b/src/sass/_no_match.scss
@@ -1,0 +1,15 @@
+.no-match {
+  margin-top: 3.75rem;
+
+  @include large {
+    margin-top: 4.5rem;
+  }
+
+  h1 {
+    margin-bottom: $spv--x-small;
+  }
+
+  p {
+    padding-top: 0;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -58,6 +58,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "instance_list";
 @import "meter";
 @import "network_map";
+@import "no_match";
 @import "pagination";
 @import "pattern_navigation";
 @import "pattern_terminal";


### PR DESCRIPTION
## Done

- Adjusted the 404 page to the new design.

Fixes [WD-3149](https://warthogs.atlassian.net/browse/WD-3149)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit any random nonexistent page, e.g. [this](https://lxd-ui-317.demos.haus/dgfdgdf)
    - Check the new design of the 404 page

[WD-3149]: https://warthogs.atlassian.net/browse/WD-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ