### PR TITLE
Consume search and filter events [WD-3865]

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -31,8 +31,10 @@ const Navigation: FC = () => {
     e.stopPropagation();
   };
 
-  const collapseOnMediumScreen = () => {
-    setMenuCollapsed(isWidthBelow(820));
+  const collapseOnMediumScreen = (e: Event) => {
+    if (!("detail" in e) || e.detail !== "search-and-filter") {
+      setMenuCollapsed(isWidthBelow(820));
+    }
   };
 
   useEventListener("resize", collapseOnMediumScreen);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,7 +6,6 @@ import classnames from "classnames";
 import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
 import ServerVersion from "components/ServerVersion";
-import useEventListener from "@use-it/event-listener";
 import { isWidthBelow } from "util/helpers";
 import { useProject } from "context/project";
 import { useMenuCollapsed } from "context/menuCollapsed";
@@ -22,22 +21,14 @@ const Navigation: FC = () => {
   const { isAuthenticated } = useAuth();
   const softToggleMenu = () => {
     if (isSmallScreen()) {
-      setMenuCollapsed(!menuCollapsed);
+      setMenuCollapsed((prev) => !prev);
     }
   };
 
   const hardToggleMenu = (e: MouseEvent<HTMLElement>) => {
-    setMenuCollapsed(!menuCollapsed);
+    setMenuCollapsed((prev) => !prev);
     e.stopPropagation();
   };
-
-  const collapseOnMediumScreen = (e: Event) => {
-    if (!("detail" in e) || e.detail !== "search-and-filter") {
-      setMenuCollapsed(isWidthBelow(820));
-    }
-  };
-
-  useEventListener("resize", collapseOnMediumScreen);
 
   return (
     <>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent, useState } from "react";
+import React, { FC, MouseEvent } from "react";
 import { NavLink } from "react-router-dom";
 import { Button, Icon } from "@canonical/react-components";
 import { useAuth } from "context/auth";
@@ -9,12 +9,12 @@ import ServerVersion from "components/ServerVersion";
 import useEventListener from "@use-it/event-listener";
 import { isWidthBelow } from "util/helpers";
 import { useProject } from "context/project";
+import { useMenuCollapsed } from "context/menuCollapsed";
 
 const isSmallScreen = () => isWidthBelow(620);
 
 const Navigation: FC = () => {
-  const [menuCollapsed, setMenuCollapsed] = useState(isSmallScreen());
-
+  const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { project, isLoading } = useProject();
 
   const projectName = project && !isLoading ? project.name : "default";
@@ -22,12 +22,12 @@ const Navigation: FC = () => {
   const { isAuthenticated } = useAuth();
   const softToggleMenu = () => {
     if (isSmallScreen()) {
-      setMenuCollapsed((prev) => !prev);
+      setMenuCollapsed(!menuCollapsed);
     }
   };
 
   const hardToggleMenu = (e: MouseEvent<HTMLElement>) => {
-    setMenuCollapsed((prev) => !prev);
+    setMenuCollapsed(!menuCollapsed);
     e.stopPropagation();
   };
 

--- a/src/context/menuCollapsed.tsx
+++ b/src/context/menuCollapsed.tsx
@@ -1,44 +1,27 @@
-import React, {
-  createContext,
-  Dispatch,
-  FC,
-  ReactNode,
-  SetStateAction,
-  useContext,
-  useState,
-} from "react";
+import { useState } from "react";
+import useEventListener from "@use-it/event-listener";
+import { isWidthBelow } from "util/helpers";
 
-interface ContextProps {
-  menuCollapsed: boolean;
-  setMenuCollapsed: Dispatch<SetStateAction<boolean>>;
-}
+const isSmallScreen = () => isWidthBelow(620);
 
-const initialState: ContextProps = {
-  menuCollapsed: false,
-  setMenuCollapsed: () => undefined,
-};
-
-export const MenuCollapsedContext = createContext<ContextProps>(initialState);
-
-interface ProviderProps {
-  children: ReactNode;
-}
-
-export const MenuCollapsedProvider: FC<ProviderProps> = ({ children }) => {
+export const useMenuCollapsed = () => {
   const [menuCollapsed, setMenuCollapsed] = useState(false);
 
-  return (
-    <MenuCollapsedContext.Provider
-      value={{
-        menuCollapsed,
-        setMenuCollapsed,
-      }}
-    >
-      {children}
-    </MenuCollapsedContext.Provider>
-  );
-};
+  const collapseOnMediumScreen = (e: Event) => {
+    if (!("detail" in e) || e.detail !== "search-and-filter") {
+      setMenuCollapsed(isWidthBelow(820));
+    }
+  };
 
-export function useMenuCollapsed() {
-  return useContext(MenuCollapsedContext);
-}
+  useEventListener("resize", collapseOnMediumScreen);
+
+  const onSearchFilterPanelToggle = () => {
+    if (!menuCollapsed && isSmallScreen()) {
+      setMenuCollapsed(true);
+    }
+  };
+
+  useEventListener("sfp-toggle", onSearchFilterPanelToggle);
+
+  return { menuCollapsed, setMenuCollapsed };
+};

--- a/src/context/menuCollapsed.tsx
+++ b/src/context/menuCollapsed.tsx
@@ -1,0 +1,44 @@
+import React, {
+  createContext,
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useState,
+} from "react";
+
+interface ContextProps {
+  menuCollapsed: boolean;
+  setMenuCollapsed: Dispatch<SetStateAction<boolean>>;
+}
+
+const initialState: ContextProps = {
+  menuCollapsed: false,
+  setMenuCollapsed: () => undefined,
+};
+
+export const MenuCollapsedContext = createContext<ContextProps>(initialState);
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export const MenuCollapsedProvider: FC<ProviderProps> = ({ children }) => {
+  const [menuCollapsed, setMenuCollapsed] = useState(false);
+
+  return (
+    <MenuCollapsedContext.Provider
+      value={{
+        menuCollapsed,
+        setMenuCollapsed,
+      }}
+    >
+      {children}
+    </MenuCollapsedContext.Provider>
+  );
+};
+
+export function useMenuCollapsed() {
+  return useContext(MenuCollapsedContext);
+}

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -12,8 +12,6 @@ import {
   SearchAndFilterChip,
 } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import { useLocation } from "react-router-dom";
-import { useMenuCollapsed } from "context/menuCollapsed";
-import { isWidthBelow } from "util/helpers";
 
 interface ProfileFilterState {
   state?: {
@@ -26,10 +24,7 @@ interface Props {
   setFilters: (newFilters: InstanceFilters) => void;
 }
 
-const isSmallScreen = () => isWidthBelow(620);
-
 const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
-  const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { state } = useLocation() as ProfileFilterState;
 
   useEffect(() => window.history.replaceState({}, ""), [state]);
@@ -102,17 +97,7 @@ const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
           );
         }}
         onPanelToggle={() => {
-          const searchAndFilterPanel = document.querySelector(
-            ".p-search-and-filter__panel"
-          );
-          if (!searchAndFilterPanel) {
-            return;
-          }
-          const isShowing =
-            searchAndFilterPanel.getAttribute("aria-hidden") === "false";
-          if (!menuCollapsed && isShowing && isSmallScreen()) {
-            setMenuCollapsed(true);
-          }
+          window.dispatchEvent(new CustomEvent("sfp-toggle"));
         }}
       />
     </div>

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -91,6 +91,11 @@ const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
         }
         filterPanelData={searchAndFilterData}
         returnSearchData={onSearchDataChange}
+        onExpandChange={() => {
+          window.dispatchEvent(
+            new CustomEvent("resize", { detail: "search-and-filter" })
+          );
+        }}
       />
     </div>
   );

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -12,6 +12,8 @@ import {
   SearchAndFilterChip,
 } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import { useLocation } from "react-router-dom";
+import { useMenuCollapsed } from "context/menuCollapsed";
+import { isWidthBelow } from "util/helpers";
 
 interface ProfileFilterState {
   state?: {
@@ -24,7 +26,10 @@ interface Props {
   setFilters: (newFilters: InstanceFilters) => void;
 }
 
+const isSmallScreen = () => isWidthBelow(620);
+
 const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
+  const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { state } = useLocation() as ProfileFilterState;
 
   useEffect(() => window.history.replaceState({}, ""), [state]);
@@ -95,6 +100,19 @@ const InstanceSearchFilter: FC<Props> = ({ instances, setFilters }) => {
           window.dispatchEvent(
             new CustomEvent("resize", { detail: "search-and-filter" })
           );
+        }}
+        onPanelToggle={() => {
+          const searchAndFilterPanel = document.querySelector(
+            ".p-search-and-filter__panel"
+          );
+          if (!searchAndFilterPanel) {
+            return;
+          }
+          const isShowing =
+            searchAndFilterPanel.getAttribute("aria-hidden") === "false";
+          if (!menuCollapsed && isShowing && isSmallScreen()) {
+            setMenuCollapsed(true);
+          }
         }}
       />
     </div>

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -159,8 +159,4 @@ export const getUrlParam = (paramName: string, url?: string): string | null => {
 export const defaultFirst = (p1: { name: string }, p2: { name: string }) =>
   p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0;
 
-export const isWidthBelow = (width: number) => {
-  // using the max from both, because there is a bug in chrome, causing a 0 outerWidth for
-  // background tabs: https://bugs.chromium.org/p/chromium/issues/detail?id=719296
-  return Math.max(window.outerWidth, window.innerWidth) < width;
-};
+export const isWidthBelow = (width: number) => window.innerWidth < width;


### PR DESCRIPTION
## Done

- Adjust height of the page on search and filter expand
- Close navigation on search and filter panel open

Fixes [WD-3865](https://warthogs.atlassian.net/browse/WD-3865)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Open instance list page
    - Set many filters so that they overflow the first line
    - Make sure that the list is filtered enough to require a height update to keep the pagination at the bottom (e.g. less than 5 filtered instances)
    - Check that the height update happens as expected
    - Open instance list page on a small screen (width below 620px)
    - Manually expand the side navigation by clicking on the "Menu" button (top-right)
    - With the side navigation expanded, click on the search and filter input
    - Check that when the search and filter panel opens, the side navigation gets automatically collapsed

[WD-3865]: https://warthogs.atlassian.net/browse/WD-3865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ