### PR TITLE
Improve settings page [WD-5801]

### DIFF
--- a/public/assets/data/config-options.json
+++ b/public/assets/data/config-options.json
@@ -10,14 +10,14 @@
     "key": "acme.domain",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Domain for which the certificate is issued"
   },
   {
     "key": "acme.email",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Email address used for the account registration"
   },
   {
@@ -38,21 +38,21 @@
     "key": "candid.api.key",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Public key of the candid server (required for HTTP-only servers)"
   },
   {
     "key": "candid.api.url",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "URL of the the external authentication endpoint using Candid"
   },
   {
     "key": "candid.domains",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Comma-separated list of allowed Candid domains (empty string means all domains are valid)"
   },
   {
@@ -66,7 +66,7 @@
     "key": "cluster.https_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to use for clustering traffic"
   },
   {
@@ -108,84 +108,84 @@
     "key": "core.bgp_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to bind the BGP server to (BGP)"
   },
   {
     "key": "core.bgp_asn",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The BGP Autonomous System Number to use for the local server"
   },
   {
     "key": "core.bgp_routerid",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "A unique identifier for this BGP server (formatted as an IPv4 address)"
   },
   {
     "key": "core.debug_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to bind the pprof debug server to (HTTP)"
   },
   {
     "key": "core.dns_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to bind the authoritative DNS server to (DNS)"
   },
   {
     "key": "core.https_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to bind for the remote API (HTTPS)"
   },
   {
     "key": "core.https_allowed_credentials",
     "type": "bool",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Whether to set Access-Control-Allow-Credentials HTTP header value to true"
   },
   {
     "key": "core.https_allowed_headers",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Access-Control-Allow-Headers HTTP header value"
   },
   {
     "key": "core.https_allowed_methods",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Access-Control-Allow-Methods HTTP header value"
   },
   {
     "key": "core.https_allowed_origin",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Access-Control-Allow-Origin HTTP header value"
   },
   {
     "key": "core.https_trusted_proxy",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Comma-separated list of IP addresses of trusted servers to provide the client’s address through the proxy connection header"
   },
   {
     "key": "core.metrics_address",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Address to bind the metrics server to (HTTPS)"
   },
   {
@@ -199,28 +199,28 @@
     "key": "core.proxy_https",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "HTTPS proxy to use, if any (falls back to HTTPS_PROXY environment variable)"
   },
   {
     "key": "core.proxy_http",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "HTTP proxy to use, if any (falls back to HTTP_PROXY environment variable)"
   },
   {
     "key": "core.proxy_ignore_hosts",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Hosts which don’t need the proxy for use (similar format to NO_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO_PROXY environment variable)"
   },
   {
     "key": "core.remote_token_expiry",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Time after which a remote add token expires (defaults to no expiry)"
   },
   {
@@ -234,21 +234,21 @@
     "key": "core.storage_buckets_address",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Address to bind the storage object server to (HTTPS)"
   },
   {
     "key": "core.trust_ca_certificates",
     "type": "bool",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Whether to automatically trust clients signed by the CA"
   },
   {
     "key": "core.trust_password",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Password to be provided by clients to set up a trust"
   },
   {
@@ -276,7 +276,7 @@
     "key": "images.default_architecture",
     "type": "string",
     "scope": "-",
-    "default": "-",
+    "default": "",
     "description": "Default architecture which should be used in mixed architecture cluster"
   },
   {
@@ -297,35 +297,35 @@
     "key": "loki.api.ca_cert",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The CA certificate for the Loki server"
   },
   {
     "key": "loki.api.url",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The URL to the Loki server"
   },
   {
     "key": "loki.auth.password",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The password used for authentication"
   },
   {
     "key": "loki.auth.username",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The username used for authentication"
   },
   {
     "key": "loki.labels",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Comma-separated list of values which should be used as labels for a Loki log entry"
   },
   {
@@ -346,14 +346,14 @@
     "key": "maas.api.key",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "API key to manage MAAS"
   },
   {
     "key": "maas.api.url",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "URL of the MAAS server"
   },
   {
@@ -381,91 +381,91 @@
     "key": "oidc.client.id",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "OpenID Connect client ID"
   },
   {
     "key": "oidc.issuer",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "OpenID Connect Discovery URL for the provider"
   },
   {
     "key": "oidc.audience",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Expected audience value for the application (required by some providers)"
   },
   {
     "key": "rbac.agent.private_key",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The Candid agent private key as provided during RBAC registration"
   },
   {
     "key": "rbac.agent.public_key",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The Candid agent public key as provided during RBAC registration"
   },
   {
     "key": "rbac.agent.url",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The Candid agent URL as provided during RBAC registration"
   },
   {
     "key": "rbac.agent.username",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "The Candid agent username as provided during RBAC registration"
   },
   {
     "key": "rbac.api.expiry",
     "type": "integer",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "RBAC macaroon expiry in seconds"
   },
   {
     "key": "rbac.api.key",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "Public key of the RBAC server (required for HTTP-only servers)"
   },
   {
     "key": "rbac.api.url",
     "type": "string",
     "scope": "global",
-    "default": "-",
+    "default": "",
     "description": "URL of the external RBAC server"
   },
   {
     "key": "storage.backups_volume",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Volume to use to store the backup tarballs (syntax is POOL/VOLUME)"
   },
   {
     "key": "storage.images_volume",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Volume to use to store the image tarballs (syntax is POOL/VOLUME)"
   },
   {
     "key": "user.ui_title",
     "type": "string",
     "scope": "local",
-    "default": "-",
+    "default": "",
     "description": "Custom identifier for the title of the UI when used on this server"
   }
 ]

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useRef, useState } from "react";
 import { Button, Icon, useNotify } from "@canonical/react-components";
 import { updateSettings } from "api/server";
-import { LxdConfigOption } from "types/config";
+import { LxdConfigField } from "types/config";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "context/auth";
@@ -14,11 +14,12 @@ export const getConfigId = (key: string) => {
 };
 
 interface Props {
-  configField: LxdConfigOption;
+  configField: LxdConfigField;
   value?: string;
+  isLast?: boolean;
 }
 
-const SettingForm: FC<Props> = ({ configField, value }) => {
+const SettingForm: FC<Props> = ({ configField, value, isLast }) => {
   const { isRestricted } = useAuth();
   const [isEditMode, setEditMode] = useState(false);
   const notify = useNotify();
@@ -66,7 +67,7 @@ const SettingForm: FC<Props> = ({ configField, value }) => {
   };
 
   useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode && isLast) {
       editRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [isEditMode]);
@@ -87,7 +88,7 @@ const SettingForm: FC<Props> = ({ configField, value }) => {
             <>
               {configField.type === "bool" ? (
                 <SettingFormCheckbox
-                  initialValue={Boolean(value)}
+                  initialValue={value}
                   configField={configField}
                   onSubmit={onSubmit}
                   onCancel={onCancel}

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -1,0 +1,55 @@
+import React, { FC, useState } from "react";
+import { Input, Button, Icon } from "@canonical/react-components";
+import { LxdConfigOption } from "types/config";
+import { getConfigId } from "./SettingForm";
+
+interface Props {
+  initialValue: boolean;
+  configField: LxdConfigOption;
+  onSubmit: (newValue: string | boolean) => void;
+  onCancel: () => void;
+}
+
+const SettingFormCheckbox: FC<Props> = ({
+  initialValue,
+  configField,
+  onSubmit,
+  onCancel,
+}) => {
+  const [checked, setChecked] = useState(initialValue);
+
+  const canBeReset = String(configField.default) !== String(checked);
+
+  const resetToDefault = () => {
+    setChecked(String(configField.default) === "true");
+  };
+
+  return (
+    <>
+      <Input
+        id={getConfigId(configField.key)}
+        wrapperClassName="input-wrapper"
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+      />
+      <Button onClick={onCancel}>Cancel</Button>
+      <Button appearance="positive" onClick={() => onSubmit(checked)}>
+        Save
+      </Button>
+      {canBeReset && (
+        <Button
+          className="reset-button"
+          appearance="base"
+          onClick={resetToDefault}
+          hasIcon
+        >
+          <Icon name="restart" className="flip-horizontally" />
+          <span>Reset to default</span>
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default SettingFormCheckbox;

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -31,7 +31,7 @@ const SettingFormCheckbox: FC<Props> = ({
   return (
     <>
       <Input
-        label={<span className="u-off-screen">{configField.key}</span>}
+        aria-label={configField.key}
         id={getConfigId(configField.key)}
         wrapperClassName="input-wrapper"
         type="checkbox"

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useState } from "react";
 import { Input, Button, Icon } from "@canonical/react-components";
-import { LxdConfigOption } from "types/config";
+import { LxdConfigField } from "types/config";
 import { getConfigId } from "./SettingForm";
 
 interface Props {
-  initialValue: boolean;
-  configField: LxdConfigOption;
+  initialValue?: string;
+  configField: LxdConfigField;
   onSubmit: (newValue: string | boolean) => void;
   onCancel: () => void;
 }
@@ -16,7 +16,11 @@ const SettingFormCheckbox: FC<Props> = ({
   onSubmit,
   onCancel,
 }) => {
-  const [checked, setChecked] = useState(initialValue);
+  const [checked, setChecked] = useState(
+    initialValue
+      ? initialValue === "true"
+      : String(configField.default) === "true"
+  );
 
   const canBeReset = String(configField.default) !== String(checked);
 
@@ -27,6 +31,7 @@ const SettingFormCheckbox: FC<Props> = ({
   return (
     <>
       <Input
+        label={<span className="u-off-screen">{configField.key}</span>}
         id={getConfigId(configField.key)}
         wrapperClassName="input-wrapper"
         type="checkbox"

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -36,8 +36,7 @@ const SettingFormInput: FC<Props> = ({
   return (
     <>
       <Input
-        label={configField.key}
-        labelClassName="u-off-screen"
+        aria-label={configField.key}
         id={getConfigId(configField.key)}
         wrapperClassName="input-wrapper"
         type={getInputType()}

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -1,0 +1,64 @@
+import React, { FC, useState } from "react";
+import { Button, Icon, Input } from "@canonical/react-components";
+import { LxdConfigOption } from "types/config";
+import { getConfigId } from "./SettingForm";
+
+interface Props {
+  initialValue: string;
+  configField: LxdConfigOption;
+  onSubmit: (newValue: string | boolean) => void;
+  onCancel: () => void;
+}
+
+const SettingFormInput: FC<Props> = ({
+  initialValue,
+  configField,
+  onSubmit,
+  onCancel,
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  const getInputType = () => {
+    switch (configField.type) {
+      case "integer":
+        return "number";
+      default:
+        return "text";
+    }
+  };
+
+  const canBeReset = String(configField.default) !== String(value);
+
+  const resetToDefault = () => {
+    setValue(configField.default as string);
+  };
+
+  return (
+    <>
+      <Input
+        id={getConfigId(configField.key)}
+        wrapperClassName="input-wrapper"
+        type={getInputType()}
+        value={configField.type === "bool" ? undefined : String(value)}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <Button onClick={onCancel}>Cancel</Button>
+      <Button appearance="positive" onClick={() => onSubmit(value)}>
+        Save
+      </Button>
+      {canBeReset && (
+        <Button
+          className="reset-button"
+          appearance="base"
+          onClick={resetToDefault}
+          hasIcon
+        >
+          <Icon name="restart" className="flip-horizontally" />
+          <span>Reset to default</span>
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default SettingFormInput;

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useState } from "react";
 import { Button, Icon, Input } from "@canonical/react-components";
-import { LxdConfigOption } from "types/config";
+import { LxdConfigField } from "types/config";
 import { getConfigId } from "./SettingForm";
 
 interface Props {
   initialValue: string;
-  configField: LxdConfigOption;
+  configField: LxdConfigField;
   onSubmit: (newValue: string | boolean) => void;
   onCancel: () => void;
 }
@@ -36,6 +36,8 @@ const SettingFormInput: FC<Props> = ({
   return (
     <>
       <Input
+        label={configField.key}
+        labelClassName="u-off-screen"
         id={getConfigId(configField.key)}
         wrapperClassName="input-wrapper"
         type={getInputType()}

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -1,0 +1,63 @@
+import React, { FC, useState } from "react";
+import { Button, Icon, Input } from "@canonical/react-components";
+import { LxdConfigOption } from "types/config";
+import { getConfigId } from "./SettingForm";
+
+interface Props {
+  isSet: boolean;
+  configField: LxdConfigOption;
+  onSubmit: (newValue: string | boolean) => void;
+  onCancel: () => void;
+}
+
+const SettingFormPassword: FC<Props> = ({
+  isSet,
+  configField,
+  onSubmit,
+  onCancel,
+}) => {
+  const [showPasswordField, setShowPasswordField] = useState(!isSet);
+  const [showPassword, setShowPassword] = useState(false);
+  const [password, setPassword] = useState("");
+
+  return (
+    <>
+      {showPasswordField && (
+        <>
+          <div className="input-row">
+            <Input
+              id={getConfigId(configField.key)}
+              wrapperClassName="input-wrapper"
+              type={showPassword ? "text" : "password"}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <Button
+              appearance="base"
+              hasIcon
+              onClick={() => setShowPassword((prev) => !prev)}
+              aria-label="toggle password visibility"
+            >
+              <Icon name={showPassword ? "hide" : "show"} />
+            </Button>
+          </div>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button appearance="positive" onClick={() => onSubmit(password)}>
+            Save
+          </Button>
+        </>
+      )}
+      {!showPasswordField && (
+        <>
+          <Button onClick={onCancel}>Cancel</Button>
+          <Button onClick={() => setShowPasswordField(true)}>Change</Button>
+          <Button appearance="negative" onClick={() => onSubmit("")}>
+            Remove
+          </Button>
+        </>
+      )}
+    </>
+  );
+};
+
+export default SettingFormPassword;

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -26,8 +26,7 @@ const SettingFormPassword: FC<Props> = ({
         <>
           <div className="input-row">
             <Input
-              label={configField.key}
-              labelClassName="u-off-screen"
+              aria-label={configField.key}
               id={getConfigId(configField.key)}
               wrapperClassName="input-wrapper"
               type={showPassword ? "text" : "password"}

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useState } from "react";
 import { Button, Icon, Input } from "@canonical/react-components";
-import { LxdConfigOption } from "types/config";
+import { LxdConfigField } from "types/config";
 import { getConfigId } from "./SettingForm";
 
 interface Props {
   isSet: boolean;
-  configField: LxdConfigOption;
+  configField: LxdConfigField;
   onSubmit: (newValue: string | boolean) => void;
   onCancel: () => void;
 }
@@ -26,6 +26,8 @@ const SettingFormPassword: FC<Props> = ({
         <>
           <div className="input-row">
             <Input
+              label={configField.key}
+              labelClassName="u-off-screen"
               id={getConfigId(configField.key)}
               wrapperClassName="input-wrapper"
               type={showPassword ? "text" : "password"}

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -8,7 +8,7 @@ import {
 } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import { handleResponse } from "util/helpers";
-import { LxdConfigOption } from "types/config";
+import { LxdConfigField } from "types/config";
 import SettingForm from "./SettingForm";
 import Loader from "components/Loader";
 import { useSettings } from "context/useSettings";
@@ -18,14 +18,14 @@ import ScrollableTable from "components/ScrollableTable";
 const configOptionsUrl = "/ui/assets/data/config-options.json";
 
 const Settings: FC = () => {
-  const [configOptions, setConfigOptions] = useState<LxdConfigOption[]>([]);
+  const [configOptions, setConfigOptions] = useState<LxdConfigField[]>([]);
   const [query, setQuery] = useState("");
   const notify = useNotify();
 
   const loadConfigOptions = () => {
     void fetch(configOptionsUrl)
       .then(handleResponse)
-      .then((data: LxdConfigOption[]) => {
+      .then((data: LxdConfigField[]) => {
         setConfigOptions(data);
       });
   };
@@ -40,7 +40,7 @@ const Settings: FC = () => {
     notify.failure("Loading settings failed", error);
   }
 
-  const getValue = (configField: LxdConfigOption): string | undefined => {
+  const getValue = (configField: LxdConfigField): string | undefined => {
     for (const [key, value] of Object.entries(settings?.config ?? {})) {
       if (key === configField.key) {
         return value;
@@ -69,7 +69,7 @@ const Settings: FC = () => {
       }
       return configField.key.toLowerCase().includes(query.toLowerCase());
     })
-    .map((configField) => {
+    .map((configField, index, { length }) => {
       const isDefault = !Object.keys(settings?.config ?? {}).some(
         (key) => key === configField.key
       );
@@ -105,7 +105,13 @@ const Settings: FC = () => {
             "aria-label": "Key",
           },
           {
-            content: <SettingForm configField={configField} value={value} />,
+            content: (
+              <SettingForm
+                configField={configField}
+                value={value}
+                isLast={index === length - 1}
+              />
+            ),
             role: "cell",
             "aria-label": "Value",
             className: "u-vertical-align-middle",

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -1,4 +1,36 @@
-.readmode-button {
-  padding: 0;
-  text-align: start;
+.settings {
+  min-height: initial !important;
+
+  .group {
+    width: 8rem;
+
+    @include mobile {
+      display: none;
+    }
+  }
+
+  .input-row,
+  .readmode-button {
+    align-items: center;
+    display: flex;
+  }
+
+  .input-wrapper {
+    flex-grow: 1;
+  }
+
+  .readmode-button {
+    max-width: 100%;
+    padding: 0;
+    text-align: start;
+
+    .edit-icon {
+      min-width: 1rem;
+    }
+  }
+
+  .reset-button {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
 }

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,9 +1,9 @@
 export type LxdConfigPair = Record<string, string>;
 
 export interface LxdConfigOption {
-  key: string;
-  type: "string" | "integer" | "bool";
-  scope: "global" | "local";
   default: string | boolean;
   description: string;
+  key: string;
+  scope: "global" | "local";
+  type: "string" | "integer" | "bool";
 }

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -1,6 +1,6 @@
 export type LxdConfigPair = Record<string, string>;
 
-export interface LxdConfigOption {
+export interface LxdConfigField {
   default: string | boolean;
   description: string;
   key: string;


### PR DESCRIPTION
## Done

- Made the logic and implementation of the Settings page consistent with that of the Configuration page of Anbox Cloud dashboard:
  - Added special handling of password fields
  - Improved styling
  - Wrapped the table inside a scrollable table so that the header is fixed

Fixes [WD-5801](https://warthogs.atlassian.net/browse/WD-5801)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Settings page
    - Check that all field types work as expected: string, number, boolean (checkbox) and special cases (password fields)

[WD-5801]: https://warthogs.atlassian.net/browse/WD-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ