### PR TITLE
Avoid navigation open/close on first paint, avoid closing menu on resize for mobile

### DIFF
--- a/src/context/menuCollapsed.tsx
+++ b/src/context/menuCollapsed.tsx
@@ -3,13 +3,17 @@ import useEventListener from "@use-it/event-listener";
 import { isWidthBelow } from "util/helpers";
 
 const isSmallScreen = () => isWidthBelow(620);
+const isMediumScreen = () => isWidthBelow(820);
 
 export const useMenuCollapsed = () => {
-  const [menuCollapsed, setMenuCollapsed] = useState(false);
+  const [menuCollapsed, setMenuCollapsed] = useState(isMediumScreen());
 
   const collapseOnMediumScreen = (e: Event) => {
+    if (isSmallScreen()) {
+      return;
+    }
     if (!("detail" in e) || e.detail !== "search-and-filter") {
-      setMenuCollapsed(isWidthBelow(820));
+      setMenuCollapsed(isMediumScreen());
     }
   };
 


### PR DESCRIPTION
## Done

- Avoid navigation open/close on first paint, avoid closing menu on resize for mobile (due to url bar hiding the resize is triggered while browsing the nav)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - test nav behaviour on large/medium/small devices