### PR TITLE
Replace pause with freeze throughout the app [WD-6701]

### DIFF
--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { LxdInstance } from "types/instance";
 
-type LoadingTypes = "Starting" | "Stopping" | "Restarting" | "Pausing";
+type LoadingTypes = "Starting" | "Stopping" | "Restarting" | "Freezing";
 
 export interface InstanceLoadingType {
   getType: (instance: LxdInstance) => LoadingTypes | undefined;

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -17,29 +17,29 @@ interface Props {
   instance: LxdInstance;
 }
 
-const PauseInstanceBtn: FC<Props> = ({ instance }) => {
+const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
   const eventQueue = useEventQueue();
   const instanceLoading = useInstanceLoading();
   const notify = useNotify();
   const queryClient = useQueryClient();
   const isLoading =
-    instanceLoading.getType(instance) === "Pausing" ||
+    instanceLoading.getType(instance) === "Freezing" ||
     instance.status === "Freezing";
 
-  const handlePause = () => {
-    instanceLoading.setLoading(instance, "Pausing");
+  const handleFreeze = () => {
+    instanceLoading.setLoading(instance, "Freezing");
     void freezeInstance(instance).then((operation) => {
       eventQueue.set(
         operation.metadata.id,
         () =>
           notify.success(
             <>
-              Instance <InstanceLink instance={instance} /> paused.
+              Instance <InstanceLink instance={instance} /> frozen.
             </>,
           ),
         (msg) =>
           notify.failure(
-            "Instance pause failed",
+            "Instance freeze failed",
             new Error(msg),
             <>
               Instance <ItemName item={instance} bold />:
@@ -62,14 +62,14 @@ const PauseInstanceBtn: FC<Props> = ({ instance }) => {
       appearance="base"
       loading={isLoading}
       confirmationModalProps={{
-        title: "Confirm pause",
+        title: "Confirm freeze",
         children: (
           <p>
-            This will pause instance <ItemName item={instance} bold />.
+            This will freeze instance <ItemName item={instance} bold />.
           </p>
         ),
-        onConfirm: handlePause,
-        confirmButtonLabel: "Pause",
+        onConfirm: handleFreeze,
+        confirmButtonLabel: "Freeze",
       }}
       className="has-icon is-dense"
       disabled={isDisabled}
@@ -81,4 +81,4 @@ const PauseInstanceBtn: FC<Props> = ({ instance }) => {
   );
 };
 
-export default PauseInstanceBtn;
+export default FreezeInstanceBtn;

--- a/src/pages/instances/actions/InstanceBulkAction.tsx
+++ b/src/pages/instances/actions/InstanceBulkAction.tsx
@@ -69,7 +69,7 @@ const InstanceBulkAction: FC<Props> = ({
       return (
         <Fragment key={currentState + desiredAction}>
           - No action for <b>{count}</b> {instance} {already}
-          {currentState.toLowerCase().replace("frozen", "paused")}.
+          {currentState.toLowerCase()}.
           <br />
         </Fragment>
       );
@@ -80,7 +80,7 @@ const InstanceBulkAction: FC<Props> = ({
     return (
       <Fragment key={currentState + desiredAction}>
         {indent}
-        This will {desiredAction.replace("freeze", "pause")} <b>{count}</b>
+        This will {desiredAction} <b>{count}</b>
         {` ${status} ${pluralizeInstance(count)}.`}
         <br />
       </Fragment>

--- a/src/pages/instances/actions/InstanceBulkActions.tsx
+++ b/src/pages/instances/actions/InstanceBulkActions.tsx
@@ -112,7 +112,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
           onClick={() => handleAction("freeze")}
           action="freeze"
           instances={instances}
-          confirmLabel="Pause"
+          confirmLabel="Freeze"
         />
         <InstanceBulkAction
           icon="stop"

--- a/src/pages/instances/actions/InstanceStateActions.tsx
+++ b/src/pages/instances/actions/InstanceStateActions.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { LxdInstance } from "types/instance";
 import StartInstanceBtn from "pages/instances/actions/StartInstanceBtn";
 import StopInstanceBtn from "pages/instances/actions/StopInstanceBtn";
-import PauseInstanceBtn from "pages/instances/actions/PauseInstanceBtn";
+import FreezeInstanceBtn from "pages/instances/actions/FreezeInstanceBtn";
 import RestartInstanceBtn from "pages/instances/actions/RestartInstanceBtn";
 import classnames from "classnames";
 import { List } from "@canonical/react-components";
@@ -20,7 +20,7 @@ const InstanceStateActions: FC<Props> = ({ instance, className }) => {
       items={[
         <StartInstanceBtn key="start" instance={instance} />,
         <RestartInstanceBtn key="restart" instance={instance} />,
-        <PauseInstanceBtn key="pause" instance={instance} />,
+        <FreezeInstanceBtn key="freeze" instance={instance} />,
         <StopInstanceBtn key="stop" instance={instance} />,
       ]}
     />

--- a/src/util/instanceBulkActions.tsx
+++ b/src/util/instanceBulkActions.tsx
@@ -63,7 +63,7 @@ export const instanceActionLabel = (action: LxdInstanceAction): string => {
     unfreeze: "started",
     start: "started",
     restart: "restarted",
-    freeze: "paused",
+    freeze: "frozen",
     stop: "stopped",
   }[action];
 };
@@ -78,7 +78,7 @@ export const pluralizeSnapshot = (count: number) => {
 
 export const statusLabel = (status: LxdInstanceStatus) => {
   const statusToLabel: Partial<Record<LxdInstanceStatus, string>> = {
-    Frozen: "paused",
+    Frozen: "frozen",
     Stopped: "stopped",
     Running: "running",
   };


### PR DESCRIPTION
## Done

- Replace all occurrences of Pause/Pausing/Paused with Freeze/Freezing/Frozen, to match the back-end status label (Frozen) and avoid confusion.

Fixes [WD-6701](https://warthogs.atlassian.net/browse/WD-6701)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to instance page
    - Multi-select instances and check the bulk action labels: "pause" should now be "freeze"
    - Go to instance detail page
    - Check the action labels: "pause" should now be "freeze"

[WD-6701]: https://warthogs.atlassian.net/browse/WD-6701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ