### PR TITLE
Deal with query strings in operation urls WD-3656

### DIFF
--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -11,7 +11,10 @@ export const watchOperation = (
   timeout = TIMEOUT_10
 ): Promise<LxdOperation> => {
   return new Promise((resolve, reject) => {
-    fetch(`${operationUrl}/wait?timeout=${timeout}`)
+    const operationParts = operationUrl.split("?");
+    const baseUrl = operationParts[0];
+    const queryString = operationParts.length === 1 ? "" : operationParts[1];
+    fetch(`${baseUrl}/wait?timeout=${timeout}&${queryString}`)
       .then(handleResponse)
       .then((data: LxdOperation) => {
         if (data.metadata.status === "Success") {


### PR DESCRIPTION
## Done

- encounter for possible query strings in the operation urls, when watching the operation
- this fixes the launch instance in a clustered lxd environment, because the returned operation includes the project as querystring. Related to [this bug in LXD core](https://github.com/lxc/lxd/issues/11664) addressing the inconsitent url.

Fixes [WD-3656](https://warthogs.atlassian.net/browse/WD-3656)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - launch an instance or other tasks that create an operation

[WD-3656]: https://warthogs.atlassian.net/browse/WD-3656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ