### PR TITLE
use instance created instead of launched in notification copy

### DIFF
--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -123,10 +123,18 @@ const CreateInstanceForm: FC = () => {
     void queryClient.invalidateQueries({
       queryKey: [queryKeys.instances],
     });
+    void queryClient.invalidateQueries({
+      queryKey: [queryKeys.operations, project],
+    });
   };
 
-  const notifyLaunchedAndStarted = (instanceLink: ReactNode) => {
-    notify.success(<>Launched and started instance {instanceLink}.</>);
+  const notifyCreatedNowStarting = (instanceLink: ReactNode) => {
+    notify.info(<>Created instance {instanceLink}, now starting it.</>);
+    clearCache();
+  };
+
+  const notifyCreatedAndStarted = (instanceLink: ReactNode) => {
+    notify.success(<>Created and started instance {instanceLink}.</>);
     clearCache();
   };
 
@@ -139,16 +147,16 @@ const CreateInstanceForm: FC = () => {
     clearCache();
   };
 
-  const notifyLaunched = (instanceLink: ReactNode, message?: ReactNode) => {
+  const notifyCreated = (instanceLink: ReactNode, message?: ReactNode) => {
     notify.success(
       <>
-        Launched instance {instanceLink}.{message}
+        Created instance {instanceLink}.{message}
       </>
     );
     clearCache();
   };
 
-  const notifyLaunchFailed = (
+  const notifyCreationFailed = (
     e: Error,
     formUrl: string,
     values: CreateInstanceFormValues
@@ -175,12 +183,13 @@ const CreateInstanceForm: FC = () => {
     );
 
     if (shouldStart) {
+      notifyCreatedNowStarting(instanceLink);
       startInstance({
         name: instanceName,
         project: project,
       } as LxdInstance)
         .then(() => {
-          notifyLaunchedAndStarted(instanceLink);
+          notifyCreatedAndStarted(instanceLink);
         })
         .catch((e: Error) => {
           notifyCreatedButStartFailed(instanceLink, e);
@@ -196,7 +205,7 @@ const CreateInstanceForm: FC = () => {
           </Button>
         </>
       );
-      notifyLaunched(instanceLink, message);
+      notifyCreated(instanceLink, message);
     }
   };
 
@@ -218,14 +227,14 @@ const CreateInstanceForm: FC = () => {
         eventQueue.set(
           operation.metadata.id,
           () => creationCompletedHandler(instanceName, shouldStart, isIsoImage),
-          (msg) => notifyLaunchFailed(new Error(msg), formUrl, values)
+          (msg) => notifyCreationFailed(new Error(msg), formUrl, values)
         );
       })
       .catch((e: Error) => {
         if (e.message === "Cancelled") {
           return;
         }
-        notifyLaunchFailed(e, formUrl, values);
+        notifyCreationFailed(e, formUrl, values);
       });
   };
 

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -34,7 +34,7 @@ export const createInstance = async (
     .selectOption(type);
   await page.getByRole("button", { name: "Create" }).first().click();
 
-  await page.waitForSelector(`text=Launched instance ${instance}.`, TIMEOUT);
+  await page.waitForSelector(`text=Created instance ${instance}.`, TIMEOUT);
 };
 
 export const visitInstance = async (page: Page, instance: string) => {

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -61,7 +61,7 @@ test("use custom iso for instance launch", async ({ page }) => {
   await page.locator(".u-align--right > .p-button--positive").click();
   await page.getByRole("button", { name: "Create" }).click();
 
-  await page.waitForSelector(`text=Launched instance ${instance}.`, TIMEOUT);
+  await page.waitForSelector(`text=Created instance ${instance}.`, TIMEOUT);
 
   await deleteInstance(page, instance);
   await page.goto("/ui/");


### PR DESCRIPTION
## Done

- use instance created instead of launched in notification copy

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create / create and start some instances