### PR TITLE
Fix handling of custom devices on editing instances or profiles

### DIFF
--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -55,6 +55,7 @@ export const formDeviceToPayload = (devices: FormDevice[]) => {
         item.type === "iso-volume"
       ) {
         return {
+          ...obj,
           [name]: item.bare,
         };
       }


### PR DESCRIPTION
## Done

- Fix handling of custom devices on editing instances or profiles
(We would drop all previous devices when encountering a custom device on iterating the devices to transform the web format for the api request)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance edit with storage/networks

This custom config can be added from the YAML editor and should all three devices from it should be persisted on editing:
```
  eth0:
    ipv4.address: 10.76.171.21
    name: eth0
    network: mybr
    type: nic
  grafananat:
    connect: tcp:10.76.171.21:3000
    listen: tcp:192.168.0.90:3000
    nat: 'true'
    type: proxy
  prometheusnat:
    connect: tcp:10.76.171.21:9090
    listen: tcp:192.168.0.90:9090
    nat: 'true'
    type: proxy
```