### PR TITLE
fix instance and profile editing with custom networks applied

### DIFF
--- a/src/pages/instances/forms/NetworkForm.tsx
+++ b/src/pages/instances/forms/NetworkForm.tsx
@@ -19,6 +19,7 @@ import { EditInstanceFormValues } from "pages/instances/EditInstanceForm";
 import { getConfigurationRowBase } from "pages/instances/forms/ConfigurationRow";
 import Loader from "components/Loader";
 import { figureInheritedNetworks } from "util/instanceConfigInheritance";
+import { CustomNetworkDevice } from "util/formDevices";
 
 interface Props {
   formik: SharedFormikTypes;
@@ -111,61 +112,75 @@ or remove the originating item"
         }),
 
         ...formik.values.devices.map((formDevice, index) => {
-          if (formDevice.type !== "nic") {
+          if (!formDevice.type?.includes("nic")) {
             return {};
           }
+          const device = formik.values.devices[index] as
+            | LxdNicDevice
+            | CustomNetworkDevice;
+
           return getConfigurationRowBase({
             override: "",
             label: (
               <Label forId={`networkDevice${index}`}>
                 <b>
-                  {isReadOnly
-                    ? (formik.values.devices[index] as LxdNicDevice).name
+                  {isReadOnly || device.type === "custom-nic"
+                    ? device.name
                     : "Network"}
                 </b>
               </Label>
             ),
-            value: isReadOnly ? (
-              (formik.values.devices[index] as LxdNicDevice).network
-            ) : (
-              <div className="network-device" key={index}>
-                <div>
-                  <Select
-                    label="Network device"
-                    name={`devices.${index}.network`}
-                    id={`networkDevice${index}`}
-                    onBlur={formik.handleBlur}
-                    onChange={formik.handleChange}
-                    value={
-                      (formik.values.devices[index] as LxdNicDevice).network
-                    }
-                    options={getNetworkOptions()}
-                  />
-                  <Input
-                    label="Network name"
-                    name={`devices.${index}.name`}
-                    id={`networkName${index}`}
-                    onBlur={formik.handleBlur}
-                    onChange={formik.handleChange}
-                    value={(formik.values.devices[index] as LxdNicDevice).name}
-                    type="text"
-                    placeholder="Enter name"
-                  />
+            value:
+              device.type === "custom-nic" ? (
+                <>
+                  custom network{" "}
+                  <Tooltip message="A custom network can be viewed and edited only from the YAML configuration">
+                    <Icon name="information" />
+                  </Tooltip>{" "}
+                </>
+              ) : isReadOnly ? (
+                (formik.values.devices[index] as LxdNicDevice).network
+              ) : (
+                <div className="network-device" key={index}>
+                  <div>
+                    <Select
+                      label="Network device"
+                      name={`devices.${index}.network`}
+                      id={`networkDevice${index}`}
+                      onBlur={formik.handleBlur}
+                      onChange={formik.handleChange}
+                      value={
+                        (formik.values.devices[index] as LxdNicDevice).network
+                      }
+                      options={getNetworkOptions()}
+                    />
+                    <Input
+                      label="Network name"
+                      name={`devices.${index}.name`}
+                      id={`networkName${index}`}
+                      onBlur={formik.handleBlur}
+                      onChange={formik.handleChange}
+                      value={
+                        (formik.values.devices[index] as LxdNicDevice).name
+                      }
+                      type="text"
+                      placeholder="Enter name"
+                    />
+                  </div>
+                  <div>
+                    <Button
+                      className="delete-device"
+                      onClick={() => removeNetwork(index)}
+                      type="button"
+                      appearance="base"
+                      aria-label="delete network"
+                      hasIcon
+                    >
+                      <Icon name="delete" />
+                    </Button>
+                  </div>
                 </div>
-                <div>
-                  <Button
-                    className="delete-device"
-                    onClick={() => removeNetwork(index)}
-                    type="button"
-                    appearance="base"
-                    aria-label="delete network"
-                    hasIcon
-                  >
-                    <Icon name="delete" />
-                  </Button>
-                </div>
-              </div>
-            ),
+              ),
             defined: `Current ${formik.values.type}`,
           });
         }),


### PR DESCRIPTION
## Done

- When instances or profiles have custom networks applied, the guided forms cannot display the information sufficiently. Furthermore the payload for custom networks must not be altered through the guided forms. We treat such networks now as custom and do not allow editing them, but display "custom networks" instead.

Fixes WD-5384 #422 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit instance and profile networks
    - check with a custom network (can be set via the YAML input) like the one below. The editing of other parts of a profile or instance with such a custom network should succeed and not alter the custom network.
```
  eth0:
    boot.priority: '2'
    name: eth0
    nictype: bridged
    parent: lxcbr
    type: nic
```

## Screenshots

![Screenshot from 2023-07-28 13-22-44](https://github.com/canonical/lxd-ui/assets/1155472/ccd2aed0-6840-4406-9184-06e67061dd38)
![Screenshot from 2023-07-28 13-22-39](https://github.com/canonical/lxd-ui/assets/1155472/c495a7f4-0902-4c7e-b629-b5114bbc68c3)
![Screenshot from 2023-07-28 13-22-34](https://github.com/canonical/lxd-ui/assets/1155472/48d7cc1b-d256-4ffa-8607-cff18d60dd3c)
