### PR TITLE
Fix terminal on virtual machines

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -198,7 +198,6 @@ export const connectInstanceExec = (
       method: "POST",
       body: JSON.stringify({
         command: [payload.command],
-        "record-output": true,
         "wait-for-websocket": true,
         environment: payload.environment.reduce(
           (a, v) => ({ ...a, [v.key]: v.value }),


### PR DESCRIPTION
## Done

- Terminal on an instance detail page for a VM would not open

Fixes #450 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open terminal on an instance that is running jammy as a vm
    - open terminal on an instance that is a container