### PR TITLE
Extend iso tests to launch an instance with it

### DIFF
--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -1,5 +1,7 @@
 import { test } from "@playwright/test";
 import { randomNameSuffix } from "./helpers/name";
+import { deleteInstance, randomInstanceName } from "./helpers/instances";
+import { TIMEOUT } from "./helpers/constants";
 
 const ISO_FILE = "./tests/fixtures/foo.iso";
 
@@ -33,6 +35,39 @@ test("upload and delete custom iso", async ({ page }) => {
 
   await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
   await page.getByText("3 B").click();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await page.getByText("Delete", { exact: true }).click();
+  await page.getByText(`Storage volume ${isoName} deleted.`).click();
+});
+
+test("use custom iso for instance launch", async ({ page }) => {
+  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+
+  const instance = randomInstanceName();
+  const isoName = randomIso();
+
+  await page.goto("/ui/");
+  await page.getByRole("link", { name: "Instances", exact: true }).click();
+  await page.getByRole("button", { name: "Create instance" }).click();
+  await page.getByLabel("Instance name").fill(instance);
+  await page.getByRole("button", { name: "Use custom ISO" }).click();
+  await page.getByRole("button", { name: "Upload custom ISO" }).click();
+  await page.getByLabel("Local file").setInputFiles(ISO_FILE);
+  await page
+    .getByRole("dialog", { name: "Upload custom ISO" })
+    .locator("#name")
+    .fill(isoName);
+  await page.getByRole("button", { name: "Upload", exact: true }).click();
+  await page.locator(".u-align--right > .p-button--positive").click();
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await page.waitForSelector(`text=Launched instance ${instance}.`, TIMEOUT);
+
+  await deleteInstance(page, instance);
+  await page.goto("/ui/");
+  await page.getByRole("link", { name: "Storage", exact: true }).click();
+  await page.getByTestId("tab-link-Custom ISOs").click();
+  await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
   await page.getByRole("button", { name: "Delete" }).click();
   await page.getByText("Delete", { exact: true }).click();
   await page.getByText(`Storage volume ${isoName} deleted.`).click();


### PR DESCRIPTION
## Done

- add test to launch instance with custom iso

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure tests are passing i.e. `npx playwright test iso-volumes`