### PR TITLE
Align network overview tab style with other pages

### DIFF
--- a/src/pages/networks/NetworkDetailOverview.tsx
+++ b/src/pages/networks/NetworkDetailOverview.tsx
@@ -57,7 +57,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
     <div className="network-overview-tab">
       <Row className="section">
         <Col size={3}>
-          <h2 className="p-heading--4">General</h2>
+          <h2 className="p-heading--5">General</h2>
         </Col>
         <Col size={7}>
           <table>
@@ -94,7 +94,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
       </Row>
       <Row className="section">
         <Col size={3}>
-          <h2 className="p-heading--4">Status</h2>
+          <h2 className="p-heading--5">Status</h2>
         </Col>
         <Col size={7}>
           <table>
@@ -127,7 +127,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
       </Row>
       <Row className="usage list-wrapper">
         <Col size={3}>
-          <h2 className="p-heading--4">Usage ({usageCount})</h2>
+          <h2 className="p-heading--5">Usage ({usageCount})</h2>
         </Col>
         <Col size={7}>
           <table>


### PR DESCRIPTION
## Done

- aligned heading style of network overview with other pages

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check network overview page