### PR TITLE
Move cluster empty states out of the table

### DIFF
--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -72,78 +72,82 @@ const ClusterList: FC = () => {
         <div className="p-panel__content cluster-content">
           <NotificationRow />
           <Row>
-            <ScrollableTable
-              dependencies={[filteredMembers, notify.notification]}
-              belowId="pagination"
-            >
-              <MainTable
-                headers={headers}
-                rows={pagination.pageData}
-                sortable
-                onUpdateSort={pagination.updateSort}
-                emptyStateMsg={
-                  isLoading && isClustered ? (
-                    <Loader text="Loading cluster members..." />
-                  ) : activeGroup ? (
-                    <EmptyState
-                      iconClass=""
-                      iconName="machines"
-                      title="Cluster group empty"
-                      message="Add cluster members to this group."
+            {isClustered && filteredMembers.length > 0 && (
+              <>
+                <ScrollableTable
+                  dependencies={[filteredMembers, notify.notification]}
+                  belowId="pagination"
+                >
+                  <MainTable
+                    headers={headers}
+                    rows={pagination.pageData}
+                    sortable
+                    onUpdateSort={pagination.updateSort}
+                    emptyStateMsg={
+                      isLoading && <Loader text="Loading cluster members..." />
+                    }
+                  />
+                </ScrollableTable>
+                <Pagination
+                  {...pagination}
+                  id="pagination"
+                  totalCount={members.length}
+                  visibleCount={
+                    filteredMembers.length === members.length
+                      ? pagination.pageData.length
+                      : filteredMembers.length
+                  }
+                  keyword="cluster member"
+                />
+              </>
+            )}
+            {!isLoading &&
+              isClustered &&
+              activeGroup &&
+              filteredMembers.length < 1 && (
+                <EmptyState
+                  iconClass=""
+                  iconName="machines"
+                  title="Cluster group empty"
+                  message="Add cluster members to this group."
+                >
+                  <p>
+                    <a
+                      className="p-link--external"
+                      href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
+                      target="_blank"
+                      rel="noreferrer"
                     >
-                      <p>
-                        <a
-                          className="p-link--external"
-                          href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Learn more about clustering
-                          <Icon
-                            className="external-link-icon"
-                            name="external-link"
-                          />
-                        </a>
-                      </p>
-                      <DeleteClusterGroupBtn group={activeGroup} />
-                    </EmptyState>
-                  ) : (
-                    <EmptyState
-                      iconClass=""
-                      iconName="machines"
-                      title="This server is not clustered"
-                      message="Creating cluster members is not supported in LXD UI. Create one using LXD CLI"
-                    >
-                      <p>
-                        <a
-                          className="p-link--external"
-                          href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Learn more about clustering
-                          <Icon
-                            className="external-link-icon"
-                            name="external-link"
-                          />
-                        </a>
-                      </p>
-                    </EmptyState>
-                  )
-                }
-              />
-            </ScrollableTable>
-            <Pagination
-              {...pagination}
-              id="pagination"
-              totalCount={members.length}
-              visibleCount={
-                filteredMembers.length === members.length
-                  ? pagination.pageData.length
-                  : filteredMembers.length
-              }
-              keyword="cluster member"
-            />
+                      Learn more about clustering
+                      <Icon
+                        className="external-link-icon"
+                        name="external-link"
+                      />
+                    </a>
+                  </p>
+                  <DeleteClusterGroupBtn group={activeGroup} />
+                </EmptyState>
+              )}
+            {!isClustered && (
+              <EmptyState
+                iconClass=""
+                iconName="machines"
+                title="This server is not clustered"
+                message="Creating cluster members is not supported in LXD UI. Create one using LXD CLI"
+              >
+                <p>
+                  <a
+                    className="p-link--external"
+                    href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Learn more about clustering
+                    <Icon className="external-link-icon" name="external-link" />
+                  </a>
+                </p>
+              </EmptyState>
+            )}
           </Row>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Moved cluster empty states out of the table, to keep consistency with the UX of the other main tables

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit cluster page when the server is not clustered
    - Check the corresponding empty state displayed out of the table
    - Visit cluster page on a clustered server
    - Create an empty group (or select it from the dropdown if it exists already)
    - Check the corresponding empty state displayed out of the table