### PR TITLE
Remove external link class

### DIFF
--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -113,7 +113,6 @@ const ClusterList: FC = () => {
                 >
                   <p>
                     <a
-                      className="p-link--external"
                       href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
                       target="_blank"
                       rel="noreferrer"
@@ -137,7 +136,6 @@ const ClusterList: FC = () => {
               >
                 <p>
                   <a
-                    className="p-link--external"
                     href="https://linuxcontainers.org/lxd/docs/latest/explanation/clustering/"
                     target="_blank"
                     rel="noreferrer"

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -589,7 +589,6 @@ const InstanceList: FC = () => {
                   <>
                     <p>
                       <a
-                        className="p-link--external"
                         href="https://linuxcontainers.org/lxd/docs/latest/howto/instances_create/"
                         target="_blank"
                         rel="noreferrer"

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -302,7 +302,6 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
           <>
             <p>
               <a
-                className="p-link--external"
                 href="https://linuxcontainers.org/lxd/docs/latest/howto/storage_backup_volume/#storage-backup-snapshots"
                 target="_blank"
                 rel="noreferrer"

--- a/src/pages/instances/forms/SnapshotsForm.tsx
+++ b/src/pages/instances/forms/SnapshotsForm.tsx
@@ -55,7 +55,6 @@ const SnapshotsForm: FC<Props> = ({ formik }) => {
                   Pongo2 template string that represents the snapshot name (used
                   for scheduled snapshots and unnamed snapshots), see{" "}
                   <a
-                    className="p-link--external"
                     href="https://linuxcontainers.org/lxd/docs/latest/reference/instance_options/#instance-options-snapshots-names"
                     target="_blank"
                     rel="noreferrer"

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -153,7 +153,6 @@ const NetworkList: FC = () => {
               <>
                 <p>
                   <a
-                    className="p-link--external"
                     href="https://linuxcontainers.org/lxd/docs/latest/explanation/networks/"
                     target="_blank"
                     rel="noreferrer"

--- a/src/pages/storage/StorageList.tsx
+++ b/src/pages/storage/StorageList.tsx
@@ -140,7 +140,6 @@ const StorageList: FC = () => {
               <>
                 <p>
                   <a
-                    className="p-link--external"
                     href="https://linuxcontainers.org/lxd/docs/latest/explanation/storage/"
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
## Done

- Remove vanilla `p-link--external` class that became unused