### PR TITLE
Move image list to top level 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const CreateProfile = lazy(() => import("pages/profiles/CreateProfile"));
 const CreateProject = lazy(() => import("pages/projects/CreateProject"));
 const CreateStoragePool = lazy(() => import("pages/storage/CreateStoragePool"));
 const EditClusterGroup = lazy(() => import("pages/cluster/EditClusterGroup"));
+const Images = lazy(() => import("pages/images/Images"));
 const InstanceDetail = lazy(() => import("pages/instances/InstanceDetail"));
 const InstanceList = lazy(() => import("pages/instances/InstanceList"));
 const Login = lazy(() => import("pages/login/Login"));
@@ -275,6 +276,10 @@ const App: FC = () => {
         <Route
           path="/ui/project/:project/storage/detail/:pool/:type/:volume/:activeTab/:activeSection"
           element={<ProtectedRoute outlet={<StorageVolumeDetail />} />}
+        />
+        <Route
+          path="/ui/project/:project/images"
+          element={<ProtectedRoute outlet={<Images />} />}
         />
         <Route
           path="/ui/cluster"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -146,6 +146,19 @@ const Navigation: FC = () => {
                       <li className="p-side-navigation__item secondary">
                         <NavLink
                           className="p-side-navigation__link"
+                          to={`/ui/project/${projectName}/images`}
+                          title={`Images (${projectName})`}
+                        >
+                          <Icon
+                            className="is-light p-side-navigation__icon"
+                            name="applications"
+                          />{" "}
+                          Images
+                        </NavLink>
+                      </li>
+                      <li className="p-side-navigation__item secondary">
+                        <NavLink
+                          className="p-side-navigation__link"
                           to={`/ui/project/${projectName}/configuration`}
                           title={`Configuration (${projectName})`}
                         >

--- a/src/pages/images/Images.tsx
+++ b/src/pages/images/Images.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from "react";
+import BaseLayout from "components/BaseLayout";
+import NotificationRow from "components/NotificationRow";
+import HelpLink from "components/HelpLink";
+import ImageList from "pages/images/ImageList";
+import { Row } from "@canonical/react-components";
+
+const Images: FC = () => {
+  return (
+    <BaseLayout
+      title={
+        <HelpLink
+          href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/"
+          title="Learn more about images"
+        >
+          Images
+        </HelpLink>
+      }
+    >
+      <NotificationRow />
+      <Row>
+        <ImageList />
+      </Row>
+    </BaseLayout>
+  );
+};
+
+export default Images;

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -15,7 +15,7 @@ interface Props {
   project: string;
 }
 
-const DeleteCachedImageBtn: FC<Props> = ({ image, project }) => {
+const DeleteImageBtn: FC<Props> = ({ image, project }) => {
   const eventQueue = useEventQueue();
   const notify = useNotify();
   const [isLoading, setLoading] = useState(false);
@@ -67,4 +67,4 @@ const DeleteCachedImageBtn: FC<Props> = ({ image, project }) => {
   );
 };
 
-export default DeleteCachedImageBtn;
+export default DeleteImageBtn;

--- a/src/pages/storage/Storage.tsx
+++ b/src/pages/storage/Storage.tsx
@@ -3,19 +3,13 @@ import { Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import NotificationRow from "components/NotificationRow";
 import { useParams } from "react-router-dom";
-import CachedImageList from "pages/images/CachedImageList";
 import CustomIsoList from "pages/storage/CustomIsoList";
 import StoragePools from "pages/storage/StoragePools";
 import StorageVolumes from "pages/storage/StorageVolumes";
 import HelpLink from "components/HelpLink";
 import TabLinks from "components/TabLinks";
 
-export const tabs: string[] = [
-  "Pools",
-  "Volumes",
-  "Cached images",
-  "Custom ISOs",
-];
+export const tabs: string[] = ["Pools", "Volumes", "Custom ISOs"];
 
 const Storage: FC = () => {
   const { project, activeTab } = useParams<{
@@ -55,12 +49,6 @@ const Storage: FC = () => {
         {activeTab === "volumes" && (
           <div role="volumes">
             <StorageVolumes />
-          </div>
-        )}
-
-        {activeTab === "cached-images" && (
-          <div role="tabpanel">
-            <CachedImageList />
           </div>
         )}
 

--- a/src/sass/_images.scss
+++ b/src/sass/_images.scss
@@ -1,0 +1,42 @@
+.image-list {
+  .search-wrapper {
+    max-width: 42rem;
+    width: 100%;
+  }
+
+  .items-per-page {
+    margin-bottom: 0;
+  }
+}
+
+.image-table {
+  @media screen and (width > 1400px) {
+    .architecture {
+      width: 9rem;
+    }
+
+    .public {
+      width: 9rem;
+    }
+
+    .type {
+      width: 9rem;
+    }
+
+    .uploaded_at {
+      width: 12rem;
+    }
+  }
+
+  .size {
+    width: 9rem;
+  }
+
+  .actions {
+    width: 9rem;
+  }
+
+  .actions-list {
+    margin-top: -7px;
+  }
+}

--- a/src/sass/_storage.scss
+++ b/src/sass/_storage.scss
@@ -1,5 +1,4 @@
 .storage-volumes,
-.cached-image-list,
 .custom-iso-list {
   .search-wrapper {
     max-width: 42rem;
@@ -22,34 +21,6 @@
 
   button {
     margin-top: -6px;
-  }
-}
-
-.cached-image-table {
-  @media screen and (width > 1400px) {
-    .architecture {
-      width: 9rem;
-    }
-
-    .type {
-      width: 9rem;
-    }
-
-    .uploaded_at {
-      width: 12rem;
-    }
-  }
-
-  .size {
-    width: 9rem;
-  }
-
-  .actions {
-    width: 9rem;
-  }
-
-  .actions-list {
-    margin-top: -7px;
   }
 }
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -57,6 +57,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "empty_state";
 @import "file_row";
 @import "forms";
+@import "images";
 @import "instance_detail_console";
 @import "instance_detail_overview";
 @import "instance_detail_page";

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -38,7 +38,7 @@ export const isoToRemoteImage = (volume: LxdStorageVolume): RemoteImage => {
   };
 };
 
-export const cachedLxdToRemoteImage = (image: LxdImage): RemoteImage => {
+export const localLxdToRemoteImage = (image: LxdImage): RemoteImage => {
   return {
     aliases: image.update_source?.alias ?? image.fingerprint,
     arch: image.architecture,


### PR DESCRIPTION
## Done

- Move image list to top level 
- rename cached image to images

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - browse the image list form the top main menu
    - delete cached image
    - start new instance and ensure the image appears in cached images
    - check image list for another profile