### PR TITLE
Fix used by lists, scrolling and simplify a function

### DIFF
--- a/src/pages/networks/NetworkDetailOverview.tsx
+++ b/src/pages/networks/NetworkDetailOverview.tsx
@@ -49,8 +49,8 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
   }
 
   const data: Record<string, LxdUsedBy[]> = {
-    instances: filterUsedByType("instances", project, network.used_by),
-    profiles: filterUsedByType("profiles", project, network.used_by),
+    instances: filterUsedByType("instances", network.used_by),
+    profiles: filterUsedByType("profiles", network.used_by),
   };
 
   return (

--- a/src/pages/networks/NetworkDetailOverview.tsx
+++ b/src/pages/networks/NetworkDetailOverview.tsx
@@ -39,7 +39,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
   const updateContentHeight = () => {
     updateMaxHeight("network-overview-tab");
   };
-  useEffect(updateContentHeight, []);
+  useEffect(updateContentHeight, [project, networkState]);
   useEventListener("resize", updateContentHeight);
 
   const usageCount = network.used_by?.length ?? 0;

--- a/src/pages/projects/ProjectSelectorList.tsx
+++ b/src/pages/projects/ProjectSelectorList.tsx
@@ -18,7 +18,7 @@ const ProjectSelectorList: FC<Props> = ({ projects, onMount }): JSX.Element => {
   const targetSection = getSubpageFromUrl(location.pathname) ?? "instances";
 
   function getInstanceCount(project: LxdProject) {
-    const count = filterUsedByType("instances", "", project.used_by).length;
+    const count = filterUsedByType("instances", project.used_by).length;
     return count === 1 ? "1 instance" : `${count} instances`;
   }
 

--- a/src/pages/storage/StorageOverview.tsx
+++ b/src/pages/storage/StorageOverview.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { Col, Row, useNotify } from "@canonical/react-components";
@@ -6,6 +6,8 @@ import Loader from "components/Loader";
 import { fetchStoragePool } from "api/storage-pools";
 import StorageSize from "pages/storage/StorageSize";
 import StorageUsedBy from "pages/storage/StorageUsedBy";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
 
 interface Props {
   name: string;
@@ -33,6 +35,12 @@ const StorageOverview: FC<Props> = ({ name, project }) => {
   } else if (!pool) {
     return <>Loading storage details failed</>;
   }
+
+  const updateContentHeight = () => {
+    updateMaxHeight("storage-overview-tab");
+  };
+  useEffect(updateContentHeight, [project, pool]);
+  useEventListener("resize", updateContentHeight);
 
   return (
     <div className="storage-overview-tab">

--- a/src/pages/storage/StorageUsedBy.tsx
+++ b/src/pages/storage/StorageUsedBy.tsx
@@ -19,11 +19,11 @@ const CUSTOM = "Custom";
 
 const StorageUsedBy: FC<Props> = ({ storage, project }) => {
   const data: Record<string, LxdUsedBy[]> = {
-    [INSTANCES]: filterUsedByType("instances", project, storage.used_by),
-    [PROFILES]: filterUsedByType("profiles", project, storage.used_by),
-    [IMAGES]: filterUsedByType("images", project, storage.used_by),
-    [SNAPSHOTS]: filterUsedByType("snapshots", project, storage.used_by),
-    [CUSTOM]: filterUsedByType("storage-pools", project, storage.used_by),
+    [INSTANCES]: filterUsedByType("instances", storage.used_by),
+    [PROFILES]: filterUsedByType("profiles", storage.used_by),
+    [IMAGES]: filterUsedByType("images", storage.used_by),
+    [SNAPSHOTS]: filterUsedByType("snapshots", storage.used_by),
+    [CUSTOM]: filterUsedByType("storage-pools", storage.used_by),
   };
 
   return (

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -2,7 +2,10 @@ import { LxdImage, RemoteImage } from "types/image";
 import { LxdStorageVolume } from "types/storage";
 
 export const isVmOnlyImage = (image: RemoteImage) => {
-  return image.variant?.includes("desktop") || image.server === LOCAL_ISO;
+  if (image.server === LOCAL_ISO) {
+    return true;
+  }
+  return image.variant?.includes("desktop");
 };
 
 export const isContainerOnlyImage = (image: RemoteImage) => {

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -14,7 +14,6 @@ export interface LxdUsedBy {
  */
 export const filterUsedByType = (
   type: "instances" | "profiles" | "snapshots" | "images" | "storage-pools",
-  defaultProject: string,
   usedByPaths?: string[]
 ): LxdUsedBy[] => {
   return (
@@ -34,7 +33,7 @@ export const filterUsedByType = (
         const url = new URL(`http://localhost/${path}`);
         return {
           name: url.pathname.split("/").slice(-1)[0] ?? "",
-          project: url.searchParams.get("project") ?? defaultProject,
+          project: url.searchParams.get("project") ?? "default",
           instance: type === "snapshots" ? url.pathname.split("/")[4] : "",
         };
       })
@@ -57,12 +56,10 @@ export const getProfileInstances = (
   isDefaultProject: boolean,
   usedByPaths?: string[]
 ): LxdUsedBy[] => {
-  return filterUsedByType("instances", "default", usedByPaths).filter(
-    (instance) => {
-      if (isDefaultProject) {
-        return true;
-      }
-      return project === instance.project;
+  return filterUsedByType("instances", usedByPaths).filter((instance) => {
+    if (isDefaultProject) {
+      return true;
     }
-  );
+    return project === instance.project;
+  });
 };


### PR DESCRIPTION
## Done

- fix links from used by lists
- fix scrolling behaviour on network overview
- fix scrolling behaviour on storage overview
- remove ambiguous `isVmOnlyImage` function

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test network overview page scrolling
    - test storage overview page scrolling
    - test used by lists in network, storage, profiles from default and non-default projects
    - test creation of instances with and without local iso volume