### PR TITLE
fix(pagination) avoid passing pagination props to div

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -2,6 +2,7 @@ import { Button, Icon, Input, Select } from "@canonical/react-components";
 import React, { FC, HTMLAttributes, useEffect, useState } from "react";
 import { paginationOptions } from "util/pagination";
 import useEventListener from "@use-it/event-listener";
+import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 
 const figureSmallScreen = () => {
   const descriptionElement = document.getElementById("pagination-description");
@@ -20,6 +21,10 @@ type Props = {
   totalCount: number;
   totalPages: number;
   keyword: string;
+  pageData: MainTableRow[];
+  itemsPerPage: number;
+  totalItems: number;
+  updateSort: (sort?: string | null) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
 const Pagination: FC<Props> = ({
@@ -31,6 +36,10 @@ const Pagination: FC<Props> = ({
   totalCount,
   totalPages,
   keyword,
+  pageData: _pageData,
+  itemsPerPage: _itemsPerPage,
+  totalItems: _totalItems,
+  updateSort: _updateSort,
   ...divProps
 }) => {
   const [isSmallScreen, setSmallScreen] = useState(figureSmallScreen());

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -21,10 +21,10 @@ type Props = {
   totalCount: number;
   totalPages: number;
   keyword: string;
-  pageData: MainTableRow[];
-  itemsPerPage: number;
-  totalItems: number;
-  updateSort: (sort?: string | null) => void;
+  pageData?: MainTableRow[];
+  itemsPerPage?: number;
+  totalItems?: number;
+  updateSort?: (sort?: string | null) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
 const Pagination: FC<Props> = ({


### PR DESCRIPTION
## Done

- fix errors in console on pagination usages, we shouldn't forward pagination props to the HTML div

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described in the [Readme](https://github.com/canonical/lxd-ui#setting-up-for-development).
2. Perform the following QA steps:
    - check pagination works as expected
    - check the console is clean of errors from the pagination component on the instance list