### PR TITLE
Use PS5 registry

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,6 +1,6 @@
 domain: lxd-ui
 
-image: prod-comms.docker-registry.canonical.com/lxd-ui
+image: prod-comms.ps5.docker-registry.canonical.com/lxd-ui
 
 env:
   - name: LXD_UI_BACKEND_IP


### PR DESCRIPTION
The konf file is only used for demos, not production, so this won't actually have any impact. But still, it should be consistent with all the other sites.