### PR TITLE
Reduce font size of the text in the cluster group selector

### DIFF
--- a/src/sass/_cluster_list.scss
+++ b/src/sass/_cluster_list.scss
@@ -74,12 +74,12 @@
       background-color: $colors--light-theme--background-hover;
       border-bottom: 1px solid $colors--light-theme--border-high-contrast;
       font-size: #{map.get($font-sizes, h4-mobile)}rem;
-      font-weight: 275;
       margin-bottom: $spv--small;
       width: 50vw;
 
       span {
         display: inline-block;
+        font-size: 1rem;
         overflow: hidden !important;
         text-align: left;
         text-overflow: ellipsis !important;


### PR DESCRIPTION
## Done

- Reduced font size of the text in the cluster group selector

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - On a local clustered back-end running this branch: open cluster page and check the group selector at the top of the page.
    - Not really possible to QA on the demo server since its back-end is not clustered. Check the screenshots below.

## Screenshots

Before:

![image](https://github.com/canonical/lxd-ui/assets/56583786/f593f6f3-71c0-4213-bd54-0732ee8a88b0)

After:

![image](https://github.com/canonical/lxd-ui/assets/56583786/7bef930d-127d-4556-9f61-195b05a05fa4)