### PR TITLE
Select 1st pool when configuring root storage

### DIFF
--- a/src/pages/instances/forms/RootStorageForm.tsx
+++ b/src/pages/instances/forms/RootStorageForm.tsx
@@ -67,6 +67,7 @@ const RootStorageForm: FC<Props> = ({ formik, project }) => {
       type: "disk",
       name: "root",
       path: "/",
+      pool: storagePools[0]?.name ?? undefined,
     });
     formik.setFieldValue("devices", copy);
     setTimeout(() => document.getElementById("rootStoragePool")?.focus(), 100);
@@ -83,6 +84,7 @@ const RootStorageForm: FC<Props> = ({ formik, project }) => {
       return {
         label: storagePool.name,
         value: storagePool.name,
+        disabled: false,
       };
     });
     options.unshift({
@@ -91,6 +93,7 @@ const RootStorageForm: FC<Props> = ({ formik, project }) => {
           ? "No storage pool available"
           : "Select option",
       value: "",
+      disabled: true,
     });
     return options;
   };


### PR DESCRIPTION
## Done

- automatically select the 1st pool, when overriding root storage, disallow to unselect the pool completely

Fixes #342 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Configure root storage on an instance/profil edit/creation