### PR TITLE
Fix terminal newlines

### DIFF
--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -44,6 +44,13 @@ const InstanceTextConsole: FC<Props> = ({
     message: "Are you sure you want to leave this page?",
   });
 
+  const handleCloseTab = (e: BeforeUnloadEvent) => {
+    if (userInteracted) {
+      e.returnValue = "Are you sure you want to leave this page?";
+    }
+  };
+  useEventListener("beforeunload", handleCloseTab);
+
   const isRunning = instance.status === "Running";
 
   const handleError = (e: object) => {
@@ -113,14 +120,9 @@ const InstanceTextConsole: FC<Props> = ({
       setDataWs(null);
     };
 
-    data.onmessage = (message: MessageEvent<Blob | string | null>) => {
-      if (typeof message.data === "string") {
-        xtermRef.current?.terminal.write(message.data);
-        return;
-      }
-      void message.data?.text().then((text: string) => {
-        xtermRef.current?.terminal.write(text);
-      });
+    data.binaryType = "arraybuffer";
+    data.onmessage = (message: MessageEvent<ArrayBuffer>) => {
+      xtermRef.current?.terminal.writeUtf8(new Uint8Array(message.data));
     };
 
     return [data, control];


### PR DESCRIPTION
## Done

- terminal was messy with newlines before due to race conditions on incoming messages through the websocket. Treating the messages as arraybuffer avoids the race
- show prompt on tab or browser close, when user interacted with the terminal, this avoids accidental terminal closing. Before we'd only prompt on navigation, not on close.

Fixes #537

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test the instance terminal. The newline bug could be reproduced by just keeping enter pressed to force a lot of new lines. This was reproducible for me only in firefox, not in chrome. This should now produce stable newlines
    - test the instance terminal prompt on tab close or reload. It should show a prompt when interacted with the terminal.

## Screenshots

Before broken terminal with newlines in wrong places due to a race condition:

![Screenshot from 2023-11-23 12-11-40](https://github.com/canonical/lxd-ui/assets/1155472/ce888ee7-ba84-4ad1-ac80-11ceb26ab975)

Fixed terminal with stable newlines:

![Screenshot from 2023-11-23 12-12-00](https://github.com/canonical/lxd-ui/assets/1155472/42572496-5651-4b22-8a52-4d90181b31f0)