### PR TITLE
feat(operations): add test for getProjectName [WD-6612]

### DIFF
--- a/src/util/operations.spec.tsx
+++ b/src/util/operations.spec.tsx
@@ -1,4 +1,4 @@
-import { getInstanceName } from "./operations";
+import { getInstanceName, getProjectName } from "./operations";
 import { LxdOperation } from "types/operation";
 
 const craftOperation = (url: string) => {
@@ -42,5 +42,32 @@ describe("getInstanceName", () => {
     const name = getInstanceName(operation);
 
     expect(name).toBe("testInstance3");
+  });
+});
+
+describe("getProjectName", () => {
+  it("identifies project name from an instance operation when no project parameter is present", () => {
+    const operation = craftOperation("/1.0/instances/testInstance1");
+    const name = getProjectName(operation);
+
+    expect(name).toBe("default");
+  });
+
+  it("identifies project name from an instance operation in a custom project", () => {
+    const operation = craftOperation(
+      "/1.0/instances/testInstance2?project=fooProject"
+    );
+    const name = getProjectName(operation);
+
+    expect(name).toBe("fooProject");
+  });
+
+  it("identifies project name from an instance operation in a custom project with other parameters", () => {
+    const operation = craftOperation(
+      "/1.0/instances/testInstance2?foo=bar&project=barProject"
+    );
+    const name = getProjectName(operation);
+
+    expect(name).toBe("barProject");
   });
 });

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -17,13 +17,15 @@ export const getInstanceName = (operation: LxdOperation): string => {
 export const getProjectName = (operation: LxdOperation): string => {
   // the url can be
   // /1.0/instances/<instance_name>?project=<project_name>
+  // /1.0/instances/<instance_name>?other=params&project=<project_name>
+  // /1.0/instances/testInstance1?other=params&project=<project_name>&other=params
   // when no project parameter is present, the project will be "default"
 
   return (
     operation.resources?.instances
       ?.filter((item) => item.startsWith("/1.0/instances/"))
-      .map((item) => item.split("/")[3])
+      .map((item) => item.split("project=")[1])
       .pop()
-      ?.split("=")[1] ?? "default"
+      ?.split("&")[0] ?? "default"
   );
 };


### PR DESCRIPTION
## Done

- Add unit test for testing getProjectName, used in OperationList.
- Checks if project name is as expected from an instance operation when project parameter is present or not.

Fixes: [WD-6612](https://warthogs.atlassian.net/browse/WD-6612)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run `npm run test`

## Screenshots

[if relevant, include a screenshot or screen capture]

[WD-6612]: https://warthogs.atlassian.net/browse/WD-6612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ