### PR TITLE
[README] Add steps to setup the development environment to run the LXD UI on a Mac [WD-3922]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Targets small and large scale private clouds.
 
 <details>
   <summary>Setup LXD - Linux (with snap)</summary>
+  <br/>
   <pre><code>snap install lxd
 lxd init # can accept all defaults
 lxc config set core.https_address "[::]:8443"</code></pre>
@@ -14,6 +15,9 @@ lxc config set core.https_address "[::]:8443"</code></pre>
 
 <details>
   <summary>Setup LXD - Mac</summary>
+  <br/>
+
+  > :warning: **VM instances cannot be created with LXC + Multipass on a Mac**. Nested virtualization is unsupported.
 
   First, if you have not already, you need to install [Homebrew](https://brew.sh/).
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,66 @@ Targets small and large scale private clouds.
 
 # Setting up for development
 
-Setup lxd
+<details>
+  <summary>Setup LXD - Linux (with snap)</summary>
+  <pre><code>snap install lxd
+lxd init # can accept all defaults
+lxc config set core.https_address "[::]:8443"</code></pre>
+</details>
 
-    snap install lxd
-    lxd init # can accept all defaults
-    lxc config set core.https_address "[::]:8443"
+<details>
+  <summary>Setup LXD - Mac</summary>
+
+  First, if you have not already, you need to install [Homebrew](https://brew.sh/).
+
+  Then install LXC client with brew:
+
+  <pre><code>brew install lxc</code></pre>
+
+  LXD cannot run natively on a Mac, so you need to connect LXC to a remote LXD server. You can set up one inside a Multipass instance. [How to install Multipass on macOS - Using brew](https://multipass.run/docs/installing-on-macos#heading--use-brew)
+
+  Once you have LXC and Multipass installed, we can create a Multipass instance where we will run the LXD daemon:
+
+  <pre><code># launch a new instance called "lxd" with 2 CPUs, 4G memory, and 50G of disk space - gauge these values as you prefer
+multipass launch -n lxd -c 2 -m 4G -d 50G</code></pre>
+
+  If you get the `Launched: lxd` output, it means that the command succeeded. We can now launch a shell into the newly created instance:
+
+  <pre><code>multipass shell lxd</code></pre>
+
+  You should be greeted with the Ubuntu shell login message `Welcome to Ubuntu ...`. Make sure the latest version of LXD is installed:
+
+  <pre><code>sudo snap refresh lxd --channel=latest/stable</code></pre>
+
+  This command will either output `snap "lxd" has no updates available` or update lxd to the latest stable version.
+
+  Initialise LXD - replace `your-password` with a password of your choice - and then close the multipass shell:
+
+  <pre><code>sudo lxd init --auto --trust-password your-password --network-address '[::]'
+exit</code></pre>
+
+  Connect the LXD server in Multipass to the local LXC. In a terminal on your Mac, run:
+
+  <pre><code>lxc remote add default $(multipass info lxd | grep IPv4 | awk '{print $2}') --password your-password --accept-certificate</code></pre>
+
+  (replace `your-password` with the password you selected before)
+
+  You should get a message saying: `Client certificate now trusted by server: default`
+
+  Switch the remote to the `default` server that we have just added:
+
+  <pre><code>lxc remote switch default</code></pre>
+
+  Launch an instance with the lxc command on your Mac:
+
+  <pre><code>lxc launch ubuntu:jammy test-jammy</code></pre>
+
+  If this succeeds, the setup of LXC and LXD is complete. Finally, expose the API on port 8443:
+
+  <pre><code>lxc config set core.https_address "[::]:8443"</code></pre>
+
+  Now, proceed with the steps to run the LXD-UI.
+</details>
 
 Install dotrun as described in https://github.com/canonical/dotrun#installation Launch it from the head of this repo
 
@@ -22,6 +77,10 @@ First time running `dotrun` will generate certificates for you. You can find the
 this repo. Trust them from your local lxd with
 
     sudo lxc config trust add keys/lxd-ui.crt
+
+If you are on a Mac and running LXD inside Multipass, set the `LXD_UI_BACKEND_IP` in the `.env.local` file:
+
+    echo "LXD_UI_BACKEND_IP=$(multipass info lxd | grep IPv4 | awk '{print $2}')" > .env.local
 
 Now you can browse through https://localhost:8407/ to reach lxd-ui.
 


### PR DESCRIPTION
## Done

- Branched the README in 2 sections about LXD setup - one for Ubuntu, another for Mac
- Added all the steps to setup the development environment to run the LXD UI on a Mac

Fixes [WD-3922](https://warthogs.atlassian.net/browse/WD-3922)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Check that the new README looks as expected and that no step is missing

[WD-3922]: https://warthogs.atlassian.net/browse/WD-3922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ