### PR TITLE
Replace ambiguous modal button labels

### DIFF
--- a/src/components/ConfirmationButton.tsx
+++ b/src/components/ConfirmationButton.tsx
@@ -6,6 +6,7 @@ import classnames from "classnames";
 import { ButtonAppearance } from "@canonical/react-components/dist/components/Button/Button";
 
 interface Props {
+  cancelButtonLabel?: string;
   className?: string;
   confirmButtonAppearance?: ValueOf<typeof ButtonAppearance> | string;
   confirmButtonLabel: string;
@@ -25,6 +26,7 @@ interface Props {
 }
 
 const ConfirmationButton: FC<Props> = ({
+  cancelButtonLabel,
   className,
   confirmButtonAppearance,
   confirmButtonLabel,
@@ -73,6 +75,7 @@ const ConfirmationButton: FC<Props> = ({
           <ConfirmationModal
             title={title}
             onClose={handleCancelModal}
+            cancelButtonLabel={cancelButtonLabel}
             confirmExtra={confirmExtra}
             confirmMessage={confirmMessage}
             confirmButtonLabel={confirmButtonLabel}

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -3,6 +3,7 @@ import { Button, Modal, ValueOf } from "@canonical/react-components";
 import { ButtonAppearance } from "@canonical/react-components/dist/components/Button/Button";
 
 interface Props {
+  cancelButtonLabel?: string;
   confirmButtonAppearance?: ValueOf<typeof ButtonAppearance> | string;
   confirmButtonLabel: string;
   confirmExtra?: ReactNode;
@@ -14,6 +15,7 @@ interface Props {
 }
 
 const ConfirmationModal: FC<Props> = ({
+  cancelButtonLabel,
   confirmButtonAppearance = "negative",
   confirmButtonLabel,
   confirmExtra,
@@ -31,7 +33,7 @@ const ConfirmationModal: FC<Props> = ({
         <>
           {confirmExtra}
           <Button className="u-no-margin--bottom" onClick={onClose}>
-            Cancel
+            {cancelButtonLabel ?? "Cancel"}
           </Button>
           <Button
             appearance={confirmButtonAppearance}

--- a/src/pages/operations/actions/CancelOperationBtn.tsx
+++ b/src/pages/operations/actions/CancelOperationBtn.tsx
@@ -35,8 +35,9 @@ const CancelOperationBtn: FC<Props> = ({ operation }) => {
       toggleAppearance=""
       isLoading={isLoading}
       title="Confirm cancel"
+      cancelButtonLabel="No"
       confirmMessage="Are you sure you want to cancel the operation?"
-      confirmButtonLabel="Cancel"
+      confirmButtonLabel="Yes, cancel operation"
       toggleCaption="Cancel"
       onConfirm={handleCancel}
       isDisabled={!operation.may_cancel}


### PR DESCRIPTION
## Done

- Replace ambiguous modal button labels in `CancelOperationBtn` component.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Start an operation, e.g. an instance creation
    - Wait for the cancel operation button to become enabled
    - Click on the cancel operation button
    - Check the 2 new labels for cancel/confirm operation, to remove the previous ambiguity:
![image](https://github.com/canonical/lxd-ui/assets/56583786/d9ffb83d-b126-497c-867e-3e0485880a59)
