### PR TITLE
Ensure clustered backend pools are created and not left in pending state

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -56,7 +56,7 @@ export const fetchStoragePoolResources = (
 };
 
 export const createPool = (
-  pool: LxdStoragePool,
+  pool: Partial<LxdStoragePool>,
   project: string,
   target?: string,
 ) => {
@@ -72,6 +72,13 @@ export const createPool = (
   });
 };
 
+const getPoolForCluster = (pool: Partial<LxdStoragePool>) => {
+  const poolForCluster = { ...pool };
+  delete poolForCluster.config;
+
+  return poolForCluster;
+};
+
 export const createClusteredPool = (
   pool: LxdStoragePool,
   project: string,
@@ -84,6 +91,7 @@ export const createClusteredPool = (
       ),
     )
       .then(handleSettledResult)
+      .then(() => createPool(getPoolForCluster(pool), project))
       .then(resolve)
       .catch(reject);
   });
@@ -118,6 +126,7 @@ export const updateClusteredPool = (
       ),
     )
       .then(handleSettledResult)
+      .then(() => updatePool(getPoolForCluster(pool), project))
       .then(resolve)
       .catch(reject);
   });

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -129,7 +129,13 @@ const StoragePools: FC = () => {
           "aria-label": "Status",
         },
         {
-          content: <DeleteStoragePoolBtn pool={pool} project={project} />,
+          content: (
+            <DeleteStoragePoolBtn
+              key={pool.name}
+              pool={pool}
+              project={project}
+            />
+          ),
           role: "rowheader",
           className: "u-align--right actions",
           "aria-label": "Actions",

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -11,6 +11,7 @@ export const createPool = async (page: Page, pool: string) => {
   await page.getByRole("link", { name: "Storage" }).click();
   await page.getByRole("button", { name: "Create pool" }).click();
   await page.getByPlaceholder("Enter name").fill(pool);
+  await page.getByLabel("Driver").selectOption("dir");
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await page.waitForSelector(`text=Storage pool ${pool} created.`, TIMEOUT);
 };

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -24,6 +24,7 @@ test("storage pool create, edit and remove", async ({ page }) => {
 
   await page.getByTestId("tab-link-Overview").click();
   await page.getByText("DescriptionA-new-description").click();
+  await page.getByText("StatusCreated").click();
 
   await deletePool(page, pool);
 });


### PR DESCRIPTION
## Done

- adding tests to ensure creating a storage pool on a clustered backend in created state. This would previously be a pending state for the pool, leaving it not fully usable.
- fixing pool creation for the cluster use case

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a pool in a clustered backend (for the ZFS driver to work, the clustered test backend must not use containers, but VMs)
    - edit a pool in a clustered backend