### PR TITLE
Add local docs for images page

### DIFF
--- a/src/pages/images/Images.tsx
+++ b/src/pages/images/Images.tsx
@@ -4,13 +4,16 @@ import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
 import ImageList from "pages/images/ImageList";
 import { Row } from "@canonical/react-components";
+import { useDocs } from "context/useDocs";
 
 const Images: FC = () => {
+  const docBaseLink = useDocs();
+
   return (
     <BaseLayout
       title={
         <HelpLink
-          href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/"
+          href={`${docBaseLink}/image-handling/`}
           title="Learn more about images"
         >
           Images


### PR DESCRIPTION
## Done

- Added the local docs logic to the Images page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to the Images page
    - Check that, if LXD version is above 5.18, a local docs link is present for the info icon in the header instead of the remote one