### PR TITLE
Invalidate operations query upon operation cancellation

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -267,7 +267,9 @@ const InstanceList: FC = () => {
                 },
               ]),
           {
-            content: <CancelOperationBtn operation={operation} />,
+            content: (
+              <CancelOperationBtn operation={operation} project={project} />
+            ),
             role: "rowheader",
             className: classnames("u-align--right", {
               "u-hide": panelParams.instance,

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -118,7 +118,9 @@ const OperationList: FC = () => {
           className: "status",
         },
         {
-          content: <CancelOperationBtn operation={operation} />,
+          content: (
+            <CancelOperationBtn operation={operation} project={project} />
+          ),
           role: "rowheader",
           className: "u-align--right cancel",
           "aria-label": "Cancel",

--- a/src/pages/operations/actions/CancelOperationBtn.tsx
+++ b/src/pages/operations/actions/CancelOperationBtn.tsx
@@ -3,14 +3,18 @@ import ConfirmationButton from "components/ConfirmationButton";
 import { useNotify } from "context/notify";
 import { LxdOperation } from "types/operation";
 import { cancelOperation } from "api/operations";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
 
 interface Props {
   operation: LxdOperation;
+  project: string;
 }
 
-const CancelOperationBtn: FC<Props> = ({ operation }) => {
+const CancelOperationBtn: FC<Props> = ({ operation, project }) => {
   const notify = useNotify();
   const [isLoading, setLoading] = useState(false);
+  const queryClient = useQueryClient();
 
   const handleCancel = () => {
     setLoading(true);
@@ -21,7 +25,12 @@ const CancelOperationBtn: FC<Props> = ({ operation }) => {
       .catch((e) => {
         notify.failure("Operation cancellation failed", e);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+        void queryClient.invalidateQueries({
+          queryKey: [queryKeys.operations, project],
+        });
+      });
   };
 
   return operation.status !== "Running" ? null : (


### PR DESCRIPTION
## Done

- Invalidate operations query upon operation cancellation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Trigger an operation that is expected to take enough time to let you cancel it, e.g. an instance creation with an image that is not cached
    - Go to operations page
    - Cancel the operation
    - Check that the operation disappears immediately from the list upon success/failure notification