### PR TITLE
Ensure new creating instances are shown consistently during creation

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -130,18 +130,24 @@ const InstanceList: FC = () => {
   }
 
   const creationNames: string[] = [];
-  const creationOperations = (operationList?.running ?? []).filter(
-    (operation) => {
-      const isCreating =
-        operation.description === "Creating instance" &&
-        operation.status === "Running";
-      if (isCreating) {
-        const createInstanceName = getInstanceName(operation);
-        creationNames.push(createInstanceName);
+  const creationOperations = (operationList?.running ?? [])
+    .concat(operationList?.success ?? [])
+    .filter((operation) => {
+      const isCreating = operation.description === "Creating instance";
+      if (!isCreating) {
+        return false;
       }
-      return isCreating;
-    },
-  );
+      const name = getInstanceName(operation);
+      const isInInstanceList = instances.some((item) => item.name === name);
+      const isRunning = operation.status === "Running";
+
+      if (!isRunning && isInInstanceList) {
+        return false;
+      }
+
+      creationNames.push(name);
+      return true;
+    });
 
   const filteredInstances = instances.filter((item) => {
     if (creationNames.includes(item.name)) {


### PR DESCRIPTION
## Done

- ensure new creating instances are shown consistently. previously instances would shortly vanish from the instance list after creation and then reappear.

Fixes #549

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to a project with few or no instances. Create a new instance hit create and start. Ensure the instance list does not get shorter until the instance is started.