### PR TITLE
Design fixes for the settings form in read mode

### DIFF
--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -112,7 +112,7 @@ const SettingForm: FC<Props> = ({ option, value }) => {
         <>
           <Button
             appearance="base"
-            className="u-no-margin"
+            className="readmode-button u-no-margin"
             onClick={() => {
               setEditMode(true);
               notify.clear();

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -1,0 +1,4 @@
+.readmode-button {
+  padding: 0;
+  text-align: start;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -74,9 +74,10 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "profile_list";
 @import "profile_used_by_default_project";
 @import "project_select";
-@import "scrollable_table";
 @import "rename_header";
+@import "scrollable_table";
 @import "selectable_main_table";
+@import "settings_page";
 
 .l-main .row {
   max-width: none;


### PR DESCRIPTION
## Done

- Fixed style of the button to switch a settings form to edit mode: text alignment and padding

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Visit the settings page
    - Check the new button style for the settings form when it is in read mode