### PR TITLE
Avoid loading project when no project name is specified

### DIFF
--- a/src/context/project.tsx
+++ b/src/context/project.tsx
@@ -30,6 +30,7 @@ export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
     queryKey: [queryKeys.projects, project],
     queryFn: () => fetchProject(project),
     retry: false,
+    enabled: project.length > 0,
   });
 
   return (


### PR DESCRIPTION
## Done

- Avoid loading project when no project name is specified

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check pages without a project have no requests for projects