### PR TITLE
fix(instance) changed to better wording for selecting all instances in project

### DIFF
--- a/src/components/SelectedTableNotification.tsx
+++ b/src/components/SelectedTableNotification.tsx
@@ -59,8 +59,9 @@ const SelectedTableNotification: FC<Props> = ({
             onClick={selectAll}
           >
             Select all <b>{filteredNames.length}</b>{" "}
-            {filteredNames.length === totalCount ? parentName : "filtered"}{" "}
-            {itemName}s
+            {filteredNames.length === totalCount
+              ? `${itemName}s in ${parentName}`
+              : `filtered ${itemName}s`}
           </Button>
         </>
       )}

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -550,7 +550,7 @@ const InstanceList: FC = () => {
                     <SelectedTableNotification
                       totalCount={totalInstanceCount}
                       itemName="instance"
-                      parentName="project"
+                      parentName={`project: ${project}`}
                       selectedNames={selectedNames}
                       setSelectedNames={setSelectedNames}
                       filteredNames={filteredInstances.map(


### PR DESCRIPTION
## Done

- Updated wording in pagination control for bulk selecting all instances in a project
- Fixes [#552](https://github.com/canonical/lxd-ui/issues/552)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - On the instances page, select one instance and check the wording in the pagination control for selecting all instances
    - On the instances page, filter the instances first then perform the previous action.
    - In the snapshots tab for a single instance, select one snapshot and check wording in pagination control should say 'select all x snapshots in instance'

## Screenshots

![Screenshot from 2023-11-24 16-06-36](https://github.com/canonical/lxd-ui/assets/151511568/9201e3ff-61e9-45d5-bfeb-817ef309503f)

![image](https://github.com/canonical/lxd-ui/assets/151511568/f2da8966-6f28-44ee-8935-d3f22cb985a7)

![Screenshot from 2023-11-24 16-08-39](https://github.com/canonical/lxd-ui/assets/151511568/1eec6bd8-9cfc-48a4-a62c-e45cb1a88e2e)
