### PR TITLE
Project details form: move notification row out of scrollable area

### DIFF
--- a/src/pages/projects/forms/ProjectForm.tsx
+++ b/src/pages/projects/forms/ProjectForm.tsx
@@ -49,27 +49,31 @@ const ProjectForm: FC<Props> = ({
         isRestrictionsDisabled={!formik.values.restricted}
         toggleRestrictionsOpen={toggleMenu}
       />
-      <Row className="form-contents" key={section}>
-        <Col size={12}>
-          <NotificationRow />
-          {section === PROJECT_DETAILS && (
-            <ProjectDetailsForm
-              formik={formik}
-              project={project}
-              isEdit={isEdit}
-            />
-          )}
-          {section === RESOURCE_LIMITS && (
-            <ProjectResourceLimitsForm formik={formik} />
-          )}
-          {section === CLUSTERS && <ClusterRestrictionForm formik={formik} />}
-          {section === INSTANCES && <InstanceRestrictionForm formik={formik} />}
-          {section === DEVICE_USAGE && (
-            <DeviceUsageRestrictionForm formik={formik} />
-          )}
-          {section === NETWORKS && <NetworkRestrictionForm formik={formik} />}
-        </Col>
-      </Row>
+      <div className="details-form-wrapper">
+        <NotificationRow />
+        <Row className="form-contents" key={section}>
+          <Col size={12}>
+            {section === PROJECT_DETAILS && (
+              <ProjectDetailsForm
+                formik={formik}
+                project={project}
+                isEdit={isEdit}
+              />
+            )}
+            {section === RESOURCE_LIMITS && (
+              <ProjectResourceLimitsForm formik={formik} />
+            )}
+            {section === CLUSTERS && <ClusterRestrictionForm formik={formik} />}
+            {section === INSTANCES && (
+              <InstanceRestrictionForm formik={formik} />
+            )}
+            {section === DEVICE_USAGE && (
+              <DeviceUsageRestrictionForm formik={formik} />
+            )}
+            {section === NETWORKS && <NetworkRestrictionForm formik={formik} />}
+          </Col>
+        </Row>
+      </div>
     </Form>
   );
 };

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -299,3 +299,9 @@
   overflow: auto;
   padding-right: $sph--large;
 }
+
+.details-form-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}


### PR DESCRIPTION
## Done

In the project configuration page, that unlike the ones for instances and profiles has no tabs, the notification of the outcome of an edit operation resulted to be hidden on medium/low window heights, as shown in the screen capture below:

![Peek 2023-12-01 12-12](https://github.com/canonical/lxd-ui/assets/56583786/49844fe8-d564-4fba-911b-37290147359c)

This can be easily solved by moving the notification row outside of the scrollable area:

![Peek 2023-12-01 12-13](https://github.com/canonical/lxd-ui/assets/56583786/575f5d0f-5cd0-4db8-a4b6-cbc6d85c143d)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open the project configuration page
    - Select "Customised" features from the dropdown
    - Reduce the window height if needed
    - Toggle the custom restrictions as shown in the screen captures below
    - Check that the notification of the result of the operation is immediately visible, and you don't have to manually scroll up to see it