### PR TITLE
Make snapshot name optional

### DIFF
--- a/src/pages/instances/actions/snapshots/SnapshotForm.tsx
+++ b/src/pages/instances/actions/snapshots/SnapshotForm.tsx
@@ -90,7 +90,6 @@ const SnapshotForm: FC<Props> = ({
           name="name"
           type="text"
           label="Snapshot name"
-          required={true}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           value={formik.values.name}

--- a/src/util/snapshots.tsx
+++ b/src/util/snapshots.tsx
@@ -105,7 +105,6 @@ export const getSnapshotSchema = (
 ) => {
   return Yup.object().shape({
     name: Yup.string()
-      .required("This field is required")
       .test(
         ...testDuplicateSnapshotName(instance, controllerState, snapshotName),
       )


### PR DESCRIPTION
## Done

- make snapshot name optional, LXD will figure out the next name automatically, when not set.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to an instance > snapshots > create snapshot. Create a snapshot with or without a name. Both should work.