### PR TITLE
Use absolute as default for memory input, adjust labels WD-5100

### DIFF
--- a/src/pages/instances/forms/CpuLimitSelector.tsx
+++ b/src/pages/instances/forms/CpuLimitSelector.tsx
@@ -45,7 +45,6 @@ const CpuLimitSelector: FC<Props> = ({ cpuLimit, setCpuLimit }) => {
     <div>
       <div className="cpu-limit-label">
         <RadioInput
-          labelClassName="right-margin"
           label="number"
           checked={cpuLimit.selectedType === CPU_LIMIT_TYPE.DYNAMIC}
           onChange={() => setCpuLimit({ selectedType: CPU_LIMIT_TYPE.DYNAMIC })}

--- a/src/pages/instances/forms/MemoryLimitSelector.tsx
+++ b/src/pages/instances/forms/MemoryLimitSelector.tsx
@@ -105,21 +105,20 @@ const MemoryLimitSelector: FC<Props> = ({ memoryLimit, setMemoryLimit }) => {
     <div>
       <div className="memory-limit-label">
         <RadioInput
-          labelClassName="right-margin"
-          label="number"
-          checked={memoryLimit.selectedType === MEM_LIMIT_TYPE.PERCENT}
-          onChange={() =>
-            setMemoryLimit({ unit: "%", selectedType: MEM_LIMIT_TYPE.PERCENT })
-          }
-        />
-        <RadioInput
-          label="fixed"
+          label="absolute"
           checked={memoryLimit.selectedType === MEM_LIMIT_TYPE.FIXED}
           onChange={() =>
             setMemoryLimit({
               unit: BYTES_UNITS.GIB,
               selectedType: MEM_LIMIT_TYPE.FIXED,
             })
+          }
+        />
+        <RadioInput
+          label="percentage"
+          checked={memoryLimit.selectedType === MEM_LIMIT_TYPE.PERCENT}
+          onChange={() =>
+            setMemoryLimit({ unit: "%", selectedType: MEM_LIMIT_TYPE.PERCENT })
           }
         />
       </div>

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -4,6 +4,7 @@ import {
   CPU_LIMIT_TYPE,
   MemoryLimit,
   MEM_LIMIT_TYPE,
+  BYTES_UNITS,
 } from "types/limits";
 
 export const DEFAULT_NIC_DEVICE: LxdNicDevice = {
@@ -23,6 +24,6 @@ export const DEFAULT_CPU_LIMIT: CpuLimit = {
 };
 
 export const DEFAULT_MEM_LIMIT: MemoryLimit = {
-  unit: "%",
-  selectedType: MEM_LIMIT_TYPE.PERCENT,
+  unit: BYTES_UNITS.GIB,
+  selectedType: MEM_LIMIT_TYPE.FIXED,
 };

--- a/src/util/limits.tsx
+++ b/src/util/limits.tsx
@@ -62,7 +62,7 @@ export const parseMemoryLimit = (limit?: string): MemoryLimit | undefined => {
   if (!limit) {
     return undefined;
   }
-  if (limit.includes("%") || !limit) {
+  if (limit.includes("%")) {
     return {
       value: limit ? parseInt(limit) : undefined,
       unit: "%",

--- a/tests/helpers/configuration.ts
+++ b/tests/helpers/configuration.ts
@@ -78,7 +78,7 @@ export const setCpuLimit = async (
 
 export const setMemLimit = async (
   page: Page,
-  type: "fixed" | "number",
+  type: "absolute" | "percentage",
   limit: string
 ) => {
   await page.getByTestId("tab-link-Configuration").click();
@@ -101,7 +101,7 @@ export const setMemLimit = async (
     .getByRole("gridcell", { name: "Memory limit" })
     .getByText(type)
     .click();
-  const text = type === "number" ? "Enter percentage" : "Enter value";
+  const text = type === "percentage" ? "Enter percentage" : "Enter value";
   await page.getByPlaceholder(text).click();
   await page.getByPlaceholder(text).press("Control+a");
   await page.getByPlaceholder(text).fill(limit);

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -80,11 +80,11 @@ test("instance cpu and memory", async ({ page }) => {
   await saveInstance(page);
   await assertReadMode(page, "Exposed CPUs 1-23");
 
-  await setMemLimit(page, "number", "2");
+  await setMemLimit(page, "percentage", "2");
   await saveInstance(page);
   await assertReadMode(page, "Memory limit 2%");
 
-  await setMemLimit(page, "fixed", "3");
+  await setMemLimit(page, "absolute", "3");
   await saveInstance(page);
   await assertReadMode(page, "Memory limit 3GiB");
 

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -66,11 +66,11 @@ test("profile cpu and memory", async ({ page }) => {
   await saveProfile(page);
   await assertReadMode(page, "Exposed CPUs 1-23");
 
-  await setMemLimit(page, "number", "2");
+  await setMemLimit(page, "percentage", "2");
   await saveProfile(page);
   await assertReadMode(page, "Memory limit 2%");
 
-  await setMemLimit(page, "fixed", "3");
+  await setMemLimit(page, "absolute", "3");
   await saveProfile(page);
   await assertReadMode(page, "Memory limit 3GiB");
 


### PR DESCRIPTION
## Done

- change memory limit labels to absolute and percentage
- use absolute and GiB as default for memory limits

Fixes WD-5100

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check memory limit selector in 4 forms:
    - instance create
    - instance edit
    - profile create
    - profile edit