### PR TITLE
Validate instance name does not start with a number

### DIFF
--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -106,6 +106,9 @@ const CreateInstanceForm: FC = () => {
       .matches(/^[A-Za-z0-9-]+$/, {
         message: "Only alphanumeric and hyphen characters are allowed",
       })
+      .matches(/^[A-Za-z].*$/, {
+        message: "Instance name must start with a letter",
+      })
       .optional(),
     instanceType: Yup.string().required("Instance type is required"),
   });

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -33,6 +33,9 @@ const InstanceDetailHeader: FC<Props> = ({ name, instance, project }) => {
       .matches(/^[A-Za-z0-9-]+$/, {
         message: "Only alphanumeric and hyphen characters are allowed",
       })
+      .matches(/^[A-Za-z].*$/, {
+        message: "Instance name must start with a letter",
+      })
       .required("Instance name is required"),
   });
 


### PR DESCRIPTION
## Done

- validate instance name does not start with a number


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create or rename instance to a name that starts with a number / not with a number