### PR TITLE
Use search and filter component for the instance list [WD-3189]

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -7,12 +7,10 @@ import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
 import { getProjectFromUrl } from "util/projects";
 import ServerVersion from "components/ServerVersion";
+import useEventListener from "@use-it/event-listener";
+import { isWidthBelow } from "util/helpers";
 
-const isSmallScreen = () => {
-  // using the max from both, because there is a bug in chrome, causing a 0 outerWidth for
-  // background tabs: https://bugs.chromium.org/p/chromium/issues/detail?id=719296
-  return Math.max(window.outerWidth, window.innerWidth) < 620;
-};
+const isSmallScreen = () => isWidthBelow(620);
 
 const Navigation: FC = () => {
   const location = useLocation();
@@ -30,6 +28,12 @@ const Navigation: FC = () => {
     setMenuCollapsed((prev) => !prev);
     e.stopPropagation();
   };
+
+  const collapseOnMediumScreen = () => {
+    setMenuCollapsed(isWidthBelow(820));
+  };
+
+  useEventListener("resize", collapseOnMediumScreen);
 
   return (
     <>

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -1,0 +1,78 @@
+import React, { FC } from "react";
+import { LxdInstance, LxdInstanceStatus } from "types/instance";
+import {
+  InstanceFilters,
+  enrichStatuses,
+  instanceStatuses,
+  instanceTypes,
+} from "util/instanceFilter";
+import { SearchAndFilter } from "@canonical/react-components";
+import {
+  SearchAndFilterData,
+  SearchAndFilterChip,
+} from "@canonical/react-components/dist/components/SearchAndFilter/types";
+
+interface Props {
+  instances: LxdInstance[];
+  setFilters: (newFilters: InstanceFilters) => void;
+}
+
+const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
+  const profileSet = [
+    ...new Set(instances.flatMap((instance) => instance.profiles)),
+  ];
+
+  const searchAndFilterData: SearchAndFilterData[] = [
+    {
+      id: 1,
+      heading: "Status",
+      chips: instanceStatuses.map((status) => {
+        return { lead: "status", value: status };
+      }),
+    },
+    {
+      id: 2,
+      heading: "Instance type",
+      chips: instanceTypes.map((type) => {
+        return { lead: "type", value: type };
+      }),
+    },
+    {
+      id: 3,
+      heading: "Profile",
+      chips: profileSet.map((profile) => {
+        return { lead: "profile", value: profile };
+      }),
+    },
+  ];
+
+  const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
+    setFilters({
+      queries: searchData
+        .filter((chip) => chip.quoteValue)
+        .map((chip) => chip.value.toLowerCase()),
+      statuses: enrichStatuses(
+        searchData
+          .filter((chip) => chip.lead === "status")
+          .map((chip) => chip.value as LxdInstanceStatus)
+      ),
+      types: searchData
+        .filter((chip) => chip.lead === "type")
+        .map((chip) => (chip.value === "VM" ? "virtual-machine" : "container")),
+      profileQueries: searchData
+        .filter((chip) => chip.lead === "profile")
+        .map((chip) => chip.value),
+    });
+  };
+
+  return (
+    <div className="search-wrapper margin-right u-no-margin--bottom">
+      <SearchAndFilter
+        filterPanelData={searchAndFilterData}
+        returnSearchData={onSearchDataChange}
+      />
+    </div>
+  );
+};
+
+export default React.memo(InstanceSearchFilter);

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -41,14 +41,14 @@
 
     .instance-header-left {
       display: flex;
-      flex-grow: 1;
+      flex: 2;
 
       h1 {
         margin-right: 2rem;
       }
 
-      .search-box {
-        max-width: 20rem;
+      .search-wrapper {
+        max-width: 70vw;
         width: 100%;
       }
     }
@@ -57,8 +57,21 @@
       margin-right: $sph--large;
     }
 
-    .filter-type {
-      min-width: 183px;
+    .create-button-wrapper {
+      align-self: flex-start;
+      flex: 1;
+    }
+  }
+
+  @media screen and (min-width: $breakpoint-large) and (max-width: 1135px) {
+    .has-side-panel {
+      .instance-header-left {
+        flex: 1;
+
+        .search-wrapper {
+          display: none;
+        }
+      }
     }
   }
 
@@ -212,44 +225,19 @@
   .p-panel {
     min-height: auto;
   }
-
-  // hide filters on small screens
-  @media screen and (max-width: $breakpoint-large) {
-    .filter-state,
-    .filter-type,
-    .search-box {
-      display: none;
-    }
-
-    .instance-list-header {
-      margin-bottom: 0 !important;
-    }
-  }
-  @media screen and (max-width: 1500px) {
-    .has-side-panel {
-      .filter-state,
-      .filter-type,
-      .search-box {
-        display: none;
-      }
-    }
-  }
 }
 
 .l-navigation.is-collapsed + .instance-list {
-  @media screen and (min-width: 900px) {
-    .filter-state,
-    .filter-type,
-    .search-box {
-      display: flex;
-    }
+  .search-wrapper {
+    max-width: 80vw;
   }
-  @media screen and (max-width: 1250px) {
-    .has-side-panel {
-      .filter-state,
-      .filter-type,
-      .search-box {
-        display: none;
+
+  .has-side-panel {
+    .instance-header-left {
+      flex: 2;
+
+      .search-wrapper {
+        display: initial;
       }
     }
   }

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -51,6 +51,11 @@
         max-width: 70vw;
         width: 100%;
       }
+
+      .p-search-and-filter__panel {
+        min-width: 100%;
+        width: 45vw;
+      }
     }
 
     .margin-right {
@@ -229,7 +234,11 @@
 
 .l-navigation.is-collapsed + .instance-list {
   .search-wrapper {
-    max-width: 80vw;
+    width: 50vw;
+  }
+
+  .p-search-and-filter__panel {
+    width: 130% !important;
   }
 
   .has-side-panel {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -158,3 +158,9 @@ export const getUrlParam = (paramName: string, url?: string): string | null => {
 
 export const defaultFirst = (p1: { name: string }, p2: { name: string }) =>
   p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0;
+
+export const isWidthBelow = (width: number) => {
+  // using the max from both, because there is a bug in chrome, causing a 0 outerWidth for
+  // background tabs: https://bugs.chromium.org/p/chromium/issues/detail?id=719296
+  return Math.max(window.outerWidth, window.innerWidth) < width;
+};

--- a/src/util/instanceFilter.tsx
+++ b/src/util/instanceFilter.tsx
@@ -1,0 +1,31 @@
+import { LxdInstanceStatus } from "types/instance";
+
+export interface InstanceFilters {
+  queries: string[];
+  statuses: LxdInstanceStatus[];
+  types: string[];
+  profileQueries: string[];
+}
+
+export const instanceStatuses: LxdInstanceStatus[] = [
+  "Running",
+  "Stopped",
+  "Frozen",
+  "Error",
+];
+
+export const instanceTypes: string[] = ["Container", "VM"];
+
+export const enrichStatuses = (statuses: LxdInstanceStatus[]) => {
+  if (statuses.includes("Frozen")) {
+    statuses.push("Freezing");
+  }
+  if (statuses.includes("Running")) {
+    statuses.push(...(["Restarting", "Starting"] as LxdInstanceStatus[]));
+  }
+  if (statuses.includes("Stopped")) {
+    statuses.push("Stopping");
+  }
+
+  return statuses;
+};

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -1,14 +1,3 @@
-export const instanceListTypes = [
-  {
-    label: "Containers",
-    value: "container",
-  },
-  {
-    label: "VMs",
-    value: "virtual-machine",
-  },
-];
-
 export const instanceCreationTypes = [
   {
     label: "Container",
@@ -17,17 +6,6 @@ export const instanceCreationTypes = [
   {
     label: "VM",
     value: "virtual-machine",
-  },
-];
-
-export const instanceStatuses = [
-  {
-    label: "Running",
-    value: "Running",
-  },
-  {
-    label: "Stopped",
-    value: "Stopped",
   },
 ];
 


### PR DESCRIPTION
## Done

- Combines the previous search box + dropdown filters into a single "Search and filter" component.
- Allows filtering by instance status, type, and applied profile.

Fixes [WD-3189](https://warthogs.atlassian.net/browse/WD-3189)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit any instance list page
    - Check the behaviour and the look-and-feel of the new search and filter component in the header

[WD-3189]: https://warthogs.atlassian.net/browse/WD-3189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ