### PR TITLE
Use constants in storage form, disable size for directory driver storage

### DIFF
--- a/src/pages/storage/StorageForm.tsx
+++ b/src/pages/storage/StorageForm.tsx
@@ -18,7 +18,13 @@ import SubmitButton from "components/SubmitButton";
 import usePanelParams from "util/usePanelParams";
 import { LxdStoragePool } from "types/storage";
 import { createStoragePool } from "api/storage-pools";
-import { getSourceHelpForDriver, storageDrivers } from "util/storageOptions";
+import {
+  btrfsDriver,
+  dirDriver,
+  getSourceHelpForDriver,
+  storageDrivers,
+  zfsDriver,
+} from "util/storageOptions";
 import ItemName from "components/ItemName";
 import { testDuplicateName } from "util/storage";
 import NotificationRow from "components/NotificationRow";
@@ -39,7 +45,7 @@ const StorageForm: FC = () => {
     initialValues: {
       name: "",
       description: "",
-      driver: "zfs",
+      driver: zfsDriver,
       source: "",
       size: "",
     },
@@ -49,7 +55,7 @@ const StorageForm: FC = () => {
         name,
         description,
         driver,
-        source: driver !== "btrfs" ? source : undefined,
+        source: driver !== btrfsDriver ? source : undefined,
         config: {
           size: size ? `${size}GiB` : undefined,
         },
@@ -117,13 +123,22 @@ const StorageForm: FC = () => {
                 id="driver"
                 name="driver"
                 help={
-                  formik.values.driver === "zfs"
+                  formik.values.driver === zfsDriver
                     ? "ZFS gives best performance and reliability"
                     : undefined
                 }
                 label="Driver"
                 options={storageDrivers}
-                onChange={formik.handleChange}
+                onChange={(target) => {
+                  const val = target.target.value;
+                  if (val === dirDriver) {
+                    void formik.setFieldValue("size", "");
+                  }
+                  if (val === btrfsDriver) {
+                    void formik.setFieldValue("source", "");
+                  }
+                  void formik.setFieldValue("driver", val);
+                }}
                 value={formik.values.driver}
                 required
                 stacked
@@ -132,19 +147,24 @@ const StorageForm: FC = () => {
                 id="size"
                 name="size"
                 type="number"
-                help="When left blank, defaults to 20% of free disk space. Default will be between 5GiB and 30GiB"
+                help={
+                  formik.values.driver === dirDriver
+                    ? "Not available"
+                    : "When left blank, defaults to 20% of free disk space. Default will be between 5GiB and 30GiB"
+                }
                 label="Size in GiB"
                 onBlur={formik.handleBlur}
                 onChange={formik.handleChange}
                 value={formik.values.size}
                 error={formik.touched.size ? formik.errors.size : null}
+                disabled={formik.values.driver === dirDriver}
                 stacked
               />
               <Input
                 id="source"
                 name="source"
                 type="text"
-                disabled={formik.values.driver === "btrfs"}
+                disabled={formik.values.driver === btrfsDriver}
                 help={getSourceHelpForDriver(formik.values.driver)}
                 label="Source"
                 onBlur={formik.handleBlur}

--- a/src/pages/storage/actions/AddStorageBtn.tsx
+++ b/src/pages/storage/actions/AddStorageBtn.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Button } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import usePanelParams from "util/usePanelParams";
 
 interface Props {
@@ -8,14 +8,20 @@ interface Props {
 }
 
 const AddStorageBtn: FC<Props> = ({ project, className }) => {
+  const notify = useNotify();
   const panelParams = usePanelParams();
+
+  const handleAdd = () => {
+    notify.clear();
+    panelParams.openStorageForm(project);
+  };
 
   return (
     <Button
       appearance="positive"
       className={className}
       hasIcon
-      onClick={() => panelParams.openStorageForm(project)}
+      onClick={handleAdd}
     >
       Add storage
     </Button>

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -1,19 +1,24 @@
+export const dirDriver = "dir";
+export const btrfsDriver = "btrfs";
+export const lvmDriver = "lvm";
+export const zfsDriver = "zfs";
+
 export const storageDrivers = [
   {
     label: "Directory",
-    value: "dir",
+    value: dirDriver,
   },
   {
     label: "Btrfs",
-    value: "btrfs",
+    value: btrfsDriver,
   },
   {
     label: "LVM",
-    value: "lvm",
+    value: lvmDriver,
   },
   {
     label: "ZFS",
-    value: "zfs",
+    value: zfsDriver,
   },
 ];
 


### PR DESCRIPTION
## Done

- disable size field in create storage form for dir driver (limiting size is unsupported for that driver)
- introduce constants for storage form drivers
- clear notification on opening storage form

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - storage > create storage pool
    - check creation with various drivers