### PR TITLE
Do not pass dynamicHeight as DOM attribute to textarea

### DIFF
--- a/src/components/AutoExpandingTextArea.tsx
+++ b/src/components/AutoExpandingTextArea.tsx
@@ -7,7 +7,8 @@ type Props = {
 } & TextareaProps;
 
 const AutoExpandingTextArea: FC<Props> = (props) => {
-  const { dynamicHeight, id, value, rows } = props;
+  const { dynamicHeight, ...textAreaProps } = props;
+  const { id, value, rows } = textAreaProps;
 
   useLayoutEffect(() => {
     if (dynamicHeight) {
@@ -23,7 +24,7 @@ const AutoExpandingTextArea: FC<Props> = (props) => {
   return (
     <div>
       <Textarea
-        {...(props as TextareaProps)}
+        {...(textAreaProps as TextareaProps)}
         rows={dynamicHeight ? undefined : rows}
       />
     </div>


### PR DESCRIPTION
## Done

- A tiny change to remove a React warning, complaining that an unrecognised "dynamicHeight" prop was being set on a DOM element:

![Screenshot from 2023-12-07 20:38:06](https://github.com/canonical/lxd-ui/assets/56583786/49277644-d54f-4af7-a970-4257ed361024)

## QA

1. Run the LXD-UI:
    - ~On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.~ The warning seems to appear only when running locally (dev).
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open the browser console from the dev tools
    - Go to a page where there is an auto-expanding textarea, e.g. the instance detail page, configuration tab
    - Check that no warning like the one in the screenshot above appears in the console