### PR TITLE
Expand collapsed navigation on hover WD-3186

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -17,6 +17,7 @@ const Navigation: FC = () => {
   const { isRestricted } = useAuth();
   const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { project, isLoading } = useProject();
+  const [isHover, setHover] = useState(false);
   const [projectName, setProjectName] = useState(
     project && !isLoading ? project.name : "default"
   );
@@ -35,6 +36,7 @@ const Navigation: FC = () => {
 
   const hardToggleMenu = (e: MouseEvent<HTMLElement>) => {
     setMenuCollapsed((prev) => !prev);
+    setHover(false);
     e.stopPropagation();
   };
 
@@ -59,10 +61,12 @@ const Navigation: FC = () => {
       <nav
         aria-label="main navigation"
         className={classnames("l-navigation", {
-          "is-collapsed": menuCollapsed,
-          "is-pinned": !menuCollapsed,
+          "is-collapsed": menuCollapsed && (isSmallScreen() || !isHover),
+          "is-pinned": !menuCollapsed || (!isSmallScreen() && isHover),
         })}
         onClick={softToggleMenu}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
       >
         <div className="l-navigation__drawer">
           <div className="p-panel is-dark">
@@ -315,7 +319,10 @@ const Navigation: FC = () => {
                 } main navigation`}
                 hasIcon
                 dense
-                className="sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle u-hide--small"
+                className={classnames(
+                  "sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle u-hide--small",
+                  { "is-rotated": menuCollapsed }
+                )}
                 onClick={hardToggleMenu}
               >
                 <Icon light name="sidebar-toggle" />

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -117,10 +117,10 @@
 
 .l-navigation.is-collapsed .sidenav-toggle-wrapper {
   text-align: left;
+}
 
-  .sidenav-toggle {
-    rotate: 180deg;
-  }
+.sidenav-toggle.is-rotated {
+  rotate: 180deg;
 }
 
 @media screen and (max-width: $breakpoint-x-large) and (max-height: 680px),


### PR DESCRIPTION
## Done

- expand collapsed navigation on hvoer

Fixes WD-3186

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check expand / collapse hover / unhover navigation