### PR TITLE
return to image overview when cancelling the instance creation and coming from there

### DIFF
--- a/src/pages/images/actions/CreateInstanceFromImageBtn.tsx
+++ b/src/pages/images/actions/CreateInstanceFromImageBtn.tsx
@@ -15,6 +15,7 @@ const CreateInstanceFromImageBtn: FC<Props> = ({ image, project }) => {
     navigate(`/ui/project/${project}/instances/create`, {
       state: {
         selectedImage: image,
+        cancelLocation: window.location.pathname,
       },
     });
   };

--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -73,6 +73,7 @@ export type CreateInstanceFormValues = InstanceDetailsFormValues &
 interface PresetFormState {
   retryFormValues?: CreateInstanceFormValues;
   selectedImage?: RemoteImage;
+  cancelLocation?: string;
 }
 
 const CreateInstanceForm: FC = () => {
@@ -374,7 +375,12 @@ const CreateInstanceForm: FC = () => {
               <Col size={12}>
                 <Button
                   appearance="base"
-                  onClick={() => navigate(`/ui/project/${project}/instances`)}
+                  onClick={() =>
+                    navigate(
+                      location.state?.cancelLocation ??
+                        `/ui/project/${project}/instances`
+                    )
+                  }
                 >
                   Cancel
                 </Button>

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -12,7 +12,7 @@ export const createInstance = async (
   type = "container"
 ) => {
   await page.goto("/ui/");
-  await page.getByRole("link", { name: "Instances" }).click();
+  await page.getByRole("link", { name: "Instances" }).first().click();
   await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByLabel("Instance name").click();
   await page.getByLabel("Instance name").fill(instance);

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -8,7 +8,6 @@ export const randomProjectName = (): string => {
 
 export const createProject = async (page: Page, project: string) => {
   await page.goto("/ui/");
-  await page.getByRole("link", { name: "Instances" }).click();
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("button", { name: "Create project" }).click();
   await page.getByPlaceholder("Enter name").click();
@@ -35,7 +34,6 @@ export const renameProject = async (
 
 export const deleteProject = async (page: Page, project: string) => {
   await page.goto("/ui/");
-  await page.getByRole("link", { name: "Instances" }).click();
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("link", { name: project }).click();
   await page.getByRole("link", { name: "Configuration" }).click();


### PR DESCRIPTION
## Done

- fixed the cancel behaviour on instance creation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to the images section
    - press the play button to go to the instance creation with an image preselected
    - click cancel and validate you land where you came from
    - go to instance list, click create instance
    - click cancel and validate you land where you came from