### PR TITLE
Keep items bottom-aligned when not authenticated

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -226,7 +226,14 @@ const Navigation: FC = () => {
                     </>
                   )}
                 </ul>
-                <ul className="p-side-navigation__list sidenav-bottom-ul">
+                <ul
+                  className={classnames(
+                    "p-side-navigation__list sidenav-bottom-ul",
+                    {
+                      "authenticated-nav": isAuthenticated,
+                    }
+                  )}
+                >
                   <li className="p-side-navigation__item">
                     <a
                       className="p-side-navigation__link"
@@ -276,7 +283,11 @@ const Navigation: FC = () => {
                 </ul>
               </div>
             </div>
-            <div className="sidenav-toggle-wrapper">
+            <div
+              className={classnames("sidenav-toggle-wrapper", {
+                "authenticated-nav": isAuthenticated,
+              })}
+            >
               <Button
                 appearance="base"
                 aria-label={`${

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -93,6 +93,8 @@
 }
 
 .sidenav-bottom-ul {
+  bottom: $spv--x-large;
+  position: absolute;
   width: 15rem;
 }
 
@@ -100,8 +102,9 @@
   background: $colors--dark-theme--background-default;
   bottom: 0;
   padding: $spv--small $sph--x-large $spv--large $sph--large;
-  position: sticky;
+  position: absolute;
   text-align: right;
+  width: 100%;
 
   .sidenav-toggle {
     background-color: #444 !important;
@@ -116,17 +119,17 @@
   }
 }
 
-@media screen and (max-width: $breakpoint-x-large) and (min-height: 670px),
-  screen and (min-width: $breakpoint-x-large) and (min-height: 800px) {
-  .sidenav-bottom-ul {
-    bottom: $spv--x-large;
-    position: absolute;
+@media screen and (max-width: $breakpoint-x-large) and (max-height: 670px),
+  screen and (min-width: $breakpoint-x-large) and (max-height: 800px) {
+  .sidenav-bottom-ul.authenticated-nav {
+    bottom: initial;
+    position: initial;
   }
 
-  .sidenav-toggle-wrapper {
-    bottom: 0;
-    position: absolute;
-    width: 100%;
+  .sidenav-toggle-wrapper.authenticated-nav {
+    bottom: initial;
+    position: initial;
+    width: initial;
   }
 }
 


### PR DESCRIPTION
## Done

- Ensure that the 3 bottom links and the expand/collapse button in the side navigation are kept bottom-aligned when the user is not authenticated

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Remove trusted certificates to get the "unauthenticated" side navigation
    - Check that the items are kept at the bottom of the side navigation