### PR TITLE
Improve tutorial for windows browsers #324

### DIFF
--- a/src/pages/certificates/BrowserImport.tsx
+++ b/src/pages/certificates/BrowserImport.tsx
@@ -4,10 +4,28 @@ import { Col, Row, Tabs } from "@canonical/react-components";
 const FIREFOX = "Firefox";
 const CHROME_LINUX = "Chrome (Linux)";
 const CHROME_WINDOWS = "Chrome (Windows)";
-const TABS: string[] = [FIREFOX, CHROME_LINUX, CHROME_WINDOWS];
+const EDGE = "Edge";
+const TABS: string[] = [FIREFOX, CHROME_LINUX, CHROME_WINDOWS, EDGE];
 
 const BrowserImport: FC = () => {
   const [activeTab, handleTabChange] = useState(FIREFOX);
+
+  const windowsDialogSteps = (
+    <>
+      <li className="p-list__item">
+        This opens a certificate management dialog. Click <code>Import...</code>
+        then <code>Next</code> and select the <code>lxd-ui.pfx</code> file you
+        just downloaded. Confirm an empty password. Click <code>Next</code>.
+      </li>
+      <li className="p-list__item">
+        Select <code>Automatically select the certificate store</code> and click{" "}
+        <code>Next</code>, then click <code>Finish</code>.
+      </li>
+      <li className="p-list__item">
+        Restart the browser and open LXD-UI. Select the LXD-UI certificate.
+      </li>
+    </>
+  );
 
   return (
     <Row>
@@ -21,13 +39,13 @@ const BrowserImport: FC = () => {
         />
 
         {activeTab === FIREFOX && (
-          <div tabIndex={0} role="tabpanel" aria-label="firefox">
+          <div role="tabpanel" aria-label="firefox">
             <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste this link into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
                   <pre className="p-code-snippet__block">
-                    <code>about:preferences#privacy</code>{" "}
+                    <code>about:preferences#privacy</code>
                   </pre>
                 </div>
               </li>
@@ -43,51 +61,74 @@ const BrowserImport: FC = () => {
                 Select the <code>lxd-ui.pfx</code> file you just downloaded.
                 Confirm an empty password.
               </li>
+              <li className="p-list__item">
+                Restart the browser and open LXD-UI. Select the LXD-UI
+                certificate.
+              </li>
             </ul>
           </div>
         )}
 
         {activeTab === CHROME_LINUX && (
-          <div tabIndex={1} role="tabpanel" aria-label="chrome linux">
+          <div role="tabpanel" aria-label="chrome linux">
             <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
                   <pre className="p-code-snippet__block">
-                    <code>chrome://settings/certificates</code>{" "}
+                    <code>chrome://settings/certificates</code>
                   </pre>
                 </div>
               </li>
-
               <li className="p-list__item">
                 Click the <code>Import</code> button and select the{" "}
                 <code>lxd-ui.pfx</code> file you just downloaded. Confirm an
                 empty password.
+              </li>
+              <li className="p-list__item">
+                Restart the browser and open LXD-UI. Select the LXD-UI
+                certificate.
               </li>
             </ul>
           </div>
         )}
 
         {activeTab === CHROME_WINDOWS && (
-          <div tabIndex={1} role="tabpanel" aria-label="chrome windows">
+          <div role="tabpanel" aria-label="chrome windows">
             <ul className="p-list--divided u-no-margin--bottom">
               <li className="p-list__item">
                 Paste into the address bar:
                 <div className="p-code-snippet u-no-margin--bottom">
                   <pre className="p-code-snippet__block">
-                    <code>chrome://settings/security</code>{" "}
+                    <code>chrome://settings/security</code>
                   </pre>
                 </div>
               </li>
               <li className="p-list__item">
-                Scroll all the way down and click the{" "}
-                <code>Manage Certificates</code> button.
+                Scroll down to the <code>Advanced settings</code> and click{" "}
+                <code>Manage device certificates</code>
+              </li>
+              {windowsDialogSteps}
+            </ul>
+          </div>
+        )}
+
+        {activeTab === EDGE && (
+          <div role="tabpanel" aria-label="chrome windows">
+            <ul className="p-list--divided u-no-margin--bottom">
+              <li className="p-list__item">
+                Paste into the address bar:
+                <div className="p-code-snippet u-no-margin--bottom">
+                  <pre className="p-code-snippet__block">
+                    <code>edge://settings/privacy</code>
+                  </pre>
+                </div>
               </li>
               <li className="p-list__item">
-                Click the <code>Import</code> button and select the{" "}
-                <code>lxd-ui.pfx</code> file you just downloaded. Confirm an
-                empty password.
+                Scroll to the <code>Security</code> section and click{" "}
+                <code>Manage Certificates</code>
               </li>
+              {windowsDialogSteps}
             </ul>
           </div>
         )}

--- a/src/pages/certificates/CertificateGenerate.tsx
+++ b/src/pages/certificates/CertificateGenerate.tsx
@@ -66,7 +66,9 @@ const CertificateGenerate: FC = () => {
                 <li className="p-stepped-list__item">
                   <Row>
                     <Col size={3}>
-                      <h3 className="p-stepped-list__title">Generate</h3>
+                      <h2 className="p-stepped-list__title p-heading--3">
+                        Generate
+                      </h2>
                     </Col>
                     <Col size={6}>
                       <div className="p-stepped-list__content">
@@ -98,7 +100,9 @@ const CertificateGenerate: FC = () => {
                 <li className="p-stepped-list__item">
                   <Row>
                     <Col size={3}>
-                      <h3 className="p-stepped-list__title">Trust</h3>
+                      <h2 className="p-stepped-list__title p-heading--3">
+                        Trust
+                      </h2>
                     </Col>
                     <Col size={6}>
                       <div className="p-stepped-list__content">
@@ -129,7 +133,9 @@ const CertificateGenerate: FC = () => {
                 <li className="p-stepped-list__item">
                   <Row>
                     <Col size={3}>
-                      <h3 className="p-stepped-list__title">Import</h3>
+                      <h2 className="p-stepped-list__title p-heading--3">
+                        Import
+                      </h2>
                     </Col>
                     <Col size={6}>
                       <div className="p-stepped-list__content">
@@ -137,7 +143,6 @@ const CertificateGenerate: FC = () => {
                           Download <code>lxd-ui.pfx</code> and import it into
                           your browser.
                         </p>
-                        <BrowserImport />
                       </div>
                     </Col>
                     {certs && (
@@ -152,11 +157,18 @@ const CertificateGenerate: FC = () => {
                       </Col>
                     )}
                   </Row>
+                  <Row>
+                    <Col emptyLarge={4} size={8}>
+                      <BrowserImport />
+                    </Col>
+                  </Row>
                 </li>
                 <li className="p-stepped-list__item u-no-margin--bottom">
                   <Row>
                     <Col size={3}>
-                      <h3 className="p-stepped-list__title">Done</h3>
+                      <h2 className="p-stepped-list__title p-heading--3">
+                        Done
+                      </h2>
                     </Col>
                     <Col size={6}>
                       <div className="p-stepped-list__content">

--- a/src/sass/_certificates.scss
+++ b/src/sass/_certificates.scss
@@ -5,7 +5,7 @@
   }
 
   .p-panel__content {
-    max-width: 65rem !important;
+    max-width: 64rem !important;
     padding-bottom: 0;
 
     .p-list__item:first-child {


### PR DESCRIPTION
## Done

- improved the Chrome windows tutorial
- added edge tutorial

Fixes #324 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check the tutorial section for windows browsers