### PR TITLE
Avoid table jumping on selecting / unselecting instances

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -490,7 +490,7 @@ const InstanceList: FC = () => {
                 />
                 <Button
                   appearance="link"
-                  className="clear-selection-btn"
+                  className="clear-selection-btn u-no-margin--bottom u-no-padding--top"
                   hasIcon
                   onClick={() => setSelectedNames([])}
                 >


### PR DESCRIPTION
## Done

- removed margin/padding from clear selection button in instance list so the table heading stays in the same spot