### PR TITLE
Fix sticky behaviour in the side panel, remove legacy vanilla spacing units

### DIFF
--- a/src/components/DetailPanel.tsx
+++ b/src/components/DetailPanel.tsx
@@ -1,11 +1,9 @@
-import React, { FC, ReactNode, useEffect } from "react";
+import React, { FC, ReactNode } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import classnames from "classnames";
 import Aside from "./Aside";
 import Loader from "./Loader";
 import usePanelParams from "util/usePanelParams";
-import useEventListener from "@use-it/event-listener";
-import { updateMaxHeight } from "util/updateMaxHeight";
 
 interface Props {
   title: string;
@@ -26,36 +24,30 @@ const DetailPanel: FC<Props> = ({
 }) => {
   const panelParams = usePanelParams();
 
-  const updateContentHeight = () => {
-    updateMaxHeight("content-scroll");
-  };
-  useEffect(updateContentHeight, []);
-  useEventListener("resize", updateContentHeight);
-
   return (
     <Aside width="narrow" pinned className="u-hide--medium u-hide--small">
       {isLoading && <Loader />}
       {!isLoading && hasLoadingError && <>Loading failed</>}
       {!hasLoadingError && (
         <div className={classnames("p-panel", "detail-panel", className)}>
-          <div className="p-panel__header">
-            <h2 className="p-panel__title">{title}</h2>
-            <div className="p-panel__controls">
-              <Button
-                appearance="base"
-                className="u-no-margin--bottom"
-                hasIcon
-                onClick={panelParams.clear}
-                aria-label="Close"
-              >
-                <Icon name="close" />
-              </Button>
+          <div className="sticky-wrapper">
+            <div className="p-panel__header">
+              <h2 className="p-panel__title">{title}</h2>
+              <div className="p-panel__controls">
+                <Button
+                  appearance="base"
+                  className="u-no-margin--bottom"
+                  hasIcon
+                  onClick={panelParams.clear}
+                  aria-label="Close"
+                >
+                  <Icon name="close" />
+                </Button>
+              </div>
             </div>
-          </div>
-          <div className="p-panel__content panel-content">
             {actions}
-            <div className="content-scroll">{children}</div>
           </div>
+          <div className="p-panel__content">{children}</div>
         </div>
       )}
     </Aside>

--- a/src/sass/_detail_panels.scss
+++ b/src/sass/_detail_panels.scss
@@ -1,11 +1,18 @@
 .detail-panel {
+  .sticky-wrapper {
+    background: white;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
   .row {
     padding-left: 0;
     padding-right: 0;
   }
 
-  .panel-content {
-    margin-left: $sp-large;
+  .p-panel__content {
+    margin-left: $sph--x-large;
     padding-bottom: 0;
   }
 
@@ -19,23 +26,17 @@
 
   th {
     max-width: 9rem;
-    padding: $sp-x-small $sp-x-small $sp-x-small 0 !important;
+    padding: $spv--x-small $sph--x-small $spv--x-small 0 !important;
     width: 9rem;
   }
 
   td {
     max-width: 12.65rem;
-    padding: $sp-x-small $sp-x-small $sp-x-small 0 !important;
+    padding: $spv--x-small $sph--x-small $spv--x-small 0 !important;
   }
 
   tr {
     border-bottom: $border-thin;
     border-color: $color-mid-x-light;
-  }
-
-  .content-scroll {
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding-right: $sp-large;
   }
 }

--- a/src/sass/_empty_state.scss
+++ b/src/sass/_empty_state.scss
@@ -2,10 +2,10 @@
   margin-top: min(5vh, $spv--strip-regular);
 
   .empty-state-icon {
-    height: $sp-xx-large;
+    height: 2.5rem;
     margin-bottom: $spv--large;
     margin-top: $spv--x-large;
-    width: $sp-xx-large;
+    width: 2.5rem;
   }
 
   h4 {

--- a/src/sass/_file_row.scss
+++ b/src/sass/_file_row.scss
@@ -3,7 +3,7 @@
     align-items: center;
     display: flex;
     justify-content: flex-start;
-    padding: $sp-small;
+    padding: $spv--small $sph--small $spv--small $sph--small;
 
     .file-row-toggle {
       flex-grow: 1;

--- a/src/sass/_instance_detail_panel.scss
+++ b/src/sass/_instance_detail_panel.scss
@@ -1,13 +1,17 @@
 .instance-detail-panel {
-  .panel-content {
-    .actions {
-      display: flex;
-      margin-right: $sp-large;
+  .actions {
+    display: flex;
+    margin-left: $sph--x-large;
+    margin-right: $sph--x-large;
+    padding-top: $spv--x-large;
 
-      .primary {
-        flex-grow: 1;
-      }
+    .primary {
+      flex-grow: 1;
     }
+  }
+
+  .p-panel__content {
+    padding-top: 0;
   }
 
   .base-image,

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -99,7 +99,7 @@
 .sidenav-toggle-wrapper {
   background: $colors--dark-theme--background-default;
   bottom: 0;
-  padding: $spv--small $sph--x-large $sp-medium $sp-medium;
+  padding: $spv--small $sph--x-large $spv--large $sph--large;
   position: sticky;
   text-align: right;
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -96,7 +96,7 @@ $border-thin: 1px solid $color-mid-light !default;
 }
 
 .u-loader {
-  margin: $sp-large;
+  margin: $spv--x-large $sph--x-large $spv--x-large $sph--x-large;
 }
 
 .p-bottom-controls {
@@ -185,7 +185,7 @@ $border-thin: 1px solid $color-mid-light !default;
   }
 
   .p-breadcrumbs__item:first-of-type {
-    margin-right: $sp-x-small;
+    margin-right: $sph--x-small;
   }
 }
 


### PR DESCRIPTION
## Done

- Fixed the behaviour of the header and actions in the side panel by using CSS position instead of dynamic height updates
- Replaced legacy vanilla spacing units with current ones

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check that the header (+ actions, for instances) in the side panel is sticky