### PR TITLE
Auto-focus for terminal and text console

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -142,6 +142,10 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   };
 
   useEffect(() => {
+    xtermRef.current?.terminal.focus();
+  }, [xtermRef.current, controlWs]);
+
+  useEffect(() => {
     xtermRef.current?.terminal.clear();
     setInTabNotification(null);
     const websocketPromise = openWebsockets(payload);

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -119,6 +119,12 @@ const InstanceTextConsole: FC<Props> = ({
   };
 
   useEffect(() => {
+    if (isRunning) {
+      xtermRef.current?.terminal.focus();
+    }
+  }, [isRunning, xtermRef.current]);
+
+  useEffect(() => {
     if (dataWs) {
       return;
     }


### PR DESCRIPTION
## Done

- Focus the terminal and the text console automatically

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit the detail page of any running instance
    - Open "Terminal" tab
    - Check that focus goes automatically to the terminal
    - Open "Console" tab - switch to text console if instance is a VM
    - Check that focus goes automatically to the terminal
    - Visit the detail page of any stopped instance
    - Open "Console" tab - switch to text console if instance is a VM
    - Check that the focus doesn't go automatically to the terminal