### PR TITLE
Sections of the edit network form get dedicated routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,6 +204,14 @@ const App: FC = () => {
           }
         />
         <Route
+          path="/ui/project/:project/networks/detail/:name/:activeTab/:activeSection"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<NetworkDetail />} />}
+            />
+          }
+        />
+        <Route
           path="/ui/project/:project/networks/map"
           element={
             <ProtectedRoute

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -20,12 +20,16 @@ import { dump as dumpYaml } from "js-yaml";
 import { isClusteredServer, supportsOvnNetwork } from "util/settings";
 import { fetchClusterMembers } from "api/cluster";
 import BaseLayout from "components/BaseLayout";
+import { MAIN_CONFIGURATION } from "pages/networks/forms/NetworkFormMenu";
+import { slugify } from "util/slugify";
+import { YAML_CONFIGURATION } from "pages/profiles/forms/ProfileFormMenu";
 
 const CreateNetwork: FC = () => {
   const navigate = useNavigate();
   const notify = useNotify();
   const queryClient = useQueryClient();
   const { project } = useParams<{ project: string }>();
+  const [section, setSection] = useState(slugify(MAIN_CONFIGURATION));
   const controllerState = useState<AbortController | null>(null);
   const { data: settings, isLoading } = useSettings();
   const isClustered = isClusteredServer(settings);
@@ -56,6 +60,7 @@ const CreateNetwork: FC = () => {
   const formik = useFormik<NetworkFormValues>({
     initialValues: {
       readOnly: false,
+      isCreating: true,
       name: "",
       type: hasOvn ? "ovn" : "bridge",
       bridge_mode: hasOvn ? undefined : "standard",
@@ -96,7 +101,18 @@ const CreateNetwork: FC = () => {
   return (
     <BaseLayout title="Create a network" contentClassName="create-network">
       <NotificationRow />
-      <NetworkForm formik={formik} getYaml={getYaml} project={project} />
+      <NetworkForm
+        formik={formik}
+        getYaml={getYaml}
+        project={project}
+        section={section}
+        setSection={(section) => {
+          if (Boolean(formik.values.yaml) && section !== YAML_CONFIGURATION) {
+            void formik.setFieldValue("yaml", undefined);
+          }
+          setSection(slugify(section));
+        }}
+      />
       <div className="p-bottom-controls">
         <hr />
         <Row className="u-align--right">

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect } from "react";
 import {
   Col,
   Form,
@@ -32,9 +32,11 @@ import NetworkFormBridge from "pages/networks/forms/NetworkFormBridge";
 import NetworkFormDns from "pages/networks/forms/NetworkFormDns";
 import NetworkFormIpv4 from "pages/networks/forms/NetworkFormIpv4";
 import NetworkFormIpv6 from "pages/networks/forms/NetworkFormIpv6";
+import { slugify } from "util/slugify";
 
 export interface NetworkFormValues {
   readOnly: boolean;
+  isCreating: boolean;
   name: string;
   description?: string;
   type: LxdNetworkType;
@@ -111,11 +113,18 @@ interface Props {
   formik: FormikProps<NetworkFormValues>;
   getYaml: () => string;
   project: string;
+  section: string;
+  setSection: (section: string) => void;
 }
 
-const NetworkForm: FC<Props> = ({ formik, getYaml, project }) => {
+const NetworkForm: FC<Props> = ({
+  formik,
+  getYaml,
+  project,
+  section,
+  setSection,
+}) => {
   const notify = useNotify();
-  const [section, setSection] = useState(MAIN_CONFIGURATION);
 
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
@@ -134,14 +143,14 @@ const NetworkForm: FC<Props> = ({ formik, getYaml, project }) => {
       />
       <Row className="form-contents" key={section}>
         <Col size={12}>
-          {section === MAIN_CONFIGURATION && (
+          {section === slugify(MAIN_CONFIGURATION) && (
             <NetworkFormMain formik={formik} project={project} />
           )}
-          {section === BRIDGE && <NetworkFormBridge formik={formik} />}
-          {section === DNS && <NetworkFormDns formik={formik} />}
-          {section === IPV4 && <NetworkFormIpv4 formik={formik} />}
-          {section === IPV6 && <NetworkFormIpv6 formik={formik} />}
-          {section === YAML_CONFIGURATION && (
+          {section === slugify(BRIDGE) && <NetworkFormBridge formik={formik} />}
+          {section === slugify(DNS) && <NetworkFormDns formik={formik} />}
+          {section === slugify(IPV4) && <NetworkFormIpv4 formik={formik} />}
+          {section === slugify(IPV6) && <NetworkFormIpv6 formik={formik} />}
+          {section === slugify(YAML_CONFIGURATION) && (
             <YamlForm
               yaml={getYaml()}
               setYaml={(yaml) => formik.setFieldValue("yaml", yaml)}

--- a/src/pages/networks/forms/NetworkFormMenu.tsx
+++ b/src/pages/networks/forms/NetworkFormMenu.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const NetworkFormMenu: FC<Props> = ({ active, setActive, formik }) => {
   const notify = useNotify();
-  const [isAdvancedOpen, setAdvancedOpen] = useState(false);
+  const [isAdvancedOpen, setAdvancedOpen] = useState(!formik.values.isCreating);
   const menuItemProps = {
     active,
     setActive,

--- a/src/util/networkEdit.tsx
+++ b/src/util/networkEdit.tsx
@@ -3,6 +3,7 @@ import { LxdNetwork } from "types/network";
 export const getNetworkEditValues = (network: LxdNetwork) => {
   return {
     readOnly: true,
+    isCreating: false,
     name: network.name,
     description: network.description,
     type: network.type,

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -28,7 +28,6 @@ test("network edit basic details", async ({ page }) => {
   await setOption(page, "IPv4 NAT", "false");
   await setOption(page, "IPv6 NAT", "false");
 
-  await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Bridge", { exact: true }).click();
   await activateOverride(page, "MTU Bridge MTU");
   await page.getByLabel("MTU").fill("1300");
@@ -68,7 +67,6 @@ test("network edit basic details", async ({ page }) => {
   await assertReadMode(page, "Ipv4 NAT", "false");
   await assertReadMode(page, "Ipv6 NAT", "false");
 
-  await page.getByRole("button", { name: "Advanced", exact: true }).click();
   await page.getByText("Bridge", { exact: true }).click();
   await assertReadMode(page, "MTU Bridge MTU", "1300");
   await assertReadMode(page, "Bridge Driver", "native");


### PR DESCRIPTION
## Done

- added dedicated routes for the edit network form
- ensure the advanced menu on the network form is open on edit, but initially closed on create.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open networks > pick a network detail page > configuration and browse through the sections, each should have a dedicated route
    - network creation and editing should work as expected.