### PR TITLE
Use info instead of warning on inherited networks in configuration screen

### DIFF
--- a/src/pages/instances/forms/NetworkForm.tsx
+++ b/src/pages/instances/forms/NetworkForm.tsx
@@ -102,7 +102,7 @@ To change it, edit it in the profile or project it originates from,
 or remove the originating item"
                   position="btm-left"
                 >
-                  <Icon name="warning-grey" />
+                  <Icon name="information" />
                 </Tooltip>{" "}
                 <b>{item.key}</b>
               </>


### PR DESCRIPTION
## Done

- changed the icon for inherited networks in instance detail/creation > configuration > network 

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the icon for inherited networks in instance detail/creation > configuration > network 
