### PR TITLE
Add hostname from url to the page title

### DIFF
--- a/public/assets/data/config-options.json
+++ b/public/assets/data/config-options.json
@@ -460,5 +460,12 @@
     "scope": "local",
     "default": "-",
     "description": "Volume to use to store the image tarballs (syntax is POOL/VOLUME)"
+  },
+  {
+    "key": "user.ui_title",
+    "type": "string",
+    "scope": "local",
+    "default": "-",
+    "description": "Custom identifier for the title of the UI when used on this server"
   }
 ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ProjectRedirect from "pages/projects/ProjectRedirect";
 import ProjectLoader from "pages/projects/ProjectLoader";
 import ClusterGroupLoader from "pages/cluster/ClusterGroupLoader";
 import { useAuth } from "context/auth";
+import { setTitle } from "util/title";
 
 const ClusterList = lazy(() => import("pages/cluster/ClusterList"));
 const InstanceList = lazy(() => import("pages/instances/InstanceList"));
@@ -48,6 +49,7 @@ const HOME_REDIRECT_PATHS = ["/", "/ui", "/ui/project"];
 
 const App: FC = () => {
   const { defaultProject, isAuthLoading } = useAuth();
+  setTitle();
 
   if (isAuthLoading) {
     return <Loader />;

--- a/src/util/title.tsx
+++ b/src/util/title.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import { useSettings } from "context/useSettings";
+
+export const setTitle = () => {
+  const { data: settings } = useSettings();
+
+  useEffect(() => {
+    const host = settings?.config["user.ui_title"] ?? location.hostname;
+    document.title = `${host} | LXD UI`;
+  }, [settings?.config]);
+};


### PR DESCRIPTION
## Done

- Add hostname from url to the page title

- Fixes #464

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check page title
    - customize page title from settings page with the user.ui_title key