### PR TITLE
Copy update: password is not necessarily empty

### DIFF
--- a/src/pages/login/BrowserImport.tsx
+++ b/src/pages/login/BrowserImport.tsx
@@ -26,7 +26,8 @@ const BrowserImport: FC<Props> = ({ sendPfx }) => {
       <li className="p-list__item">
         This opens a certificate management dialog. Click <code>Import...</code>
         then <code>Next</code> and select the <code>lxd-ui.pfx</code> file you
-        just downloaded. Confirm an empty password. Click <code>Next</code>.
+        just downloaded. Enter your password, or leave the field empty if you
+        have not set one. Click <code>Next</code>.
       </li>
       <li className="p-list__item">
         Select <code>Automatically select the certificate store</code> and click{" "}
@@ -82,7 +83,8 @@ const BrowserImport: FC<Props> = ({ sendPfx }) => {
               </li>
               <li className="p-list__item">
                 Select the <code>lxd-ui.pfx</code> file you just downloaded.
-                Confirm an empty password.
+                Enter your password, or leave the field empty if you have not
+                set one.
               </li>
               <li className="p-list__item">
                 Restart the browser and open LXD-UI. Select the LXD-UI
@@ -106,8 +108,8 @@ const BrowserImport: FC<Props> = ({ sendPfx }) => {
               </li>
               <li className="p-list__item">
                 Click the <code>Import</code> button and select the{" "}
-                <code>lxd-ui.pfx</code> file you just downloaded. Confirm an
-                empty password.
+                <code>lxd-ui.pfx</code> file you just downloaded. Enter your
+                password, or leave the field empty if you have not set one.
               </li>
               <li className="p-list__item">
                 Restart the browser and open LXD-UI. Select the LXD-UI


### PR DESCRIPTION
## Done

- Updated the "Confirm an empty password" copy: the password is not necessarily empty, so this text is misleading.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - (on a local copy of this branch) replace line 53 in `auth.tsx` with `isAuthenticated: false`
    - Check the new copy in the browser tutorials (step 3) in `/ui/login/certificate-generate` (all except macOS)
    - Alternatively, check the screenshots below


## Screenshots

- Previous copy:

![image](https://github.com/canonical/lxd-ui/assets/56583786/4b677998-897b-4d51-9b9a-cb81a3161472)

- New copy:

![image](https://github.com/canonical/lxd-ui/assets/56583786/bb3afe60-0bce-4e6c-9747-a19b418a09fb)