### PR TITLE
Use events stream for all long-running operations [WD-6846]

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -1,4 +1,3 @@
-import { TIMEOUT_300, watchOperation } from "./operations";
 import { handleResponse } from "util/helpers";
 import { ImportImage, LxdImage } from "types/image";
 import { LxdApiResponse } from "types/apiResponse";
@@ -25,20 +24,23 @@ export const fetchImageList = (project: string): Promise<LxdImage[]> => {
   });
 };
 
-export const deleteImage = (image: LxdImage, project: string) => {
+export const deleteImage = (
+  image: LxdImage,
+  project: string,
+): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/images/${image.fingerprint}?project=${project}`, {
       method: "DELETE",
     })
       .then(handleResponse)
-      .then((data: LxdOperationResponse) => {
-        watchOperation(data.operation).then(resolve).catch(reject);
-      })
+      .then(resolve)
       .catch(reject);
   });
 };
 
-export const importImage = (remoteImage: ImportImage) => {
+export const importImage = (
+  remoteImage: ImportImage,
+): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
     fetch("/1.0/images", {
       method: "POST",
@@ -54,9 +56,7 @@ export const importImage = (remoteImage: ImportImage) => {
       }),
     })
       .then(handleResponse)
-      .then((data: LxdOperationResponse) => {
-        watchOperation(data.operation, TIMEOUT_300).then(resolve).catch(reject);
-      })
+      .then(resolve)
       .catch(reject);
   });
 };

--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -1,43 +1,6 @@
 import { handleResponse } from "util/helpers";
-import {
-  LxdOperation,
-  LxdOperationList,
-  LxdOperationResponse,
-} from "types/operation";
+import { LxdOperation, LxdOperationList } from "types/operation";
 import { LxdApiResponse } from "types/apiResponse";
-
-export const TIMEOUT_300 = 300;
-export const TIMEOUT_120 = 120;
-export const TIMEOUT_60 = 60;
-export const TIMEOUT_10 = 10;
-
-export const watchOperation = (
-  operationUrl: string,
-  timeout = TIMEOUT_10,
-): Promise<LxdOperationResponse> => {
-  return new Promise((resolve, reject) => {
-    const operationParts = operationUrl.split("?");
-    const baseUrl = operationParts[0];
-    const queryString = operationParts.length === 1 ? "" : operationParts[1];
-    fetch(`${baseUrl}/wait?timeout=${timeout}&${queryString}`)
-      .then(handleResponse)
-      .then((data: LxdOperationResponse) => {
-        if (data.metadata.status === "Success") {
-          return resolve(data);
-        }
-        if (data.metadata.status === "Running") {
-          throw Error(
-            "Timeout while waiting for the operation to succeed. Watched operation continues in the background.",
-          );
-        } else if (data.metadata.status === "Cancelled") {
-          throw new Error("Cancelled");
-        } else {
-          throw Error(data.metadata.err);
-        }
-      })
-      .catch(reject);
-  });
-};
 
 const sortOperationList = (operations: LxdOperationList) => {
   const newestFirst = (a: LxdOperation, b: LxdOperation) => {

--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -2,7 +2,6 @@ import { handleEtagResponse, handleResponse } from "util/helpers";
 import { LxdProject } from "types/project";
 import { LxdApiResponse } from "types/apiResponse";
 import { LxdOperationResponse } from "types/operation";
-import { TIMEOUT_60, watchOperation } from "api/operations";
 
 export const fetchProjects = (recursion: number): Promise<LxdProject[]> => {
   return new Promise((resolve, reject) => {
@@ -49,7 +48,10 @@ export const updateProject = (project: LxdProject) => {
   });
 };
 
-export const renameProject = (oldName: string, newName: string) => {
+export const renameProject = (
+  oldName: string,
+  newName: string,
+): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/projects/${oldName}`, {
       method: "POST",
@@ -58,9 +60,7 @@ export const renameProject = (oldName: string, newName: string) => {
       }),
     })
       .then(handleResponse)
-      .then((data: LxdOperationResponse) => {
-        watchOperation(data.operation, TIMEOUT_60).then(resolve).catch(reject);
-      })
+      .then(resolve)
       .catch(reject);
   });
 };

--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -8,7 +8,6 @@ import {
 } from "types/storage";
 import { LxdApiResponse } from "types/apiResponse";
 import { LxdOperationResponse } from "types/operation";
-import { TIMEOUT_300, watchOperation } from "api/operations";
 import axios, { AxiosResponse } from "axios";
 
 export const fetchStoragePool = (
@@ -199,9 +198,7 @@ export const createIsoStorageVolume = (
         },
       )
       .then((response: AxiosResponse<LxdOperationResponse>) => response.data)
-      .then((data: LxdOperationResponse) => {
-        watchOperation(data.operation, TIMEOUT_300).then(resolve).catch(reject);
-      })
+      .then(resolve)
       .catch(reject);
   });
 };

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -46,8 +46,8 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
     setInTabNotification(success(message));
   };
 
-  const onFailure = (title: string, e: unknown) => {
-    setInTabNotification(failure(title, e));
+  const onFailure = (title: string, e: unknown, message?: ReactNode) => {
+    setInTabNotification(failure(title, e, message));
   };
 
   const { project, isLoading } = useProject();

--- a/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/CreateSnapshotForm.tsx
@@ -14,6 +14,7 @@ import {
 } from "util/snapshots";
 import SnapshotForm from "./SnapshotForm";
 import { useNotify } from "@canonical/react-components";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   instance: LxdInstance;
@@ -22,6 +23,7 @@ interface Props {
 }
 
 const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
+  const eventQueue = useEventQueue();
   const notify = useNotify();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
@@ -43,22 +45,31 @@ const CreateSnapshotForm: FC<Props> = ({ instance, close, onSuccess }) => {
               getExpiresAt(values.expirationDate, values.expirationTime),
             )
           : UNDEFINED_DATE;
-      createSnapshot(instance, values.name, expiresAt, values.stateful)
-        .then(() => {
-          void queryClient.invalidateQueries({
-            predicate: (query) => query.queryKey[0] === queryKeys.instances,
-          });
-          onSuccess(
-            <>
-              Snapshot <ItemName item={values} bold /> created.
-            </>,
-          );
-          close();
-        })
-        .catch((e) => {
-          notify.failure("Snapshot creation failed", e);
-          formik.setSubmitting(false);
-        });
+      void createSnapshot(
+        instance,
+        values.name,
+        expiresAt,
+        values.stateful,
+      ).then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () => {
+            void queryClient.invalidateQueries({
+              predicate: (query) => query.queryKey[0] === queryKeys.instances,
+            });
+            onSuccess(
+              <>
+                Snapshot <ItemName item={values} bold /> created.
+              </>,
+            );
+            close();
+          },
+          (msg) => {
+            notify.failure("Snapshot creation failed", new Error(msg));
+            formik.setSubmitting(false);
+          },
+        ),
+      );
     },
   });
 

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -196,5 +196,32 @@ export const getPromiseSettledCounts = (
   return { fulfilledCount, rejectedCount };
 };
 
+export const pushSuccess = (results: PromiseSettledResult<void>[]) => {
+  results.push({
+    status: "fulfilled",
+    value: undefined,
+  });
+};
+
+export const pushFailure = (
+  results: PromiseSettledResult<void>[],
+  msg: string,
+) => {
+  results.push({
+    status: "rejected",
+    reason: msg,
+  });
+};
+
+export const continueOrFinish = (
+  results: PromiseSettledResult<void>[],
+  totalLength: number,
+  resolve: (value: PromiseSettledResult<void>[]) => void,
+) => {
+  if (totalLength === results.length) {
+    resolve(results);
+  }
+};
+
 export const logout = () =>
   void fetch("/oidc/logout").then(() => window.location.reload());


### PR DESCRIPTION
## Done

- Removed all usages of `watchOperation`, to generalise the usage of the events stream for all long-running operations.

Fixes [WD-6846](https://warthogs.atlassian.net/browse/WD-6846)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that the following operations all work as expected, and that they notify success/failure correctly once completed:
      1. Delete cached image
      2. Instance bulk actions including bulk delete
      3. Project rename
      4. All snapshot operations: create, restore, delete, rename, update and bulk delete
      5. Custom ISO upload

[WD-6846]: https://warthogs.atlassian.net/browse/WD-6846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ