### PR TITLE
Add documentation links to all main page headings WD-6525

### DIFF
--- a/src/components/HelpLink.tsx
+++ b/src/components/HelpLink.tsx
@@ -1,0 +1,21 @@
+import React, { FC, ReactNode } from "react";
+import { Icon } from "@canonical/react-components";
+
+interface Props {
+  children: ReactNode;
+  href: string;
+  title: string;
+}
+
+const HelpLink: FC<Props> = ({ children, href, title }) => {
+  return (
+    <div className="help-link">
+      {children}
+      <a href={href} target="_blank" rel="noreferrer" title={title}>
+        <Icon name="information" className="help-link-icon" />
+      </a>
+    </div>
+  );
+};
+
+export default HelpLink;

--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -26,6 +26,7 @@ import { useSettings } from "context/useSettings";
 import NotificationRow from "components/NotificationRow";
 import { isClusteredServer } from "util/settings";
 import BaseLayout from "components/BaseLayout";
+import HelpLink from "components/HelpLink";
 
 const ClusterList: FC = () => {
   const notify = useNotify();
@@ -60,14 +61,19 @@ const ClusterList: FC = () => {
       mainClassName="cluster-list"
       contentClassName="cluster-content"
       title={
-        isClustered ? (
-          <ClusterGroupSelector
-            activeGroup={activeGroup ?? allClusterGroups}
-            key={activeGroup}
-          />
-        ) : (
-          "Cluster"
-        )
+        <HelpLink
+          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/clustering/"
+          title="Learn more about clustering"
+        >
+          {isClustered ? (
+            <ClusterGroupSelector
+              activeGroup={activeGroup ?? allClusterGroups}
+              key={activeGroup}
+            />
+          ) : (
+            "Cluster"
+          )}
+        </HelpLink>
       }
       controls={
         activeGroup ? <EditClusterGroupBtn group={activeGroup} /> : null

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -52,6 +52,7 @@ import ScrollableTable from "components/ScrollableTable";
 import NotificationRow from "components/NotificationRow";
 import SelectedTableNotification from "components/SelectedTableNotification";
 import CustomLayout from "components/CustomLayout";
+import HelpLink from "components/HelpLink";
 
 const loadHidden = () => {
   const saved = localStorage.getItem("instanceListHiddenColumns");
@@ -478,7 +479,14 @@ const InstanceList: FC = () => {
       header={
         <div className="p-panel__header instance-list-header">
           <div className="instance-header-left">
-            <h1 className="p-heading--4 u-no-margin--bottom">Instances</h1>
+            <h1 className="p-heading--4 u-no-margin--bottom">
+              <HelpLink
+                href="https://documentation.ubuntu.com/lxd/en/latest/explanation/instances/#expl-instances"
+                title="Learn more about Instances"
+              >
+                Instances
+              </HelpLink>
+            </h1>
             {selectedNames.length > 0 && (
               <>
                 <InstanceBulkActions

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -482,7 +482,7 @@ const InstanceList: FC = () => {
             <h1 className="p-heading--4 u-no-margin--bottom">
               <HelpLink
                 href="https://documentation.ubuntu.com/lxd/en/latest/explanation/instances/#expl-instances"
-                title="Learn more about Instances"
+                title="Learn more about instances"
               >
                 Instances
               </HelpLink>

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -14,6 +14,7 @@ import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
+import HelpLink from "components/HelpLink";
 
 const NetworkList: FC = () => {
   const navigate = useNavigate();
@@ -121,7 +122,14 @@ const NetworkList: FC = () => {
   return (
     <>
       <BaseLayout
-        title="Networks"
+        title={
+          <HelpLink
+            href="https://documentation.ubuntu.com/lxd/en/latest/explanation/networks/"
+            title="Learn more about networking"
+          >
+            Networks
+          </HelpLink>
+        }
         controls={
           <>
             {hasNetworks && (

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -24,6 +24,7 @@ import { useProject } from "context/project";
 import ScrollableTable from "components/ScrollableTable";
 import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
+import HelpLink from "components/HelpLink";
 
 const ProfileList: FC = () => {
   const navigate = useNavigate();
@@ -165,7 +166,14 @@ const ProfileList: FC = () => {
       header={
         <div className="p-panel__header profile-list-header">
           <div className="profile-header-left">
-            <h1 className="p-heading--4 u-no-margin--bottom">Profiles</h1>
+            <h1 className="p-heading--4 u-no-margin--bottom">
+              <HelpLink
+                href="https://documentation.ubuntu.com/lxd/en/latest/profiles/"
+                title="Learn how to use profiles"
+              >
+                Profiles
+              </HelpLink>
+            </h1>
             <SearchBox
               className="search-box margin-right u-no-margin--bottom"
               name="search-profile"

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -8,6 +8,7 @@ import { useFormik } from "formik";
 import { checkDuplicateName } from "util/helpers";
 import DeleteProjectBtn from "./actions/DeleteProjectBtn";
 import { useNotify } from "@canonical/react-components";
+import HelpLink from "components/HelpLink";
 
 interface Props {
   project: LxdProject;
@@ -60,7 +61,15 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
   return (
     <RenameHeader
       name={project.name}
-      parentItems={["Project configuration"]}
+      parentItems={[
+        <HelpLink
+          key="project-configuration"
+          href="https://documentation.ubuntu.com/lxd/en/latest/reference/projects/"
+          title="Learn more about project configuration"
+        >
+          Project configuration
+        </HelpLink>,
+      ]}
       renameDisabledReason={
         project.name === "default"
           ? "Cannot rename the default project"

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -14,6 +14,7 @@ import Loader from "components/Loader";
 import { useSettings } from "context/useSettings";
 import NotificationRow from "components/NotificationRow";
 import ScrollableTable from "components/ScrollableTable";
+import HelpLink from "components/HelpLink";
 
 const configOptionsUrl = "/ui/assets/data/config-options.json";
 
@@ -122,7 +123,17 @@ const Settings: FC = () => {
 
   return (
     <>
-      <BaseLayout title="Settings" contentClassName="settings">
+      <BaseLayout
+        title={
+          <HelpLink
+            href="https://documentation.ubuntu.com/lxd/en/latest/server/"
+            title="Learn more about server configuration"
+          >
+            Settings
+          </HelpLink>
+        }
+        contentClassName="settings"
+      >
         <NotificationRow />
         {isLoading && <Loader text="Loading settings..." />}
         {!isLoading && (

--- a/src/pages/storage/Storage.tsx
+++ b/src/pages/storage/Storage.tsx
@@ -7,6 +7,7 @@ import { slugify } from "util/slugify";
 import CachedImageList from "pages/images/CachedImageList";
 import CustomIsoList from "pages/storage/CustomIsoList";
 import StoragePools from "pages/storage/StoragePools";
+import HelpLink from "components/HelpLink";
 
 const TABS: string[] = ["Storage pools", "Cached images", "Custom ISOs"];
 
@@ -32,7 +33,16 @@ const Storage: FC = () => {
   };
 
   return (
-    <BaseLayout title="Storage">
+    <BaseLayout
+      title={
+        <HelpLink
+          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/"
+          title="Learn more about storage pools, volumes and buckets"
+        >
+          Storage
+        </HelpLink>
+      }
+    >
       <NotificationRow />
       <Row>
         <Tabs

--- a/src/pages/storage/UploadCustomImageHint.tsx
+++ b/src/pages/storage/UploadCustomImageHint.tsx
@@ -12,7 +12,7 @@ const UploadCustomImageHint: FC = () => {
           <p>
             <a
               className="p-notification__action"
-              href="https://discourse.ubuntu.com/t/how-to-install-a-windows-11-vm-using-lxd/28940"
+              href="https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd#1-overview"
               target="_blank"
               rel="noreferrer"
             >

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import NotificationRow from "components/NotificationRow";
+import HelpLink from "components/HelpLink";
 
 const WarningList: FC = () => {
   const notify = useNotify();
@@ -96,7 +97,16 @@ const WarningList: FC = () => {
 
   return (
     <>
-      <BaseLayout title="Warnings">
+      <BaseLayout
+        title={
+          <HelpLink
+            href="https://documentation.ubuntu.com/lxd/en/latest/howto/troubleshoot/"
+            title="Learn more about troubleshooting"
+          >
+            Warnings
+          </HelpLink>
+        }
+      >
         <NotificationRow />
         <Row>
           <MainTable

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -243,3 +243,18 @@ $border-thin: 1px solid $color-mid-light !default;
 .margin-right {
   margin-right: $sph--large;
 }
+
+.help-link {
+  display: flex;
+
+  .help-link-icon {
+    height: 1rem;
+    margin-left: $spv--small;
+    margin-top: 0.55rem; // extra margin to align with the text should be removed when this is fixed: https://github.com/canonical/vanilla-framework/issues/4891
+    width: 1rem;
+
+    @include extra-large {
+      margin-top: 0.665rem; // extra margin to align with the text should be removed when this is fixed: https://github.com/canonical/vanilla-framework/issues/4891
+    }
+  }
+}


### PR DESCRIPTION
## Done

- added an info icon linking to documentation for most main headings

Fixes WD-6525

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the headings of all pages from the main navigation. Most should have an info icon linking to the docs of that page.