### PR TITLE
feat(tab-links): Refactor into new TabLinks component [WD-6842]

### DIFF
--- a/src/components/TabLinks.tsx
+++ b/src/components/TabLinks.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from "react";
+import { Tabs } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+import { slugify } from "util/slugify";
+
+interface Props {
+  tabs: string[];
+  activeTab?: string;
+  tabUrl: string;
+}
+
+const TabLinks: FC<Props> = ({ tabs, activeTab, tabUrl }) => {
+  const notify = useNotify();
+  const navigate = useNavigate();
+  const tabsPath = tabs.map((tab) => slugify(tab));
+
+  return (
+    <Tabs
+      links={tabs.map((tab, index) => {
+        const tabPath = tabsPath[index];
+        const href = tab === tabs[0] ? tabUrl : `${tabUrl}/${tabPath}`;
+
+        return {
+          label: tab,
+          id: tabPath,
+          active: tabPath === activeTab || (tab === tabs[0] && !activeTab),
+          onClick: (e) => {
+            e.preventDefault();
+            notify.clear();
+            navigate(href);
+          },
+          href,
+        };
+      })}
+    />
+  );
+};
+
+export default TabLinks;

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
+import { Row, useNotify } from "@canonical/react-components";
 import InstanceOverview from "./InstanceOverview";
 import InstanceTerminal from "./InstanceTerminal";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import InstanceSnapshots from "./InstanceSnapshots";
 import { useQuery } from "@tanstack/react-query";
 import { fetchInstance } from "api/instances";
@@ -12,11 +12,11 @@ import InstanceConsole from "pages/instances/InstanceConsole";
 import InstanceLogs from "pages/instances/InstanceLogs";
 import EditInstance from "./EditInstance";
 import InstanceDetailHeader from "pages/instances/InstanceDetailHeader";
-import { slugify } from "util/slugify";
 import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = [
+const tabs: string[] = [
   "Overview",
   "Configuration",
   "Snapshots",
@@ -27,7 +27,6 @@ const TABS: string[] = [
 
 const InstanceDetail: FC = () => {
   const notify = useNotify();
-  const navigate = useNavigate();
   const { name, project, activeTab } = useParams<{
     name: string;
     project: string;
@@ -54,15 +53,6 @@ const InstanceDetail: FC = () => {
     notify.failure("Loading instance failed", error);
   }
 
-  const handleTabChange = (newTab: string) => {
-    notify.clear();
-    if (newTab === "overview") {
-      navigate(`/ui/project/${project}/instances/detail/${name}`);
-    } else {
-      navigate(`/ui/project/${project}/instances/detail/${name}/${newTab}`);
-    }
-  };
-
   return (
     <CustomLayout
       header={
@@ -79,15 +69,10 @@ const InstanceDetail: FC = () => {
       {!isLoading && !instance && <>Loading instance failed</>}
       {!isLoading && instance && (
         <Row>
-          <Tabs
-            links={TABS.map((tab) => ({
-              id: slugify(tab),
-              label: tab,
-              active:
-                slugify(tab) === activeTab ||
-                (tab === "Overview" && !activeTab),
-              onClick: () => handleTabChange(slugify(tab)),
-            }))}
+          <TabLinks
+            tabs={tabs}
+            activeTab={activeTab}
+            tabUrl={`/ui/project/${project}/instances/detail/${name}`}
           />
 
           {!activeTab && (

--- a/src/pages/networks/NetworkDetail.tsx
+++ b/src/pages/networks/NetworkDetail.tsx
@@ -1,22 +1,20 @@
 import React, { FC } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { fetchNetwork } from "api/networks";
 import NotificationRow from "components/NotificationRow";
 import EditNetwork from "pages/networks/EditNetwork";
 import NetworkDetailHeader from "pages/networks/NetworkDetailHeader";
 import Loader from "components/Loader";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
-import { slugify } from "util/slugify";
+import { Row } from "@canonical/react-components";
 import NetworkDetailOverview from "pages/networks/NetworkDetailOverview";
 import CustomLayout from "components/CustomLayout";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = ["Overview", "Configuration"];
+const tabs: string[] = ["Overview", "Configuration"];
 
 const NetworkDetail: FC = () => {
-  const navigate = useNavigate();
-  const notify = useNotify();
   const { name, project, activeTab } = useParams<{
     name: string;
     project: string;
@@ -40,15 +38,6 @@ const NetworkDetail: FC = () => {
     return <Loader />;
   }
 
-  const handleTabChange = (newTab: string) => {
-    notify.clear();
-    if (newTab === "overview") {
-      navigate(`/ui/project/${project}/networks/detail/${name}`);
-    } else {
-      navigate(`/ui/project/${project}/networks/detail/${name}/${newTab}`);
-    }
-  };
-
   return (
     <CustomLayout
       header={
@@ -58,16 +47,10 @@ const NetworkDetail: FC = () => {
     >
       <NotificationRow />
       <Row>
-        <Tabs
-          links={TABS.filter(
-            (tab) => tab !== "Configuration" || network?.managed === true,
-          ).map((tab) => ({
-            label: tab,
-            id: slugify(tab),
-            active:
-              slugify(tab) === activeTab || (tab === "Overview" && !activeTab),
-            onClick: () => handleTabChange(slugify(tab)),
-          }))}
+        <TabLinks
+          tabs={tabs}
+          activeTab={activeTab}
+          tabUrl={`/ui/project/${project}/networks/detail/${name}`}
         />
         {!activeTab && (
           <div role="tabpanel" aria-labelledby="overview">

--- a/src/pages/profiles/ProfileDetail.tsx
+++ b/src/pages/profiles/ProfileDetail.tsx
@@ -1,23 +1,22 @@
 import React, { FC } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { fetchProfile } from "api/profiles";
 import { queryKeys } from "util/queryKeys";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
+import { Row, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import EditProfile from "pages/profiles/EditProfile";
 import ProfileDetailOverview from "pages/profiles/ProfileDetailOverview";
 import ProfileDetailHeader from "./ProfileDetailHeader";
-import { slugify } from "util/slugify";
 import { isProjectWithProfiles } from "util/projects";
 import { useProject } from "context/project";
 import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = ["Overview", "Configuration"];
+const tabs: string[] = ["Overview", "Configuration"];
 
 const ProfileDetail: FC = () => {
-  const navigate = useNavigate();
   const notify = useNotify();
   const {
     name,
@@ -55,15 +54,6 @@ const ProfileDetail: FC = () => {
 
   const featuresProfiles = isProjectWithProfiles(project);
 
-  const handleTabChange = (newTab: string) => {
-    notify.clear();
-    if (newTab === "overview") {
-      navigate(`/ui/project/${projectName}/profiles/detail/${name}`);
-    } else {
-      navigate(`/ui/project/${projectName}/profiles/detail/${name}/${newTab}`);
-    }
-  };
-
   return (
     <CustomLayout
       header={
@@ -81,15 +71,10 @@ const ProfileDetail: FC = () => {
       {!isLoading && !profile && <>Loading profile failed</>}
       {!isLoading && profile && (
         <Row>
-          <Tabs
-            links={TABS.map((tab) => ({
-              label: tab,
-              id: slugify(tab),
-              active:
-                slugify(tab) === activeTab ||
-                (tab === "Overview" && !activeTab),
-              onClick: () => handleTabChange(slugify(tab)),
-            }))}
+          <TabLinks
+            tabs={tabs}
+            activeTab={activeTab}
+            tabUrl={`/ui/project/${projectName}/profiles/detail/${name}`}
           />
 
           {!activeTab && (

--- a/src/pages/storage/Storage.tsx
+++ b/src/pages/storage/Storage.tsx
@@ -1,22 +1,23 @@
 import React, { FC } from "react";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
+import { Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import NotificationRow from "components/NotificationRow";
-import { useNavigate, useParams } from "react-router-dom";
-import { slugify } from "util/slugify";
+import { useParams } from "react-router-dom";
 import CachedImageList from "pages/images/CachedImageList";
 import CustomIsoList from "pages/storage/CustomIsoList";
 import StoragePools from "pages/storage/StoragePools";
 import StorageVolumes from "pages/storage/StorageVolumes";
 import HelpLink from "components/HelpLink";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = ["Pools", "Volumes", "Cached images", "Custom ISOs"];
-
-export const STORAGE_TAB_PATHS = TABS.map((tab) => slugify(tab));
+export const tabs: string[] = [
+  "Pools",
+  "Volumes",
+  "Cached images",
+  "Custom ISOs",
+];
 
 const Storage: FC = () => {
-  const navigate = useNavigate();
-  const notify = useNotify();
   const { project, activeTab } = useParams<{
     project: string;
     activeTab?: string;
@@ -25,15 +26,6 @@ const Storage: FC = () => {
   if (!project) {
     return <>Missing project</>;
   }
-
-  const handleTabChange = (newTabPath: string) => {
-    notify.clear();
-    if (newTabPath === STORAGE_TAB_PATHS[0]) {
-      navigate(`/ui/project/${project}/storage`);
-    } else {
-      navigate(`/ui/project/${project}/storage/${newTabPath}`);
-    }
-  };
 
   return (
     <BaseLayout
@@ -48,17 +40,10 @@ const Storage: FC = () => {
     >
       <NotificationRow />
       <Row>
-        <Tabs
-          links={TABS.map((tab, index) => {
-            const tabPath = STORAGE_TAB_PATHS[index];
-
-            return {
-              label: tab,
-              id: tabPath,
-              active: tabPath === activeTab || (tab === TABS[0] && !activeTab),
-              onClick: () => handleTabChange(tabPath),
-            };
-          })}
+        <TabLinks
+          tabs={tabs}
+          activeTab={activeTab}
+          tabUrl={`/ui/project/${project}/storage`}
         />
 
         {!activeTab && (

--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -1,22 +1,21 @@
 import React, { FC } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
+import { Row, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import { fetchStoragePool } from "api/storage-pools";
 import StoragePoolHeader from "pages/storage/StoragePoolHeader";
 import NotificationRow from "components/NotificationRow";
-import { slugify } from "util/slugify";
 import StoragePoolOverview from "pages/storage/StoragePoolOverview";
 import CustomLayout from "components/CustomLayout";
 import EditStoragePool from "pages/storage/EditStoragePool";
 import { useClusterMembers } from "context/useClusterMembers";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = ["Overview", "Configuration"];
+const tabs: string[] = ["Overview", "Configuration"];
 
 const StoragePoolDetail: FC = () => {
-  const navigate = useNavigate();
   const notify = useNotify();
   const { data: clusterMembers = [] } = useClusterMembers();
   const { name, project, activeTab } = useParams<{
@@ -53,15 +52,6 @@ const StoragePoolDetail: FC = () => {
     return <>Loading storage details failed</>;
   }
 
-  const handleTabChange = (newTab: string) => {
-    notify.clear();
-    if (newTab === "overview") {
-      navigate(`/ui/project/${project}/storage/detail/${name}`);
-    } else {
-      navigate(`/ui/project/${project}/storage/detail/${name}/${newTab}`);
-    }
-  };
-
   return (
     <CustomLayout
       header={<StoragePoolHeader name={name} pool={pool} project={project} />}
@@ -69,14 +59,10 @@ const StoragePoolDetail: FC = () => {
     >
       <NotificationRow />
       <Row>
-        <Tabs
-          links={TABS.map((tab) => ({
-            label: tab,
-            id: slugify(tab),
-            active:
-              slugify(tab) === activeTab || (tab === "Overview" && !activeTab),
-            onClick: () => handleTabChange(slugify(tab)),
-          }))}
+        <TabLinks
+          tabs={tabs}
+          activeTab={activeTab}
+          tabUrl={`/ui/project/${project}/storage/detail/${name}`}
         />
 
         {!activeTab && (

--- a/src/pages/storage/StorageVolumeDetail.tsx
+++ b/src/pages/storage/StorageVolumeDetail.tsx
@@ -1,20 +1,19 @@
 import React, { FC } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { Row, Tabs, useNotify } from "@canonical/react-components";
+import { Row, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import { fetchStorageVolume } from "api/storage-pools";
 import NotificationRow from "components/NotificationRow";
-import { slugify } from "util/slugify";
 import StorageVolumeHeader from "pages/storage/StorageVolumeHeader";
 import StorageVolumeOverview from "pages/storage/StorageVolumeOverview";
 import StorageVolumeEdit from "pages/storage/forms/StorageVolumeEdit";
+import TabLinks from "components/TabLinks";
 
-const TABS: string[] = ["Overview", "Configuration"];
+const tabs: string[] = ["Overview", "Configuration"];
 
 const StorageVolumeDetail: FC = () => {
-  const navigate = useNavigate();
   const notify = useNotify();
   const {
     pool,
@@ -62,19 +61,6 @@ const StorageVolumeDetail: FC = () => {
     return <>Loading storage volume failed</>;
   }
 
-  const handleTabChange = (newTab: string) => {
-    notify.clear();
-    if (newTab === "overview") {
-      navigate(
-        `/ui/project/${project}/storage/detail/${pool}/${type}/${volume.name}`,
-      );
-    } else {
-      navigate(
-        `/ui/project/${project}/storage/detail/${pool}/${type}/${volume.name}/${newTab}`,
-      );
-    }
-  };
-
   return (
     <main className="l-main">
       <div className="p-panel">
@@ -82,15 +68,10 @@ const StorageVolumeDetail: FC = () => {
         <div className="p-panel__content storage-volume-form">
           <NotificationRow />
           <Row>
-            <Tabs
-              links={TABS.map((tab) => ({
-                label: tab,
-                id: slugify(tab),
-                active:
-                  slugify(tab) === activeTab ||
-                  (tab === "Overview" && !activeTab),
-                onClick: () => handleTabChange(slugify(tab)),
-              }))}
+            <TabLinks
+              tabs={tabs}
+              activeTab={activeTab}
+              tabUrl={`/ui/project/${project}/storage/detail/${pool}/${type}/${volume.name}`}
             />
 
             {!activeTab && (

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -1,6 +1,8 @@
-import { STORAGE_TAB_PATHS } from "pages/storage/Storage";
 import { LxdProject } from "types/project";
+import { tabs } from "pages/storage/Storage";
+import { slugify } from "./slugify";
 
+export const STORAGE_TAB_PATHS = tabs.map((tab) => slugify(tab));
 export const projectSubpages = [
   "instances",
   "profiles",


### PR DESCRIPTION
## Done

- Refactored all tab usages into a new TabLinks component to reduce code duplication across components.
- Made tabs links, that can be opened into a new tab etc.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to storage page, instance, network, profile, storagepool, storagevolume detail pages and check if the tabs work well.
    - Check that the tabs can be right clicked and opened into a new tab etc. (because the tabs now have a href)

## Screenshots

![Screen Recording showing tab links](https://github.com/canonical/lxd-ui/assets/54525904/8521e732-116c-4f25-829e-d899174db907)
