### PR TITLE
Add js test execution and first two test cases WD-6235

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,3 +113,22 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+  js-tests:
+    name: js-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Install Dotrun
+        run: |
+          sudo pip3 install dotrun
+
+      - name: Install LXD-UI dependencies
+        run: |
+          set -x
+          sudo chmod 0777 ../lxd-ui
+          dotrun install
+
+      - name: Run Javascript tests
+        run: dotrun test-js

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "hooks-add": "husky install",
     "hooks-remove": "husky uninstall",
     "start": "concurrently --kill-others --raw 'vite | grep -v localhost' 'yarn serve'",
-    "serve": "./entrypoint"
-  },
+    "serve": "./entrypoint",
+    "test-js": "react-scripts test src/ --watchAll=false"},
   "dependencies": {
     "@canonical/react-components": "0.47.0",
     "@monaco-editor/react": "^4.4.6",

--- a/src/util/formDevices.spec.tsx
+++ b/src/util/formDevices.spec.tsx
@@ -1,0 +1,49 @@
+import { formDeviceToPayload, parseDevices } from "./formDevices";
+import { yamlToObject } from "./yaml";
+import { LxdInstance } from "types/instance";
+import { dump as dumpYaml } from "js-yaml";
+
+const deviceYaml =
+  "devices:\n" +
+  "  root:\n" +
+  "    path: /\n" +
+  "    pool: big-pool\n" +
+  "    type: disk\n" +
+  "  eth0:\n" +
+  "    network: lxcbr\n" +
+  "    type: nic\n" +
+  "  eth1:\n" +
+  "    ipv4.address: 10.76.171.21\n" +
+  "    name: eth0\n" +
+  "    network: mybr\n" +
+  "    type: nic\n" +
+  "  grafananat:\n" +
+  "    connect: tcp:10.76.171.21:3000\n" +
+  "    listen: tcp:192.168.0.90:3000\n" +
+  "    nat: 'true'\n" +
+  "    type: proxy\n" +
+  "  prometheusnat:\n" +
+  "    connect: tcp:10.76.171.21:9090\n" +
+  "    listen: tcp:192.168.0.90:9090\n" +
+  "    nat: 'true'\n" +
+  "    type: proxy\n" +
+  "";
+
+describe("parseDevices and formDeviceToPayload", () => {
+  it("preserves disk, network and custom devices", () => {
+    const instance = yamlToObject(deviceYaml) as LxdInstance;
+    const formDevices = parseDevices(instance.devices);
+    const payload = formDeviceToPayload(formDevices);
+
+    const matchFormDeviceType = (deviceType: string) =>
+      Object.values(formDevices).filter((item) => item.type === deviceType);
+
+    expect(matchFormDeviceType("disk").length).toBe(1);
+    expect(matchFormDeviceType("nic").length).toBe(1);
+    expect(matchFormDeviceType("custom-nic").length).toBe(1);
+    expect(matchFormDeviceType("unknown").length).toBe(2);
+
+    const outYaml = dumpYaml({ devices: payload });
+    expect(outYaml).toBe(deviceYaml);
+  });
+});

--- a/src/util/operations.spec.tsx
+++ b/src/util/operations.spec.tsx
@@ -1,0 +1,46 @@
+import { getInstanceName } from "./operations";
+import { LxdOperation } from "types/operation";
+
+const craftOperation = (url: string) => {
+  return {
+    resources: {
+      instances: [url],
+    },
+  } as LxdOperation;
+};
+
+describe("getInstanceName", () => {
+  it("identifies instance name from an instance operation", () => {
+    const operation = craftOperation("/1.0/instances/testInstance1");
+    const name = getInstanceName(operation);
+
+    expect(name).toBe("testInstance1");
+  });
+
+  it("identifies instance name from an instance operation in a custom project", () => {
+    const operation = craftOperation(
+      "/1.0/instances/testInstance2?project=project"
+    );
+    const name = getInstanceName(operation);
+
+    expect(name).toBe("testInstance2");
+  });
+
+  it("identifies instance name from snapshot operation", () => {
+    const operation = craftOperation(
+      "/1.0/instances/testInstance3/snapshots/testSnap"
+    );
+    const name = getInstanceName(operation);
+
+    expect(name).toBe("testInstance3");
+  });
+
+  it("identifies instance name from a snapshot operation in a custom project", () => {
+    const operation = craftOperation(
+      "/1.0/instances/testInstance3/snapshots/testSnap?project=project"
+    );
+    const name = getInstanceName(operation);
+
+    expect(name).toBe("testInstance3");
+  });
+});


### PR DESCRIPTION
## Done

- add two js test cases
- add test runner to package.json
- schedule tests on github PR

Fixes WD-6235

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check PR tests include js-tests and are passing
