### PR TITLE
Link to network detail page

### DIFF
--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -173,10 +173,9 @@ const InstanceDetailPanel: FC = () => {
                   <List
                     className="list"
                     items={networkDevices.map((item) => (
-                      // TODO: fix this link to point to the network detail page
                       <Link
                         key={item.network}
-                        to={`/ui/project/${instance.project}/networks`}
+                        to={`/ui/project/${instance.project}/networks/detail/${item.network}`}
                       >
                         {item.network}
                       </Link>

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -62,9 +62,8 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
         columns: [
           {
             content: (
-              // TODO: fix this link to point to the network detail page
               <Link
-                to={`/ui/project/${instance.project}/networks`}
+                to={`/ui/project/${instance.project}/networks/detail/${network.name}`}
                 title={network.name}
               >
                 {network.name}


### PR DESCRIPTION
## Done

- change links from instance to networks to go to new detail pages

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check links on instance side panel and overview page to networks
    - also check on non-default projects