### PR TITLE
README: Pass the `--channel` argument to `snap refresh`, not only `--stable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Targets small and large scale private clouds.
 
 Get the LXD snap
 
-    sudo snap install --stable lxd
+    sudo snap install --channel=latest/stable lxd
 
 Or refresh to ensure at least version 5.14 is installed
 
-    sudo snap refresh --stable lxd
+    sudo snap refresh --channel=latest/stable lxd
 
 Follow the guide to [access the LXD web UI](https://documentation.ubuntu.com/lxd/en/latest/howto/access_ui/).
 


### PR DESCRIPTION
## Done

On the README you can read the following:

> Or refresh to ensure at least version 5.14 is installed
> ```
> sudo snap refresh --stable lxd
> ```

But this doesn't work. If you are on 5.0.2, you'll get this output:

```
root@dear-dinosaur:~# snap refresh --stable lxd
lxd (5.0/stable) 5.0.2-838e1b2 from Canonical✓ refreshed
```

The `latest/stable` channel should be passed instead, to ensure that you refresh to at least the 5.14 version.