### PR TITLE
Hide cached images when selecting an image for instance creation

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -108,6 +108,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const images = isLoading
     ? []
     : localImages
+        .filter((image) => !image.cached)
         .map(localLxdToRemoteImage)
         .concat([...minimalImages].reverse().sort(byLtsFirst))
         .concat([...canonicalImages].reverse().sort(byLtsFirst))

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -26,6 +26,7 @@ export interface LxdImage {
   size: number;
   uploaded_at: string;
   aliases: LxdImageAlias[];
+  cached: boolean;
 }
 
 export interface ImportImage {


### PR DESCRIPTION
## Done

- Hide locally cached images when selecting an image for instance launch

Fixes #551

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instance > chose image > the list should not list local images if they are cached. Only imported local images should be displayed. Importing is not yet supported by the UI, but possible on the CLI. We should support launching an instance with a local image that was imported in this way.