### PR TITLE
Add ui version to navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "context/auth";
 import classnames from "classnames";
 import Logo from "./Logo";
 import ProjectSelector from "pages/projects/ProjectSelector";
-import ServerVersion from "components/ServerVersion";
+import Version from "components/Version";
 import { isWidthBelow, logout } from "util/helpers";
 import { useProject } from "context/project";
 import { useMenuCollapsed } from "context/menuCollapsed";
@@ -299,7 +299,7 @@ const Navigation: FC = () => {
                       Report a bug
                     </a>
                   </li>
-                  <ServerVersion />
+                  <Version />
                 </ul>
               </div>
             </div>

--- a/src/components/Version.tsx
+++ b/src/components/Version.tsx
@@ -1,26 +1,30 @@
 import React, { FC } from "react";
 import { Icon, Tooltip } from "@canonical/react-components";
 import { useSettings } from "context/useSettings";
+import { RECENT_MAJOR_SERVER_VERSION, UI_VERSION } from "util/version";
 
-const ServerVersion: FC = () => {
+const Version: FC = () => {
   const { data: settings } = useSettings();
 
-  const version = settings?.environment?.server_version;
-  if (!version) {
+  const serverVersion = settings?.environment?.server_version;
+  if (!serverVersion) {
     return null;
   }
 
-  const major = version.includes(".") ? version.split(".")[0] : undefined;
-  const recentMajor = 5;
-  const isOutdated = major ? parseInt(major) < recentMajor : false;
+  const serverMajor = serverVersion.includes(".")
+    ? serverVersion.split(".")[0]
+    : undefined;
+  const isOutdated = serverMajor
+    ? parseInt(serverMajor) < RECENT_MAJOR_SERVER_VERSION
+    : false;
 
   return (
     <>
       <hr className="p-side-navigation__list is-dark navigation-hr" />
-      <li className="p-side-navigation__link server-version">
+      <li className="p-side-navigation__link server-version p-text--x-small">
         {isOutdated && (
           <Tooltip
-            message="You are using an outdated version.
+            message="You are using an outdated server version.
 Update your LXD server to benefit from the latest features."
             tooltipClassName="version-warning"
             zIndex={1000}
@@ -28,10 +32,10 @@ Update your LXD server to benefit from the latest features."
             <Icon name="warning" className="p-side-navigation__icon" />
           </Tooltip>
         )}
-        Server {version}
+        Version {serverVersion}-ui-{UI_VERSION}
       </li>
     </>
   );
 };
 
-export default ServerVersion;
+export default Version;

--- a/src/util/version.tsx
+++ b/src/util/version.tsx
@@ -1,0 +1,2 @@
+export const RECENT_MAJOR_SERVER_VERSION = 5;
+export const UI_VERSION = "0.1";


### PR DESCRIPTION
## Done

- added ui version const
- change navigation version string to include backend and ui

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check version in nav