### PR TITLE
Fix storage cache key for detail page #325

### DIFF
--- a/src/pages/storages/StorageDetail.tsx
+++ b/src/pages/storages/StorageDetail.tsx
@@ -30,7 +30,7 @@ const StorageDetail: FC = () => {
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.storage, name],
+    queryKey: [queryKeys.storage, project, name],
     queryFn: () => fetchStorage(name, project),
   });
 


### PR DESCRIPTION
## Done

- fixed bug when stoarge pool has same name as project and switching back and forth from storage list and detail page

Fixes #325 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check storage list and detail page, especially when pool has same name as the project