### PR TITLE
Warn when leaving the terminal and interacted with it 

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,0 +1,38 @@
+import React, { FC } from "react";
+import Navigation from "components/Navigation";
+import { NotificationProvider } from "@canonical/react-components";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Panels from "components/Panels";
+import { AuthProvider } from "context/auth";
+import { EventQueueProvider } from "context/eventQueue";
+import { InstanceLoadingProvider } from "context/instanceLoading";
+import { ProjectProvider } from "context/project";
+import Events from "pages/instances/Events";
+import App from "./App";
+
+const queryClient = new QueryClient();
+
+const Root: FC = () => {
+  return (
+    <NotificationProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <ProjectProvider>
+            <InstanceLoadingProvider>
+              <EventQueueProvider>
+                <div className="l-application" role="presentation">
+                  <Navigation />
+                  <App />
+                  <Panels />
+                  <Events />
+                </div>
+              </EventQueueProvider>
+            </InstanceLoadingProvider>
+          </ProjectProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </NotificationProvider>
+  );
+};
+
+export default Root;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,42 +1,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter as Router } from "react-router-dom";
-import Navigation from "components/Navigation";
-import Panels from "components/Panels";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthProvider } from "context/auth";
-import App from "./App";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import "./sass/styles.scss";
-import { ProjectProvider } from "context/project";
-import { InstanceLoadingProvider } from "context/instanceLoading";
-import Events from "pages/instances/Events";
-import { EventQueueProvider } from "context/eventQueue";
-import { NotificationProvider } from "@canonical/react-components";
-
-const queryClient = new QueryClient();
+import Root from "./Root";
 
 const rootElement = document.getElementById("app");
+
 if (!rootElement) throw new Error("Failed to find the root element");
+
 const root = createRoot(rootElement);
-root.render(
-  <Router>
-    <NotificationProvider>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <ProjectProvider>
-            <InstanceLoadingProvider>
-              <EventQueueProvider>
-                <div className="l-application" role="presentation">
-                  <Navigation />
-                  <App />
-                  <Panels />
-                  <Events />
-                </div>
-              </EventQueueProvider>
-            </InstanceLoadingProvider>
-          </ProjectProvider>
-        </AuthProvider>
-      </QueryClientProvider>
-    </NotificationProvider>
-  </Router>,
-);
+
+const router = createBrowserRouter([{ path: "*", Component: Root }]);
+
+root.render(<RouterProvider router={router} />);

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -20,6 +20,7 @@ import {
   NotificationType,
   failure,
 } from "@canonical/react-components";
+import { unstable_usePrompt as usePrompt } from "react-router-dom";
 
 const XTERM_OPTIONS = {
   theme: {
@@ -61,6 +62,12 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
   const [payload, setPayload] = useState(defaultPayload);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
+  const [userInteracted, setUserInteracted] = useState(false);
+
+  usePrompt({
+    when: userInteracted,
+    message: "Are you sure you want to leave this page?",
+  });
 
   const isRunning = instance.status === "Running";
 
@@ -220,6 +227,7 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
               addons={[fitAddon]}
               className="p-terminal"
               onData={(data) => {
+                setUserInteracted(true);
                 dataWs?.send(textEncoder.encode(data));
               }}
               options={XTERM_OPTIONS}

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -12,6 +12,7 @@ import Loader from "components/Loader";
 import useEventListener from "@use-it/event-listener";
 import { LxdInstance } from "types/instance";
 import { updateMaxHeight } from "util/updateMaxHeight";
+import { unstable_usePrompt as usePrompt } from "react-router-dom";
 
 interface Props {
   instance: LxdInstance;
@@ -36,6 +37,12 @@ const InstanceTextConsole: FC<Props> = ({
   const [textBuffer, setTextBuffer] = useState("");
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
+  const [userInteracted, setUserInteracted] = useState(false);
+
+  usePrompt({
+    when: userInteracted,
+    message: "Are you sure you want to leave this page?",
+  });
 
   const isRunning = instance.status === "Running";
 
@@ -179,6 +186,7 @@ const InstanceTextConsole: FC<Props> = ({
           addons={[fitAddon]}
           className="p-terminal"
           onData={(data) => {
+            setUserInteracted(true);
             dataWs?.send(textEncoder.encode(data));
           }}
         />


### PR DESCRIPTION
## Done

- Migrated the old `BrowserRouter` to the more modern [`createBrowserRouter`](https://reactrouter.com/en/main/routers/create-browser-router) - recommended practice, see docs [here](https://reactrouter.com/en/main/routers/picking-a-router#web-projects).
- Added a confirmation prompt that is displayed when navigating away from the terminal tab if the user has interacted with the terminal.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that navigation, contexts and routes all work as expected after the migration
    - Go to instance list
    - Open the detail page of a running instance
    - Go to Terminal tab / Console tab
    - Interact with the terminal or the text console, e.g. by writing a command (or just a single letter)
    - Try navigating away, e.g. by clicking on the "Logs" tab
    - Check that a prompt appears asking you if you really want to leave the page
    - Check that the Cancel/OK buttons work as expected