### PR TITLE
Add validation on instance create

### DIFF
--- a/.github/workflows/commits.yaml
+++ b/.github/workflows/commits.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: read   # to get list of commits from the PR
     name: Canonical CLA signed and Signed-off-by (DCO)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check if CLA signed
       uses: canonical/has-signed-canonical-cla@v1

--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -12,6 +12,7 @@ import { getConfigurationRowBase } from "components/ConfigurationRow";
 import DetachDiskDeviceBtn from "pages/instances/actions/DetachDiskDeviceBtn";
 import classnames from "classnames";
 import { LxdStorageVolume } from "types/storage";
+import { isDiskDeviceMountPointMissing } from "util/instanceValidation";
 
 interface Props {
   formik: SharedFormikTypes;
@@ -39,6 +40,9 @@ const DiskDeviceFormCustom: FC<Props> = ({
       source: volume.name,
     });
     void formik.setFieldValue("devices", copy);
+
+    const name = `devices.${copy.length - 1}.path`;
+    setTimeout(() => document.getElementById(name)?.focus(), 100);
   };
 
   const changeVolume = (
@@ -96,7 +100,7 @@ const DiskDeviceFormCustom: FC<Props> = ({
       getConfigurationRowBase({
         className: "no-border-top inherited-with-form",
         configuration: (
-          <Label forId={`volume-${index}-pool`}>Pool / volume</Label>
+          <Label forId={`devices.${index}.pool`}>Pool / volume</Label>
         ),
         inherited: (
           <div className="custom-disk-volume-source">
@@ -119,7 +123,7 @@ const DiskDeviceFormCustom: FC<Props> = ({
                 project={project}
                 setValue={(volume) => changeVolume(volume, formVolume, index)}
                 buttonProps={{
-                  id: `volume-${index}-pool`,
+                  id: `devices.${index}.pool`,
                   appearance: "base",
                   className: "u-no-margin--bottom",
                 }}
@@ -134,11 +138,12 @@ const DiskDeviceFormCustom: FC<Props> = ({
     );
 
     if (formVolume.path !== undefined) {
+      const hasError = isDiskDeviceMountPointMissing(formik, index);
       rows.push(
         getConfigurationRowBase({
           className: "no-border-top inherited-with-form",
           configuration: (
-            <Label forId={`volume-${index}-path`} required>
+            <Label forId={`devices.${index}.path`} required>
               Mount point
             </Label>
           ),
@@ -148,7 +153,8 @@ const DiskDeviceFormCustom: FC<Props> = ({
             </div>
           ) : (
             <Input
-              id={`volume-${index}-path`}
+              id={`devices.${index}.path`}
+              name={`devices.${index}.path`}
               onBlur={formik.handleBlur}
               onChange={(e) => {
                 void formik.setFieldValue(
@@ -159,7 +165,8 @@ const DiskDeviceFormCustom: FC<Props> = ({
               value={formVolume.path}
               type="text"
               placeholder="Enter full path (e.g. /data)"
-              className="u-no-margin--bottom"
+              className={hasError ? undefined : "u-no-margin--bottom"}
+              error={hasError ? "Path is required" : undefined}
             />
           ),
           override: "",
@@ -171,7 +178,7 @@ const DiskDeviceFormCustom: FC<Props> = ({
       getConfigurationRowBase({
         className: "no-border-top inherited-with-form",
         configuration: (
-          <Label forId={`volume-${index}-read-limit`}>Read limit</Label>
+          <Label forId={`devices.${index}.limits.read`}>Read limit</Label>
         ),
         inherited: isReadOnly ? (
           <div className="mono-font">
@@ -184,7 +191,8 @@ const DiskDeviceFormCustom: FC<Props> = ({
         ) : (
           <div className="custom-disk-device-limits">
             <Input
-              id={`volume-${index}-read-limit`}
+              id={`devices.${index}.limits.read`}
+              name={`devices.${index}.limits.read`}
               onBlur={formik.handleBlur}
               onChange={(e) => {
                 void formik.setFieldValue(
@@ -208,7 +216,7 @@ const DiskDeviceFormCustom: FC<Props> = ({
       getConfigurationRowBase({
         className: "no-border-top inherited-with-form",
         configuration: (
-          <Label forId={`volume-${index}-write-limit`}>Write limit</Label>
+          <Label forId={`devices.${index}.limits.write`}>Write limit</Label>
         ),
         inherited: isReadOnly ? (
           <div className="mono-font">
@@ -221,7 +229,8 @@ const DiskDeviceFormCustom: FC<Props> = ({
         ) : (
           <div className="custom-disk-device-limits">
             <Input
-              id={`volume-${index}-write-limit`}
+              id={`devices.${index}.limits.write`}
+              name={`devices.${index}.limits.write`}
               onBlur={formik.handleBlur}
               onChange={(e) => {
                 void formik.setFieldValue(

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -12,6 +12,7 @@ import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import { LxdStoragePool } from "types/storage";
 import { LxdProfile } from "types/profile";
 import { removeDevice } from "util/formDevices";
+import { hasNoRootDisk } from "util/instanceValidation";
 
 interface Props {
   formik: SharedFormikTypes;
@@ -141,6 +142,14 @@ const DiskDeviceFormRoot: FC<Props> = ({
           }),
         ]}
       />
+      {hasNoRootDisk(formik.values, profiles) && (
+        <div className="is-error ">
+          <p className="p-form-validation__message">
+            <strong>Error:</strong> Missing root storage. Create an override, or
+            add a profile with root storage.
+          </p>
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/forms/FormMenuItem.tsx
+++ b/src/components/forms/FormMenuItem.tsx
@@ -1,12 +1,14 @@
 import React, { FC } from "react";
 import { slugify } from "util/slugify";
 import { Button } from "@canonical/react-components";
+import classnames from "classnames";
 
 interface Props {
   active: string;
   setActive: (item: string) => void;
   label: string;
   disableReason?: string;
+  hasError?: boolean;
 }
 
 const FormMenuItem: FC<Props> = ({
@@ -14,6 +16,7 @@ const FormMenuItem: FC<Props> = ({
   setActive,
   label,
   disableReason,
+  hasError,
 }) => {
   if (disableReason) {
     return (
@@ -29,7 +32,11 @@ const FormMenuItem: FC<Props> = ({
     );
   }
   return (
-    <li className="p-side-navigation__item">
+    <li
+      className={classnames("p-side-navigation__item", {
+        "has-error": hasError,
+      })}
+    >
       <a
         className="p-side-navigation__link"
         onClick={() => setActive(label)}

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -54,6 +54,7 @@ import {
 } from "util/instanceEdit";
 import { slugify } from "util/slugify";
 import { useEventQueue } from "context/eventQueue";
+import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 
 export type EditInstanceFormValues = InstanceEditDetailsFormValues &
   FormDeviceValues &
@@ -161,6 +162,8 @@ const EditInstance: FC<Props> = ({ instance }) => {
           isConfigDisabled={false}
           isConfigOpen={isConfigOpen}
           toggleConfigOpen={toggleMenu}
+          hasDiskError={hasDiskError(formik)}
+          hasNetworkError={hasNetworkError(formik)}
         />
         <Row className="form-contents" key={activeSection}>
           <Col size={12}>
@@ -239,7 +242,11 @@ const EditInstance: FC<Props> = ({ instance }) => {
                 </Button>
                 <SubmitButton
                   isSubmitting={formik.isSubmitting}
-                  isDisabled={!formik.isValid}
+                  isDisabled={
+                    !formik.isValid ||
+                    hasDiskError(formik) ||
+                    hasNetworkError(formik)
+                  }
                   buttonLabel="Save changes"
                   onClick={() => void formik.submitForm()}
                 />

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -19,6 +19,8 @@ interface Props {
   toggleConfigOpen: () => void;
   active: string;
   setActive: (val: string) => void;
+  hasDiskError: boolean;
+  hasNetworkError: boolean;
 }
 
 const InstanceFormMenu: FC<Props> = ({
@@ -27,6 +29,8 @@ const InstanceFormMenu: FC<Props> = ({
   toggleConfigOpen,
   active,
   setActive,
+  hasDiskError,
+  hasNetworkError,
 }) => {
   const notify = useNotify();
   const menuItemProps = {
@@ -64,8 +68,16 @@ const InstanceFormMenu: FC<Props> = ({
               className="p-side-navigation__list"
               aria-expanded={isConfigOpen ? "true" : "false"}
             >
-              <MenuItem label={DISK_DEVICES} {...menuItemProps} />
-              <MenuItem label={NETWORK_DEVICES} {...menuItemProps} />
+              <MenuItem
+                label={DISK_DEVICES}
+                hasError={hasDiskError}
+                {...menuItemProps}
+              />
+              <MenuItem
+                label={NETWORK_DEVICES}
+                hasError={hasNetworkError}
+                {...menuItemProps}
+              />
               <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
               <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
               <MenuItem label={SNAPSHOTS} {...menuItemProps} />

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -55,6 +55,7 @@ import DiskDeviceForm from "components/forms/DiskDeviceForm";
 import NetworkDevicesForm from "components/forms/NetworkDevicesForm";
 import NotificationRow from "components/NotificationRow";
 import BaseLayout from "components/BaseLayout";
+import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 
 export type CreateProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -94,7 +95,7 @@ const CreateProfile: FC = () => {
   const formik = useFormik<CreateProfileFormValues>({
     initialValues: {
       name: "",
-      devices: [{ type: "nic", name: "" }],
+      devices: [],
       readOnly: false,
       type: "profile",
     },
@@ -164,6 +165,7 @@ const CreateProfile: FC = () => {
           isConfigOpen={isConfigOpen}
           toggleConfigOpen={toggleMenu}
           hasName={Boolean(formik.values.name)}
+          formik={formik}
         />
         <Row className="form-contents" key={section}>
           <Col size={12}>
@@ -221,7 +223,12 @@ const CreateProfile: FC = () => {
             </Button>
             <SubmitButton
               isSubmitting={formik.isSubmitting}
-              isDisabled={!formik.isValid || !formik.values.name}
+              isDisabled={
+                !formik.isValid ||
+                !formik.values.name ||
+                hasDiskError(formik) ||
+                hasNetworkError(formik)
+              }
               buttonLabel="Create"
               onClick={() => void formik.submitForm()}
             />

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -57,6 +57,7 @@ import { getUnhandledKeyValues } from "util/formFields";
 import { getProfileConfigKeys } from "util/instanceConfigFields";
 import { getProfileEditValues } from "util/instanceEdit";
 import { slugify } from "util/slugify";
+import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -186,6 +187,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
           isConfigOpen={isConfigOpen}
           toggleConfigOpen={toggleMenu}
           hasName={true}
+          formik={formik}
         />
         <Row className="form-contents" key={activeSection}>
           <Col size={12}>
@@ -262,7 +264,11 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
                 </Button>
                 <SubmitButton
                   isSubmitting={formik.isSubmitting}
-                  isDisabled={!formik.isValid}
+                  isDisabled={
+                    !formik.isValid ||
+                    hasDiskError(formik) ||
+                    hasNetworkError(formik)
+                  }
                   buttonLabel="Save changes"
                   onClick={() => void formik.submitForm()}
                 />

--- a/src/pages/profiles/forms/ProfileFormMenu.tsx
+++ b/src/pages/profiles/forms/ProfileFormMenu.tsx
@@ -3,6 +3,8 @@ import MenuItem from "components/forms/FormMenuItem";
 import { Button, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
+import { hasDiskError, hasNetworkError } from "util/instanceValidation";
+import { SharedFormikTypes } from "components/forms/sharedFormTypes";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk devices";
@@ -19,6 +21,7 @@ interface Props {
   active: string;
   setActive: (val: string) => void;
   hasName: boolean;
+  formik: SharedFormikTypes;
 }
 
 const ProfileFormMenu: FC<Props> = ({
@@ -27,6 +30,7 @@ const ProfileFormMenu: FC<Props> = ({
   active,
   setActive,
   hasName,
+  formik,
 }) => {
   const notify = useNotify();
   const menuItemProps = {
@@ -64,8 +68,16 @@ const ProfileFormMenu: FC<Props> = ({
               className="p-side-navigation__list"
               aria-expanded={isConfigOpen ? "true" : "false"}
             >
-              <MenuItem label={DISK_DEVICES} {...menuItemProps} />
-              <MenuItem label={NETWORK_DEVICES} {...menuItemProps} />
+              <MenuItem
+                label={DISK_DEVICES}
+                hasError={hasDiskError(formik)}
+                {...menuItemProps}
+              />
+              <MenuItem
+                label={NETWORK_DEVICES}
+                hasError={hasNetworkError(formik)}
+                {...menuItemProps}
+              />
               <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
               <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
               <MenuItem label={SNAPSHOTS} {...menuItemProps} />

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -33,6 +33,14 @@
         min-width: 13rem;
         text-align: left;
       }
+
+      .has-error::before {
+        content: url("data:image/svg+xml,%3Csvg width='16' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Ccircle stroke='%23c7162b' stroke-width='1.5' fill='%23c7162b' cx='8' cy='8' r='6.25'/%3E%3Cpath fill='%23fff' fill-rule='nonzero' d='M10.282 4.638l1.06 1.06L9.05 7.99l2.293 2.292-1.06 1.06L7.99 9.05 5.7 11.343l-1.06-1.06 2.29-2.293L4.64 5.7l1.06-1.06 2.291 2.29z'/%3E%3C/g%3E%3C/svg%3E");
+        left: 3rem;
+        position: absolute;
+        top: 0.3rem;
+        z-index: 1;
+      }
     }
 
     .form-contents {

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -43,9 +43,12 @@ export type FormDiskDevice = Partial<LxdDiskDevice> &
     };
   };
 
+export type FormNetworkDevice = Partial<LxdNicDevice> &
+  Required<Pick<LxdNicDevice, "name">>;
+
 export type FormDevice =
   | FormDiskDevice
-  | (Partial<LxdNicDevice> & Required<Pick<LxdNicDevice, "name">>)
+  | FormNetworkDevice
   | UnknownDevice
   | NoneDevice
   | CustomNetworkDevice

--- a/src/util/instanceValidation.tsx
+++ b/src/util/instanceValidation.tsx
@@ -1,0 +1,77 @@
+import { FormDevice, FormDiskDevice } from "util/formDevices";
+import {
+  SharedFormikTypes,
+  SharedFormTypes,
+} from "components/forms/sharedFormTypes";
+import { figureInheritedRootStorage } from "util/instanceConfigInheritance";
+import { LxdProfile } from "types/profile";
+import { LxdNicDevice } from "types/device";
+import { FormikTouched } from "formik";
+
+export const hasNoRootDisk = (
+  values: SharedFormTypes & { profiles?: string[] },
+  profiles: LxdProfile[],
+) => {
+  if (!values.profiles) {
+    return false;
+  }
+  return (
+    missingRoot(values.devices) && !inheritsRoot(values.profiles, profiles)
+  );
+};
+
+const missingRoot = (devices: FormDevice[]) => {
+  return !devices.some((item) => item.type === "disk" && item.name === "root");
+};
+
+const inheritsRoot = (selectedProfiles: string[], profiles: LxdProfile[]) => {
+  const form = { profiles: selectedProfiles } as SharedFormTypes;
+  const [inheritValue] = figureInheritedRootStorage(form, profiles);
+
+  return !!inheritValue;
+};
+
+export const hasDiskError = (formik: SharedFormikTypes) =>
+  !formik.values.yaml &&
+  formik.values.devices.some((_device, index) =>
+    isDiskDeviceMountPointMissing(formik, index),
+  );
+
+export const isDiskDeviceMountPointMissing = (
+  formik: SharedFormikTypes,
+  index: number,
+): boolean => {
+  const formDevice = formik.values.devices[index] as FormDiskDevice;
+  if (formDevice.path === undefined || formDevice.type !== "disk") {
+    return false;
+  }
+  const hasTouched =
+    formik.touched.devices &&
+    formik.touched.devices[index] &&
+    (formik.touched.devices[index] as FormikTouched<FormDiskDevice>).path;
+
+  return Boolean(hasTouched) && formDevice.path.length < 1;
+};
+
+export const hasNetworkError = (formik: SharedFormikTypes) =>
+  !formik.values.yaml &&
+  formik.values.devices.some((_device, index) =>
+    isNicDeviceNameMissing(formik, index),
+  );
+
+export const isNicDeviceNameMissing = (
+  formik: SharedFormikTypes,
+  index: number,
+): boolean => {
+  const formDevice = formik.values.devices[index] as LxdNicDevice;
+  if (formDevice.name || formDevice.type !== "nic") {
+    return false;
+  }
+
+  const hasTouched =
+    formik.touched.devices &&
+    formik.touched.devices[index] &&
+    (formik.touched.devices[index] as FormikTouched<LxdNicDevice>).name;
+
+  return Boolean(hasTouched);
+};

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -87,8 +87,9 @@ test("profile edit networks", async ({ page }) => {
   await startProfileCreation(page, profile);
   await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Network devices").click();
-  await page.getByLabel("Network").selectOption({ index: 1 });
+  await page.getByRole("button", { name: "Attach network" }).click();
   await page.getByPlaceholder("Enter name").fill("eth0");
+  await page.getByLabel("Network").selectOption({ index: 1 });
   await finishProfileCreation(page, profile);
 
   await visitProfile(page, profile);
@@ -98,8 +99,8 @@ test("profile edit networks", async ({ page }) => {
 
   await page.getByRole("button", { name: "Edit profile" }).click();
   await page.getByRole("button", { name: "Attach network" }).click();
-  await page.locator("#networkDevice1").selectOption({ index: 1 });
-  await page.locator("#networkName1").fill("eth1");
+  await page.locator("[id='devices.1.network']").selectOption({ index: 1 });
+  await page.locator("[id='devices.1.name']").fill("eth1");
   await saveProfile(page);
 
   await page.getByRole("gridcell", { name: "eth0" }).click();


### PR DESCRIPTION
## Done

- added instance creation validation:
- for missing root storage
- missing network device name and
-  missing storage volume path 

Fixes #485

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance without root storage
    - Create an instance with a network device that has no name
    - Create an instance with a custom storage volume that has no mount point