### PR TITLE
Use websocket to track long running operations

### DIFF
--- a/src/context/eventQueue.tsx
+++ b/src/context/eventQueue.tsx
@@ -5,7 +5,8 @@ export interface EventQueue {
   set: (
     operationId: string,
     onSuccess: () => void,
-    onFailure: (msg: string) => void
+    onFailure: (msg: string) => void,
+    onFinish?: () => void
   ) => void;
   remove: (operationId: string) => void;
 }
@@ -23,6 +24,7 @@ interface Props {
 interface EventCallback {
   onSuccess: () => void;
   onFailure: (msg: string) => void;
+  onFinish?: () => void;
 }
 
 const eventQueue = new Map<string, EventCallback>();
@@ -32,8 +34,8 @@ export const EventQueueProvider: FC<Props> = ({ children }) => {
     <EventQueueContext.Provider
       value={{
         get: (operationId) => eventQueue.get(operationId),
-        set: (operationId, onSuccess, onFailure) => {
-          eventQueue.set(operationId, { onSuccess, onFailure });
+        set: (operationId, onSuccess, onFailure, onFinish) => {
+          eventQueue.set(operationId, { onSuccess, onFailure, onFinish });
         },
         remove: (operationId) => eventQueue.delete(operationId),
       }}

--- a/src/pages/instances/CreateInstanceForm.tsx
+++ b/src/pages/instances/CreateInstanceForm.tsx
@@ -185,16 +185,16 @@ const CreateInstanceForm: FC = () => {
 
     if (shouldStart) {
       notifyCreatedNowStarting(instanceLink);
-      startInstance({
+      void startInstance({
         name: instanceName,
         project: project,
-      } as LxdInstance)
-        .then(() => {
-          notifyCreatedAndStarted(instanceLink);
-        })
-        .catch((e: Error) => {
-          notifyCreatedButStartFailed(instanceLink, e);
-        });
+      } as LxdInstance).then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () => notifyCreatedAndStarted(instanceLink),
+          (msg) => notifyCreatedButStartFailed(instanceLink, new Error(msg))
+        );
+      });
     } else {
       const consoleUrl = `/ui/project/${project}/instances/detail/${instanceName}/console`;
       const message = isIsoImage && (

--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -15,10 +15,12 @@ const Events: FC = () => {
     }
     if (event.metadata.status === "Success") {
       eventCallback.onSuccess();
+      eventCallback.onFinish?.();
       eventQueue.remove(event.metadata.id);
     }
     if (event.metadata.status === "Failure") {
       eventCallback.onFailure(event.metadata.err ?? "");
+      eventCallback.onFinish?.();
       eventQueue.remove(event.metadata.id);
     }
   };

--- a/src/pages/instances/actions/InstanceBulkDelete.tsx
+++ b/src/pages/instances/actions/InstanceBulkDelete.tsx
@@ -11,6 +11,7 @@ import {
   Icon,
   useNotify,
 } from "@canonical/react-components";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   instances: LxdInstance[];
@@ -19,6 +20,7 @@ interface Props {
 }
 
 const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
+  const eventQueue = useEventQueue();
   const notify = useNotify();
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
@@ -33,7 +35,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
   const handleDelete = () => {
     setLoading(true);
     onStart(deletableInstances.map((item) => item.name));
-    void deleteInstanceBulk(deletableInstances).then((results) => {
+    void deleteInstanceBulk(deletableInstances, eventQueue).then((results) => {
       const { fulfilledCount, rejectedCount } =
         getPromiseSettledCounts(results);
       if (fulfilledCount === deleteCount) {

--- a/src/sass/_instance_detail_snapshots.scss
+++ b/src/sass/_instance_detail_snapshots.scss
@@ -26,8 +26,7 @@
     }
   }
 
-  th:last-child,
-  td:last-child {
+  .p-table__expanding-panel {
     display: none !important;
   }
 

--- a/src/util/instanceStart.tsx
+++ b/src/util/instanceStart.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { unfreezeInstance, startInstance } from "api/instances";
-import ItemName from "components/ItemName";
 import { useInstanceLoading } from "context/instanceLoading";
 import InstanceLink from "pages/instances/InstanceLink";
 import { LxdInstance } from "types/instance";
 import { queryKeys } from "./queryKeys";
 import { useNotify } from "@canonical/react-components";
+import { useEventQueue } from "context/eventQueue";
+import ItemName from "components/ItemName";
 
 export const useInstanceStart = (instance: LxdInstance) => {
+  const eventQueue = useEventQueue();
   const instanceLoading = useInstanceLoading();
   const notify = useNotify();
   const queryClient = useQueryClient();
@@ -24,29 +26,31 @@ export const useInstanceStart = (instance: LxdInstance) => {
     instanceLoading.setLoading(instance, "Starting");
     const mutation =
       instance.status === "Frozen" ? unfreezeInstance : startInstance;
-    mutation(instance)
-      .then(() => {
-        notify.success(
-          <>
-            Instance <InstanceLink instance={instance} /> started.
-          </>
-        );
-      })
-      .catch((e) => {
-        notify.failure(
-          "Instance start failed",
-          e,
-          <>
-            Instance <ItemName item={instance} bold />:
-          </>
-        );
-      })
-      .finally(() => {
-        instanceLoading.setFinish(instance);
-        void queryClient.invalidateQueries({
-          queryKey: [queryKeys.instances],
-        });
-      });
+    void mutation(instance).then((operation) => {
+      eventQueue.set(
+        operation.metadata.id,
+        () =>
+          notify.success(
+            <>
+              Instance <InstanceLink instance={instance} /> started.
+            </>
+          ),
+        (msg) =>
+          notify.failure(
+            "Instance start failed",
+            new Error(msg),
+            <>
+              Instance <ItemName item={instance} bold />:
+            </>
+          ),
+        () => {
+          instanceLoading.setFinish(instance);
+          void queryClient.invalidateQueries({
+            queryKey: [queryKeys.instances],
+          });
+        }
+      );
+    });
   };
   return { handleStart, isLoading, isDisabled };
 };


### PR DESCRIPTION
## Done

- removed long-running requests to track instance operations
- use websocket to update on operation finish/fail

Fixes WD-6611

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance create, create and start, delete, start, stop, pause, unpause, also bulk actions, rename, update config, update snapshot config, attach/unattach iso, delete, bulk delete
    - the notifications and loading state should work as before.