### PR TITLE
Keep table headers sticky in the image selection modal [WD-4289]

### DIFF
--- a/src/components/ScrollableTable.tsx
+++ b/src/components/ScrollableTable.tsx
@@ -1,5 +1,6 @@
 import React, { DependencyList, FC, ReactNode, useEffect, useRef } from "react";
 import useEventListener from "@use-it/event-listener";
+import { getParentsBottomSpacing } from "util/helpers";
 
 interface Props {
   children: ReactNode;
@@ -28,7 +29,8 @@ const ScrollableTable: FC<Props> = ({ dependencies, children, belowId }) => {
     const tBody = table.children[1];
     const above = tBody.getBoundingClientRect().top + 1;
     const below = getAbsoluteHeightBelow();
-    const offset = Math.ceil(above + below);
+    const parentsBottomSpacing = getParentsBottomSpacing(table as HTMLElement);
+    const offset = Math.ceil(above + below + parentsBottomSpacing);
     const style = `height: calc(100vh - ${offset}px); min-height: calc(100vh - ${offset}px)`;
     tBody.setAttribute("style", style);
   };

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -342,10 +342,7 @@ const ImageSelector: FC<Props> = ({ onClose, onSelect }) => {
             value={query}
           />
           <div className="image-list">
-            <ScrollableTable
-              belowId="modal-bottom-space"
-              dependencies={[images]}
-            >
+            <ScrollableTable dependencies={[images]}>
               <MainTable
                 className="table-image-select"
                 emptyStateMsg={
@@ -361,7 +358,6 @@ const ImageSelector: FC<Props> = ({ onClose, onSelect }) => {
                 sortable
               />
             </ScrollableTable>
-            <div id="modal-bottom-space" />
           </div>
         </Col>
       </Row>

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -18,6 +18,7 @@ import Loader from "components/Loader";
 import { getArchitectureAliases } from "util/architectures";
 import { instanceCreationTypes } from "util/instanceOptions";
 import { useSettings } from "context/useSettings";
+import ScrollableTable from "components/ScrollableTable";
 
 interface Props {
   onClose: () => void;
@@ -341,20 +342,26 @@ const ImageSelector: FC<Props> = ({ onClose, onSelect }) => {
             value={query}
           />
           <div className="image-list">
-            <MainTable
-              className="table-image-select"
-              emptyStateMsg={
-                isLoading ? (
-                  <Loader text="Loading images..." />
-                ) : (
-                  "No matching images found"
-                )
-              }
-              headers={headers}
-              rows={rows}
-              paginate={null}
-              sortable
-            />
+            <ScrollableTable
+              belowId="modal-bottom-space"
+              dependencies={[images]}
+            >
+              <MainTable
+                className="table-image-select"
+                emptyStateMsg={
+                  isLoading ? (
+                    <Loader text="Loading images..." />
+                  ) : (
+                    "No matching images found"
+                  )
+                }
+                headers={headers}
+                rows={rows}
+                paginate={null}
+                sortable
+              />
+            </ScrollableTable>
+            <div id="modal-bottom-space" />
           </div>
         </Col>
       </Row>

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -141,10 +141,6 @@
 }
 
 .image-select-modal {
-  .p-modal__dialog {
-    overflow-y: hidden;
-  }
-
   > section {
     min-height: 100%;
   }
@@ -214,9 +210,5 @@
     .image-list {
       max-height: calc(100vh - 250px);
     }
-  }
-
-  #modal-bottom-space {
-    margin-bottom: 2rem;
   }
 }

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -141,6 +141,10 @@
 }
 
 .image-select-modal {
+  .p-modal__dialog {
+    overflow-y: hidden;
+  }
+
   > section {
     min-height: 100%;
   }
@@ -192,7 +196,7 @@
 
   .image-list {
     max-height: calc(100vh - 140px);
-    overflow-y: auto;
+    overflow-y: hidden;
   }
 
   @include large {
@@ -210,5 +214,9 @@
     .image-list {
       max-height: calc(100vh - 250px);
     }
+  }
+
+  #modal-bottom-space {
+    margin-bottom: 2rem;
   }
 }

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -160,3 +160,15 @@ export const defaultFirst = (p1: { name: string }, p2: { name: string }) =>
   p1.name === "default" ? -1 : p2.name === "default" ? 1 : 0;
 
 export const isWidthBelow = (width: number) => window.innerWidth < width;
+
+export const getParentsBottomSpacing = (element: HTMLElement) => {
+  let sum = 0;
+  while (element.parentElement) {
+    element = element.parentElement;
+    const style = window.getComputedStyle(element);
+    const margin = parseInt(style.marginBottom);
+    const padding = parseInt(style.paddingBottom);
+    sum += margin + padding;
+  }
+  return sum;
+};


### PR DESCRIPTION
## Done

- Keep table headers sticky in the image selection modal

Fixes [WD-4289](https://warthogs.atlassian.net/browse/WD-4289)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance
    - Select image
    - Check that the table headers are sticky in the image selection modal

[WD-4289]: https://warthogs.atlassian.net/browse/WD-4289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ