### PR TITLE
Avoid busy fetching operations but rely on events websocket

### DIFF
--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -2,10 +2,13 @@ import React, { FC, useEffect, useState } from "react";
 import { LxdEvent } from "types/event";
 import { useEventQueue } from "context/eventQueue";
 import { useAuth } from "context/auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
 
 const Events: FC = () => {
   const { isAuthenticated } = useAuth();
   const eventQueue = useEventQueue();
+  const queryClient = useQueryClient();
   const [eventWs, setEventWs] = useState<WebSocket | null>(null);
 
   const handleEvent = (event: LxdEvent) => {
@@ -40,6 +43,11 @@ const Events: FC = () => {
         return;
       }
       const event = JSON.parse(message.data) as LxdEvent;
+      if (event.type === "operation") {
+        void queryClient.invalidateQueries({
+          queryKey: [queryKeys.operations, event.project],
+        });
+      }
       setTimeout(() => handleEvent(event), 1000); // handle with delay to allow operations to vanish
     };
   };

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -114,7 +114,6 @@ const InstanceList: FC = () => {
   const { data: operationList } = useQuery({
     queryKey: [queryKeys.operations, project],
     queryFn: () => fetchOperations(project),
-    refetchInterval: 1000,
   });
 
   if (error) {


### PR DESCRIPTION
## Done

- remove busy refresh of operations list on instance list
- rely on events websocket for signal to clear cache instead

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new instance
    - On the instance list: ensure live updates on the creation progress of a new instance still works and the creation line vanishes once the instance is started or created