### PR TITLE
Use base style for all cancel buttons

### DIFF
--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -116,7 +116,11 @@ const CustomIsoSelector: FC<Props> = ({
         />
       </div>
       <footer className="p-modal__footer">
-        <Button className="u-no-margin--bottom" onClick={onCancel}>
+        <Button
+          appearance="base"
+          className="u-no-margin--bottom"
+          onClick={onCancel}
+        >
           Cancel
         </Button>
         <Button

--- a/src/pages/instances/EditInstanceForm.tsx
+++ b/src/pages/instances/EditInstanceForm.tsx
@@ -230,6 +230,7 @@ const EditInstanceForm: FC<Props> = ({ instance }) => {
             ) : (
               <>
                 <Button
+                  appearance="base"
                   onClick={() =>
                     formik.setValues(getInstanceEditValues(instance))
                   }

--- a/src/pages/instances/MigrateInstanceForm.tsx
+++ b/src/pages/instances/MigrateInstanceForm.tsx
@@ -52,6 +52,7 @@ const MigrateInstanceForm: FC<Props> = ({
             className="u-no-margin--bottom"
             type="button"
             aria-label="cancel migrate"
+            appearance="base"
             onClick={close}
           >
             Cancel

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -73,6 +73,7 @@ const TerminalPayloadForm: FC<Props> = ({ payload, close, reconnect }) => {
       buttonRow={
         <>
           <Button
+            appearance="base"
             className="u-no-margin--bottom"
             type="button"
             aria-label="cancel reconnect"

--- a/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/ConfigureSnapshotModal.tsx
@@ -89,6 +89,7 @@ const ConfigureSnapshotModal: FC<Props> = ({
         ) : (
           <>
             <Button
+              appearance="base"
               className="u-no-margin--bottom"
               type="button"
               onClick={close}

--- a/src/pages/instances/actions/snapshots/SnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotForm.tsx
@@ -65,7 +65,12 @@ const SnapshotForm: FC<Props> = ({
       title={`${isEdit ? "Edit" : "Create"} snapshot`}
       buttonRow={
         <>
-          <Button className="u-no-margin--bottom" type="button" onClick={close}>
+          <Button
+            appearance="base"
+            className="u-no-margin--bottom"
+            type="button"
+            onClick={close}
+          >
             Cancel
           </Button>
           <SubmitButton

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -150,6 +150,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
             ) : (
               <>
                 <Button
+                  appearance="base"
                   onClick={() =>
                     formik.setValues(getNetworkEditValues(network))
                   }

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -44,7 +44,7 @@ const OperationList: FC = () => {
     { content: "Action", className: "action", sortKey: "action" },
     { content: "Info", className: "info" },
     { content: "Status", className: "status", sortKey: "status" },
-    { "aria-label": "Cancel", className: "cancel u-align--right" },
+    { "aria-label": "Actions", className: "cancel u-align--right" },
   ];
 
   const getIconNameForStatus = (status: LxdOperationStatus) => {
@@ -124,7 +124,7 @@ const OperationList: FC = () => {
           content: <CancelOperationBtn operation={operation} />,
           role: "rowheader",
           className: "u-align--right cancel",
-          "aria-label": "Cancel",
+          "aria-label": "Actions",
         },
       ],
       sortData: {

--- a/src/pages/profiles/EditProfileForm.tsx
+++ b/src/pages/profiles/EditProfileForm.tsx
@@ -253,6 +253,7 @@ const EditProfileForm: FC<Props> = ({ profile, featuresProfiles }) => {
             ) : (
               <>
                 <Button
+                  appearance="base"
                   onClick={() =>
                     formik.setValues(getProfileEditValues(profile))
                   }

--- a/src/pages/projects/EditProjectForm.tsx
+++ b/src/pages/projects/EditProjectForm.tsx
@@ -127,7 +127,10 @@ const EditProjectForm: FC<Props> = ({ project }) => {
                 </>
               ) : (
                 <>
-                  <Button onClick={() => formik.setValues(initialValues)}>
+                  <Button
+                    appearance="base"
+                    onClick={() => formik.setValues(initialValues)}
+                  >
                     Cancel
                   </Button>
                   <SubmitButton

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -38,7 +38,9 @@ const SettingFormCheckbox: FC<Props> = ({
         checked={checked}
         onChange={(e) => setChecked(e.target.checked)}
       />
-      <Button onClick={onCancel}>Cancel</Button>
+      <Button appearance="base" onClick={onCancel}>
+        Cancel
+      </Button>
       <Button appearance="positive" onClick={() => onSubmit(checked)}>
         Save
       </Button>

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -50,7 +50,9 @@ const SettingFormInput: FC<Props> = ({
         value={configField.type === "bool" ? undefined : String(value)}
         onChange={(e) => setValue(e.target.value)}
       />
-      <Button onClick={onCancel}>Cancel</Button>
+      <Button appearance="base" onClick={onCancel}>
+        Cancel
+      </Button>
       <Button appearance="positive" onClick={() => onSubmit(value)}>
         Save
       </Button>

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -49,7 +49,9 @@ const SettingFormPassword: FC<Props> = ({
               <Icon name={showPassword ? "hide" : "show"} />
             </Button>
           </div>
-          <Button onClick={onCancel}>Cancel</Button>
+          <Button appearance="base" onClick={onCancel}>
+            Cancel
+          </Button>
           <Button appearance="positive" onClick={() => onSubmit(password)}>
             Save
           </Button>
@@ -57,7 +59,9 @@ const SettingFormPassword: FC<Props> = ({
       )}
       {!showPasswordField && (
         <>
-          <Button onClick={onCancel}>Cancel</Button>
+          <Button appearance="base" onClick={onCancel}>
+            Cancel
+          </Button>
           <Button onClick={() => setShowPasswordField(true)}>Change</Button>
           <Button appearance="negative" onClick={() => onSubmit("")}>
             Remove

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -120,7 +120,11 @@ const CustomVolumeCreateModal: FC<Props> = ({
         <StorageVolumeFormMain formik={formik} />
       </div>
       <footer className="p-modal__footer">
-        <Button className="u-no-margin--bottom" onClick={onCancel}>
+        <Button
+          appearance="base"
+          className="u-no-margin--bottom"
+          onClick={onCancel}
+        >
           Cancel
         </Button>
         <Button

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -153,7 +153,11 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
         </>
       )}
       <footer className="p-modal__footer">
-        <Button onClick={handleCancel} className="u-no-margin--bottom">
+        <Button
+          appearance="base"
+          onClick={handleCancel}
+          className="u-no-margin--bottom"
+        >
           Cancel
         </Button>
         <SubmitButton

--- a/src/pages/storage/forms/StorageVolumeEdit.tsx
+++ b/src/pages/storage/forms/StorageVolumeEdit.tsx
@@ -82,6 +82,7 @@ const StorageVolumeEdit: FC<Props> = ({ volume, pool }) => {
             ) : (
               <>
                 <Button
+                  appearance="base"
                   onClick={() =>
                     formik.setValues(getStorageVolumeEditValues(volume, pool))
                   }


### PR DESCRIPTION
## Done

- changed appearance of all cancel buttons to base style

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check cancel buttons in creation/edit forms
    - base appearance for confirmation modals are [pending this PR](https://github.com/canonical/react-components/pull/989)