### PR TITLE
Show ips from all interfaces, not only eth0 [WD-3635]

### DIFF
--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -14,7 +14,7 @@ import usePanelParams from "util/usePanelParams";
 import { useNotify } from "context/notify";
 import InstanceStateActions from "pages/instances/actions/InstanceStateActions";
 import InstanceLink from "pages/instances/InstanceLink";
-import { getIpAddresses } from "util/networks";
+import { getIpAddressElements } from "util/networks";
 import ExpandableList from "../../components/ExpandableList";
 import ItemName from "components/ItemName";
 import DetailPanel from "components/DetailPanel";
@@ -40,8 +40,8 @@ const InstanceDetailPanel: FC = () => {
     notify.failure("Loading instance failed", error);
   }
 
-  const ip4Addresses = getIpAddresses("inet", instance);
-  const ip6Addresses = getIpAddresses("inet6", instance);
+  const ip4Addresses = instance ? getIpAddressElements(instance, "inet") : [];
+  const ip6Addresses = instance ? getIpAddressElements(instance, "inet6") : [];
 
   const networkDevices = Object.values(instance?.expanded_devices ?? {}).filter(
     isNicDevice

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -33,6 +33,7 @@ import { usePagination } from "util/pagination";
 import { updateTBodyHeight } from "util/updateTBodyHeight";
 import SelectableMainTable from "components/SelectableMainTable";
 import InstanceBulkActions from "pages/instances/actions/InstanceBulkActions";
+import { getIpAddresses } from "util/networks";
 
 const STATUS = "Status";
 const NAME = "Name";
@@ -192,20 +193,8 @@ const InstanceList: FC = () => {
       const openSummary = () =>
         panelParams.openInstanceSummary(instance.name, project);
 
-      const ipv4 =
-        instance.state?.network?.eth0?.addresses
-          .filter(
-            (item) => item.family === "inet" && !item.address.startsWith("127")
-          )
-          .map((item) => item.address) ?? [];
-
-      const ipv6 =
-        instance.state?.network?.eth0?.addresses
-          .filter(
-            (item) =>
-              item.family === "inet6" && !item.address.startsWith("fe80")
-          )
-          .map((item) => item.address) ?? [];
+      const ip4Addresses = getIpAddresses(instance, "inet", false);
+      const ip6Addresses = getIpAddresses(instance, "inet6", false);
 
       return {
         className:
@@ -250,14 +239,20 @@ const InstanceList: FC = () => {
             className: "clickable-cell description",
           },
           {
-            content: ipv4.length > 1 ? `${ipv4.length} addresses` : ipv4,
+            content:
+              ip4Addresses.length > 1
+                ? `${ip4Addresses.length} addresses`
+                : ip4Addresses,
             role: "rowheader",
             className: "u-align--right clickable-cell ipv4",
             "aria-label": IPV4,
             onClick: openSummary,
           },
           {
-            content: ipv6.length > 1 ? `${ipv6.length} addresses` : ipv6,
+            content:
+              ip6Addresses.length > 1
+                ? `${ip6Addresses.length} addresses`
+                : ip6Addresses,
             role: "rowheader",
             "aria-label": IPV6,
             onClick: openSummary,

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -11,7 +11,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import InstanceOverviewNetworks from "./InstanceOverviewNetworks";
 import InstanceOverviewProfiles from "./InstanceOverviewProfiles";
 import InstanceOverviewMetrics from "./InstanceOverviewMetrics";
-import { getIpAddresses } from "util/networks";
+import { getIpAddressElements } from "util/networks";
 import ExpandableList from "../../components/ExpandableList";
 
 interface Props {
@@ -32,8 +32,8 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
   useEffect(updateContentHeight, [inTabNotification]);
   useEventListener("resize", updateContentHeight);
 
-  const ip4Addresses = getIpAddresses("inet", instance);
-  const ip6Addresses = getIpAddresses("inet6", instance);
+  const ip4Addresses = getIpAddressElements(instance, "inet");
+  const ip6Addresses = getIpAddressElements(instance, "inet6");
 
   const pid =
     !instance.state || instance.state.pid === 0 ? "-" : instance.state.pid;

--- a/src/pages/networks/MapTooltip.tsx
+++ b/src/pages/networks/MapTooltip.tsx
@@ -3,6 +3,7 @@ import { LxdInstance } from "types/instance";
 import { LxdNetwork } from "types/network";
 import { createRoot } from "react-dom/client";
 import ItemName from "components/ItemName";
+import { getIpAddresses } from "util/networks";
 
 export interface MapTooltipProps {
   type: string;
@@ -21,6 +22,13 @@ export const mountElement = (component: ReactNode) => {
 const MapTooltip: FC<MapTooltipProps> = ({ item, type }) => {
   if (type === "instance") {
     const instance = item as LxdInstance;
+
+    const ipAddresses = getIpAddresses(instance).map((address) => (
+      <li key={address} className="p-list__item">
+        {address}
+      </li>
+    ));
+
     return (
       <div className="p-text--small tooltip">
         <a href={`/ui/${instance.project}/instances/detail/${instance.name}`}>
@@ -31,11 +39,7 @@ const MapTooltip: FC<MapTooltipProps> = ({ item, type }) => {
         <br />
         IPs:{" "}
         <ul className="p-list u-no-margin--bottom">
-          {instance.state?.network?.eth0?.addresses.map((item) => (
-            <li key={item.address} className="p-list__item">
-              {item.address}
-            </li>
-          )) ?? <li>None</li>}
+          {ipAddresses.length > 0 ? ipAddresses : <li>None</li>}
         </ul>
       </div>
     );

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -46,9 +46,7 @@ interface LxdInstanceState {
     root: LxdInstanceUsageProp;
   } & Record<string, LxdInstanceUsageProp>;
   memory: LxdInstanceMemory;
-  network?: {
-    eth0?: LxdInstanceNetwork;
-  } & Record<string, LxdInstanceNetwork>;
+  network?: Record<string, LxdInstanceNetwork>;
   pid: number;
   processes: number;
   status: string;

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -1,20 +1,38 @@
 import React from "react";
 import { LxdInstance } from "types/instance";
 
-export const getIpAddresses = (family: string, instance?: LxdInstance) => {
-  return (
-    instance?.state?.network?.eth0?.addresses
-      .filter((item) => item.family === family)
-      .map((item) => {
-        return (
-          <div
-            key={item.address}
-            className="ip u-truncate"
-            title={item.address}
-          >
-            {item.address}
-          </div>
-        );
-      }) ?? []
+export const getIpAddresses = (
+  instance: LxdInstance,
+  family?: string,
+  showLocal = true
+) => {
+  if (!instance.state?.network) return [];
+  const interfaces = Object.entries(instance.state.network).filter(
+    ([key, _value]) => key !== "lo"
   );
+  const addresses = interfaces.flatMap(([_key, value]) => value.addresses);
+  const filteredAddresses =
+    !family && showLocal
+      ? addresses
+      : addresses.filter(
+          (item) =>
+            (family ? item.family === family : true) &&
+            (showLocal
+              ? true
+              : !(
+                  item.address.startsWith("127") ||
+                  item.address.startsWith("fe80")
+                ))
+        );
+  return filteredAddresses.map((item) => item.address);
+};
+
+export const getIpAddressElements = (instance: LxdInstance, family: string) => {
+  return getIpAddresses(instance, family).map((address) => {
+    return (
+      <div key={address} className="ip u-truncate" title={address}>
+        {address}
+      </div>
+    );
+  });
 };


### PR DESCRIPTION
## Done

- Show IP addresses from all network interfaces, not only the `eth0` one.

Fixes #333
Fixed [WD-3635](https://warthogs.atlassian.net/browse/WD-3635)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check that IPs from other network interfaces than `eth0` are correctly shown in the instance table, instance summary panel, and instance detail page.