### PR TITLE
Submit in custom disk device creation modal improvements

### DIFF
--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -30,8 +30,10 @@ const CustomVolumeSelectModal: FC<Props> = ({
     data: volumes = [],
     error,
     isLoading,
+    isFetching,
   } = useQuery({
     queryKey: [queryKeys.customVolumes],
+    refetchOnMount: (query) => query.state.isInvalidated,
     queryFn: () => loadCustomVolumes(project),
   });
 
@@ -52,57 +54,61 @@ const CustomVolumeSelectModal: FC<Props> = ({
     { "aria-label": "Actions", className: "actions" },
   ];
 
-  const rows = volumes.map((volume) => {
-    return {
-      columns: [
-        {
-          content: (
-            <div className="u-truncate iso-name" title={volume.name}>
-              {volume.name}
-            </div>
-          ),
-          role: "cell",
-          "aria-label": "Name",
-        },
-        {
-          content: volume.pool,
-          role: "cell",
-          "aria-label": "Storage pool",
-        },
-        {
-          content: contentTypeForDisplay(volume),
-          role: "cell",
-          "aria-label": "Content type",
-        },
-        {
-          content: volume.used_by?.length,
-          role: "cell",
-          "aria-label": "Used by",
-        },
-        {
-          content: (
-            <Button
-              onClick={() => handleSelect(volume)}
-              dense
-              appearance={
-                primaryVolume?.name === volume.name &&
-                primaryVolume.type === volume.type &&
-                primaryVolume.pool == volume.pool
-                  ? "positive"
-                  : ""
-              }
-              aria-label={`Select ${volume.name}`}
-            >
-              Select
-            </Button>
-          ),
-          role: "cell",
-          "aria-label": "Actions",
-          className: "u-align--right",
-        },
-      ],
-    };
-  });
+  const rows = isFetching
+    ? []
+    : volumes
+        .sort((a, b) => (a.created_at > b.created_at ? -1 : 1))
+        .map((volume) => {
+          return {
+            columns: [
+              {
+                content: (
+                  <div className="u-truncate iso-name" title={volume.name}>
+                    {volume.name}
+                  </div>
+                ),
+                role: "cell",
+                "aria-label": "Name",
+              },
+              {
+                content: volume.pool,
+                role: "cell",
+                "aria-label": "Storage pool",
+              },
+              {
+                content: contentTypeForDisplay(volume),
+                role: "cell",
+                "aria-label": "Content type",
+              },
+              {
+                content: volume.used_by?.length,
+                role: "cell",
+                "aria-label": "Used by",
+              },
+              {
+                content: (
+                  <Button
+                    onClick={() => handleSelect(volume)}
+                    dense
+                    appearance={
+                      primaryVolume?.name === volume.name &&
+                      primaryVolume.type === volume.type &&
+                      primaryVolume.pool == volume.pool
+                        ? "positive"
+                        : ""
+                    }
+                    aria-label={`Select ${volume.name}`}
+                  >
+                    Select
+                  </Button>
+                ),
+                role: "cell",
+                "aria-label": "Actions",
+                className: "u-align--right",
+              },
+            ],
+          };
+        });
 
   return (
     <>
@@ -118,7 +124,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
           sortable
           className="u-table-layout--auto"
           emptyStateMsg={
-            isLoading ? (
+            isLoading || isFetching ? (
               <Loader text="Loading volumes..." />
             ) : (
               "No custom volumes found"


### PR DESCRIPTION
## Done

- improve behaviour of submit in custom disk device creation modal for the instance configuration

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit or create an instance
    - select disk devices > Attach disk device > Create volume
    - ensure the creation and selection works.
    - The "Create volume" form should render the create button busy after submit (used to be no indicator while loading)
    - Coming back to the "Choose custom volume" should
      - render the new volume on top (used to be in the middle, now sorted by most recent created)
      - initially show a loading state until the new volume is included (used to be hidden and updating in the background at some time)