### PR TITLE
fix(component) improved textarea height adjustment to fit content exactly

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false
+}

--- a/src/components/AutoExpandingTextArea.tsx
+++ b/src/components/AutoExpandingTextArea.tsx
@@ -1,0 +1,33 @@
+import React, { FC, useLayoutEffect } from "react";
+import { Textarea, TextareaProps } from "@canonical/react-components";
+
+type Props = {
+  dynamicHeight?: boolean;
+  value?: string;
+} & TextareaProps;
+
+const AutoExpandingTextArea: FC<Props> = (props) => {
+  const { dynamicHeight, id, value, rows } = props;
+
+  useLayoutEffect(() => {
+    if (dynamicHeight) {
+      const textArea = document.getElementById(id || "");
+      if (textArea) {
+        textArea.style.height = "0px";
+        const scrollHeight = textArea.scrollHeight;
+        textArea.style.height = `${scrollHeight + 1}px`;
+      }
+    }
+  }, [value]);
+
+  return (
+    <div>
+      <Textarea
+        {...(props as TextareaProps)}
+        rows={dynamicHeight ? undefined : rows}
+      />
+    </div>
+  );
+};
+
+export default AutoExpandingTextArea;

--- a/src/pages/cluster/ClusterGroupForm.tsx
+++ b/src/pages/cluster/ClusterGroupForm.tsx
@@ -5,7 +5,6 @@ import {
   Form,
   Input,
   Row,
-  Textarea,
   useNotify,
 } from "@canonical/react-components";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -27,7 +26,7 @@ import { getClusterHeaders, getClusterRows } from "util/clusterGroups";
 import SelectableMainTable from "components/SelectableMainTable";
 import NotificationRow from "components/NotificationRow";
 import BaseLayout from "components/BaseLayout";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 export interface ClusterGroupFormValues {
   description: string;
@@ -131,7 +130,7 @@ const ClusterGroupForm: FC<Props> = ({ group }) => {
                 value={formik.values.name}
                 error={formik.touched.name ? formik.errors.name : null}
               />
-              <Textarea
+              <AutoExpandingTextArea
                 id="description"
                 name="description"
                 label="Description"
@@ -142,7 +141,7 @@ const ClusterGroupForm: FC<Props> = ({ group }) => {
                 error={
                   formik.touched.description ? formik.errors.description : null
                 }
-                rows={getTextareaRows(formik.values.description?.length)}
+                dynamicHeight
               />
             </div>
             <div className="choose-label">

--- a/src/pages/instances/forms/EditInstanceDetails.tsx
+++ b/src/pages/instances/forms/EditInstanceDetails.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from "react";
-import { Col, Input, Row, Textarea } from "@canonical/react-components";
+import { Col, Input, Row } from "@canonical/react-components";
 import ProfileSelect from "pages/profiles/ProfileSelector";
 import { FormikProps } from "formik/dist/types";
 import { EditInstanceFormValues } from "pages/instances/EditInstance";
 import { useSettings } from "context/useSettings";
 import MigrateInstanceBtn from "pages/instances/actions/MigrateInstanceBtn";
 import { isClusteredServer } from "util/settings";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 export interface InstanceEditDetailsFormValues {
   name: string;
@@ -55,7 +55,7 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
             required
             disabled={true}
           />
-          <Textarea
+          <AutoExpandingTextArea
             id="description"
             name="description"
             label="Description"
@@ -63,7 +63,7 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             value={formik.values.description}
-            rows={getTextareaRows(formik.values.description?.length)}
+            dynamicHeight
             disabled={isReadOnly}
           />
         </Col>

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -6,7 +6,6 @@ import {
   Input,
   Row,
   Select,
-  Textarea,
 } from "@canonical/react-components";
 import ProfileSelect from "pages/profiles/ProfileSelector";
 import SelectImageBtn from "pages/images/actions/SelectImageBtn";
@@ -17,7 +16,7 @@ import { CreateInstanceFormValues } from "pages/instances/CreateInstance";
 import { LxdImageType, RemoteImage } from "types/image";
 import InstanceLocationSelect from "pages/instances/forms/InstanceLocationSelect";
 import UseCustomIsoBtn from "pages/images/actions/UseCustomIsoBtn";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 export interface InstanceDetailsFormValues {
   name?: string;
@@ -89,7 +88,7 @@ const InstanceCreateDetailsForm: FC<Props> = ({
             value={formik.values.name}
             error={formik.touched.name ? formik.errors.name : null}
           />
-          <Textarea
+          <AutoExpandingTextArea
             id="description"
             name="description"
             label="Description"
@@ -97,7 +96,7 @@ const InstanceCreateDetailsForm: FC<Props> = ({
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             value={formik.values.description}
-            rows={getTextareaRows(formik.values.description?.length)}
+            dynamicHeight
           />
         </Col>
       </Row>

--- a/src/pages/networks/forms/NetworkFormMain.tsx
+++ b/src/pages/networks/forms/NetworkFormMain.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from "react";
-import { Col, Input, Row, Select, Textarea } from "@canonical/react-components";
+import { Col, Input, Row, Select } from "@canonical/react-components";
 import { FormikProps } from "formik/dist/types";
 import IpAddressSelector from "pages/networks/forms/IpAddressSelector";
 import ConfigurationTable from "components/ConfigurationTable";
@@ -8,7 +8,7 @@ import UplinkSelector from "pages/networks/forms/UplinkSelector";
 import { NetworkFormValues } from "pages/networks/forms/NetworkForm";
 import NetworkTypeSelector from "pages/networks/forms/NetworkTypeSelector";
 import { optionTrueFalse } from "util/instanceOptions";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 interface Props {
   formik: FormikProps<NetworkFormValues>;
@@ -45,11 +45,11 @@ const NetworkFormMain: FC<Props> = ({ formik, project }) => {
                 : undefined
             }
           />
-          <Textarea
+          <AutoExpandingTextArea
             {...getFormProps("description")}
             label="Description"
             disabled={formik.values.readOnly}
-            rows={getTextareaRows(formik.values.description?.length)}
+            dynamicHeight
           />
           {formik.values.type === "ovn" && (
             <UplinkSelector

--- a/src/pages/profiles/forms/ProfileDetailsForm.tsx
+++ b/src/pages/profiles/forms/ProfileDetailsForm.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
-import { Col, Input, Row, Textarea } from "@canonical/react-components";
+import { Col, Input, Row } from "@canonical/react-components";
 import { FormikProps } from "formik/dist/types";
 import { CreateProfileFormValues } from "pages/profiles/CreateProfile";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 export interface ProfileDetailsFormValues {
   name: string;
@@ -49,7 +49,7 @@ const ProfileDetailsForm: FC<Props> = ({ formik, isEdit }) => {
             required
             disabled={isEdit}
           />
-          <Textarea
+          <AutoExpandingTextArea
             id="description"
             name="description"
             label="Description"
@@ -57,8 +57,8 @@ const ProfileDetailsForm: FC<Props> = ({ formik, isEdit }) => {
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             value={formik.values.description}
-            rows={getTextareaRows(formik.values.description?.length)}
             disabled={isReadOnly}
+            dynamicHeight
           />
         </Col>
       </Row>

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -6,14 +6,13 @@ import {
   Input,
   Row,
   Select,
-  Textarea,
   Tooltip,
 } from "@canonical/react-components";
 import { FormikProps } from "formik/dist/types";
 import { getProjectKey } from "util/projectConfigFields";
 import { isProjectEmpty } from "util/projects";
 import { LxdProject } from "types/project";
-import { getTextareaRows } from "util/formFields";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 export interface ProjectDetailsFormValues {
   name: string;
@@ -127,7 +126,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             }
             required
           />
-          <Textarea
+          <AutoExpandingTextArea
             id="description"
             name="description"
             label="Description"
@@ -135,8 +134,8 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             onBlur={formik.handleBlur}
             onChange={formik.handleChange}
             value={formik.values.description}
-            rows={getTextareaRows(formik.values.description?.length)}
             disabled={formik.values.readOnly}
+            dynamicHeight
           />
           <Select
             id="features"

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode } from "react";
-import { Row, Input, Select, Col, Textarea } from "@canonical/react-components";
+import { Row, Input, Select, Col } from "@canonical/react-components";
 import { FormikProps } from "formik";
 import {
   zfsDriver,
@@ -9,8 +9,8 @@ import {
   getSourceHelpForDriver,
 } from "util/storageOptions";
 import { StoragePoolFormValues } from "./StoragePoolForm";
-import { getTextareaRows } from "util/formFields";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -44,11 +44,11 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
               : undefined
           }
         />
-        <Textarea
+        <AutoExpandingTextArea
           {...getFormProps("description")}
           label="Description"
-          rows={getTextareaRows(formik.values.description?.length)}
           disabled={formik.values.isReadOnly}
+          dynamicHeight
         />
         <Select
           id="driver"

--- a/src/util/formFields.tsx
+++ b/src/util/formFields.tsx
@@ -28,6 +28,3 @@ export const optionRenderer = (
 
   return "";
 };
-
-export const getTextareaRows = (textLength?: number) =>
-  Math.max(1, Math.ceil((textLength ?? 0) / 46));


### PR DESCRIPTION
## Done

- Improved text area dynamic height adjustment to fit contents exactly.
- Instead of using the row attribute for adjusting text area height, using comparison between scroll height and element height results in a better fit.
- Created a new component `AutoExpandingTextArea.tsx` which wraps `TextArea` from vanilla react component library, taking in a dynamic prop to cater for auto adjusting behaviour.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check text inputs in config forms for: editing instance details, editing cluster group details, editing network details, editing profile details, editing project details and editing storage pool details