### PR TITLE
Change instance filtering to url instead of state [WD-7026]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,13 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     semi: ["error", "always"],
     "object-curly-spacing": ["error", "always"],
-    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,13 +34,6 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     semi: ["error", "always"],
     "object-curly-spacing": ["error", "always"],
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        caughtErrorsIgnorePattern: "^_",
-      },
-    ],
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
   },
 };

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -12,7 +12,7 @@ import { fetchInstances } from "api/instances";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import usePanelParams from "util/usePanelParams";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import Loader from "components/Loader";
 import { instanceCreationTypes } from "util/instanceOptions";
 import InstanceStatusIcon from "./InstanceStatusIcon";
@@ -29,7 +29,7 @@ import InstanceBulkActions from "pages/instances/actions/InstanceBulkActions";
 import { getIpAddresses } from "util/networks";
 import InstanceBulkDelete from "pages/instances/actions/InstanceBulkDelete";
 import InstanceSearchFilter from "./InstanceSearchFilter";
-import { InstanceFilters } from "util/instanceFilter";
+import { enrichStatuses } from "util/instanceFilter";
 import { isWidthBelow } from "util/helpers";
 import { fetchOperations } from "api/operations";
 import CancelOperationBtn from "pages/operations/actions/CancelOperationBtn";
@@ -53,6 +53,7 @@ import NotificationRow from "components/NotificationRow";
 import SelectedTableNotification from "components/SelectedTableNotification";
 import CustomLayout from "components/CustomLayout";
 import HelpLink from "components/HelpLink";
+import { LxdInstanceStatus } from "types/instance";
 
 const loadHidden = () => {
   const saved = localStorage.getItem("instanceListHiddenColumns");
@@ -73,12 +74,17 @@ const InstanceList: FC = () => {
   const { project } = useParams<{ project: string }>();
   const [createButtonLabel, _setCreateButtonLabel] =
     useState<string>("Create instance");
-  const [filters, setFilters] = useState<InstanceFilters>({
-    queries: [],
-    statuses: [],
-    types: [],
-    profileQueries: [],
-  });
+  // const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  const filters = {
+    queries: searchParams.getAll("queries"),
+    statuses: enrichStatuses(
+      searchParams.getAll("statuses") as LxdInstanceStatus[],
+    ),
+    types: searchParams.getAll("types"),
+    profileQueries: searchParams.getAll("profileQueries"),
+  };
   const [userHidden, setUserHidden] = useState<string[]>(loadHidden());
   const [sizeHidden, setSizeHidden] = useState<string[]>([]);
   const [selectedNames, setSelectedNames] = useState<string[]>([]);
@@ -501,11 +507,7 @@ const InstanceList: FC = () => {
               </>
             )}
             {hasInstances && selectedNames.length === 0 && (
-              <InstanceSearchFilter
-                key={project}
-                instances={instances}
-                setFilters={setFilters}
-              />
+              <InstanceSearchFilter key={project} instances={instances} />
             )}
           </div>
           {hasInstances && selectedNames.length === 0 && (

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -81,7 +81,9 @@ const InstanceList: FC = () => {
     statuses: enrichStatuses(
       searchParams.getAll("status") as LxdInstanceStatus[],
     ),
-    types: searchParams.getAll("type"),
+    types: searchParams
+      .getAll("type")
+      .map((value) => (value === "VM" ? "virtual-machine" : "container")),
     profileQueries: searchParams.getAll("profile"),
   };
   const [userHidden, setUserHidden] = useState<string[]>(loadHidden());

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -29,7 +29,7 @@ import InstanceBulkActions from "pages/instances/actions/InstanceBulkActions";
 import { getIpAddresses } from "util/networks";
 import InstanceBulkDelete from "pages/instances/actions/InstanceBulkDelete";
 import InstanceSearchFilter from "./InstanceSearchFilter";
-import { enrichStatuses } from "util/instanceFilter";
+import { InstanceFilters, enrichStatuses } from "util/instanceFilter";
 import { isWidthBelow } from "util/helpers";
 import { fetchOperations } from "api/operations";
 import CancelOperationBtn from "pages/operations/actions/CancelOperationBtn";
@@ -74,16 +74,15 @@ const InstanceList: FC = () => {
   const { project } = useParams<{ project: string }>();
   const [createButtonLabel, _setCreateButtonLabel] =
     useState<string>("Create instance");
-  // const location = useLocation();
   const [searchParams] = useSearchParams();
 
-  const filters = {
-    queries: searchParams.getAll("queries"),
+  const filters: InstanceFilters = {
+    queries: searchParams.getAll("q"),
     statuses: enrichStatuses(
-      searchParams.getAll("statuses") as LxdInstanceStatus[],
+      searchParams.getAll("status") as LxdInstanceStatus[],
     ),
-    types: searchParams.getAll("types"),
-    profileQueries: searchParams.getAll("profileQueries"),
+    types: searchParams.getAll("type"),
+    profileQueries: searchParams.getAll("profile"),
   };
   const [userHidden, setUserHidden] = useState<string[]>(loadHidden());
   const [sizeHidden, setSizeHidden] = useState<string[]>([]);

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -60,7 +60,7 @@ const InstanceSearchFilter: FC<Props> = ({ instances }) => {
       .map((chip) => chip.value as LxdInstanceStatus);
     const filteredTypes = searchData
       .filter((chip) => chip.lead === "type")
-      .map((chip) => (chip.value === "VM" ? "virtual-machine" : "container"));
+      .map((chip) => chip.value);
 
     const profileQueries = searchData
       .filter((chip) => chip.lead === "profile")

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -1,10 +1,6 @@
 import React, { FC, useEffect } from "react";
 import { LxdInstance, LxdInstanceStatus } from "types/instance";
-import {
-  enrichStatuses,
-  instanceStatuses,
-  instanceTypes,
-} from "util/instanceFilter";
+import { instanceStatuses, instanceTypes } from "util/instanceFilter";
 import { SearchAndFilter } from "@canonical/react-components";
 import {
   SearchAndFilterData,
@@ -53,7 +49,7 @@ const InstanceSearchFilter: FC<Props> = ({ instances }) => {
       }),
     },
   ];
-  const [_, setSearchParams] = useSearchParams();
+  const setSearchParams = useSearchParams()[1];
   const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
     const filteredQueries = searchData
       .filter((chip) => chip.quoteValue === true || chip.lead === "query")
@@ -70,53 +66,50 @@ const InstanceSearchFilter: FC<Props> = ({ instances }) => {
       .filter((chip) => chip.lead === "profile")
       .map((chip) => chip.value);
 
-    const url = new URL(window.location.origin + window.location.pathname);
-
+    const currentWindowSearchParams = new URLSearchParams(
+      window.location.search,
+    );
+    const newSearchParams = new URLSearchParams();
     filteredQueries.forEach((query) => {
-      url.searchParams.append("queries", query);
+      newSearchParams.append("q", query);
     });
 
     filteredStatuses.forEach((status) => {
-      url.searchParams.append("statuses", status);
+      newSearchParams.append("status", status);
     });
 
     filteredTypes.forEach((type) => {
-      url.searchParams.append("types", type);
+      newSearchParams.append("type", type);
     });
     profileQueries.forEach((profile) => {
-      url.searchParams.append("profileQueries", profile);
+      newSearchParams.append("profile", profile);
     });
-    if (url.href !== window.location.href) {
-      setSearchParams(url.searchParams);
+    if (newSearchParams.toString() !== currentWindowSearchParams.toString()) {
+      setSearchParams(newSearchParams);
     }
   };
 
   const getChips = (): SearchAndFilterChip[] => {
     const searchParams = new URLSearchParams(window.location.search);
     const statusChipUrl = [
-      ...enrichStatuses(searchParams.getAll("statuses") as LxdInstanceStatus[])
-        .filter(
-          (statusType) =>
-            statusType === "Running" ||
-            statusType === "Stopped" ||
-            statusType === "Frozen",
-        )
-        .map((status) => ({
+      ...(searchParams.getAll("status") as LxdInstanceStatus[]).map(
+        (status) => ({
           lead: "status",
           value: status,
-        })),
+        }),
+      ),
     ];
 
     const newSearchData = [
       ...searchParams
-        .getAll("queries")
+        .getAll("q")
         .map((query) => ({ lead: "query", value: query })),
       ...statusChipUrl,
       ...searchParams
-        .getAll("types")
+        .getAll("type")
         .map((type) => ({ lead: "type", value: type })),
       ...searchParams
-        .getAll("profileQueries")
+        .getAll("profile")
         .map((profile) => ({ lead: "profile", value: profile })),
     ];
 


### PR DESCRIPTION
## Done

- Changed instance filtering to use url search query parameters instead of state
- Changed eslintrc to ignore variables that start with underscore as they remain unused ( happens in the case of useSearchParams where the variable is not used in the file InstanceSearchFilter.tsx)


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to instances page
    - Apply any combination of filters
    - Check if they are applied correctly
    - Check if filters are applied when reloading the page or pasting an url with existing filters on it
    - Check if additional filters can be applied/removed in the case mentioned above