### PR TITLE
Show 404 in all project subpages if project does not exist [WD-4068]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { FC, lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import Loader from "components/Loader";
 import ProjectRedirect from "pages/projects/ProjectRedirect";
+import ProjectLoader from "pages/projects/ProjectLoader";
 
 const ClusterList = lazy(() => import("pages/cluster/ClusterList"));
 const ImageList = lazy(() => import("pages/images/ImageList"));
@@ -51,27 +52,51 @@ const App: FC = () => {
         />
         <Route
           path="/ui/:project"
-          element={<ProtectedRoute outlet={<ProjectRedirect />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProjectRedirect />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/instances"
-          element={<ProtectedRoute outlet={<InstanceList />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<InstanceList />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/instances/create"
-          element={<ProtectedRoute outlet={<CreateInstanceForm />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<CreateInstanceForm />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/instances/detail/:name"
-          element={<ProtectedRoute outlet={<InstanceDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<InstanceDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/instances/detail/:name/:activeTab"
-          element={<ProtectedRoute outlet={<InstanceDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<InstanceDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/instances/detail/:name/:activeTab/:activeSection"
-          element={<ProtectedRoute outlet={<InstanceDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<InstanceDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/images"
@@ -79,39 +104,75 @@ const App: FC = () => {
         />
         <Route
           path="/ui/:project/profiles"
-          element={<ProtectedRoute outlet={<ProfileList />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProfileList />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/profiles/create"
-          element={<ProtectedRoute outlet={<CreateProfileForm />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<CreateProfileForm />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/profiles/detail/:name"
-          element={<ProtectedRoute outlet={<ProfileDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProfileDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/profiles/detail/:name/:activeTab"
-          element={<ProtectedRoute outlet={<ProfileDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProfileDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/profiles/detail/:name/:activeTab/:activeSection"
-          element={<ProtectedRoute outlet={<ProfileDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProfileDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/networks"
-          element={<ProtectedRoute outlet={<NetworkList />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkList />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/networks/map"
-          element={<ProtectedRoute outlet={<NetworkMap />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkMap />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/operations"
-          element={<ProtectedRoute outlet={<OperationList />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<OperationList />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/configuration"
-          element={<ProtectedRoute outlet={<ProjectConfiguration />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<ProjectConfiguration />} />}
+            />
+          }
         />
         <Route
           path="/ui/projects/create"
@@ -119,11 +180,19 @@ const App: FC = () => {
         />
         <Route
           path="/ui/:project/storage"
-          element={<ProtectedRoute outlet={<StorageList />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<StorageList />} />}
+            />
+          }
         />
         <Route
           path="/ui/:project/storage/:name"
-          element={<ProtectedRoute outlet={<StorageDetail />} />}
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<StorageDetail />} />}
+            />
+          }
         />
         <Route
           path="/ui/cluster"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,20 +38,23 @@ const ProjectConfiguration = lazy(
   () => import("pages/projects/ProjectConfiguration")
 );
 
+const HOME_REDIRECT_PATHS = ["/", "/ui", "/ui/project"];
+
 const App: FC = () => {
   return (
     <Suspense fallback={<Loader />}>
       <Routes>
+        {HOME_REDIRECT_PATHS.map((path) => (
+          <Route
+            key={path}
+            path={path}
+            element={
+              <Navigate to="/ui/project/default/instances" replace={true} />
+            }
+          />
+        ))}
         <Route
-          path="/"
-          element={<Navigate to="/ui/default/instances" replace={true} />}
-        />
-        <Route
-          path="/ui"
-          element={<Navigate to="/ui/default/instances" replace={true} />}
-        />
-        <Route
-          path="/ui/:project"
+          path="/ui/project/:project"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProjectRedirect />} />}
@@ -59,7 +62,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/instances"
+          path="/ui/project/:project/instances"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<InstanceList />} />}
@@ -67,7 +70,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/instances/create"
+          path="/ui/project/:project/instances/create"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<CreateInstanceForm />} />}
@@ -75,7 +78,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/instances/detail/:name"
+          path="/ui/project/:project/instances/detail/:name"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<InstanceDetail />} />}
@@ -83,7 +86,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/instances/detail/:name/:activeTab"
+          path="/ui/project/:project/instances/detail/:name/:activeTab"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<InstanceDetail />} />}
@@ -91,7 +94,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/instances/detail/:name/:activeTab/:activeSection"
+          path="/ui/project/:project/instances/detail/:name/:activeTab/:activeSection"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<InstanceDetail />} />}
@@ -103,7 +106,7 @@ const App: FC = () => {
           element={<ProtectedRoute outlet={<ImageList />} />}
         />
         <Route
-          path="/ui/:project/profiles"
+          path="/ui/project/:project/profiles"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProfileList />} />}
@@ -111,7 +114,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/profiles/create"
+          path="/ui/project/:project/profiles/create"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<CreateProfileForm />} />}
@@ -119,7 +122,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/profiles/detail/:name"
+          path="/ui/project/:project/profiles/detail/:name"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProfileDetail />} />}
@@ -127,7 +130,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/profiles/detail/:name/:activeTab"
+          path="/ui/project/:project/profiles/detail/:name/:activeTab"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProfileDetail />} />}
@@ -135,7 +138,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/profiles/detail/:name/:activeTab/:activeSection"
+          path="/ui/project/:project/profiles/detail/:name/:activeTab/:activeSection"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProfileDetail />} />}
@@ -143,7 +146,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/networks"
+          path="/ui/project/:project/networks"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<NetworkList />} />}
@@ -151,7 +154,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/networks/map"
+          path="/ui/project/:project/networks/map"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<NetworkMap />} />}
@@ -159,7 +162,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/operations"
+          path="/ui/project/:project/operations"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<OperationList />} />}
@@ -167,7 +170,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/configuration"
+          path="/ui/project/:project/configuration"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<ProjectConfiguration />} />}
@@ -179,7 +182,7 @@ const App: FC = () => {
           element={<ProtectedRoute outlet={<CreateProjectForm />} />}
         />
         <Route
-          path="/ui/:project/storage"
+          path="/ui/project/:project/storage"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<StorageList />} />}
@@ -187,7 +190,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/:project/storage/:name"
+          path="/ui/project/:project/storage/:name"
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<StorageDetail />} />}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,21 +1,23 @@
 import React, { FC, MouseEvent, useState } from "react";
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import { Button, Icon } from "@canonical/react-components";
 import { useAuth } from "context/auth";
 import classnames from "classnames";
 import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
-import { getProjectFromUrl } from "util/projects";
 import ServerVersion from "components/ServerVersion";
 import useEventListener from "@use-it/event-listener";
 import { isWidthBelow } from "util/helpers";
+import { useProject } from "context/project";
 
 const isSmallScreen = () => isWidthBelow(620);
 
 const Navigation: FC = () => {
-  const location = useLocation();
   const [menuCollapsed, setMenuCollapsed] = useState(isSmallScreen());
-  const project = getProjectFromUrl(location.pathname) ?? "default";
+
+  const { project, isLoading } = useProject();
+
+  const projectName = project && !isLoading ? project.name : "default";
 
   const { isAuthenticated } = useAuth();
   const softToggleMenu = () => {
@@ -85,14 +87,14 @@ const Navigation: FC = () => {
                       <li onClick={(e) => e.stopPropagation()}>
                         <ProjectSelector
                           key={location.pathname}
-                          activeProject={project}
+                          activeProject={projectName}
                         />
                       </li>
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/instances`}
-                          title={`Instances (${project})`}
+                          to={`/ui/${projectName}/instances`}
+                          title={`Instances (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
@@ -104,8 +106,8 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/profiles`}
-                          title={`Profiles (${project})`}
+                          to={`/ui/${projectName}/profiles`}
+                          title={`Profiles (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
@@ -117,8 +119,8 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/networks`}
-                          title={`Networks (${project})`}
+                          to={`/ui/${projectName}/networks`}
+                          title={`Networks (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
@@ -130,8 +132,8 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/storage`}
-                          title={`Storage pools (${project})`}
+                          to={`/ui/${projectName}/storage`}
+                          title={`Storage pools (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
@@ -143,8 +145,8 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/operations`}
-                          title={`Operations (${project})`}
+                          to={`/ui/${projectName}/operations`}
+                          title={`Operations (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"
@@ -156,8 +158,8 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${project}/configuration`}
-                          title={`Configuration (${project})`}
+                          to={`/ui/${projectName}/configuration`}
+                          title={`Configuration (${projectName})`}
                         >
                           <Icon
                             className="is-light p-side-navigation__icon"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -93,7 +93,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/instances`}
+                          to={`/ui/project/${projectName}/instances`}
                           title={`Instances (${projectName})`}
                         >
                           <Icon
@@ -106,7 +106,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/profiles`}
+                          to={`/ui/project/${projectName}/profiles`}
                           title={`Profiles (${projectName})`}
                         >
                           <Icon
@@ -119,7 +119,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/networks`}
+                          to={`/ui/project/${projectName}/networks`}
                           title={`Networks (${projectName})`}
                         >
                           <Icon
@@ -132,7 +132,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/storage`}
+                          to={`/ui/project/${projectName}/storage`}
                           title={`Storage pools (${projectName})`}
                         >
                           <Icon
@@ -145,7 +145,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/operations`}
+                          to={`/ui/project/${projectName}/operations`}
                           title={`Operations (${projectName})`}
                         >
                           <Icon
@@ -158,7 +158,7 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item--title secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/${projectName}/configuration`}
+                          to={`/ui/project/${projectName}/configuration`}
                           title={`Configuration (${projectName})`}
                         >
                           <Icon

--- a/src/context/project.tsx
+++ b/src/context/project.tsx
@@ -4,7 +4,6 @@ import { queryKeys } from "util/queryKeys";
 import { fetchProject } from "api/projects";
 import { LxdProject } from "types/project";
 import { useLocation } from "react-router-dom";
-import { getProjectFromUrl } from "util/projects";
 
 interface ContextProps {
   project?: LxdProject;
@@ -24,7 +23,8 @@ interface ProviderProps {
 
 export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
   const location = useLocation();
-  const project = getProjectFromUrl(location.pathname);
+  const url = location.pathname;
+  const project = url.startsWith("/ui/project/") ? url.split("/")[3] : "";
 
   const { data, isLoading } = useQuery({
     queryKey: [queryKeys.projects, project],

--- a/src/context/project.tsx
+++ b/src/context/project.tsx
@@ -29,6 +29,7 @@ export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
   const { data, isLoading } = useQuery({
     queryKey: [queryKeys.projects, project],
     queryFn: () => fetchProject(project),
+    retry: false,
   });
 
   return (

--- a/src/context/project.tsx
+++ b/src/context/project.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, FC, ReactNode, useContext } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchProject } from "api/projects";
+import { LxdProject } from "types/project";
+import { useLocation } from "react-router-dom";
+import { getProjectFromUrl } from "util/projects";
+
+interface ContextProps {
+  project?: LxdProject;
+  isLoading: boolean;
+}
+
+const initialState: ContextProps = {
+  project: undefined,
+  isLoading: false,
+};
+
+export const ProjectContext = createContext<ContextProps>(initialState);
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
+  const location = useLocation();
+  const project = getProjectFromUrl(location.pathname);
+
+  const { data, isLoading } = useQuery({
+    queryKey: [queryKeys.projects, project],
+    queryFn: () => fetchProject(project),
+  });
+
+  return (
+    <ProjectContext.Provider
+      value={{
+        project: data,
+        isLoading,
+      }}
+    >
+      {children}
+    </ProjectContext.Provider>
+  );
+};
+
+export function useProject() {
+  return useContext(ProjectContext);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "context/auth";
 import { NotifyProvider } from "context/notify";
 import App from "./App";
 import "./sass/styles.scss";
+import { ProjectProvider } from "context/project";
 import { InstanceLoadingProvider } from "context/instanceLoading";
 
 const queryClient = new QueryClient();
@@ -20,13 +21,15 @@ root.render(
     <NotifyProvider>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <InstanceLoadingProvider>
-            <div className="l-application" role="presentation">
-              <Navigation />
-              <App />
-              <Panels />
-            </div>
-          </InstanceLoadingProvider>
+          <ProjectProvider>
+            <InstanceLoadingProvider>
+              <div className="l-application" role="presentation">
+                <Navigation />
+                <App />
+                <Panels />
+              </div>
+            </InstanceLoadingProvider>
+          </ProjectProvider>
         </AuthProvider>
       </QueryClientProvider>
     </NotifyProvider>

--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -135,7 +135,7 @@ const CreateInstanceForm: FC = () => {
 
   const submit = (values: CreateInstanceFormValues, shouldStart = true) => {
     const formUrl = location.pathname + location.search;
-    navigate(`/ui/${project}/instances`);
+    navigate(`/ui/project/${project}/instances`);
 
     const instancePayload = values.yaml
       ? yamlToObject(values.yaml)
@@ -150,7 +150,7 @@ const CreateInstanceForm: FC = () => {
           return;
         }
         const instanceLink = (
-          <Link to={`/ui/${project}/instances/detail/${instanceName}`}>
+          <Link to={`/ui/project/${project}/instances/detail/${instanceName}`}>
             {instanceName}
           </Link>
         );
@@ -313,7 +313,7 @@ const CreateInstanceForm: FC = () => {
               <Col size={12}>
                 <Button
                   appearance="base"
-                  onClick={() => navigate(`/ui/${project}/instances`)}
+                  onClick={() => navigate(`/ui/project/${project}/instances`)}
                 >
                   Cancel
                 </Button>

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -121,7 +121,7 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
       void formik.setFieldValue("yaml", undefined);
     }
 
-    const baseUrl = `/ui/${project}/instances/detail/${instance.name}/configuration`;
+    const baseUrl = `/ui/project/${project}/instances/detail/${instance.name}/configuration`;
     newSection === INSTANCE_DETAILS
       ? navigate(baseUrl)
       : navigate(`${baseUrl}/${slugify(newSection)}`);

--- a/src/pages/instances/FileRow.tsx
+++ b/src/pages/instances/FileRow.tsx
@@ -14,7 +14,7 @@ interface FileRowProps {
 
 const FileRow: FC<FileRowProps> = ({ instance, path }) => {
   const fileName = path.split("/").at(-1) ?? "";
-  const fileUrl = `/ui/${instance.project}/instances/detail/${instance.name}/logs/?file=${fileName}`;
+  const fileUrl = `/ui/project/${instance.project}/instances/detail/${instance.name}/logs/?file=${fileName}`;
   const [isOpen, setOpen] = useState(getUrlParam("file") === fileName);
 
   const {

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -57,9 +57,9 @@ const InstanceDetail: FC = () => {
   const handleTabChange = (newTab: string) => {
     notify.clear();
     if (newTab === "overview") {
-      navigate(`/ui/${project}/instances/detail/${name}`);
+      navigate(`/ui/project/${project}/instances/detail/${name}`);
     } else {
-      navigate(`/ui/${project}/instances/detail/${name}/${newTab}`);
+      navigate(`/ui/project/${project}/instances/detail/${name}/${newTab}`);
     }
   };
 

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -48,7 +48,7 @@ const InstanceDetailHeader: FC<Props> = ({ name, instance, project }) => {
       renameInstance(name, values.name, project)
         .then(() => {
           navigate(
-            `/ui/${project}/instances/detail/${values.name}`,
+            `/ui/project/${project}/instances/detail/${values.name}`,
             notify.queue(notify.success("Instance renamed."))
           );
           void formik.setFieldValue("isRenaming", false);
@@ -63,7 +63,9 @@ const InstanceDetailHeader: FC<Props> = ({ name, instance, project }) => {
   return (
     <RenameHeader
       name={name}
-      parentItem={<Link to={`/ui/${project}/instances`}>Instances</Link>}
+      parentItem={
+        <Link to={`/ui/project/${project}/instances`}>Instances</Link>
+      }
       renameDisabledReason={
         instance?.status !== "Stopped"
           ? "Stop the instance to rename"

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -135,7 +135,7 @@ const InstanceDetailPanel: FC = () => {
               <th>
                 <h3 className="p-muted-heading p-heading--5">
                   <Link
-                    to={`/ui/${instance.project}/instances/detail/${instance.name}/configuration`}
+                    to={`/ui/project/${instance.project}/instances/detail/${instance.name}/configuration`}
                   >
                     Profiles
                   </Link>
@@ -147,7 +147,7 @@ const InstanceDetailPanel: FC = () => {
                   items={instance.profiles.map((name) => (
                     <Link
                       key={name}
-                      to={`/ui/${instance.project}/profiles/detail/${name}`}
+                      to={`/ui/project/${instance.project}/profiles/detail/${name}`}
                     >
                       {name}
                     </Link>
@@ -167,7 +167,7 @@ const InstanceDetailPanel: FC = () => {
                       // TODO: fix this link to point to the network detail page
                       <Link
                         key={item.network}
-                        to={`/ui/${instance.project}/networks`}
+                        to={`/ui/project/${instance.project}/networks`}
                       >
                         {item.network}
                       </Link>
@@ -183,7 +183,7 @@ const InstanceDetailPanel: FC = () => {
                     No networks found.
                     <br />
                     <Link
-                      to={`/ui/${instance.project}/instances/detail/${instance.name}/configuration/networks`}
+                      to={`/ui/project/${instance.project}/instances/detail/${instance.name}/configuration/networks`}
                     >
                       Configure instance networks
                     </Link>
@@ -195,7 +195,7 @@ const InstanceDetailPanel: FC = () => {
               <th colSpan={2} className="snapshots-header">
                 <h3 className="p-muted-heading p-heading--5">
                   <Link
-                    to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
+                    to={`/ui/project/${instance.project}/instances/detail/${instance.name}/snapshots`}
                   >
                     Snapshots
                   </Link>
@@ -229,7 +229,7 @@ const InstanceDetailPanel: FC = () => {
                   <tr>
                     <td colSpan={2}>
                       <Link
-                        to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
+                        to={`/ui/project/${instance.project}/instances/detail/${instance.name}/snapshots`}
                       >
                         {`View all (${instance.snapshots.length})`}
                       </Link>
@@ -244,7 +244,7 @@ const InstanceDetailPanel: FC = () => {
                     No snapshots found.
                     <br />
                     <Link
-                      to={`/ui/${instance.project}/instances/detail/${instance.name}/snapshots`}
+                      to={`/ui/project/${instance.project}/instances/detail/${instance.name}/snapshots`}
                     >
                       Manage instance snapshots
                     </Link>

--- a/src/pages/instances/InstanceLink.tsx
+++ b/src/pages/instances/InstanceLink.tsx
@@ -12,7 +12,7 @@ interface Props {
 const InstanceLink: FC<Props> = ({ instance }) => {
   return (
     <Link
-      to={`/ui/${instance.project}/instances/detail/${instance.name}`}
+      to={`/ui/project/${instance.project}/instances/detail/${instance.name}`}
       onClick={(e) => e.stopPropagation()}
     >
       <ItemName item={instance} />

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -512,7 +512,9 @@ const InstanceList: FC = () => {
               <Button
                 appearance="positive"
                 className="u-float-right u-no-margin--bottom"
-                onClick={() => navigate(`/ui/${project}/instances/create`)}
+                onClick={() =>
+                  navigate(`/ui/project/${project}/instances/create`)
+                }
               >
                 {createButtonLabel}
               </Button>
@@ -611,7 +613,7 @@ const InstanceList: FC = () => {
                       className="empty-state-button"
                       appearance="positive"
                       onClick={() =>
-                        navigate(`/ui/${project}/instances/create`)
+                        navigate(`/ui/project/${project}/instances/create`)
                       }
                     >
                       Create instance

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -529,7 +529,9 @@ const InstanceList: FC = () => {
                     columns={[TYPE, DESCRIPTION, IPV4, IPV6, SNAPSHOTS]}
                     hidden={userHidden}
                     setHidden={setHidden}
-                    className={classnames({ "u-hide": panelParams.instance })}
+                    className={classnames({
+                      "u-hide": panelParams.instance,
+                    })}
                   />
                   <SelectableMainTable
                     headers={getHeaders(userHidden.concat(sizeHidden))}

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -64,7 +64,7 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
             content: (
               // TODO: fix this link to point to the network detail page
               <Link
-                to={`/ui/${instance.project}/networks`}
+                to={`/ui/project/${instance.project}/networks`}
                 title={network.name}
               >
                 {network.name}

--- a/src/pages/instances/InstanceOverviewProfiles.tsx
+++ b/src/pages/instances/InstanceOverviewProfiles.tsx
@@ -48,7 +48,7 @@ const InstanceOverviewProfiles: FC<Props> = ({ instance, onFailure }) => {
         {
           content: (
             <Link
-              to={`/ui/${instance.project}/profiles/detail/${profile}`}
+              to={`/ui/project/${instance.project}/profiles/detail/${profile}`}
               title={profile}
             >
               {profile}

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -16,10 +16,8 @@ import ItemName from "components/ItemName";
 import SelectableMainTable from "components/SelectableMainTable";
 import SnapshotBulkDelete from "pages/instances/actions/snapshots/SnapshotBulkDelete";
 import ConfigureSnapshotsBtn from "pages/instances/actions/snapshots/ConfigureSnapshotsBtn";
-import { useQuery } from "@tanstack/react-query";
 import Loader from "components/Loader";
-import { fetchProject } from "api/projects";
-import { queryKeys } from "util/queryKeys";
+import { useProject } from "context/project";
 
 const collapsedViewMaxWidth = 1250;
 export const figureCollapsedScreen = (): boolean =>
@@ -46,18 +44,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
     setInTabNotification(failure(title, e));
   };
 
-  const {
-    data: project,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: [queryKeys.projects, instance.project],
-    queryFn: () => fetchProject(instance.project),
-  });
-
-  if (error) {
-    onFailure("Loading project failed", error);
-  }
+  const { project, isLoading } = useProject();
 
   const snapshotsDisabled = project?.config["restricted.snapshots"] === "block";
 

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -21,7 +21,7 @@ const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
     deleteInstance(instance)
       .then(() => {
         navigate(
-          `/ui/${instance.project}/instances`,
+          `/ui/project/${instance.project}/instances`,
           notify.queue(notify.success(`Instance ${instance.name} deleted.`))
         );
       })

--- a/src/pages/instances/actions/OpenConsoleBtn.tsx
+++ b/src/pages/instances/actions/OpenConsoleBtn.tsx
@@ -12,7 +12,7 @@ const OpenConsoleBtn: FC<Props> = ({ instance }) => {
 
   const handleOpen = () => {
     navigate(
-      `/ui/${instance.project}/instances/detail/${instance.name}/console`
+      `/ui/project/${instance.project}/instances/detail/${instance.name}/console`
     );
   };
 

--- a/src/pages/instances/actions/OpenTerminalBtn.tsx
+++ b/src/pages/instances/actions/OpenTerminalBtn.tsx
@@ -12,7 +12,7 @@ const OpenTerminalBtn: FC<Props> = ({ instance }) => {
 
   const handleOpen = () => {
     navigate(
-      `/ui/${instance.project}/instances/detail/${instance.name}/terminal`
+      `/ui/project/${instance.project}/instances/detail/${instance.name}/terminal`
     );
   };
 

--- a/src/pages/networks/MapTooltip.tsx
+++ b/src/pages/networks/MapTooltip.tsx
@@ -33,7 +33,9 @@ const MapTooltip: FC<MapTooltipProps> = ({ item, type }) => {
 
     return (
       <div className="p-text--small tooltip">
-        <a href={`/ui/${instance.project}/instances/detail/${instance.name}`}>
+        <a
+          href={`/ui/project/${instance.project}/instances/detail/${instance.name}`}
+        >
           <ItemName item={instance} />
         </a>
         <br />

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -117,7 +117,7 @@ const NetworkList: FC = () => {
           hasNetworks && (
             <Button
               className="u-no-margin--bottom"
-              onClick={() => navigate(`/ui/${project}/networks/map`)}
+              onClick={() => navigate(`/ui/project/${project}/networks/map`)}
             >
               See map
             </Button>

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -49,14 +49,12 @@ const OperationList: FC = () => {
   ];
 
   const getIconNameForStatus = (status: LxdOperationStatus) => {
-    return (
-      {
-        Cancelled: "status-failed-small",
-        Failure: "status-failed-small",
-        Running: "status-in-progress-small",
-        Success: "status-succeeded-small",
-      }[status] ?? ""
-    );
+    return {
+      Cancelled: "status-failed-small",
+      Failure: "status-failed-small",
+      Running: "status-in-progress-small",
+      Success: "status-succeeded-small",
+    }[status];
   };
 
   const rows = operations.map((operation) => {

--- a/src/pages/profiles/CreateProfileForm.tsx
+++ b/src/pages/profiles/CreateProfileForm.tsx
@@ -106,7 +106,7 @@ const CreateProfileForm: FC = () => {
       createProfile(JSON.stringify(profilePayload), project)
         .then(() => {
           navigate(
-            `/ui/${project}/profiles`,
+            `/ui/project/${project}/profiles`,
             notify.queue(notify.success(`Profile ${values.name} created.`))
           );
         })
@@ -219,7 +219,7 @@ const CreateProfileForm: FC = () => {
               <Col size={12}>
                 <Button
                   appearance="base"
-                  onClick={() => navigate(`/ui/${project}/profiles`)}
+                  onClick={() => navigate(`/ui/project/${project}/profiles`)}
                 >
                   Cancel
                 </Button>

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -146,7 +146,7 @@ const EditProfileForm: FC<Props> = ({ profile, featuresProfiles }) => {
       void formik.setFieldValue("yaml", undefined);
     }
 
-    const baseUrl = `/ui/${project}/profiles/detail/${profile.name}/configuration`;
+    const baseUrl = `/ui/project/${project}/profiles/detail/${profile.name}/configuration`;
     newSection === PROFILE_DETAILS
       ? navigate(baseUrl)
       : navigate(`${baseUrl}/${slugify(newSection)}`);

--- a/src/pages/profiles/ProfileDetail.tsx
+++ b/src/pages/profiles/ProfileDetail.tsx
@@ -68,9 +68,9 @@ const ProfileDetail: FC = () => {
   const handleTabChange = (newTab: string) => {
     notify.clear();
     if (newTab === "overview") {
-      navigate(`/ui/${projectName}/profiles/detail/${name}`);
+      navigate(`/ui/project/${projectName}/profiles/detail/${name}`);
     } else {
-      navigate(`/ui/${projectName}/profiles/detail/${name}/${newTab}`);
+      navigate(`/ui/project/${projectName}/profiles/detail/${name}/${newTab}`);
     }
   };
 

--- a/src/pages/profiles/ProfileDetail.tsx
+++ b/src/pages/profiles/ProfileDetail.tsx
@@ -59,7 +59,7 @@ const ProfileDetail: FC = () => {
   }
 
   if (projectError) {
-    notify.failure("Loading project failed", error);
+    notify.failure("Loading project failed", projectError);
   }
   const isLoading = isProfileLoading || isProjectLoading;
 

--- a/src/pages/profiles/ProfileDetail.tsx
+++ b/src/pages/profiles/ProfileDetail.tsx
@@ -11,8 +11,8 @@ import EditProfileForm from "pages/profiles/EditProfileForm";
 import ProfileDetailOverview from "pages/profiles/ProfileDetailOverview";
 import ProfileDetailHeader from "./ProfileDetailHeader";
 import { slugify } from "util/slugify";
-import { fetchProject } from "api/projects";
 import { isProjectWithProfiles } from "util/projects";
+import { useProject } from "context/project";
 
 const TABS: string[] = ["Overview", "Configuration"];
 
@@ -36,6 +36,8 @@ const ProfileDetail: FC = () => {
     return <>Missing project</>;
   }
 
+  const { project, isLoading: isProjectLoading } = useProject();
+
   const {
     data: profile,
     error,
@@ -45,22 +47,10 @@ const ProfileDetail: FC = () => {
     queryFn: () => fetchProfile(name, projectName),
   });
 
-  const {
-    data: project,
-    error: projectError,
-    isLoading: isProjectLoading,
-  } = useQuery({
-    queryKey: [queryKeys.projects, projectName],
-    queryFn: () => fetchProject(projectName),
-  });
-
   if (error) {
     notify.failure("Loading profile failed", error);
   }
 
-  if (projectError) {
-    notify.failure("Loading project failed", projectError);
-  }
   const isLoading = isProfileLoading || isProjectLoading;
 
   const featuresProfiles = isProjectWithProfiles(project);

--- a/src/pages/profiles/ProfileDetailHeader.tsx
+++ b/src/pages/profiles/ProfileDetailHeader.tsx
@@ -53,7 +53,7 @@ const ProfileDetailHeader: FC<Props> = ({
       renameProfile(name, values.name, project)
         .then(() => {
           navigate(
-            `/ui/${project}/profiles/detail/${values.name}`,
+            `/ui/project/${project}/profiles/detail/${values.name}`,
             notify.queue(notify.success("Profile renamed."))
           );
           void formik.setFieldValue("isRenaming", false);
@@ -68,7 +68,7 @@ const ProfileDetailHeader: FC<Props> = ({
   return (
     <RenameHeader
       name={name}
-      parentItem={<Link to={`/ui/${project}/profiles`}>Profiles</Link>}
+      parentItem={<Link to={`/ui/project/${project}/profiles`}>Profiles</Link>}
       renameDisabledReason={
         profile && profile.name === "default"
           ? "Cannot rename the default profile"

--- a/src/pages/profiles/ProfileDetailOverview.tsx
+++ b/src/pages/profiles/ProfileDetailOverview.tsx
@@ -123,7 +123,7 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
         </Col>
         <Col size={7} className="view-config">
           <Link
-            to={`/ui/${project}/profiles/detail/${
+            to={`/ui/project/${project}/profiles/detail/${
               profile.name
             }/configuration/${slugify(CLOUD_INIT)}`}
           >

--- a/src/pages/profiles/ProfileDetailPanel.tsx
+++ b/src/pages/profiles/ProfileDetailPanel.tsx
@@ -5,13 +5,13 @@ import usePanelParams from "util/usePanelParams";
 import { useNotify } from "context/notify";
 import { fetchProfile } from "api/profiles";
 import ProfileLink from "./ProfileLink";
-import { fetchProject } from "api/projects";
 import { isProjectWithProfiles } from "util/projects";
 import { getProfileInstances } from "util/usedBy";
 import ProfileInstances from "./ProfileInstances";
 import DetailPanel from "components/DetailPanel";
 import ProfileNetworkList from "./ProfileNetworkList";
 import ProfileStorageList from "./ProfileStorageList";
+import { useProject } from "context/project";
 
 const ProfileDetailPanel: FC = () => {
   const notify = useNotify();
@@ -19,6 +19,8 @@ const ProfileDetailPanel: FC = () => {
 
   const profileName = panelParams.profile;
   const projectName = panelParams.project;
+
+  const { project, isLoading: isProjectLoading } = useProject();
 
   const {
     data: profile,
@@ -29,22 +31,10 @@ const ProfileDetailPanel: FC = () => {
     queryFn: () => fetchProfile(profileName ?? "", projectName),
   });
 
-  const {
-    data: project,
-    error: projectError,
-    isLoading: isProjectLoading,
-  } = useQuery({
-    queryKey: [queryKeys.projects, projectName],
-    queryFn: () => fetchProject(projectName),
-  });
-
   if (error) {
     notify.failure("Loading profile failed", error);
   }
 
-  if (projectError) {
-    notify.failure("Loading project failed", error);
-  }
   const isLoading = isProfileLoading || isProjectLoading;
 
   const featuresProfiles = isProjectWithProfiles(project);

--- a/src/pages/profiles/ProfileLink.tsx
+++ b/src/pages/profiles/ProfileLink.tsx
@@ -12,7 +12,7 @@ interface Props {
 const ProfileLink: FC<Props> = ({ profile }) => {
   return (
     <Link
-      to={`/ui/${profile.project}/profiles/detail/${profile.name}`}
+      to={`/ui/project/${profile.project}/profiles/detail/${profile.name}`}
       onClick={(e) => e.stopPropagation()}
     >
       <ItemName item={profile} />

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -60,7 +60,7 @@ const ProfileList: FC = () => {
   }
 
   if (projectError) {
-    notify.failure("Loading project failed", error);
+    notify.failure("Loading project failed", projectError);
   }
   const isLoading = isProfilesLoading || isProjectLoading;
 

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -20,10 +20,10 @@ import useEventListener from "@use-it/event-listener";
 import { updateTBodyHeight } from "util/updateTBodyHeight";
 import Pagination from "components/Pagination";
 import NotificationRow from "components/NotificationRow";
-import { fetchProject } from "api/projects";
 import { defaultFirst } from "util/helpers";
 import ProfileLink from "./ProfileLink";
 import { isProjectWithProfiles } from "util/projects";
+import { useProject } from "context/project";
 
 const ProfileList: FC = () => {
   const navigate = useNavigate();
@@ -37,6 +37,8 @@ const ProfileList: FC = () => {
   }
   const isDefaultProject = projectName === "default";
 
+  const { project, isLoading: isProjectLoading } = useProject();
+
   const {
     data: profiles = [],
     error,
@@ -46,22 +48,10 @@ const ProfileList: FC = () => {
     queryFn: () => fetchProfiles(projectName),
   });
 
-  const {
-    data: project,
-    error: projectError,
-    isLoading: isProjectLoading,
-  } = useQuery({
-    queryKey: [queryKeys.projects, projectName],
-    queryFn: () => fetchProject(projectName),
-  });
-
   if (error) {
     notify.failure("Loading profiles failed", error);
   }
 
-  if (projectError) {
-    notify.failure("Loading project failed", projectError);
-  }
   const isLoading = isProfilesLoading || isProjectLoading;
 
   const featuresProfiles = isProjectWithProfiles(project);

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -201,7 +201,9 @@ const ProfileList: FC = () => {
             <Button
               appearance="positive"
               className="u-no-margin--bottom"
-              onClick={() => navigate(`/ui/${projectName}/profiles/create`)}
+              onClick={() =>
+                navigate(`/ui/project/${projectName}/profiles/create`)
+              }
             >
               Create profile
             </Button>

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -27,7 +27,7 @@ const DeleteProfileBtn: FC<Props> = ({
       .then(() => {
         setLoading(false);
         navigate(
-          `/ui/${project}/profiles`,
+          `/ui/project/${project}/profiles`,
           notify.queue(notify.success(`Profile ${profile.name} deleted.`))
         );
       })

--- a/src/pages/profiles/actions/ViewProfileInstancesBtn.tsx
+++ b/src/pages/profiles/actions/ViewProfileInstancesBtn.tsx
@@ -16,7 +16,7 @@ const ViewProfileInstancesBtn: FC<Props> = ({ profile, project }) => {
       className="u-no-margin u-no-padding"
       small
       onClick={() => {
-        navigate(`/ui/${project}/instances`, {
+        navigate(`/ui/project/${project}/instances`, {
           state: {
             appliedProfile: profile,
           },

--- a/src/pages/projects/CreateProjectForm.tsx
+++ b/src/pages/projects/CreateProjectForm.tsx
@@ -97,7 +97,7 @@ const CreateProjectForm: FC = () => {
       )
         .then(() => {
           navigate(
-            `/ui/${values.name}/instances`,
+            `/ui/project/${values.name}/instances`,
             notify.queue(notify.success(`Project ${values.name} created.`))
           );
         })

--- a/src/pages/projects/ProjectConfiguration.tsx
+++ b/src/pages/projects/ProjectConfiguration.tsx
@@ -1,35 +1,20 @@
 import React, { FC } from "react";
-import { fetchProject } from "api/projects";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { useNotify } from "context/notify";
 import { useParams } from "react-router-dom";
 import EditProjectForm from "pages/projects/EditProjectForm";
 import Loader from "components/Loader";
+import { useProject } from "context/project";
 
 const ProjectConfiguration: FC = () => {
-  const notify = useNotify();
   const { project: projectName } = useParams<{ project: string }>();
 
   if (!projectName) {
     return <>Missing project</>;
   }
 
-  const {
-    data: project,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: [queryKeys.projects, projectName],
-    queryFn: () => fetchProject(projectName),
-  });
+  const { project, isLoading } = useProject();
 
   if (isLoading) {
     return <Loader />;
-  }
-
-  if (error) {
-    notify.failure("Loading project failed", error);
   }
 
   return project ? (

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -44,7 +44,7 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
       renameProject(project.name, values.name)
         .then(() => {
           navigate(
-            `/ui/${values.name}/configuration`,
+            `/ui/project/${values.name}/configuration`,
             notify.queue(notify.success("Project renamed."))
           );
           void formik.setFieldValue("isRenaming", false);

--- a/src/pages/projects/ProjectLoader.tsx
+++ b/src/pages/projects/ProjectLoader.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import Loader from "components/Loader";
+import NoMatch from "components/NoMatch";
+import { useProject } from "context/project";
+
+interface Props {
+  outlet: JSX.Element;
+}
+
+const ProjectLoader = ({ outlet }: Props) => {
+  const { project, isLoading } = useProject();
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (!project) {
+    return <NoMatch />;
+  }
+
+  return outlet;
+};
+
+export default ProjectLoader;

--- a/src/pages/projects/ProjectRedirect.tsx
+++ b/src/pages/projects/ProjectRedirect.tsx
@@ -8,7 +8,7 @@ const ProjectRedirect: FC = () => {
     return <>Missing project</>;
   }
 
-  return <Navigate to={`/ui/${project}/instances`} replace={true} />;
+  return <Navigate to={`/ui/project/${project}/instances`} replace={true} />;
 };
 
 export default ProjectRedirect;

--- a/src/pages/projects/ProjectSelectorList.tsx
+++ b/src/pages/projects/ProjectSelectorList.tsx
@@ -41,7 +41,7 @@ const ProjectSelectorList: FC<Props> = ({ projects, onMount }): JSX.Element => {
         .map((project) => (
           <div key={project.name} className="p-contextual-menu__group">
             <Link
-              to={`/ui/${project.name}/${targetSection}`}
+              to={`/ui/project/${project.name}/${targetSection}`}
               className="p-contextual-menu__link link"
             >
               <div title={project.name} className="u-truncate name">

--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -24,7 +24,7 @@ const DeleteProjectBtn: FC<Props> = ({ project }) => {
     deleteProject(project)
       .then(() => {
         navigate(
-          `/ui/default/instances`,
+          `/ui/project/default/instances`,
           notify.queue(notify.success(`Project ${project.name} deleted.`))
         );
       })

--- a/src/pages/storage/StorageDetailHeader.tsx
+++ b/src/pages/storage/StorageDetailHeader.tsx
@@ -41,7 +41,7 @@ const StorageDetailHeader: FC<Props> = ({ name, storagePool, project }) => {
       renameStoragePool(name, values.name, project)
         .then(() => {
           navigate(
-            `/ui/${project}/storage/${values.name}`,
+            `/ui/project/${project}/storage/${values.name}`,
             notify.queue(notify.success("Storage pool renamed."))
           );
           void formik.setFieldValue("isRenaming", false);
@@ -56,7 +56,9 @@ const StorageDetailHeader: FC<Props> = ({ name, storagePool, project }) => {
   return (
     <RenameHeader
       name={name}
-      parentItem={<Link to={`/ui/${project}/storage`}>Storage pools</Link>}
+      parentItem={
+        <Link to={`/ui/project/${project}/storage`}>Storage pools</Link>
+      }
       controls={
         <DeleteStorageBtn
           key="delete"

--- a/src/pages/storage/StorageList.tsx
+++ b/src/pages/storage/StorageList.tsx
@@ -51,7 +51,7 @@ const StorageList: FC = () => {
       columns: [
         {
           content: (
-            <Link to={`/ui/${project}/storage/${storage.name}`}>
+            <Link to={`/ui/project/${project}/storage/${storage.name}`}>
               {storage.name}
             </Link>
           ),

--- a/src/pages/storage/StorageUsedBy.tsx
+++ b/src/pages/storage/StorageUsedBy.tsx
@@ -58,7 +58,9 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
             className="u-no-margin--bottom"
             items={data[PROFILES].map((item) => (
               <Fragment key={item.name}>
-                <Link to={`/ui/${item.project}/profiles/detail/${item.name}`}>
+                <Link
+                  to={`/ui/project/${item.project}/profiles/detail/${item.name}`}
+                >
                   {item.name}
                 </Link>
                 {item.project !== project && ` (project ${item.project})`}
@@ -92,7 +94,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
             items={data[SNAPSHOTS].map((item) => (
               <Fragment key={item.name}>
                 <Link
-                  to={`/ui/${item.project}/instances/detail/${item.instance}/snapshots`}
+                  to={`/ui/project/${item.project}/instances/detail/${item.instance}/snapshots`}
                 >
                   {`${item.instance} ${item.name}`}
                 </Link>

--- a/src/pages/storage/actions/DeleteStorageBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBtn.tsx
@@ -28,7 +28,7 @@ const DeleteStorageBtn: FC<Props> = ({ storage, project }) => {
           queryKey: [queryKeys.storage],
         });
         navigate(
-          `/ui/${project}/storage`,
+          `/ui/project/${project}/storage`,
           notify.queue(notify.success(`Storage pool ${storage.name} deleted.`))
         );
       })

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -9,13 +9,9 @@ export const projectSubpages = [
   "configuration",
 ];
 
-export const getProjectFromUrl = (url: string) => {
-  return url.split("/")[3] ?? "";
-};
-
 export const getSubpageFromUrl = (url: string) => {
   const parts = url.split("/");
-  if (projectSubpages.includes(parts[3])) {
+  if (projectSubpages.includes(parts[4])) {
     return parts[4];
   }
   return undefined;

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -10,11 +10,7 @@ export const projectSubpages = [
 ];
 
 export const getProjectFromUrl = (url: string) => {
-  const parts = url.split("/");
-  if (projectSubpages.includes(parts[3])) {
-    return parts[2];
-  }
-  return undefined;
+  return url.split("/")[2] ?? "";
 };
 
 export const getSubpageFromUrl = (url: string) => {

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -10,13 +10,13 @@ export const projectSubpages = [
 ];
 
 export const getProjectFromUrl = (url: string) => {
-  return url.split("/")[2] ?? "";
+  return url.split("/")[3] ?? "";
 };
 
 export const getSubpageFromUrl = (url: string) => {
   const parts = url.split("/");
   if (projectSubpages.includes(parts[3])) {
-    return parts[3];
+    return parts[4];
   }
   return undefined;
 };


### PR DESCRIPTION
## Done

- When visiting the `/:project` URL, or any `/:project/` subpage, show the 404 if the project does not exist.

Fixes [WD-4068](https://warthogs.atlassian.net/browse/WD-4068)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit [a bogus project URL](https://lxd-ui-351.demos.haus/ui/bogusproject), or any of its subpages
    - Check that the 404 is shown

[WD-4068]: https://warthogs.atlassian.net/browse/WD-4068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ