### PR TITLE
Link to local docs

### DIFF
--- a/haproxy-demo.cfg
+++ b/haproxy-demo.cfg
@@ -10,10 +10,12 @@ defaults
 
 frontend lxd_frontend
   bind 0.0.0.0:80
-  acl is_lxd_core path_beg /1.0
+  acl is_core path_beg /1.0
+  acl is_docs path_beg /documentation
   acl is_backend_allowed hdr_sub(cookie) lxdUiBackend=LXD_UI_BACKEND_SECRET
-  use_backend lxd_core if is_lxd_core is_backend_allowed
-  use_backend lxd_core_denied if is_lxd_core !is_backend_allowed
+  use_backend lxd_core if is_core is_backend_allowed
+  use_backend lxd_core if is_docs is_backend_allowed
+  use_backend lxd_core_denied if is_core !is_backend_allowed
   default_backend lxd_ui
 
 backend lxd_ui

--- a/haproxy-dev.cfg
+++ b/haproxy-dev.cfg
@@ -10,9 +10,10 @@ defaults
 
 frontend lxd_frontend
   bind 0.0.0.0:8407 ssl verify optional crt keys/lxd-ui.pem ca-file keys/lxd-ui.crt
-  acl is_lxd_core path_beg /1.0
-  acl is_lxd_oidc path_beg /oidc
-  use_backend lxd_core if is_lxd_core || is_lxd_oidc
+  acl is_core path_beg /1.0
+  acl is_oidc path_beg /oidc
+  acl is_docs path_beg /documentation
+  use_backend lxd_core if is_core || is_oidc || is_docs
   default_backend lxd_ui
 
 backend lxd_ui

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,11 +10,13 @@ import { isWidthBelow, logout } from "util/helpers";
 import { useProject } from "context/project";
 import { useMenuCollapsed } from "context/menuCollapsed";
 import { getCookie } from "util/cookies";
+import { useDocs } from "context/useDocs";
 
 const isSmallScreen = () => isWidthBelow(620);
 
 const Navigation: FC = () => {
   const { isRestricted } = useAuth();
+  const docBaseLink = useDocs();
   const { menuCollapsed, setMenuCollapsed } = useMenuCollapsed();
   const { project, isLoading } = useProject();
   const [projectName, setProjectName] = useState(
@@ -257,7 +259,7 @@ const Navigation: FC = () => {
                   <li className="p-side-navigation__item">
                     <a
                       className="p-side-navigation__link"
-                      href="https://documentation.ubuntu.com/lxd/en/latest/"
+                      href={docBaseLink}
                       target="_blank"
                       rel="noreferrer"
                       title="Documentation"

--- a/src/components/forms/SnapshotsForm.tsx
+++ b/src/components/forms/SnapshotsForm.tsx
@@ -7,6 +7,7 @@ import InstanceConfigurationTable from "components/forms/InstanceConfigurationTa
 import { getInstanceKey } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 import SnapshotScheduleInput from "components/SnapshotScheduleInput";
+import { useDocs } from "context/useDocs";
 
 export interface SnapshotFormValues {
   snapshots_pattern?: string;
@@ -31,6 +32,8 @@ interface Props {
 }
 
 const SnapshotsForm: FC<Props> = ({ formik }) => {
+  const docBaseLink = useDocs();
+
   return (
     <InstanceConfigurationTable
       rows={[
@@ -47,7 +50,7 @@ const SnapshotsForm: FC<Props> = ({ formik }) => {
                   Pongo2 template string that represents the snapshot name (used
                   for scheduled snapshots and unnamed snapshots), see{" "}
                   <a
-                    href="https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/#instance-options-snapshots-names"
+                    href={`${docBaseLink}/reference/instance_options/#instance-options-snapshots-names`}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/src/context/useDocs.tsx
+++ b/src/context/useDocs.tsx
@@ -1,0 +1,21 @@
+import { useSettings } from "context/useSettings";
+
+export const useDocs = (): string => {
+  const remoteBase = "https://documentation.ubuntu.com/lxd/en/latest";
+  const localBase = "/documentation";
+
+  const { data: settings } = useSettings();
+  const serverVersion = settings?.environment?.server_version;
+  const serverMajor = parseInt(serverVersion?.split(".")[0] ?? "0");
+  const serverMinor = parseInt(serverVersion?.split(".")[1] ?? "0");
+
+  if (
+    !serverVersion ||
+    serverMajor < 5 ||
+    (serverMajor === 5 && serverMinor < 19)
+  ) {
+    return remoteBase;
+  }
+
+  return localBase;
+};

--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -27,8 +27,10 @@ import NotificationRow from "components/NotificationRow";
 import { isClusteredServer } from "util/settings";
 import BaseLayout from "components/BaseLayout";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 
 const ClusterList: FC = () => {
+  const docBaseLink = useDocs();
   const notify = useNotify();
   const { group: activeGroup } = useParams<{ group: string }>();
   const { data: settings } = useSettings();
@@ -62,7 +64,7 @@ const ClusterList: FC = () => {
       contentClassName="cluster-content"
       title={
         <HelpLink
-          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/clustering/"
+          href={`${docBaseLink}/explanation/clustering/`}
           title="Learn more about clustering"
         >
           {isClustered ? (
@@ -122,7 +124,7 @@ const ClusterList: FC = () => {
               <p>Add cluster members to this group.</p>
               <p>
                 <a
-                  href="https://documentation.ubuntu.com/lxd/en/latest/explanation/clustering/"
+                  href={`${docBaseLink}/explanation/clustering/`}
                   target="_blank"
                   rel="noreferrer"
                 >
@@ -145,7 +147,7 @@ const ClusterList: FC = () => {
             </p>
             <p>
               <a
-                href="https://documentation.ubuntu.com/lxd/en/latest/explanation/clustering/"
+                href={`${docBaseLink}/explanation/clustering/`}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -53,6 +53,7 @@ import NotificationRow from "components/NotificationRow";
 import SelectedTableNotification from "components/SelectedTableNotification";
 import CustomLayout from "components/CustomLayout";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 import { LxdInstanceStatus } from "types/instance";
 
 const loadHidden = () => {
@@ -67,6 +68,7 @@ const saveHidden = (columns: string[]) => {
 const isMediumScreen = () => isWidthBelow(820);
 
 const InstanceList: FC = () => {
+  const docBaseLink = useDocs();
   const instanceLoading = useInstanceLoading();
   const navigate = useNavigate();
   const notify = useNotify();
@@ -487,7 +489,7 @@ const InstanceList: FC = () => {
           <div className="instance-header-left">
             <h1 className="p-heading--4 u-no-margin--bottom">
               <HelpLink
-                href="https://documentation.ubuntu.com/lxd/en/latest/explanation/instances/#expl-instances"
+                href={`${docBaseLink}/explanation/instances/#expl-instances`}
                 title="Learn more about instances"
               >
                 Instances
@@ -621,7 +623,7 @@ const InstanceList: FC = () => {
               </p>
               <p>
                 <a
-                  href="https://documentation.ubuntu.com/lxd/en/latest/howto/instances_create/"
+                  href={`${docBaseLink}/howto/instances_create/`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -24,6 +24,7 @@ import Loader from "components/Loader";
 import { useProject } from "context/project";
 import ScrollableTable from "components/ScrollableTable";
 import SelectedTableNotification from "components/SelectedTableNotification";
+import { useDocs } from "context/useDocs";
 
 const collapsedViewMaxWidth = 1250;
 export const figureCollapsedScreen = (): boolean =>
@@ -34,6 +35,7 @@ interface Props {
 }
 
 const InstanceSnapshots: FC<Props> = ({ instance }) => {
+  const docBaseLink = useDocs();
   const [query, setQuery] = useState<string>("");
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const [inTabNotification, setInTabNotification] =
@@ -309,7 +311,7 @@ const InstanceSnapshots: FC<Props> = ({ instance }) => {
           </p>
           <p>
             <a
-              href="https://documentation.ubuntu.com/lxd/en/latest/howto/storage_backup_volume/#storage-backup-snapshots"
+              href={`${docBaseLink}/howto/storage_backup_volume/#storage-backup-snapshots`}
               target="_blank"
               rel="noreferrer"
             >

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -15,8 +15,10 @@ import Loader from "components/Loader";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 
 const NetworkList: FC = () => {
+  const docBaseLink = useDocs();
   const navigate = useNavigate();
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
@@ -124,7 +126,7 @@ const NetworkList: FC = () => {
       <BaseLayout
         title={
           <HelpLink
-            href="https://documentation.ubuntu.com/lxd/en/latest/explanation/networks/"
+            href={`${docBaseLink}/explanation/networks/`}
             title="Learn more about networking"
           >
             Networks
@@ -178,7 +180,7 @@ const NetworkList: FC = () => {
               <p>There are no networks in this project.</p>
               <p>
                 <a
-                  href="https://documentation.ubuntu.com/lxd/en/latest/explanation/networks/"
+                  href={`${docBaseLink}/explanation/networks/`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/pages/networks/forms/NetworkTypeSelector.tsx
+++ b/src/pages/networks/forms/NetworkTypeSelector.tsx
@@ -5,12 +5,14 @@ import { NetworkFormValues } from "pages/networks/forms/NetworkForm";
 import { useSettings } from "context/useSettings";
 import { supportsFanNetwork, supportsOvnNetwork } from "util/settings";
 import Loader from "components/Loader";
+import { useDocs } from "context/useDocs";
 
 interface Props {
   formik: FormikProps<NetworkFormValues>;
 }
 
 const NetworkTypeSelector: FC<Props> = ({ formik }) => {
+  const docBaseLink = useDocs();
   const { data: settings, isLoading } = useSettings();
   const hasOvn = supportsOvnNetwork(settings);
   const hasFan = supportsFanNetwork(settings);
@@ -29,7 +31,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           Bridge (FAN) is only available on ubuntu, OVN needs to be configured
           in LXD as <code>network.ovn.northbound_connection</code>{" "}
           <a
-            href="https://documentation.ubuntu.com/lxd/en/latest/howto/network_ovn_setup/#set-up-a-lxd-cluster-on-ovn"
+            href={`${docBaseLink}/howto/network_ovn_setup/#set-up-a-lxd-cluster-on-ovn`}
             target="_blank"
             rel="noreferrer"
           >

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -25,8 +25,10 @@ import ScrollableTable from "components/ScrollableTable";
 import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 
 const ProfileList: FC = () => {
+  const docBaseLink = useDocs();
   const navigate = useNavigate();
   const notify = useNotify();
   const panelParams = usePanelParams();
@@ -168,7 +170,7 @@ const ProfileList: FC = () => {
           <div className="profile-header-left">
             <h1 className="p-heading--4 u-no-margin--bottom">
               <HelpLink
-                href="https://documentation.ubuntu.com/lxd/en/latest/profiles/"
+                href={`${docBaseLink}/profiles/`}
                 title="Learn how to use profiles"
               >
                 Profiles

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -10,12 +10,14 @@ import DeleteProjectBtn from "./actions/DeleteProjectBtn";
 import { useNotify } from "@canonical/react-components";
 import HelpLink from "components/HelpLink";
 import { useEventQueue } from "context/eventQueue";
+import { useDocs } from "context/useDocs";
 
 interface Props {
   project: LxdProject;
 }
 
 const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
+  const docBaseLink = useDocs();
   const eventQueue = useEventQueue();
   const navigate = useNavigate();
   const notify = useNotify();
@@ -68,7 +70,7 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
       parentItems={[
         <HelpLink
           key="project-configuration"
-          href="https://documentation.ubuntu.com/lxd/en/latest/reference/projects/"
+          href={`${docBaseLink}/reference/projects/`}
           title="Learn more about project configuration"
         >
           Project configuration

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -15,10 +15,12 @@ import { useSettings } from "context/useSettings";
 import NotificationRow from "components/NotificationRow";
 import ScrollableTable from "components/ScrollableTable";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 
 const configOptionsUrl = "/ui/assets/data/config-options.json";
 
 const Settings: FC = () => {
+  const docBaseLink = useDocs();
   const [configOptions, setConfigOptions] = useState<LxdConfigField[]>([]);
   const [query, setQuery] = useState("");
   const notify = useNotify();
@@ -126,7 +128,7 @@ const Settings: FC = () => {
       <BaseLayout
         title={
           <HelpLink
-            href="https://documentation.ubuntu.com/lxd/en/latest/server/"
+            href={`${docBaseLink}/server/`}
             title="Learn more about server configuration"
           >
             Settings

--- a/src/pages/storage/CustomIsoList.tsx
+++ b/src/pages/storage/CustomIsoList.tsx
@@ -19,12 +19,14 @@ import ScrollableTable from "components/ScrollableTable";
 import { usePagination } from "util/pagination";
 import Pagination from "components/Pagination";
 import { Link } from "react-router-dom";
+import { useDocs } from "context/useDocs";
 
 interface Props {
   project: string;
 }
 
 const CustomIsoList: FC<Props> = ({ project }) => {
+  const docBaseLink = useDocs();
   const notify = useNotify();
   const [query, setQuery] = useState<string>("");
 
@@ -145,7 +147,7 @@ const CustomIsoList: FC<Props> = ({ project }) => {
       <p>Custom ISOs will appear here</p>
       <p>
         <a
-          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/"
+          href={`${docBaseLink}/explanation/storage/`}
           target="_blank"
           rel="noreferrer"
         >

--- a/src/pages/storage/Storage.tsx
+++ b/src/pages/storage/Storage.tsx
@@ -9,6 +9,7 @@ import StoragePools from "pages/storage/StoragePools";
 import StorageVolumes from "pages/storage/StorageVolumes";
 import HelpLink from "components/HelpLink";
 import TabLinks from "components/TabLinks";
+import { useDocs } from "context/useDocs";
 
 export const tabs: string[] = [
   "Pools",
@@ -18,6 +19,7 @@ export const tabs: string[] = [
 ];
 
 const Storage: FC = () => {
+  const docBaseLink = useDocs();
   const { project, activeTab } = useParams<{
     project: string;
     activeTab?: string;
@@ -31,7 +33,7 @@ const Storage: FC = () => {
     <BaseLayout
       title={
         <HelpLink
-          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/"
+          href={`${docBaseLink}/explanation/storage/`}
           title="Learn more about storage pools, volumes and buckets"
         >
           Storage

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -16,8 +16,10 @@ import StoragePoolSize from "pages/storage/StoragePoolSize";
 import CreateStoragePoolBtn from "pages/storage/actions/CreateStoragePoolBtn";
 import ScrollableTable from "components/ScrollableTable";
 import StorageVolumesInPoolBtn from "pages/storage/actions/StorageVolumesInPoolBtn";
+import { useDocs } from "context/useDocs";
 
 const StoragePools: FC = () => {
+  const docBaseLink = useDocs();
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
 
@@ -178,7 +180,7 @@ const StoragePools: FC = () => {
       <p>Storage pools will appear here.</p>
       <p>
         <a
-          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/"
+          href={`${docBaseLink}/explanation/storage/`}
           target="_blank"
           rel="noreferrer"
         >

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -20,8 +20,10 @@ import StorageVolumesFilter, {
   StorageVolumesFilterType,
 } from "pages/storage/StorageVolumesFilter";
 import StorageVolumeSize from "pages/storage/StorageVolumeSize";
+import { useDocs } from "context/useDocs";
 
 const StorageVolumes: FC = () => {
+  const docBaseLink = useDocs();
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
   const [filters, setFilters] = useState<StorageVolumesFilterType>({
@@ -199,7 +201,7 @@ const StorageVolumes: FC = () => {
       <p>Storage volumes will appear here</p>
       <p>
         <a
-          href="https://documentation.ubuntu.com/lxd/en/latest/explanation/storage/"
+          href={`${docBaseLink}/explanation/storage/`}
           target="_blank"
           rel="noreferrer"
         >

--- a/src/pages/storage/forms/StorageVolumeFormSnapshots.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormSnapshots.tsx
@@ -5,12 +5,15 @@ import ConfigurationTable from "components/ConfigurationTable";
 import { getStorageConfigurationRow } from "pages/storage/forms/StorageConfigurationRow";
 import { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
 import SnapshotScheduleInput from "components/SnapshotScheduleInput";
+import { useDocs } from "context/useDocs";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
 }
 
 const StorageVolumeFormSnapshots: FC<Props> = ({ formik }) => {
+  const docBaseLink = useDocs();
+
   return (
     <ConfigurationTable
       rows={[
@@ -27,7 +30,7 @@ const StorageVolumeFormSnapshots: FC<Props> = ({ formik }) => {
                   Pongo2 template string that represents the snapshot name (used
                   for scheduled snapshots and unnamed snapshots), see{" "}
                   <a
-                    href="https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/#instance-options-snapshots-names"
+                    href={`${docBaseLink}/reference/instance_options/#instance-options-snapshots-names`}
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -8,8 +8,10 @@ import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
 
 const WarningList: FC = () => {
+  const docBaseLink = useDocs();
   const notify = useNotify();
 
   const {
@@ -100,7 +102,7 @@ const WarningList: FC = () => {
       <BaseLayout
         title={
           <HelpLink
-            href="https://documentation.ubuntu.com/lxd/en/latest/howto/troubleshoot/"
+            href={`${docBaseLink}/howto/troubleshoot/`}
             title="Learn more about troubleshooting"
           >
             Warnings

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -28,8 +28,7 @@ export const deleteNetwork = async (page: Page, network: string) => {
 };
 
 export const visitNetwork = async (page: Page, network: string) => {
-  await page.goto("/ui/");
-  await page.getByRole("link", { name: "Networks", exact: true }).click();
+  await page.getByTitle("Networks (default)").click();
   await page.getByRole("link", { name: network }).first().click();
 };
 


### PR DESCRIPTION
## Done

- docs are now shipped with lxd, link to the local docs,  when server version is bigger than 5.18

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check documentation links for a lxd backend with a recent version (bigger than 5.18) -- spot checking should be enough and code review that they are unchanged apart from the base url.