### PR TITLE
Auto-logout on token issue (expired/invalid refresh token)

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,10 +6,9 @@ import classnames from "classnames";
 import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
 import ServerVersion from "components/ServerVersion";
-import { isWidthBelow } from "util/helpers";
+import { isWidthBelow, logout } from "util/helpers";
 import { useProject } from "context/project";
 import { useMenuCollapsed } from "context/menuCollapsed";
-import { useSettings } from "context/useSettings";
 import { getCookie } from "util/cookies";
 
 const isSmallScreen = () => isWidthBelow(620);
@@ -17,12 +16,10 @@ const isSmallScreen = () => isWidthBelow(620);
 const Navigation: FC = () => {
   const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { project, isLoading } = useProject();
-  const { data: settings } = useSettings();
   const [projectName, setProjectName] = useState(
     project && !isLoading ? project.name : "default"
   );
   const hasOidcCookie = Boolean(getCookie("oidc_access"));
-  const hasLogout = hasOidcCookie || settings?.auth_user_method === "oidc";
 
   useEffect(() => {
     project && project.name !== projectName && setProjectName(project.name);
@@ -211,16 +208,12 @@ const Navigation: FC = () => {
                           Settings
                         </NavLink>
                       </li>
-                      {hasLogout && (
+                      {hasOidcCookie && (
                         <li className="p-side-navigation__item">
                           <a
                             className="p-side-navigation__link"
                             title="Log out"
-                            onClick={() =>
-                              void fetch("/oidc/logout").then(() =>
-                                window.location.reload()
-                              )
-                            }
+                            onClick={logout}
                           >
                             <Icon
                               className="is-light p-side-navigation__icon"


### PR DESCRIPTION
## Done

- Intercept auth-related errors and do an auto-logout instead of notifying them to the user (see screenshot below).

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - Login with OIDC
    - Open Chrome dev tools, Console tab
    - Set some bogus values for the `oidc_refresh` and `oidc_access` cookies:
    `document.cookie="oidc_refresh=sdfsdfsdfsd;path=/";`
    `document.cookie="oidc_access=sdfsdfsdfsd;path=/";`
    - Check that you get automatically logged out and shown the Login page, instead of seeing the error shown in the screenshot below.

## Screenshots

Before, the user would see this:

![image](https://github.com/canonical/lxd-ui/assets/56583786/b7716889-3343-42b9-b4fc-9377d5502023)

Now, we don't display this but do an auto-logout instead, to clear away the expired/invalid cookies.
