### PR TITLE
Improve storage

### DIFF
--- a/src/components/TabLinks.tsx
+++ b/src/components/TabLinks.tsx
@@ -3,9 +3,10 @@ import { Tabs } from "@canonical/react-components";
 import { useNotify } from "@canonical/react-components";
 import { useNavigate } from "react-router-dom";
 import { slugify } from "util/slugify";
+import { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
 
 interface Props {
-  tabs: string[];
+  tabs: (string | TabLink)[];
   activeTab?: string;
   tabUrl: string;
 }
@@ -13,12 +14,15 @@ interface Props {
 const TabLinks: FC<Props> = ({ tabs, activeTab, tabUrl }) => {
   const notify = useNotify();
   const navigate = useNavigate();
-  const tabsPath = tabs.map((tab) => slugify(tab));
 
   return (
     <Tabs
-      links={tabs.map((tab, index) => {
-        const tabPath = tabsPath[index];
+      links={tabs.map((tab) => {
+        if (typeof tab !== "string") {
+          return tab;
+        }
+
+        const tabPath = slugify(tab);
         const href = tab === tabs[0] ? tabUrl : `${tabUrl}/${tabPath}`;
 
         return {

--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -7,8 +7,17 @@ import {
   SearchAndFilterData,
 } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import { useSearchParams } from "react-router-dom";
+import {
+  paramsFromSearchData,
+  searchParamsToChips,
+} from "util/searchAndFilter";
 
-const QUERY_PARAMS = ["query", "status", "type", "profile"];
+export const QUERY = "query";
+export const STATUS = "status";
+export const TYPE = "type";
+export const PROFILE = "profile";
+
+const QUERY_PARAMS = [QUERY, STATUS, TYPE, PROFILE];
 
 interface Props {
   instances: LxdInstance[];
@@ -26,69 +35,41 @@ const InstanceSearchFilter: FC<Props> = ({ instances }) => {
       id: 1,
       heading: "Status",
       chips: instanceStatuses.map((status) => {
-        return { lead: "status", value: status };
+        return { lead: STATUS, value: status };
       }),
     },
     {
       id: 2,
       heading: "Instance type",
       chips: instanceTypes.map((type) => {
-        return { lead: "type", value: type };
+        return { lead: TYPE, value: type };
       }),
     },
     {
       id: 3,
       heading: "Profile",
       chips: profileSet.map((profile) => {
-        return { lead: "profile", value: profile };
+        return { lead: PROFILE, value: profile };
       }),
     },
   ];
 
   const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
-    const searchValuesByLead = (lead: string) =>
-      searchData
-        .filter(
-          (chip) => chip.lead === lead || (lead === "query" && chip.quoteValue),
-        )
-        .map((chip) => chip.value);
-
-    const newParams = new URLSearchParams(searchParams.toString());
-
-    QUERY_PARAMS.forEach((param) => {
-      newParams.delete(param);
-      searchValuesByLead(param).forEach((value) => {
-        if (!newParams.has(param, value)) {
-          newParams.append(param, value);
-        }
-      });
-    });
+    const newParams = paramsFromSearchData(
+      searchData,
+      searchParams,
+      QUERY_PARAMS,
+    );
 
     if (newParams.toString() !== searchParams.toString()) {
       setSearchParams(newParams);
     }
   };
 
-  const searchParamsToChips = () => {
-    const searchData: SearchAndFilterChip[] = [];
-    QUERY_PARAMS.forEach((param) =>
-      searchData.push(
-        ...searchParams
-          .getAll(param)
-          .map((value) =>
-            param === "query"
-              ? { quoteValue: true, value }
-              : { lead: param, value },
-          ),
-      ),
-    );
-    return searchData;
-  };
-
   return (
     <div className="search-wrapper margin-right u-no-margin--bottom">
       <SearchAndFilter
-        existingSearchData={searchParamsToChips()}
+        existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}
         filterPanelData={searchAndFilterData}
         returnSearchData={onSearchDataChange}
         onExpandChange={() => {

--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -7,6 +7,7 @@ import { loadCustomVolumes } from "context/loadCustomVolumes";
 import ScrollableTable from "components/ScrollableTable";
 import { LxdStorageVolume } from "types/storage";
 import NotificationRow from "components/NotificationRow";
+import { contentTypeForDisplay } from "util/storageVolume";
 
 interface Props {
   project: string;
@@ -69,7 +70,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
           "aria-label": "Storage pool",
         },
         {
-          content: volume.content_type,
+          content: contentTypeForDisplay(volume),
           role: "cell",
           "aria-label": "Content type",
         },

--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { Row, useNotify } from "@canonical/react-components";
+import { Icon, Row, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import { fetchStoragePool } from "api/storage-pools";
 import StoragePoolHeader from "pages/storage/StoragePoolHeader";
@@ -12,8 +12,7 @@ import CustomLayout from "components/CustomLayout";
 import EditStoragePool from "pages/storage/EditStoragePool";
 import { useClusterMembers } from "context/useClusterMembers";
 import TabLinks from "components/TabLinks";
-
-const tabs: string[] = ["Overview", "Configuration"];
+import { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
 
 const StoragePoolDetail: FC = () => {
   const notify = useNotify();
@@ -51,6 +50,22 @@ const StoragePoolDetail: FC = () => {
   } else if (!pool) {
     return <>Loading storage details failed</>;
   }
+
+  const tabs: (string | TabLink)[] = [
+    "Overview",
+    "Configuration",
+    {
+      component: () => (
+        <a
+          href={`/ui/project/${project}/storage/volumes?pool=${pool.name}`}
+          className="p-tabs__link"
+        >
+          Volumes <Icon name="external-link" />
+        </a>
+      ),
+      label: "Volumes",
+    },
+  ];
 
   return (
     <CustomLayout

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -8,7 +8,6 @@ import { renameStoragePool } from "api/storage-pools";
 import DeleteStoragePoolBtn from "pages/storage/actions/DeleteStoragePoolBtn";
 import { testDuplicateStoragePoolName } from "util/storagePool";
 import { useNotify } from "@canonical/react-components";
-import StorageVolumesInPoolBtn from "pages/storage/actions/StorageVolumesInPoolBtn";
 
 interface Props {
   name: string;
@@ -63,13 +62,6 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
         </Link>,
       ]}
       controls={[
-        <StorageVolumesInPoolBtn
-          key="volumes"
-          pool={pool.name}
-          project={project}
-        >
-          Go to volumes
-        </StorageVolumesInPoolBtn>,
         <DeleteStoragePoolBtn
           key="delete"
           pool={pool}

--- a/src/pages/storage/StorageVolumeOverview.tsx
+++ b/src/pages/storage/StorageVolumeOverview.tsx
@@ -6,6 +6,10 @@ import useEventListener from "@use-it/event-listener";
 import { LxdStorageVolume } from "types/storage";
 import { isoTimeToString } from "util/helpers";
 import StorageVolumeSize from "pages/storage/StorageVolumeSize";
+import {
+  contentTypeForDisplay,
+  volumeTypeForDisplay,
+} from "util/storageVolume";
 
 interface Props {
   project: string;
@@ -34,11 +38,11 @@ const StorageVolumeOverview: FC<Props> = ({ project, volume }) => {
               </tr>
               <tr>
                 <th className="p-muted-heading">Type</th>
-                <td>{volume.type}</td>
+                <td>{volumeTypeForDisplay(volume)}</td>
               </tr>
               <tr>
                 <th className="p-muted-heading">Content type</th>
-                <td>{volume.content_type}</td>
+                <td>{contentTypeForDisplay(volume)}</td>
               </tr>
               <tr>
                 <th className="p-muted-heading">Description</th>

--- a/src/pages/storage/StorageVolumesFilter.tsx
+++ b/src/pages/storage/StorageVolumesFilter.tsx
@@ -1,17 +1,15 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { SearchAndFilter } from "@canonical/react-components";
 import {
   SearchAndFilterData,
   SearchAndFilterChip,
 } from "@canonical/react-components/dist/components/SearchAndFilter/types";
-import { useLocation } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { LxdStorageVolume } from "types/storage";
-
-interface StorageFilterState {
-  state?: {
-    appliedPool: string;
-  };
-}
+import {
+  paramsFromSearchData,
+  searchParamsToChips,
+} from "util/searchAndFilter";
 
 export interface StorageVolumesFilterType {
   queries: string[];
@@ -22,48 +20,48 @@ export interface StorageVolumesFilterType {
 
 interface Props {
   volumes: LxdStorageVolume[];
-  setFilters: (newFilters: StorageVolumesFilterType) => void;
 }
 
 const volumeTypes: string[] = [
-  "container",
-  "virtual-machine",
-  "snapshot",
-  "image",
-  "custom",
+  "Container",
+  "VM",
+  "Snapshot",
+  "Image",
+  "Custom",
 ];
 
-const contentTypes: string[] = ["block", "filesystem", "iso"];
+export const QUERY = "query";
+export const POOL = "pool";
+export const VOLUME_TYPE = "volume-type";
+export const CONTENT_TYPE = "content-type";
 
-const POOL = "Pool";
-const VOLUME_TYPE = "Volume type";
-const CONTENT_TYPE = "Content type";
+const QUERY_PARAMS = [QUERY, POOL, VOLUME_TYPE, CONTENT_TYPE];
 
-const StorageVolumesFilter: FC<Props> = ({ volumes, setFilters }) => {
-  const { state } = useLocation() as StorageFilterState;
+const contentTypes: string[] = ["Block", "Filesystem", "ISO"];
 
-  useEffect(() => window.history.replaceState({}, ""), [state]);
+const StorageVolumesFilter: FC<Props> = ({ volumes }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const pools = [...new Set(volumes.map((volume) => volume.pool))];
 
   const searchAndFilterData: SearchAndFilterData[] = [
     {
       id: 1,
-      heading: POOL,
+      heading: "Pool",
       chips: pools.map((pool) => {
         return { lead: POOL, value: pool };
       }),
     },
     {
       id: 2,
-      heading: VOLUME_TYPE,
+      heading: "Volume type",
       chips: volumeTypes.map((volumeType) => {
         return { lead: VOLUME_TYPE, value: volumeType };
       }),
     },
     {
       id: 3,
-      heading: CONTENT_TYPE,
+      heading: "Content type",
       chips: contentTypes.map((contentType) => {
         return { lead: CONTENT_TYPE, value: contentType };
       }),
@@ -71,32 +69,21 @@ const StorageVolumesFilter: FC<Props> = ({ volumes, setFilters }) => {
   ];
 
   const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
-    const getChipValue = (lead: string) =>
-      searchData.filter((chip) => chip.lead === lead).map((chip) => chip.value);
+    const newParams = paramsFromSearchData(
+      searchData,
+      searchParams,
+      QUERY_PARAMS,
+    );
 
-    setFilters({
-      queries: searchData
-        .filter((chip) => chip.quoteValue)
-        .map((chip) => chip.value.toLowerCase()),
-      pools: getChipValue(POOL),
-      volumeTypes: getChipValue(VOLUME_TYPE),
-      contentTypes: getChipValue(CONTENT_TYPE),
-    });
+    if (newParams.toString() !== searchParams.toString()) {
+      setSearchParams(newParams);
+    }
   };
 
   return (
     <div className="search-wrapper margin-right u-sv3">
       <SearchAndFilter
-        existingSearchData={
-          state?.appliedPool
-            ? [
-                {
-                  lead: POOL,
-                  value: state.appliedPool,
-                },
-              ]
-            : undefined
-        }
+        existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}
         filterPanelData={searchAndFilterData}
         returnSearchData={onSearchDataChange}
         onExpandChange={() => {

--- a/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
@@ -29,12 +29,29 @@ const DeleteStorageVolumeBtn: FC<Props> = ({
   const notify = useNotify();
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
-  const disabledReason =
-    volume.type !== "custom"
-      ? "Only custom volumes can be deleted"
-      : (volume.used_by?.length ?? 0) > 0
-      ? "Remove all usages of the volume to delete it"
-      : undefined;
+
+  const getDisabledReason = () => {
+    if (volume.name.includes("/")) {
+      return "Go to the instance detail page, to remove this snapshot";
+    }
+    if (volume.type === "container") {
+      return "Go to the instance detail page, to remove this container";
+    }
+    if (volume.type === "virtual-machine") {
+      return "Go to the instance detail page, to remove this virtual-machine";
+    }
+    if (volume.type === "image") {
+      return "Go to the image list, to remove this image";
+    }
+    if (volume.type !== "custom") {
+      return "Only custom volumes can be deleted";
+    }
+    if (volume.used_by?.length ?? 0) {
+      return "Remove all usages of the volume to delete it";
+    }
+    return undefined;
+  };
+  const disabledReason = getDisabledReason();
 
   const handleDelete = () => {
     setLoading(true);

--- a/src/pages/storage/actions/StorageVolumesInPoolBtn.tsx
+++ b/src/pages/storage/actions/StorageVolumesInPoolBtn.tsx
@@ -21,11 +21,7 @@ const StorageVolumesInPoolBtn: FC<Props> = ({
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/ui/project/${project}/storage/volumes`, {
-      state: {
-        appliedPool: pool,
-      },
-    });
+    navigate(`/ui/project/${project}/storage/volumes?pool=${pool}`);
   };
 
   return (

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -48,12 +48,17 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
           <DiskSizeSelector
             label="Size"
             value={formik.values.size}
-            help="Size of storage volume. If empty, volume will not have a size limit
-            within its storage pool."
+            help={
+              formik.values.type === "custom"
+                ? "Size of storage volume. If empty, volume will not have a size limit within its storage pool."
+                : "Size is immutable for non-custom volumes."
+            }
             setMemoryLimit={(val?: string) =>
               void formik.setFieldValue("size", val)
             }
-            disabled={formik.values.isReadOnly}
+            disabled={
+              formik.values.isReadOnly || formik.values.type !== "custom"
+            }
           />
           <Select
             {...getFormProps(formik, "content_type")}
@@ -68,7 +73,11 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
               },
             ]}
             label="Content type"
-            help="Type filesystem is ready to mount and write files to. Type block can only be attached to VMs, and is treated like an empty block device."
+            help={
+              formik.values.isCreating
+                ? "Type filesystem is ready to mount and write files to. Type block can only be attached to VMs, and is treated like an empty block device."
+                : "Content type is immutable after creation."
+            }
             onChange={(e) => {
               if (e.target.value === "block") {
                 void formik.setFieldValue("block_filesystem", undefined);
@@ -78,7 +87,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
               }
               void formik.setFieldValue("content_type", e.target.value);
             }}
-            disabled={formik.values.isReadOnly}
+            disabled={formik.values.isReadOnly || !formik.values.isCreating}
           />
         </Col>
       </Row>

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -244,3 +244,6 @@ export const continueOrFinish = (
 
 export const logout = () =>
   void fetch("/oidc/logout").then(() => window.location.reload());
+
+export const capitalizeFirstLetter = (val: string) =>
+  val.charAt(0).toUpperCase() + val.slice(1);

--- a/src/util/searchAndFilter.spec.tsx
+++ b/src/util/searchAndFilter.spec.tsx
@@ -1,0 +1,66 @@
+import { paramsFromSearchData, searchParamsToChips } from "./searchAndFilter";
+
+describe("paramsFromSearchData and searchParamsToChips", () => {
+  it("translates searchdata to url params", () => {
+    const searchData = [
+      { quoteValue: true, value: "homer" },
+      { quoteValue: true, value: "simpson" },
+      { lead: "foo", value: "foo1" },
+      { lead: "foo", value: "foo2" },
+      { lead: "bar", value: "bar1" },
+    ];
+    const searchParams = new URLSearchParams();
+    const queryParams = ["query", "foo", "bar", "baz"];
+
+    const results = paramsFromSearchData(searchData, searchParams, queryParams);
+
+    expect(results.getAll("query").length).toBe(2);
+    expect(results.getAll("query")[0]).toBe("homer");
+    expect(results.getAll("query")[1]).toBe("simpson");
+    expect(results.getAll("foo").length).toBe(2);
+    expect(results.getAll("foo")[0]).toBe("foo1");
+    expect(results.getAll("foo")[1]).toBe("foo2");
+    expect(results.getAll("bar").length).toBe(1);
+    expect(results.getAll("bar")[0]).toBe("bar1");
+    expect(results.getAll("baz").length).toBe(0);
+  });
+
+  it("preserves other url params", () => {
+    const searchData = [
+      { quoteValue: true, value: "homer" },
+      { lead: "foo", value: "foo1" },
+    ];
+    const searchParams = new URLSearchParams();
+    searchParams.set("keepMe", "keepMeValue");
+    const queryParams = ["query", "foo", "bar"];
+
+    const results = paramsFromSearchData(searchData, searchParams, queryParams);
+
+    expect(results.getAll("query").length).toBe(1);
+    expect(results.getAll("query")[0]).toBe("homer");
+    expect(results.getAll("foo").length).toBe(1);
+    expect(results.getAll("foo")[0]).toBe("foo1");
+    expect(results.getAll("bar").length).toBe(0);
+    expect(results.getAll("keepMe").length).toBe(1);
+    expect(results.getAll("keepMe")[0]).toBe("keepMeValue");
+  });
+
+  it("translates url params to search chips", () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append("query", "homer");
+    searchParams.append("query", "simpson");
+    searchParams.append("foo", "foo1");
+    searchParams.append("otherValue", "ignoreMe");
+    const queryParams = ["query", "foo", "bar", "baz"];
+
+    const results = searchParamsToChips(searchParams, queryParams);
+
+    expect(results.length).toBe(3);
+    expect(results[0].quoteValue).toBe(true);
+    expect(results[0].value).toBe("homer");
+    expect(results[1].quoteValue).toBe(true);
+    expect(results[1].value).toBe("simpson");
+    expect(results[2].lead).toBe("foo");
+    expect(results[2].value).toBe("foo1");
+  });
+});

--- a/src/util/searchAndFilter.tsx
+++ b/src/util/searchAndFilter.tsx
@@ -1,0 +1,44 @@
+import { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
+
+export const paramsFromSearchData = (
+  searchData: SearchAndFilterChip[],
+  searchParams: URLSearchParams,
+  queryParams: string[],
+): URLSearchParams => {
+  const newParams = new URLSearchParams(searchParams.toString());
+
+  queryParams.forEach((param) => {
+    newParams.delete(param);
+    searchValuesByLead(searchData, param).forEach((value) =>
+      newParams.append(param, value),
+    );
+  });
+
+  return newParams;
+};
+
+const searchValuesByLead = (searchData: SearchAndFilterChip[], lead: string) =>
+  searchData
+    .filter(
+      (chip) => chip.lead === lead || (lead === "query" && chip.quoteValue),
+    )
+    .map((chip) => chip.value);
+
+export const searchParamsToChips = (
+  searchParams: URLSearchParams,
+  queryParams: string[],
+) => {
+  const searchData: SearchAndFilterChip[] = [];
+  queryParams.forEach((param) =>
+    searchData.push(
+      ...searchParams
+        .getAll(param)
+        .map((value) =>
+          param === "query"
+            ? { quoteValue: true, value }
+            : { lead: param, value },
+        ),
+    ),
+  );
+  return searchData;
+};

--- a/src/util/storageVolume.tsx
+++ b/src/util/storageVolume.tsx
@@ -1,6 +1,10 @@
-import { AbortControllerState, checkDuplicateName } from "util/helpers";
+import {
+  AbortControllerState,
+  capitalizeFirstLetter,
+  checkDuplicateName,
+} from "util/helpers";
 import { AnyObject, TestContext, TestFunction } from "yup";
-import { LxdStoragePool } from "types/storage";
+import { LxdStoragePool, LxdStorageVolume } from "types/storage";
 import { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
 
 export const testDuplicateStorageVolumeName = (
@@ -79,4 +83,19 @@ export const getLxdDefault = (
     return [storageVolumeDefaults[formField], "LXD"];
   }
   return ["", "LXD"];
+};
+
+export const volumeTypeForDisplay = (volume: LxdStorageVolume) => {
+  const typePrefix =
+    volume.type === "virtual-machine"
+      ? "VM"
+      : capitalizeFirstLetter(volume.type);
+  const typeSuffix = volume.name.includes("/") ? " (snapshot)" : "";
+  return `${typePrefix}${typeSuffix}`;
+};
+
+export const contentTypeForDisplay = (volume: LxdStorageVolume) => {
+  return volume.content_type === "iso"
+    ? "ISO"
+    : capitalizeFirstLetter(volume.content_type);
 };


### PR DESCRIPTION
## Done

- address various issues around storage creation/editing discovered during in person review. Notes are in [this doc](https://docs.google.com/document/d/1BehzsvBhTVXrSrlSjFUoo7eMppzwmNLNfYQ_aDhfgi4/edit#heading=h.4dkuyqueii9u)
- improve link from storage pool detail page to volumes, make it part of the tabs
- change storage volume filter state, to be persisted in the url, so it can be bookmarked, shared and linked to
- make content type immutable on storage volume edit form
- make size immutable on storage volume edit form, when the volume is not of type custom
- improve help text for disabled storage volume delete button, to hint the user how to remove this storage volume.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test storage pool detail page: link to volumes from tab list
    - test filters on storage volume list in url, reload, linking to it and changing filters should work as expected
    - edit a storage volume, ensure size and content type are immutable as described above in the "done" section
    - check the storage volume delete buttons help text from the storage volume list.