### PR TITLE
Settings page: improved alignment, end-aligned edit icon in read mode [WD-6659]

### DIFF
--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -118,7 +118,9 @@ const SettingForm: FC<Props> = ({ configField, value, isLast }) => {
               }}
               hasIcon
             >
-              <div className="u-truncate">{getReadModeValue()}</div>
+              <div className="readmode-value u-truncate">
+                {getReadModeValue()}
+              </div>
               <Icon name="edit" className="edit-icon" />
             </Button>
           )}

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -90,7 +90,7 @@ const Settings: FC = () => {
           },
           {
             content: (
-              <>
+              <div className="key-cell">
                 {isDefault ? (
                   configField.key
                 ) : (
@@ -99,7 +99,7 @@ const Settings: FC = () => {
                 <p className="p-text--small u-no-margin u-text--muted">
                   {configField.description}
                 </p>
-              </>
+              </div>
             ),
             role: "cell",
             className: "key",

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -9,6 +9,10 @@
     }
   }
 
+  .key-cell {
+    padding: 0.4rem 0;
+  }
+
   .input-row,
   .readmode-button {
     align-items: center;
@@ -20,9 +24,14 @@
   }
 
   .readmode-button {
-    max-width: 100%;
-    padding: 0;
+    padding: 0 1rem 0 0;
     text-align: start;
+    width: 100%;
+
+    .readmode-value {
+      flex-grow: 1;
+      padding: 0.4rem 0;
+    }
 
     .edit-icon {
       min-width: 1rem;


### PR DESCRIPTION
## Done

- Improved baseline alignment of the top row in the 3 columns of the settings table
- End-aligned the edit icon in read mode

Fixes [WD-6659](https://warthogs.atlassian.net/browse/WD-6659)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to settings page
    - Check that alignment and visual appearance are as expected

## Screenshots

- Read mode:

![Screenshot from 2023-10-26 13:18:44](https://github.com/canonical/lxd-ui/assets/56583786/d2ed8702-de98-4842-9b27-b1d775c7e31b)

- Edit mode:

![Screenshot from 2023-10-26 13:20:23](https://github.com/canonical/lxd-ui/assets/56583786/a4520a86-1aaa-4c02-bdc8-6a736b4f7c7c)

[WD-6659]: https://warthogs.atlassian.net/browse/WD-6659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ