### PR TITLE
Optimise usage of setLoading/setSubmitting functions

### DIFF
--- a/src/pages/cluster/ClusterGroupForm.tsx
+++ b/src/pages/cluster/ClusterGroupForm.tsx
@@ -91,11 +91,11 @@ const ClusterGroupForm: FC<Props> = ({ group }) => {
           );
         })
         .catch((e: Error) => {
+          formik.setSubmitting(false);
           const verb = group ? "save" : "creation";
           notify.failure(`Cluster group ${verb} failed`, e);
         })
         .finally(() => {
-          formik.setSubmitting(false);
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.cluster, queryKeys.groups],
           });

--- a/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
@@ -20,15 +20,16 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
     setLoading(true);
     deleteClusterGroup(group)
       .then(() => {
-        setLoading(false);
         navigate(
           `/ui/cluster`,
           notify.queue(notify.success(`Cluster group ${group} deleted.`)),
         );
       })
-      .catch((e) => notify.failure("Cluster group deletion failed", e))
-      .finally(() => {
+      .catch((e) => {
         setLoading(false);
+        notify.failure("Cluster group deletion failed", e);
+      })
+      .finally(() => {
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.cluster, queryKeys.groups],
         });

--- a/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
@@ -19,7 +19,6 @@ const EvacuateClusterMemberBtn: FC<Props> = ({ member }) => {
     setLoading(true);
     postClusterMemberState(member, "evacuate")
       .then(() => {
-        setLoading(false);
         notify.success(
           `Cluster member ${member.server_name} evacuation started.`,
         );

--- a/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
@@ -19,7 +19,6 @@ const RestoreClusterMemberBtn: FC<Props> = ({ member }) => {
     setLoading(true);
     postClusterMemberState(member, "restore")
       .then(() => {
-        setLoading(false);
         notify.success(`Cluster member ${member.server_name} restore started.`);
       })
       .catch((e) => notify.failure("Cluster member restore failed", e))

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -56,7 +56,6 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
       const saveNetwork = yamlToObject(yaml) as LxdNetwork;
       updateNetwork({ ...saveNetwork, etag: network.etag }, project)
         .then(() => {
-          formik.setSubmitting(false);
           void formik.setValues(getNetworkEditValues(saveNetwork));
           void queryClient.invalidateQueries({
             queryKey: [
@@ -69,9 +68,9 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
           notify.success("Network updated.");
         })
         .catch((e) => {
-          formik.setSubmitting(false);
           notify.failure("Network update failed", e);
-        });
+        })
+        .finally(() => formik.setSubmitting(false));
     },
   });
 

--- a/src/pages/networks/actions/DeleteNetworkBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkBtn.tsx
@@ -22,7 +22,6 @@ const DeleteNetworkBtn: FC<Props> = ({ network, project }) => {
     setLoading(true);
     deleteNetwork(network.name, project)
       .then(() => {
-        setLoading(false);
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.networks],
         });
@@ -31,8 +30,10 @@ const DeleteNetworkBtn: FC<Props> = ({ network, project }) => {
           notify.queue(notify.success(`Network ${network.name} deleted.`)),
         );
       })
-      .catch((e) => notify.failure("Network deletion failed", e))
-      .finally(() => setLoading(false));
+      .catch((e) => {
+        setLoading(false);
+        notify.failure("Network deletion failed", e);
+      });
   };
 
   const isUsed = (network.used_by?.length ?? 0) > 0;

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -112,10 +112,10 @@ const CreateProfile: FC = () => {
           );
         })
         .catch((e: Error) => {
+          formik.setSubmitting(false);
           notify.failure("Profile creation failed", e);
         })
         .finally(() => {
-          formik.setSubmitting(false);
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.profiles],
           });

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -34,7 +34,6 @@ const DeleteProfileBtn: FC<Props> = ({
     setLoading(true);
     deleteProfile(profile.name, project)
       .then(() => {
-        setLoading(false);
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.projects, project],
         });
@@ -43,8 +42,10 @@ const DeleteProfileBtn: FC<Props> = ({
           notify.queue(notify.success(`Profile ${profile.name} deleted.`)),
         );
       })
-      .catch((e) => notify.failure("Profile deletion failed", e))
-      .finally(() => setLoading(false));
+      .catch((e) => {
+        setLoading(false);
+        notify.failure("Profile deletion failed", e);
+      });
   };
 
   const isDefaultProfile = profile.name === "default";

--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -102,10 +102,10 @@ const CreateProject: FC = () => {
           );
         })
         .catch((e: Error) => {
+          formik.setSubmitting(false);
           notify.failure("Project creation failed", e);
         })
         .finally(() => {
-          formik.setSubmitting(false);
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.projects],
           });

--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -47,10 +47,10 @@ const DeleteProjectBtn: FC<Props> = ({ project }) => {
         );
       })
       .catch((e) => {
+        setLoading(false);
         notify.failure("Project deletion failed", e);
       })
       .finally(() => {
-        setLoading(false);
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.projects],
         });

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -87,9 +87,9 @@ const CustomVolumeCreateModal: FC<Props> = ({
           onFinish(volume);
         })
         .catch((e) => {
-          formik.setSubmitting(false);
           notify.failure("Storage volume creation failed", e);
-        });
+        })
+        .finally(() => formik.setSubmitting(false));
     },
   });
 

--- a/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
+++ b/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
@@ -34,7 +34,6 @@ const DeleteStoragePoolBtn: FC<Props> = ({
     setLoading(true);
     deleteStoragePool(pool.name, project)
       .then(() => {
-        setLoading(false);
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.storage],
         });

--- a/src/pages/storage/forms/StorageVolumeEdit.tsx
+++ b/src/pages/storage/forms/StorageVolumeEdit.tsx
@@ -45,7 +45,6 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
         etag: volume.etag,
       })
         .then(() => {
-          formik.setSubmitting(false);
           void formik.setValues(getStorageVolumeEditValues(saveVolume));
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.storage],
@@ -62,9 +61,9 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
           notify.success(`Storage volume updated.`);
         })
         .catch((e) => {
-          formik.setSubmitting(false);
           notify.failure("Storage volume update failed", e);
-        });
+        })
+        .finally(() => formik.setSubmitting(false));
     },
   });
 


### PR DESCRIPTION
## Done

- Optimised usage of `setLoading(false)` and `setSubmitting(false)` throughout the app, following these criteria:
  - In the general case or when there's only a notification with no navigation, `setLoading`/`setSubmitting` should be called inside the `finally` block.
  - When there's navigation, `setLoading`/`setSubmitting` should be called inside the `catch` block (not needed for the success block as we navigate).
- Removed some duplicates (e.g. calls to `setLoading` in the success block when there was already a call in the `finally` block).

Files affected by #506 are <ins>intentionally</ins> excluded from the scope of this PR.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that all the affected buttons look and behave as expected