### PR TITLE
Fix handling of restricted accounts #426

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Loader from "components/Loader";
 import ProjectRedirect from "pages/projects/ProjectRedirect";
 import ProjectLoader from "pages/projects/ProjectLoader";
 import ClusterGroupLoader from "pages/cluster/ClusterGroupLoader";
+import { useAuth } from "context/auth";
 
 const ClusterList = lazy(() => import("pages/cluster/ClusterList"));
 const ImageList = lazy(() => import("pages/images/ImageList"));
@@ -45,6 +46,12 @@ const EditClusterGroup = lazy(() => import("pages/cluster/EditClusterGroup"));
 const HOME_REDIRECT_PATHS = ["/", "/ui", "/ui/project"];
 
 const App: FC = () => {
+  const { defaultProject, isAuthLoading } = useAuth();
+
+  if (isAuthLoading) {
+    return <Loader />;
+  }
+
   return (
     <Suspense
       fallback={
@@ -59,7 +66,10 @@ const App: FC = () => {
             key={path}
             path={path}
             element={
-              <Navigate to="/ui/project/default/instances" replace={true} />
+              <Navigate
+                to={`/ui/project/${defaultProject}/instances`}
+                replace={true}
+              />
             }
           />
         ))}

--- a/src/api/certificates.tsx
+++ b/src/api/certificates.tsx
@@ -1,7 +1,15 @@
 import { handleResponse } from "util/helpers";
+import { LxdApiResponse } from "types/apiResponse";
+import { LxdCertificate } from "types/certificate";
 
-export const checkAuth = () =>
-  fetch("/1.0/certificates").then((response) => response.status !== 403);
+export const fetchCertificates = (): Promise<LxdCertificate[]> => {
+  return new Promise((resolve, reject) => {
+    fetch("/1.0/certificates?recursion=1")
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdCertificate[]>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
 
 export const addCertificate = (token: string) => {
   return new Promise((resolve, reject) => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,6 +14,7 @@ import { getCookie } from "util/cookies";
 const isSmallScreen = () => isWidthBelow(620);
 
 const Navigation: FC = () => {
+  const { isRestricted } = useAuth();
   const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { project, isLoading } = useProject();
   const [projectName, setProjectName] = useState(
@@ -182,19 +183,21 @@ const Navigation: FC = () => {
                           Cluster
                         </NavLink>
                       </li>
-                      <li className="p-side-navigation__item">
-                        <NavLink
-                          className="p-side-navigation__link"
-                          to="/ui/warnings"
-                          title="Warnings"
-                        >
-                          <Icon
-                            className="is-light p-side-navigation__icon"
-                            name="warning-grey"
-                          />{" "}
-                          Warnings
-                        </NavLink>
-                      </li>
+                      {!isRestricted && (
+                        <li className="p-side-navigation__item">
+                          <NavLink
+                            className="p-side-navigation__link"
+                            to="/ui/warnings"
+                            title="Warnings"
+                          >
+                            <Icon
+                              className="is-light p-side-navigation__icon"
+                              name="warning-grey"
+                            />{" "}
+                            Warnings
+                          </NavLink>
+                        </li>
+                      )}
                       <li className="p-side-navigation__item">
                         <NavLink
                           className="p-side-navigation__link"

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,16 +1,21 @@
 import React, { createContext, FC, ReactNode, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { checkAuth } from "api/certificates";
+import { fetchCertificates } from "api/certificates";
+import { useSettings } from "context/useSettings";
 
 interface ContextProps {
   isAuthenticated: boolean;
   isAuthLoading: boolean;
+  isRestricted: boolean;
+  defaultProject: string;
 }
 
 const initialState: ContextProps = {
   isAuthenticated: false,
   isAuthLoading: true,
+  isRestricted: false,
+  defaultProject: "default",
 };
 
 export const AuthContext = createContext<ContextProps>(initialState);
@@ -20,16 +25,35 @@ interface ProviderProps {
 }
 
 export const AuthProvider: FC<ProviderProps> = ({ children }) => {
-  const { data, isLoading } = useQuery<boolean>({
-    queryKey: [queryKeys.certificates],
-    queryFn: checkAuth,
+  const { data: settings, isLoading } = useSettings();
+
+  const isTls = settings?.auth_user_method === "tls";
+
+  const { data: certificates = [] } = useQuery({
+    queryKey: [queryKeys.certificates, 1],
+    queryFn: fetchCertificates,
+    enabled: isTls,
   });
+
+  const fingerprint = isTls ? settings.auth_user_name : undefined;
+  const certificate = certificates.find(
+    (certificate) => certificate.fingerprint === fingerprint
+  );
+  const isRestricted = certificate?.restricted ?? false;
+  const defaultProject =
+    isRestricted &&
+    certificate &&
+    !certificate.projects.find((p) => p === "default")
+      ? certificate.projects[0]
+      : "default";
 
   return (
     <AuthContext.Provider
       value={{
-        isAuthenticated: data ?? false,
+        isAuthenticated: (settings && settings.auth !== "untrusted") ?? false,
         isAuthLoading: isLoading,
+        isRestricted,
+        defaultProject,
       }}
     >
       {children}

--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useEffect, useState } from "react";
 import { LxdEvent } from "types/event";
 import { useEventQueue } from "context/eventQueue";
+import { useAuth } from "context/auth";
 
 const Events: FC = () => {
+  const { isAuthenticated } = useAuth();
   const eventQueue = useEventQueue();
   const [eventWs, setEventWs] = useState<WebSocket | null>(null);
 
@@ -41,10 +43,10 @@ const Events: FC = () => {
   };
 
   useEffect(() => {
-    if (!eventWs) {
+    if (!eventWs && isAuthenticated) {
       connectEventWs();
     }
-  }, [eventWs]);
+  }, [eventWs, isAuthenticated]);
   return <></>;
 };
 

--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -37,7 +37,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
   if (isRestricted) {
     return (
       <div className="u-text--muted">
-        Usage details unavailable for restricted users
+        Details are not available for restricted users
       </div>
     );
   }

--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -7,6 +7,7 @@ import { getInstanceMetrics } from "util/metricSelectors";
 import Meter from "components/Meter";
 import Loader from "components/Loader";
 import { LxdInstance } from "types/instance";
+import { useAuth } from "context/auth";
 
 interface Props {
   instance: LxdInstance;
@@ -14,6 +15,8 @@ interface Props {
 }
 
 const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
+  const { isRestricted } = useAuth();
+
   const {
     data: metrics = [],
     error,
@@ -22,6 +25,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
     queryKey: [queryKeys.metrics],
     queryFn: fetchMetrics,
     refetchInterval: 15 * 1000, // 15 seconds
+    enabled: !isRestricted,
   });
 
   if (error) {
@@ -29,6 +33,14 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
   }
 
   const instanceMetrics = getInstanceMetrics(metrics, instance);
+
+  if (isRestricted) {
+    return (
+      <div className="u-text--muted">
+        Usage details unavailable for restricted users
+      </div>
+    );
+  }
 
   return (
     <>

--- a/src/pages/projects/EditProjectForm.tsx
+++ b/src/pages/projects/EditProjectForm.tsx
@@ -26,12 +26,14 @@ import ProjectForm from "pages/projects/forms/ProjectForm";
 import { getUnhandledKeyValues } from "util/formFields";
 import { getProjectConfigKeys } from "util/projectConfigFields";
 import ProjectConfigurationHeader from "pages/projects/ProjectConfigurationHeader";
+import { useAuth } from "context/auth";
 
 interface Props {
   project: LxdProject;
 }
 
 const EditProjectForm: FC<Props> = ({ project }) => {
+  const { isRestricted } = useAuth();
   const notify = useNotify();
   const queryClient = useQueryClient();
   const [section, setSection] = useState(PROJECT_DETAILS);
@@ -108,35 +110,37 @@ const EditProjectForm: FC<Props> = ({ project }) => {
             updateSection={setSection}
             isEdit={true}
           />
-          <div className="p-bottom-controls">
-            <hr />
-            <Row>
-              <Col size={12} className="u-align--right">
-                {formik.values.readOnly ? (
-                  <>
-                    <Button
-                      appearance="positive"
-                      onClick={() => formik.setFieldValue("readOnly", false)}
-                    >
-                      Edit configuration
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    <Button onClick={() => formik.setValues(initialValues)}>
-                      Cancel
-                    </Button>
-                    <SubmitButton
-                      isSubmitting={formik.isSubmitting}
-                      isDisabled={!formik.isValid || !formik.values.name}
-                      buttonLabel="Save changes"
-                      onClick={() => void formik.submitForm()}
-                    />
-                  </>
-                )}
-              </Col>
-            </Row>
-          </div>
+          {!isRestricted && (
+            <div className="p-bottom-controls">
+              <hr />
+              <Row>
+                <Col size={12} className="u-align--right">
+                  {formik.values.readOnly ? (
+                    <>
+                      <Button
+                        appearance="positive"
+                        onClick={() => formik.setFieldValue("readOnly", false)}
+                      >
+                        Edit configuration
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button onClick={() => formik.setValues(initialValues)}>
+                        Cancel
+                      </Button>
+                      <SubmitButton
+                        isSubmitting={formik.isSubmitting}
+                        isDisabled={!formik.isValid || !formik.values.name}
+                        buttonLabel="Save changes"
+                        onClick={() => void formik.submitForm()}
+                      />
+                    </>
+                  )}
+                </Col>
+              </Row>
+            </div>
+          )}
         </div>
       </div>
     </main>

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -11,6 +11,7 @@ import { useFormik } from "formik";
 import { LxdConfigOption } from "types/config";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "context/auth";
 
 interface Props {
   option: LxdConfigOption;
@@ -18,6 +19,7 @@ interface Props {
 }
 
 const SettingForm: FC<Props> = ({ option, value }) => {
+  const { isRestricted } = useAuth();
   const [isEditMode, setEditMode] = useState(false);
   const notify = useNotify();
   const queryClient = useQueryClient();
@@ -113,6 +115,8 @@ const SettingForm: FC<Props> = ({ option, value }) => {
             Save
           </Button>
         </Form>
+      ) : isRestricted ? (
+        <span>{value ?? "-"}</span>
       ) : (
         <>
           <Button

--- a/src/types/certificate.ts
+++ b/src/types/certificate.ts
@@ -1,0 +1,5 @@
+export interface LxdCertificate {
+  fingerprint: string;
+  restricted: boolean;
+  projects: string[];
+}

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -10,7 +10,8 @@ export interface LxdSettings {
     server_version: ?string;
     server_clustered: boolean;
   };
-  auth?: "trusted";
+  auth?: "trusted" | "untrusted";
   auth_methods?: LXDAuthMethods;
   auth_user_method?: LXDAuthMethods;
+  auth_user_name?: string;
 }


### PR DESCRIPTION
## Done

- in useAuth hook figure if a current user is restricted
- use a different default project if user has no access to project with name "default" 
- on restricted users
  - avoid 403 requests to the metrics api
  - hide edit buttons for projects
  - hide warnings section in navigation
  - hide edit buttons for settings

Fixes #426 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a restricted account (lxc config trust edit $hash, change restricted to true and projects to [$project] where $hash is the hash of your certificate and $project is a non-default project
    - check the default redirect brings the user to a project that is acessible
    - check the instance detail page is displayed without error
    - check the server settings are not editable (no edit button)
    - check the project is not editable (no edit button)
    - check the warnings link is not in the main navigation
    - ensure all of the above still work correctly for a non-restricted user.
    - ensure the login process for a new user still works (identifying non-authenticated users is slightly changed)