### PR TITLE
Target cluster group or member on instance creation WD-4263

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -33,10 +33,11 @@ export const fetchInstances = (project: string): Promise<LxdInstance[]> => {
 
 export const createInstance = (
   body: string,
-  project: string
+  project: string,
+  target?: string
 ): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/instances?project=${project}`, {
+    fetch(`/1.0/instances?project=${project}&target=${target ?? ""}`, {
       method: "POST",
       body: body,
     })

--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -174,7 +174,7 @@ const CreateInstanceForm: FC = () => {
       ? yamlToObject(values.yaml)
       : getPayload(values);
 
-    createInstance(JSON.stringify(instancePayload), project)
+    createInstance(JSON.stringify(instancePayload), project, values.target)
       .then((operation) => {
         const instanceName = operation.metadata.resources?.instances?.[0]
           .split("/")

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -7,6 +7,7 @@ import { instanceCreationTypes } from "util/instanceOptions";
 import { FormikProps } from "formik/dist/types";
 import { CreateInstanceFormValues } from "pages/instances/CreateInstanceForm";
 import { RemoteImage } from "types/image";
+import InstanceLocationSelect from "pages/instances/forms/InstanceLocationSelect";
 
 export interface InstanceDetailsFormValues {
   name?: string;
@@ -14,6 +15,7 @@ export interface InstanceDetailsFormValues {
   image?: RemoteImage;
   instanceType: string;
   profiles: string[];
+  target?: string;
   type: string;
   readOnly: boolean;
 }
@@ -125,6 +127,7 @@ const InstanceCreateDetailsForm: FC<Props> = ({
                   isVmOnlyImage(formik.values.image)
                 }
               />
+              <InstanceLocationSelect formik={formik} />
             </Col>
           </Row>
           <ProfileSelect

--- a/src/pages/instances/forms/InstanceLocationSelect.tsx
+++ b/src/pages/instances/forms/InstanceLocationSelect.tsx
@@ -1,0 +1,100 @@
+import React, { FC, useState } from "react";
+import { Select } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import Loader from "components/Loader";
+import { useSettings } from "context/useSettings";
+import { fetchClusterGroups } from "api/cluster";
+import { FormikProps } from "formik/dist/types";
+import { CreateInstanceFormValues } from "pages/instances/CreateInstanceForm";
+
+interface Props {
+  formik: FormikProps<CreateInstanceFormValues>;
+}
+
+const figureDefaultGroup = (target?: string) => {
+  if (!target?.startsWith("@")) {
+    return "default";
+  }
+  return target.split("@")[1];
+};
+
+const figureDefaultMember = (target?: string) => {
+  if (!target || target.startsWith("@")) {
+    return "";
+  }
+  return target;
+};
+
+const InstanceLocationSelect: FC<Props> = ({ formik }) => {
+  const { data: settings } = useSettings();
+  const isClustered = settings?.environment?.server_clustered;
+
+  if (!isClustered) {
+    return <></>;
+  }
+
+  const defaultGroup = figureDefaultGroup(formik.values.target);
+  const [selectedGroup, setSelectedGroup] = useState(defaultGroup);
+  const defaultMember = figureDefaultMember(formik.values.target);
+  const [selectedMember, setSelectedMember] = useState(defaultMember);
+
+  const { data: clusterGroups = [], isLoading } = useQuery({
+    queryKey: [queryKeys.cluster, queryKeys.groups],
+    queryFn: fetchClusterGroups,
+  });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  const setGroup = (group: string) => {
+    formik.setFieldValue("target", `@${group}`);
+    setSelectedGroup(group);
+    setSelectedMember("");
+  };
+
+  const setMember = (member: string) => {
+    if (member === "") {
+      setGroup(selectedGroup);
+    } else {
+      formik.setFieldValue("target", member);
+      setSelectedMember(member);
+    }
+  };
+
+  const availableMembers =
+    clusterGroups.find((group) => group.name === selectedGroup)?.members ?? [];
+
+  return (
+    <>
+      <Select
+        id="locationGroup"
+        label="Location group"
+        onChange={(e) => setGroup(e.target.value)}
+        value={selectedGroup}
+        options={clusterGroups.map((group) => {
+          return {
+            label: group.name,
+            value: group.name,
+            disabled: group.members.length < 1,
+          };
+        })}
+      />
+      <Select
+        id="locationMember"
+        label="Location member"
+        onChange={(e) => setMember(e.target.value)}
+        value={selectedMember}
+        options={[
+          ...(availableMembers.length > 1 ? [{ label: "any", value: "" }] : []),
+          ...availableMembers.map((member) => {
+            return { label: member, value: member };
+          }),
+        ]}
+      />
+    </>
+  );
+};
+
+export default InstanceLocationSelect;


### PR DESCRIPTION
## Done

- add location group/member selector to instance creation

Fixes WD-4263

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - instance creation in clustered / unclustered configuration with a group and/or a member targetted