### PR TITLE
Ensure certificate serial number is short enough for firefox

### DIFF
--- a/src/pages/login/CertificateGenerate.tsx
+++ b/src/pages/login/CertificateGenerate.tsx
@@ -138,7 +138,12 @@ const CertificateGenerate: FC = () => {
                 {certs && (
                   <Col size={3}>
                     <Button
-                      onClick={() => downloadText("lxd-ui.crt", certs.crt)}
+                      onClick={() =>
+                        downloadText(
+                          `lxd-ui-${location.hostname}.crt`,
+                          certs.crt
+                        )
+                      }
                     >
                       Download crt
                     </Button>
@@ -155,7 +160,11 @@ const CertificateGenerate: FC = () => {
                   <BrowserImport
                     sendPfx={
                       certs
-                        ? () => downloadBase64("lxd-ui.pfx", certs.pfx)
+                        ? () =>
+                            downloadBase64(
+                              `lxd-ui-${location.hostname}.pfx`,
+                              certs.pfx
+                            )
                         : undefined
                     }
                   />

--- a/src/util/certificate.tsx
+++ b/src/util/certificate.tsx
@@ -21,7 +21,7 @@ const details = [
   },
   {
     name: "organizationName",
-    value: "Browser Generated LXD UI",
+    value: "LXD UI " + location.hostname + " (Browser Generated)",
   },
 ];
 
@@ -32,8 +32,7 @@ export const generateCert = (password: string) => {
   const cert = forge.pki.createCertificate();
   cert.publicKey = keys.publicKey;
 
-  // @ts-expect-error toString can have an argument
-  cert.serialNumber = "01" + getRandomBytes(19).toString(16);
+  cert.serialNumber = "01" + getRandomBytes(20).toString().substring(0, 30);
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date(
     Date.now() + 1000 * 60 * 60 * 24 * validDays


### PR DESCRIPTION
## Done

- Make generated certificates compatible to firefox, too long serial numbers cause problems in it. See [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1856925).
- Add hostname to the downloaded pfx and crt files
- Add hostname to certificate name

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create new certificates
    - import to firefox and test usage
    - ensure name contains hostname