### PR TITLE
fix(snapshot-form): Expiration time form field error when not touched WD-4163

### DIFF
--- a/src/pages/instances/actions/snapshots/SnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotForm.tsx
@@ -103,7 +103,11 @@ const SnapshotForm: FC<Props> = ({
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.expirationDate ?? ""}
-              error={formik.errors.expirationDate}
+              error={
+                formik.touched.expirationDate
+                  ? formik.errors.expirationDate
+                  : null
+              }
             />
           </Col>
           <Col size={6}>
@@ -115,7 +119,11 @@ const SnapshotForm: FC<Props> = ({
               onChange={formik.handleChange}
               onBlur={formik.handleBlur}
               value={formik.values.expirationTime ?? ""}
-              error={formik.errors.expirationTime}
+              error={
+                formik.touched.expirationTime
+                  ? formik.errors.expirationTime
+                  : null
+              }
             />
           </Col>
         </Row>


### PR DESCRIPTION
## Done

- Previously, when manually creating a snapshot, users got an error in the “Expiry time” field as soon as entering the Expiry date. 
- The error now appear only if the user has touched with the field.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
Before:
<img width="400" alt="image" src="https://github.com/canonical/lxd-ui/assets/54525904/f95fb4a5-2a64-49bc-8ca1-f15e7e2bda43">
After:
<img width="400" alt="image" src="https://github.com/canonical/lxd-ui/assets/54525904/8402f8b7-0d6e-48bd-91c2-9de66f58b09f">

