### PR TITLE
Ensure correct type is set when creating an instance from a cached image

### DIFF
--- a/src/pages/images/CachedImageList.tsx
+++ b/src/pages/images/CachedImageList.tsx
@@ -75,6 +75,7 @@ const ImageList: FC = () => {
             key="launch"
             project={project}
             image={cachedLxdToRemoteImage(image)}
+            type={image.type}
           />,
           <DeleteCachedImageBtn key="delete" image={image} project={project} />,
         ]}

--- a/src/pages/images/CustomIsoModal.tsx
+++ b/src/pages/images/CustomIsoModal.tsx
@@ -1,13 +1,13 @@
 import React, { FC, useState } from "react";
 import { Modal } from "@canonical/react-components";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import UploadCustomIso from "pages/storage/UploadCustomIso";
 import CustomIsoSelector from "pages/images/CustomIsoSelector";
 import { IsoImage } from "types/iso";
 
 interface Props {
   onClose: () => void;
-  onSelect: (image: RemoteImage, type: string | null) => void;
+  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
 }
 
 const SELECT_ISO = "selectIso";

--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -6,12 +6,12 @@ import { loadIsoVolumes } from "context/loadIsoVolumes";
 import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import { useProject } from "context/project";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import { IsoImage } from "types/iso";
 
 interface Props {
   primaryImage: IsoImage | null;
-  onSelect: (image: RemoteImage, type: string | null) => void;
+  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
   onUpload: () => void;
   onCancel: () => void;
 }

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -8,7 +8,7 @@ import {
   SearchBox,
   Select,
 } from "@canonical/react-components";
-import { RemoteImage, RemoteImageList } from "types/image";
+import { LxdImageType, RemoteImage, RemoteImageList } from "types/image";
 import { handleResponse } from "util/helpers";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
@@ -21,7 +21,7 @@ import { useSettings } from "context/useSettings";
 import ScrollableTable from "components/ScrollableTable";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: string | null) => void;
+  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
   onClose: () => void;
 }
 
@@ -40,7 +40,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [os, setOs] = useState<string>("");
   const [release, setRelease] = useState<string>("");
   const [arch, setArch] = useState<string>("amd64");
-  const [type, setType] = useState<string>(ANY);
+  const [type, setType] = useState<LxdImageType | null>(null);
   const [variant, setVariant] = useState<string>(ANY);
 
   const loadImages = (file: string, server: string): Promise<RemoteImage[]> => {
@@ -167,7 +167,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       };
       const itemType = figureType();
 
-      const selectImage = () => onSelect(item, type === ANY ? null : type);
+      const selectImage = () => onSelect(item, type);
 
       const displayRelease =
         item.os === "Ubuntu" &&
@@ -338,7 +338,11 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
               label="Type"
               name="type"
               onChange={(v) => {
-                setType(v.target.value);
+                setType(
+                  v.target.value === ANY
+                    ? "container"
+                    : (v.target.value as LxdImageType),
+                );
               }}
               options={[
                 {
@@ -347,7 +351,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 },
                 ...instanceCreationTypes,
               ]}
-              value={type}
+              value={type ?? ""}
             />
           </div>
         </Col>

--- a/src/pages/images/actions/CreateInstanceFromImageBtn.tsx
+++ b/src/pages/images/actions/CreateInstanceFromImageBtn.tsx
@@ -1,14 +1,15 @@
 import React, { FC } from "react";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import { Button, Icon } from "@canonical/react-components";
 import { useNavigate } from "react-router-dom";
 
 interface Props {
   image: RemoteImage;
   project: string;
+  type: LxdImageType;
 }
 
-const CreateInstanceFromImageBtn: FC<Props> = ({ image, project }) => {
+const CreateInstanceFromImageBtn: FC<Props> = ({ image, project, type }) => {
   const navigate = useNavigate();
 
   const openLaunchFlow = () => {
@@ -16,6 +17,7 @@ const CreateInstanceFromImageBtn: FC<Props> = ({ image, project }) => {
       state: {
         selectedImage: image,
         cancelLocation: window.location.pathname,
+        type,
       },
     });
   };

--- a/src/pages/images/actions/SelectImageBtn.tsx
+++ b/src/pages/images/actions/SelectImageBtn.tsx
@@ -1,17 +1,17 @@
 import React, { FC } from "react";
 import { Button } from "@canonical/react-components";
 import usePortal from "react-useportal";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import ImageSelector from "pages/images/ImageSelector";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: string | null) => void;
+  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
 }
 
 const SelectImageBtn: FC<Props> = ({ onSelect }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
-  const handleSelect = (image: RemoteImage, type: string | null) => {
+  const handleSelect = (image: RemoteImage, type: LxdImageType | null) => {
     closePortal();
     onSelect(image, type);
   };

--- a/src/pages/images/actions/UseCustomIsoBtn.tsx
+++ b/src/pages/images/actions/UseCustomIsoBtn.tsx
@@ -1,17 +1,17 @@
 import React, { FC } from "react";
 import { Button } from "@canonical/react-components";
 import usePortal from "react-useportal";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import CustomIsoModal from "pages/images/CustomIsoModal";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: string | null) => void;
+  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
 }
 
 const UseCustomIsoBtn: FC<Props> = ({ onSelect }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
-  const handleSelect = (image: RemoteImage, type: string | null) => {
+  const handleSelect = (image: RemoteImage, type: LxdImageType | null) => {
     closePortal();
     onSelect(image, type);
   };

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -14,7 +14,7 @@ import { createInstance, startInstance } from "api/instances";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import SubmitButton from "components/SubmitButton";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import { isContainerOnlyImage, isVmOnlyImage, LOCAL_ISO } from "util/images";
 import { checkDuplicateName } from "util/helpers";
 import { dump as dumpYaml } from "js-yaml";
@@ -79,6 +79,7 @@ interface PresetFormState {
   retryFormValues?: CreateInstanceFormValues;
   selectedImage?: RemoteImage;
   cancelLocation?: string;
+  type: LxdImageType;
 }
 
 const CreateInstance: FC = () => {
@@ -258,7 +259,7 @@ const CreateInstance: FC = () => {
 
   const isLocalIsoImage = formik.values.image?.server === LOCAL_ISO;
 
-  const handleSelectImage = (image: RemoteImage, type: string | null) => {
+  const handleSelectImage = (image: RemoteImage, type: LxdImageType | null) => {
     void formik.setFieldValue("image", image);
 
     const devices = formik.values.devices.filter(
@@ -272,11 +273,9 @@ const CreateInstance: FC = () => {
 
     if (type) {
       void formik.setFieldValue("instanceType", type);
-    }
-    if (isVmOnlyImage(image)) {
+    } else if (isVmOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "virtual-machine");
-    }
-    if (isContainerOnlyImage(image)) {
+    } else if (isContainerOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "container");
     }
     notify.clear();
@@ -284,7 +283,9 @@ const CreateInstance: FC = () => {
 
   useEffect(() => {
     if (location.state?.selectedImage) {
-      const type = location.state.selectedImage.volume ? "iso-volume" : null;
+      const type = location.state.selectedImage.volume
+        ? "iso-volume"
+        : location.state.type ?? null;
       handleSelectImage(location.state.selectedImage, type);
     }
   }, [location.state?.selectedImage]);

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -14,7 +14,7 @@ import { isContainerOnlyImage, isVmOnlyImage, LOCAL_ISO } from "util/images";
 import { instanceCreationTypes } from "util/instanceOptions";
 import { FormikProps } from "formik/dist/types";
 import { CreateInstanceFormValues } from "pages/instances/CreateInstance";
-import { RemoteImage } from "types/image";
+import { LxdImageType, RemoteImage } from "types/image";
 import InstanceLocationSelect from "pages/instances/forms/InstanceLocationSelect";
 import UseCustomIsoBtn from "pages/images/actions/UseCustomIsoBtn";
 import { getTextareaRows } from "util/formFields";
@@ -58,7 +58,7 @@ export const instanceDetailPayload = (values: CreateInstanceFormValues) => {
 
 interface Props {
   formik: FormikProps<CreateInstanceFormValues>;
-  onSelectImage: (image: RemoteImage, type: string | null) => void;
+  onSelectImage: (image: RemoteImage, type: LxdImageType | null) => void;
   project: string;
 }
 

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -1,5 +1,7 @@
 import { LxdStorageVolume } from "types/storage";
 
+export type LxdImageType = "container" | "virtual-machine" | "iso-volume";
+
 interface LxdImageAlias {
   name: string;
   description: string;
@@ -20,7 +22,7 @@ export interface LxdImage {
     server: string;
   };
   architecture: string;
-  type: string;
+  type: LxdImageType;
   size: number;
   uploaded_at: string;
   aliases: LxdImageAlias[];


### PR DESCRIPTION
## Done

- Passed the correct image type when creating an instance from a cached image

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to storage page, select "Cached images" tab
    - Click on the "Play" button to create an instance using a VM cached image (if you don't have one, first create a VM instance following the regular instance creation flow from the instances page)
    - Check that, on the instance creation page, the correct image type is selected in the (disabled) dropdown