### PR TITLE
Ensure instances are started after creation even with long running create processes WD-4050

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -41,9 +41,7 @@ export const createInstance = (
       body: body,
     })
       .then(handleResponse)
-      .then((data: LxdOperationResponse) => {
-        watchOperation(data.operation, TIMEOUT_120).then(resolve).catch(reject);
-      })
+      .then(resolve)
       .catch(reject);
   });
 };

--- a/src/context/eventQueue.tsx
+++ b/src/context/eventQueue.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, FC, ReactNode, useContext } from "react";
+
+export interface EventQueue {
+  get: (operationId: string) => EventCallback | undefined;
+  set: (
+    operationId: string,
+    onSuccess: () => void,
+    onFailure: (msg: string) => void
+  ) => void;
+  remove: (operationId: string) => void;
+}
+
+const EventQueueContext = createContext<EventQueue>({
+  get: () => undefined,
+  set: () => undefined,
+  remove: () => undefined,
+});
+
+interface Props {
+  children: ReactNode;
+}
+
+interface EventCallback {
+  onSuccess: () => void;
+  onFailure: (msg: string) => void;
+}
+
+const eventQueue = new Map<string, EventCallback>();
+
+export const EventQueueProvider: FC<Props> = ({ children }) => {
+  return (
+    <EventQueueContext.Provider
+      value={{
+        get: (operationId) => eventQueue.get(operationId),
+        set: (operationId, onSuccess, onFailure) => {
+          eventQueue.set(operationId, { onSuccess, onFailure });
+        },
+        remove: (operationId) => eventQueue.delete(operationId),
+      }}
+    >
+      {children}
+    </EventQueueContext.Provider>
+  );
+};
+
+export function useEventQueue() {
+  return useContext(EventQueueContext);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,8 @@ import App from "./App";
 import "./sass/styles.scss";
 import { ProjectProvider } from "context/project";
 import { InstanceLoadingProvider } from "context/instanceLoading";
+import Events from "pages/instances/Events";
+import { EventQueueProvider } from "context/eventQueue";
 
 const queryClient = new QueryClient();
 
@@ -23,11 +25,14 @@ root.render(
         <AuthProvider>
           <ProjectProvider>
             <InstanceLoadingProvider>
-              <div className="l-application" role="presentation">
-                <Navigation />
-                <App />
-                <Panels />
-              </div>
+              <EventQueueProvider>
+                <div className="l-application" role="presentation">
+                  <Navigation />
+                  <App />
+                  <Panels />
+                  <Events />
+                </div>
+              </EventQueueProvider>
             </InstanceLoadingProvider>
           </ProjectProvider>
         </AuthProvider>

--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -1,0 +1,51 @@
+import React, { FC, useEffect, useState } from "react";
+import { LxdEvent } from "types/event";
+import { useEventQueue } from "context/eventQueue";
+
+const Events: FC = () => {
+  const eventQueue = useEventQueue();
+  const [eventWs, setEventWs] = useState<WebSocket | null>(null);
+
+  const handleEvent = (event: LxdEvent) => {
+    const eventCallback = eventQueue.get(event.metadata.id);
+    if (!eventCallback) {
+      return;
+    }
+    if (event.metadata.status === "Success") {
+      eventCallback.onSuccess();
+      eventQueue.remove(event.metadata.id);
+    }
+    if (event.metadata.status === "Failure") {
+      eventCallback.onFailure(event.metadata.err ?? "");
+      eventQueue.remove(event.metadata.id);
+    }
+  };
+
+  const connectEventWs = () => {
+    const wsUrl = `wss://${location.host}/1.0/events?type=operation,lifecycle`;
+    const ws = new WebSocket(wsUrl);
+    ws.onopen = () => {
+      setEventWs(ws);
+    };
+    ws.onclose = () => {
+      setEventWs(null);
+    };
+    ws.onmessage = (message: MessageEvent<Blob | string | null>) => {
+      if (typeof message.data !== "string") {
+        console.log("Invalid format on event api: ", message.data);
+        return;
+      }
+      const event = JSON.parse(message.data) as LxdEvent;
+      setTimeout(() => handleEvent(event), 1000); // handle with delay to allow operations to vanish
+    };
+  };
+
+  useEffect(() => {
+    if (!eventWs) {
+      connectEventWs();
+    }
+  }, [eventWs]);
+  return <></>;
+};
+
+export default Events;

--- a/src/pages/instances/InstanceStatusIcon.tsx
+++ b/src/pages/instances/InstanceStatusIcon.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const InstanceStatusIcon: FC<Props> = ({ instance }) => {
   const instanceLoading = useInstanceLoading();
-  const loadingState = instanceLoading.getType(instance);
+  const loadingType = instanceLoading.getType(instance);
 
   const getIconNameForStatus = (status: string) => {
     return (
@@ -25,10 +25,10 @@ const InstanceStatusIcon: FC<Props> = ({ instance }) => {
     );
   };
 
-  return loadingState ? (
+  return loadingType ? (
     <>
       <Icon className="u-animation--spin status-icon" name="spinner" />
-      <i>{loadingState}</i>
+      <i>{loadingType}</i>
     </>
   ) : (
     <>

--- a/src/types/event.d.ts
+++ b/src/types/event.d.ts
@@ -1,0 +1,17 @@
+export interface LxdEvent {
+  type: string;
+  timestamp: string;
+  metadata: {
+    id: string;
+    action: string;
+    description: string;
+    source: string;
+    resources: {
+      instances: [string];
+    };
+    status: "Failure" | "Success";
+    err?: string;
+  };
+  location: string;
+  project: string;
+}


### PR DESCRIPTION
## Done

- subscribe to events websocket to get live updates from LXD for any lifecycle changes
- use events to launch an instance that was created and is supposed to start.

Fixes WD-4050

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - create or create+start some container and/or VMs and see the notifications work and the desired outcome is reached.