### PR TITLE
Boolean config options should have boolean default value

### DIFF
--- a/public/assets/data/config-options.json
+++ b/public/assets/data/config-options.json
@@ -150,7 +150,7 @@
     "key": "core.https_allowed_credentials",
     "type": "bool",
     "scope": "global",
-    "default": "",
+    "default": false,
     "description": "Whether to set Access-Control-Allow-Credentials HTTP header value to true"
   },
   {
@@ -241,7 +241,7 @@
     "key": "core.trust_ca_certificates",
     "type": "bool",
     "scope": "global",
-    "default": "",
+    "default": false,
     "description": "Whether to automatically trust clients signed by the CA"
   },
   {


### PR DESCRIPTION
## Done

- Changed a string default value for 2 config options with type `bool`, so that no broken "Reset to default" button appears due to this type mismatch.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to settings page
    - Check that `core.https_allowed_credentials` and `core.trust_ca_certificates` are showing a boolean value in read mode, and that the "Reset to default" functionality works as expected.