### PR TITLE
Use en-gb date language locale for snapshot expiry form

### DIFF
--- a/src/pages/instances/actions/snapshots/SnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotForm.tsx
@@ -98,6 +98,7 @@ const SnapshotForm: FC<Props> = ({
               id="expirationDate"
               name="expirationDate"
               type="date"
+              lang="en-GB"
               label="Expiry date"
               min={getTomorrow()}
               onChange={formik.handleChange}


### PR DESCRIPTION
## Done

- fixed the date format on the expiry input for snapshot creation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check snapshot creation/edit date picker