### PR TITLE
Show interface name next to ip addresses WD-7270

### DIFF
--- a/src/pages/instances/InstanceIps.tsx
+++ b/src/pages/instances/InstanceIps.tsx
@@ -12,9 +12,13 @@ const InstanceIps: FC<Props> = ({ instance, family }) => {
   const addresses = getIpAddresses(instance, family);
   return addresses.length ? (
     <ExpandableList
-      items={addresses.map((address) => (
-        <div key={address} className="ip u-truncate" title={address}>
-          {address}
+      items={addresses.map((item) => (
+        <div
+          key={item.address}
+          className="ip u-truncate"
+          title={`${item.address} (${item.iface})`}
+        >
+          {item.address} ({item.iface})
         </div>
       ))}
     />

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -309,12 +309,12 @@ const InstanceList: FC = () => {
       const openSummary = () =>
         panelParams.openInstanceSummary(instance.name, project);
 
-      const ipv4 = getIpAddresses(instance, "inet").filter(
-        (val) => !val.startsWith("127"),
-      );
-      const ipv6 = getIpAddresses(instance, "inet6").filter(
-        (val) => !val.startsWith("fe80"),
-      );
+      const ipv4 = getIpAddresses(instance, "inet")
+        .filter((val) => !val.address.startsWith("127"))
+        .map((val) => val.address);
+      const ipv6 = getIpAddresses(instance, "inet6")
+        .filter((val) => !val.address.startsWith("fe80"))
+        .map((val) => val.address);
 
       return {
         className:

--- a/src/pages/networks/MapTooltip.tsx
+++ b/src/pages/networks/MapTooltip.tsx
@@ -25,9 +25,9 @@ const MapTooltip: FC<MapTooltipProps> = ({ item, type }) => {
 
     const ipAddresses = getIpAddresses(instance, "inet")
       .concat(getIpAddresses(instance, "inet6"))
-      .map((address) => (
-        <li key={address} className="p-list__item">
-          {address}
+      .map((val) => (
+        <li key={val.address} className="p-list__item">
+          {val.address} ({val.iface})
         </li>
       ));
 

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -8,9 +8,12 @@ export const getIpAddresses = (
   if (!instance.state?.network) return [];
   return Object.entries(instance.state.network)
     .filter(([key, _value]) => key !== "lo")
-    .flatMap(([_key, value]) => value.addresses)
-    .filter((item) => item.family === family)
-    .map((item) => item.address);
+    .flatMap(([key, value]) =>
+      value.addresses.map((item) => {
+        return { ...item, iface: key };
+      }),
+    )
+    .filter((item) => item.family === family);
 };
 
 const networkDefaults: Record<string, string> = {


### PR DESCRIPTION
## Done

- display interface name next to ip address in instance detail page and side panel

Fixes WD-7270

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check ip addresses are displayed correctly in:
    - instance detail page (with interface)
    - instance list (no interface)
    - instance side panel (with interface)