### PR TITLE
feat(operations): Move operations list to global scope [WD-4462]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -203,14 +203,6 @@ const App: FC = () => {
           }
         />
         <Route
-          path="/ui/project/:project/operations"
-          element={
-            <ProtectedRoute
-              outlet={<ProjectLoader outlet={<OperationList />} />}
-            />
-          }
-        />
-        <Route
           path="/ui/project/:project/configuration"
           element={
             <ProtectedRoute
@@ -269,6 +261,10 @@ const App: FC = () => {
               outlet={<ClusterGroupLoader outlet={<EditClusterGroup />} />}
             />
           }
+        />
+        <Route
+          path="/ui/operations"
+          element={<ProtectedRoute outlet={<OperationList />} />}
         />
         <Route
           path="/ui/warnings"

--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -39,21 +39,33 @@ export const watchOperation = (
   });
 };
 
+const sortOperationList = (operations: LxdOperationList) => {
+  const newestFirst = (a: LxdOperation, b: LxdOperation) => {
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  };
+  operations.failure?.sort(newestFirst);
+  operations.success?.sort(newestFirst);
+  operations.running?.sort(newestFirst);
+};
+
 export const fetchOperations = (project: string): Promise<LxdOperationList> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/operations?project=${project}&recursion=1`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdOperationList>) => {
-        const newestFirst = (a: LxdOperation, b: LxdOperation) => {
-          return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-          );
-        };
+        sortOperationList(data.metadata);
+        return resolve(data.metadata);
+      })
+      .catch(reject);
+  });
+};
 
-        data.metadata.failure?.sort(newestFirst);
-        data.metadata.success?.sort(newestFirst);
-        data.metadata.running?.sort(newestFirst);
-
+export const fetchAllOperations = (): Promise<LxdOperationList> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/operations?all-projects=true&recursion=1`)
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdOperationList>) => {
+        sortOperationList(data.metadata);
         return resolve(data.metadata);
       })
       .catch(reject);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -146,19 +146,6 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item secondary">
                         <NavLink
                           className="p-side-navigation__link"
-                          to={`/ui/project/${projectName}/operations`}
-                          title={`Operations (${projectName})`}
-                        >
-                          <Icon
-                            className="is-light p-side-navigation__icon"
-                            name="status"
-                          />{" "}
-                          Operations
-                        </NavLink>
-                      </li>
-                      <li className="p-side-navigation__item secondary">
-                        <NavLink
-                          className="p-side-navigation__link"
                           to={`/ui/project/${projectName}/configuration`}
                           title={`Configuration (${projectName})`}
                         >
@@ -181,6 +168,19 @@ const Navigation: FC = () => {
                             name="machines"
                           />{" "}
                           Cluster
+                        </NavLink>
+                      </li>
+                      <li className="p-side-navigation__item">
+                        <NavLink
+                          className="p-side-navigation__link"
+                          to={`/ui/operations`}
+                          title={`Operations (${projectName})`}
+                        >
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="status"
+                          />{" "}
+                          Operations
                         </NavLink>
                       </li>
                       {!isRestricted && (

--- a/src/pages/operations/OperationInstanceName.tsx
+++ b/src/pages/operations/OperationInstanceName.tsx
@@ -2,17 +2,14 @@ import React, { FC } from "react";
 import ItemName from "components/ItemName";
 import { LxdOperation } from "types/operation";
 import InstanceLink from "pages/instances/InstanceLink";
-import { useParams } from "react-router-dom";
-import { getInstanceName } from "util/operations";
+import { getInstanceName, getProjectName } from "util/operations";
 
 interface Props {
   operation: LxdOperation;
 }
 
 const OperationInstanceName: FC<Props> = ({ operation }) => {
-  const { project: projectName } = useParams<{
-    project: string;
-  }>();
+  const projectName = getProjectName(operation);
 
   const instanceName = getInstanceName(operation);
   if (!instanceName) {

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -80,7 +80,7 @@ const OperationList: FC = () => {
                 <OperationInstanceName operation={operation} />
               </div>
               <div className="u-text--muted">
-                Project name: {getProjectName(operation)}
+                Project: {getProjectName(operation)}
               </div>
             </>
           ),

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -57,6 +57,7 @@ const OperationList: FC = () => {
   };
 
   const rows = operations.map((operation) => {
+    const projectName = getProjectName(operation);
     return {
       columns: [
         {
@@ -79,8 +80,8 @@ const OperationList: FC = () => {
               <div className="u-truncate u-text--muted">
                 <OperationInstanceName operation={operation} />
               </div>
-              <div className="u-text--muted u-truncate" title={getProjectName(operation)}>
-                Project: {getProjectName(operation)}
+              <div className="u-text--muted u-truncate" title={projectName}>
+                Project: {projectName}
               </div>
             </>
           ),

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -79,7 +79,7 @@ const OperationList: FC = () => {
               <div className="u-truncate u-text--muted">
                 <OperationInstanceName operation={operation} />
               </div>
-              <div className="u-text--muted">
+              <div className="u-text--muted u-truncate" title={getProjectName(operation)}>
                 Project: {getProjectName(operation)}
               </div>
             </>

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -10,9 +10,8 @@ import BaseLayout from "components/BaseLayout";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
-import { fetchOperations } from "api/operations";
+import { fetchAllOperations } from "api/operations";
 import CancelOperationBtn from "pages/operations/actions/CancelOperationBtn";
-import { useParams } from "react-router-dom";
 import { isoTimeToString } from "util/helpers";
 import { LxdOperationStatus } from "types/operation";
 import OperationInstanceName from "pages/operations/OperationInstanceName";
@@ -20,19 +19,14 @@ import NotificationRow from "components/NotificationRow";
 
 const OperationList: FC = () => {
   const notify = useNotify();
-  const { project } = useParams<{ project: string }>();
-
-  if (!project) {
-    return <>Missing project</>;
-  }
 
   const {
     data: operationList,
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.operations, project],
-    queryFn: () => fetchOperations(project),
+    queryKey: [queryKeys.operations],
+    queryFn: fetchAllOperations,
   });
 
   if (error) {
@@ -122,9 +116,7 @@ const OperationList: FC = () => {
           className: "status",
         },
         {
-          content: (
-            <CancelOperationBtn operation={operation} project={project} />
-          ),
+          content: <CancelOperationBtn operation={operation} />,
           role: "rowheader",
           className: "u-align--right cancel",
           "aria-label": "Cancel",
@@ -166,7 +158,7 @@ const OperationList: FC = () => {
               image={<Icon name="status" className="empty-state-icon" />}
               title="No operations found"
             >
-              <p>There are no ongoing operations in this project.</p>
+              <p>There are no ongoing operations.</p>
             </EmptyState>
           )}
         </Row>

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -16,6 +16,7 @@ import { isoTimeToString } from "util/helpers";
 import { LxdOperationStatus } from "types/operation";
 import OperationInstanceName from "pages/operations/OperationInstanceName";
 import NotificationRow from "components/NotificationRow";
+import { getProjectName } from "util/operations";
 
 const OperationList: FC = () => {
   const notify = useNotify();
@@ -77,6 +78,9 @@ const OperationList: FC = () => {
               <div>{operation.description}</div>
               <div className="u-truncate u-text--muted">
                 <OperationInstanceName operation={operation} />
+              </div>
+              <div className="u-text--muted">
+                Project name: {getProjectName(operation)}
               </div>
             </>
           ),

--- a/src/pages/operations/actions/CancelOperationBtn.tsx
+++ b/src/pages/operations/actions/CancelOperationBtn.tsx
@@ -7,7 +7,7 @@ import { ConfirmationButton, useNotify } from "@canonical/react-components";
 
 interface Props {
   operation: LxdOperation;
-  project: string;
+  project?: string;
 }
 
 const CancelOperationBtn: FC<Props> = ({ operation, project }) => {
@@ -27,7 +27,9 @@ const CancelOperationBtn: FC<Props> = ({ operation, project }) => {
       .finally(() => {
         setLoading(false);
         void queryClient.invalidateQueries({
-          queryKey: [queryKeys.operations, project],
+          queryKey: project
+            ? [queryKeys.operations, project]
+            : [queryKeys.operations],
         });
       });
   };

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -13,3 +13,17 @@ export const getInstanceName = (operation: LxdOperation): string => {
       ?.split("?")[0] ?? ""
   );
 };
+
+export const getProjectName = (operation: LxdOperation): string => {
+  // the url can be
+  // /1.0/instances/<instance_name>?project=<project_name>
+  // when no project parameter is present, the project will be "default"
+
+  return (
+    operation.resources?.instances
+      ?.filter((item) => item.startsWith("/1.0/instances/"))
+      .map((item) => item.split("/")[3])
+      .pop()
+      ?.split("=")[1] ?? "default"
+  );
+};


### PR DESCRIPTION
## Done

- Operations page now lists operations across all projects!
- Moved operations from project scope to under the cluster tab
- Uses https://github.com/canonical/lxd/pull/12172
- Fixes https://github.com/canonical/lxd/issues/11808

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run an operation (eg: create instance) > check the operations page to see if the operation is being shown in the list

## Screenshots

<img width="246" alt="image" src="https://github.com/canonical/lxd-ui/assets/54525904/e3e83712-37ee-4b2b-a53e-9de6449bcbef">