### PR TITLE
fix(operations) ensure instance parsing is compatible with future urls

### DIFF
--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -1,9 +1,13 @@
 import { LxdOperation } from "types/operation";
 
 export const getInstanceName = (operation: LxdOperation): string => {
+  // the url can be one of below formats
+  // /1.0/instances/<instance_name>
+  // /1.0/instances/<instance_name>/snapshots/<snapshot_name>
   return (
     operation.resources?.instances
-      ?.map((item) => item.split("/").pop())
+      ?.filter((item) => item.startsWith("/1.0/instances/"))
+      .map((item) => item.split("/")[3])
       .pop() ?? ""
   );
 };


### PR DESCRIPTION
## Done

- ensure operation instance URL parsing is future-proof for https://github.com/lxc/lxd/pull/11795#issuecomment-1580113865

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check operation list when snapshotting an instance is linking to the right instance name