### PR TITLE
Add network forwards

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check inclusive naming
-        uses: canonical-web-and-design/inclusive-naming@main
+        uses: canonical/Inclusive-naming@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,16 @@ const CreateClusterGroup = lazy(
 );
 const CreateInstance = lazy(() => import("pages/instances/CreateInstance"));
 const CreateNetwork = lazy(() => import("pages/networks/CreateNetwork"));
+const CreateNetworkForward = lazy(
+  () => import("pages/networks/CreateNetworkForward"),
+);
 const CreateProfile = lazy(() => import("pages/profiles/CreateProfile"));
 const CreateProject = lazy(() => import("pages/projects/CreateProject"));
 const CreateStoragePool = lazy(() => import("pages/storage/CreateStoragePool"));
 const EditClusterGroup = lazy(() => import("pages/cluster/EditClusterGroup"));
+const EditNetworkForward = lazy(
+  () => import("pages/networks/EditNetworkForward"),
+);
 const Images = lazy(() => import("pages/images/Images"));
 const InstanceDetail = lazy(() => import("pages/instances/InstanceDetail"));
 const InstanceList = lazy(() => import("pages/instances/InstanceList"));
@@ -202,6 +208,22 @@ const App: FC = () => {
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<NetworkDetail />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/networks/detail/:network/forwards/create"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<CreateNetworkForward />} />}
+            />
+          }
+        />
+        <Route
+          path="/ui/project/:project/networks/detail/:network/forwards/:forwardAddress/edit"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<EditNetworkForward />} />}
             />
           }
         />

--- a/src/api/network-forwards.tsx
+++ b/src/api/network-forwards.tsx
@@ -1,0 +1,85 @@
+import { handleResponse } from "util/helpers";
+import { LxdNetwork, LxdNetworkForward } from "types/network";
+import { LxdApiResponse } from "types/apiResponse";
+
+export const fetchNetworkForwards = (
+  network: string,
+  project: string,
+): Promise<LxdNetworkForward[]> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/networks/${network}/forwards?project=${project}&recursion=1`)
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdNetworkForward[]>) =>
+        resolve(data.metadata),
+      )
+      .catch(reject);
+  });
+};
+
+export const fetchNetworkForward = (
+  network: string,
+  listenAddress: string,
+  project: string,
+): Promise<LxdNetworkForward> => {
+  return new Promise((resolve, reject) => {
+    fetch(
+      `/1.0/networks/${network}/forwards/${listenAddress}?project=${project}&recursion=1`,
+    )
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdNetworkForward>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
+
+export const createNetworkForward = (
+  network: string,
+  forward: Partial<LxdNetworkForward>,
+  project: string,
+) => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/networks/${network}/forwards?project=${project}`, {
+      method: "POST",
+      body: JSON.stringify(forward),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const updateNetworkForward = (
+  network: string,
+  forward: Partial<LxdNetworkForward>,
+  project: string,
+) => {
+  return new Promise((resolve, reject) => {
+    fetch(
+      `/1.0/networks/${network}/forwards/${forward.listen_address}?project=${project}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(forward),
+      },
+    )
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};
+
+export const deleteNetworkForward = (
+  network: LxdNetwork,
+  forward: LxdNetworkForward,
+  project: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    fetch(
+      `/1.0/networks/${network.name}/forwards/${forward.listen_address}?project=${project}`,
+      {
+        method: "DELETE",
+      },
+    )
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};

--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -47,7 +47,7 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
     isLoading: isNetworkLoading,
     error: networkError,
   } = useQuery({
-    queryKey: [queryKeys.networks],
+    queryKey: [queryKeys.projects, project, queryKeys.networks],
     queryFn: () => fetchNetworks(project),
   });
 

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -19,7 +19,7 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.networks, instance.project],
+    queryKey: [queryKeys.projects, instance.project, queryKeys.networks],
     queryFn: () => fetchNetworks(instance.project),
   });
 

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -87,7 +87,7 @@ const CreateNetwork: FC = () => {
       mutation()
         .then(() => {
           void queryClient.invalidateQueries({
-            queryKey: [queryKeys.networks],
+            queryKey: [queryKeys.projects, project, queryKeys.networks],
           });
           navigate(
             `/ui/project/${project}/networks`,

--- a/src/pages/networks/CreateNetworkForward.tsx
+++ b/src/pages/networks/CreateNetworkForward.tsx
@@ -1,0 +1,99 @@
+import React, { FC } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useNotify } from "@canonical/react-components";
+import SubmitButton from "components/SubmitButton";
+import { useFormik } from "formik";
+import NetworkForwardForm, {
+  NetworkForwardFormValues,
+  NetworkForwardSchema,
+  toNetworkForward,
+} from "pages/networks/forms/NetworkForwardForm";
+import { createNetworkForward } from "api/network-forwards";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import BaseLayout from "components/BaseLayout";
+import { useDocs } from "context/useDocs";
+import HelpLink from "components/HelpLink";
+import FormFooterLayout from "components/forms/FormFooterLayout";
+
+const CreateNetworkForward: FC = () => {
+  const docBaseLink = useDocs();
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const { network, project } = useParams<{
+    network: string;
+    project: string;
+  }>();
+
+  const formik = useFormik<NetworkForwardFormValues>({
+    initialValues: {
+      listenAddress: "",
+      ports: [],
+    },
+    validationSchema: NetworkForwardSchema,
+    onSubmit: (values) => {
+      const forward = toNetworkForward(values);
+      createNetworkForward(network ?? "", forward, project ?? "")
+        .then(() => {
+          void queryClient.invalidateQueries({
+            queryKey: [
+              queryKeys.projects,
+              project,
+              queryKeys.networks,
+              network,
+              queryKeys.forwards,
+            ],
+          });
+          navigate(
+            `/ui/project/${project}/networks/detail/${network}/forwards`,
+            notify.queue(
+              notify.success(
+                `Network forward ${forward.listen_address} created.`,
+              ),
+            ),
+          );
+        })
+        .catch((e) => {
+          formik.setSubmitting(false);
+          notify.failure("Network forward creation failed", e);
+        });
+    },
+  });
+
+  return (
+    <BaseLayout
+      title={
+        <HelpLink
+          href={`${docBaseLink}/howto/network_forwards/`}
+          title="Learn more about network forwards"
+        >
+          Create a network forward
+        </HelpLink>
+      }
+      contentClassName="create-network"
+    >
+      <NetworkForwardForm
+        formik={formik}
+        networkName={network ?? ""}
+        project={project ?? ""}
+      />
+      <FormFooterLayout>
+        <Link
+          className="p-button--base"
+          to={`/ui/project/${project}/networks/detail/${network}/forwards`}
+        >
+          Cancel
+        </Link>
+        <SubmitButton
+          isSubmitting={formik.isSubmitting}
+          isDisabled={!formik.isValid || !formik.values.listenAddress}
+          buttonLabel="Create"
+          onClick={() => void formik.submitForm()}
+        />
+      </FormFooterLayout>
+    </BaseLayout>
+  );
+};
+
+export default CreateNetworkForward;

--- a/src/pages/networks/EditNetworkForward.tsx
+++ b/src/pages/networks/EditNetworkForward.tsx
@@ -1,0 +1,127 @@
+import React, { FC } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useNotify } from "@canonical/react-components";
+import SubmitButton from "components/SubmitButton";
+import { useFormik } from "formik";
+import NetworkForwardForm, {
+  NetworkForwardFormValues,
+  NetworkForwardSchema,
+  toNetworkForward,
+} from "pages/networks/forms/NetworkForwardForm";
+import {
+  fetchNetworkForward,
+  updateNetworkForward,
+} from "api/network-forwards";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import BaseLayout from "components/BaseLayout";
+import HelpLink from "components/HelpLink";
+import { useDocs } from "context/useDocs";
+import FormFooterLayout from "components/forms/FormFooterLayout";
+
+const EditNetworkForward: FC = () => {
+  const docBaseLink = useDocs();
+  const navigate = useNavigate();
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const { network, project, forwardAddress } = useParams<{
+    network: string;
+    project: string;
+    forwardAddress: string;
+  }>();
+
+  const { data: forward } = useQuery({
+    queryKey: [
+      queryKeys.projects,
+      project,
+      queryKeys.networks,
+      network,
+      queryKeys.forwards,
+      forwardAddress,
+    ],
+    queryFn: () =>
+      fetchNetworkForward(network ?? "", forwardAddress ?? "", project ?? ""),
+  });
+
+  const formik = useFormik<NetworkForwardFormValues>({
+    initialValues: {
+      listenAddress: forwardAddress ?? "",
+      defaultTargetAddress: forward?.config.target_address ?? "",
+      description: forward?.description ?? "",
+      ports:
+        forward?.ports.map((port) => ({
+          listenPort: port.listen_port,
+          protocol: port.protocol,
+          targetAddress: port.target_address,
+          targetPort: port.target_port,
+        })) ?? [],
+    },
+    enableReinitialize: true,
+    validationSchema: NetworkForwardSchema,
+    onSubmit: (values) => {
+      const forward = toNetworkForward(values);
+
+      updateNetworkForward(network ?? "", forward, project ?? "")
+        .then(() => {
+          void queryClient.invalidateQueries({
+            queryKey: [
+              queryKeys.projects,
+              project,
+              queryKeys.networks,
+              network,
+              queryKeys.forwards,
+            ],
+          });
+          navigate(
+            `/ui/project/${project}/networks/detail/${network}/forwards`,
+            notify.queue(
+              notify.success(
+                `Network forward ${forward.listen_address} updated.`,
+              ),
+            ),
+          );
+        })
+        .catch((e) => {
+          formik.setSubmitting(false);
+          notify.failure("Network forward update failed", e);
+        });
+    },
+  });
+
+  return (
+    <BaseLayout
+      title={
+        <HelpLink
+          href={`${docBaseLink}/howto/network_forwards/`}
+          title="Learn more about network forwards"
+        >
+          Edit a network forward
+        </HelpLink>
+      }
+      contentClassName="edit-network"
+    >
+      <NetworkForwardForm
+        formik={formik}
+        isEdit
+        networkName={network ?? ""}
+        project={project ?? ""}
+      />
+      <FormFooterLayout>
+        <Link
+          className="p-button--base"
+          to={`/ui/project/${project}/networks/detail/${network}/forwards`}
+        >
+          Cancel
+        </Link>
+        <SubmitButton
+          isSubmitting={formik.isSubmitting}
+          isDisabled={!formik.isValid || !formik.values.listenAddress}
+          buttonLabel="Update"
+          onClick={() => void formik.submitForm()}
+        />
+      </FormFooterLayout>
+    </BaseLayout>
+  );
+};
+
+export default EditNetworkForward;

--- a/src/pages/networks/NetworkDetail.tsx
+++ b/src/pages/networks/NetworkDetail.tsx
@@ -11,8 +11,9 @@ import { Row } from "@canonical/react-components";
 import NetworkDetailOverview from "pages/networks/NetworkDetailOverview";
 import CustomLayout from "components/CustomLayout";
 import TabLinks from "components/TabLinks";
+import NetworkForwards from "pages/networks/NetworkForwards";
 
-const tabs: string[] = ["Overview", "Configuration"];
+const tabs: string[] = ["Overview", "Configuration", "Forwards"];
 
 const NetworkDetail: FC = () => {
   const { name, project, activeTab } = useParams<{
@@ -45,13 +46,13 @@ const NetworkDetail: FC = () => {
       }
       contentClassName="edit-network"
     >
-      <NotificationRow />
       <Row>
         <TabLinks
-          tabs={tabs}
+          tabs={network?.managed ? tabs : ["Overview"]}
           activeTab={activeTab}
           tabUrl={`/ui/project/${project}/networks/detail/${name}`}
         />
+        <NotificationRow />
         {!activeTab && (
           <div role="tabpanel" aria-labelledby="overview">
             {network && <NetworkDetailOverview network={network} />}
@@ -60,6 +61,11 @@ const NetworkDetail: FC = () => {
         {activeTab === "configuration" && (
           <div role="tabpanel" aria-labelledby="configuration">
             {network && <EditNetwork network={network} project={project} />}
+          </div>
+        )}
+        {activeTab === "forwards" && (
+          <div role="tabpanel" aria-labelledby="forwards">
+            {network && <NetworkForwards network={network} project={project} />}
           </div>
         )}
       </Row>

--- a/src/pages/networks/NetworkForwardCount.tsx
+++ b/src/pages/networks/NetworkForwardCount.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { LxdNetwork } from "types/network";
+import { fetchNetworkForwards } from "api/network-forwards";
+
+interface Props {
+  network: LxdNetwork;
+  project: string;
+}
+
+const NetworkForwardCount: FC<Props> = ({ network, project }) => {
+  if (network.managed === false) {
+    return <>-</>;
+  }
+
+  const { data: forwards = [], isLoading } = useQuery({
+    queryKey: [
+      queryKeys.projects,
+      project,
+      queryKeys.networks,
+      network,
+      queryKeys.forwards,
+      project,
+    ],
+    queryFn: () => fetchNetworkForwards(network.name, project),
+  });
+
+  return <>{isLoading ? "" : forwards.length}</>;
+};
+
+export default NetworkForwardCount;

--- a/src/pages/networks/NetworkForwardPort.tsx
+++ b/src/pages/networks/NetworkForwardPort.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from "react";
+import { LxdNetworkForwardPort } from "types/network";
+
+interface Props {
+  port: LxdNetworkForwardPort;
+}
+
+const NetworkForwardPort: FC<Props> = ({ port }) => {
+  const targetPort =
+    port.target_port && port.target_port.length > 0
+      ? port.target_port
+      : port.listen_port;
+
+  const rightArrow = String.fromCharCode(8594);
+  const caption = `:${port.listen_port} ${rightArrow} ${port.target_address}:${targetPort} (${port.protocol})`;
+
+  return (
+    <div className="u-truncate" title={caption}>
+      {caption}
+    </div>
+  );
+};
+
+export default NetworkForwardPort;

--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -1,0 +1,174 @@
+import React, { FC } from "react";
+import {
+  EmptyState,
+  Icon,
+  MainTable,
+  Row,
+  useNotify,
+} from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { LxdNetwork } from "types/network";
+import Loader from "components/Loader";
+import { fetchNetworkForwards } from "api/network-forwards";
+import { useDocs } from "context/useDocs";
+import DeleteNetworkForwardBtn from "pages/networks/actions/DeleteNetworkForwardBtn";
+import { Link } from "react-router-dom";
+import ExpandableList from "components/ExpandableList";
+import NetworkForwardPort from "pages/networks/NetworkForwardPort";
+
+interface Props {
+  network: LxdNetwork;
+  project: string;
+}
+
+const NetworkForwards: FC<Props> = ({ network, project }) => {
+  const docBaseLink = useDocs();
+  const notify = useNotify();
+
+  const {
+    data: forwards = [],
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [
+      queryKeys.projects,
+      project,
+      queryKeys.networks,
+      network.name,
+      queryKeys.forwards,
+    ],
+    queryFn: () => fetchNetworkForwards(network.name, project),
+  });
+
+  if (error) {
+    notify.failure("Loading network forwards failed", error);
+  }
+
+  const hasNetworkForwards = forwards.length > 0;
+
+  const headers = [
+    { content: "Listen address", sortKey: "listenAddress" },
+    { content: "Description", sortKey: "description" },
+    { content: "Default target address", sortKey: "defaultTarget" },
+    { content: "Ports" },
+    { "aria-label": "Actions", className: "u-align--right actions" },
+  ];
+
+  const rows = forwards.map((forward) => {
+    return {
+      columns: [
+        {
+          content: forward.listen_address,
+          role: "cell",
+          "aria-label": "Listen address",
+        },
+        {
+          content: forward.description,
+          role: "cell",
+          "aria-label": "Description",
+        },
+        {
+          content: forward.config.target_address,
+          role: "cell",
+          "aria-label": "Default target address",
+        },
+        {
+          content: (
+            <ExpandableList
+              items={forward.ports.map((port) => (
+                <NetworkForwardPort key={port.listen_port} port={port} />
+              ))}
+            />
+          ),
+          role: "cell",
+          "aria-label": "Forwarded ports",
+        },
+        {
+          content: (
+            <>
+              <Link
+                className="p-button--base u-no-margin--bottom has-icon"
+                to={`/ui/project/${project}/networks/detail/${network.name}/forwards/${forward.listen_address}/edit`}
+              >
+                <Icon name="edit" />
+              </Link>
+              <DeleteNetworkForwardBtn
+                key={forward.listen_address}
+                network={network}
+                forward={forward}
+                project={project}
+              />
+            </>
+          ),
+          role: "rowheader",
+          className: "u-align--right actions",
+          "aria-label": "Actions",
+        },
+      ],
+      sortData: {
+        listenAddress: forward.listen_address,
+        description: forward.description,
+        defaultTarget: forward.config.target_address ?? "",
+      },
+    };
+  });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <>
+      <Link
+        className="p-button--positive u-no-margin--bottom u-float-right"
+        to={`/ui/project/${project}/networks/detail/${network.name}/forwards/create`}
+      >
+        Create forward
+      </Link>
+      <Row>
+        {hasNetworkForwards && (
+          <MainTable
+            headers={headers}
+            expanding
+            rows={rows}
+            paginate={30}
+            responsive
+            sortable
+            defaultSort="listenAddress"
+            defaultSortDirection="ascending"
+            className="u-table-layout--auto network-forwards-table"
+            emptyStateMsg={
+              isLoading ? (
+                <Loader text="Loading network forwards..." />
+              ) : (
+                "No data to display"
+              )
+            }
+          />
+        )}
+        {!isLoading && !hasNetworkForwards && (
+          <EmptyState
+            className="empty-state"
+            image={<Icon className="empty-state-icon" name="connected" />}
+            title="No network forwards found"
+          >
+            <p>There are no network forwards in this project.</p>
+            <p>
+              <a
+                href={`${docBaseLink}/howto/network_forwards/`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Learn more about network forwards
+                <Icon className="external-link-icon" name="external-link" />
+              </a>
+            </p>
+          </EmptyState>
+        )}
+      </Row>
+    </>
+  );
+};
+
+export default NetworkForwards;

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -16,6 +16,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
 import { useDocs } from "context/useDocs";
+import NetworkForwardCount from "pages/networks/NetworkForwardCount";
 
 const NetworkList: FC = () => {
   const docBaseLink = useDocs();
@@ -32,7 +33,7 @@ const NetworkList: FC = () => {
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.networks, project],
+    queryKey: [queryKeys.projects, project, queryKeys.networks],
     queryFn: () => fetchNetworks(project),
   });
 
@@ -49,9 +50,9 @@ const NetworkList: FC = () => {
     { content: "IPV4", className: "u-align--right" },
     { content: "IPV6" },
     { content: "Description", sortKey: "description" },
+    { content: "Forwards", className: "u-align--right" },
     { content: "Used by", sortKey: "usedBy", className: "u-align--right" },
     { content: "State", sortKey: "state" },
-    { "aria-label": "Actions", className: "u-align--right" },
   ];
 
   const rows = networks.map((network) => {
@@ -93,6 +94,12 @@ const NetworkList: FC = () => {
           "aria-label": "Description",
         },
         {
+          content: <NetworkForwardCount network={network} project={project} />,
+          role: "rowheader",
+          className: "u-align--right",
+          "aria-label": "Forwards",
+        },
+        {
           content: network.used_by?.length ?? "0",
           role: "rowheader",
           className: "u-align--right",
@@ -102,12 +109,6 @@ const NetworkList: FC = () => {
           content: network.status,
           role: "rowheader",
           "aria-label": "State",
-        },
-        {
-          content: <></>,
-          role: "rowheader",
-          className: "u-align--right",
-          "aria-label": "Actions",
         },
       ],
       sortData: {
@@ -120,6 +121,10 @@ const NetworkList: FC = () => {
       },
     };
   });
+
+  if (isLoading) {
+    return <Loader />;
+  }
 
   return (
     <>

--- a/src/pages/networks/NetworkMap.tsx
+++ b/src/pages/networks/NetworkMap.tsx
@@ -52,7 +52,7 @@ const NetworkMap: FC = () => {
   });
 
   const { data: networks = [], isLoading: networkLoading } = useQuery({
-    queryKey: [queryKeys.networks],
+    queryKey: [queryKeys.projects, project, queryKeys.networks],
     queryFn: () => fetchNetworks(project ?? ""),
     enabled: Boolean(project),
   });

--- a/src/pages/networks/actions/DeleteNetworkBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkBtn.tsx
@@ -23,7 +23,10 @@ const DeleteNetworkBtn: FC<Props> = ({ network, project }) => {
     deleteNetwork(network.name, project)
       .then(() => {
         void queryClient.invalidateQueries({
-          queryKey: [queryKeys.networks],
+          predicate: (query) =>
+            query.queryKey[0] === queryKeys.projects &&
+            query.queryKey[1] === project &&
+            query.queryKey[2] === queryKeys.networks,
         });
         navigate(
           `/ui/project/${project}/networks`,

--- a/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
@@ -1,0 +1,68 @@
+import React, { FC, useState } from "react";
+import { LxdNetwork, LxdNetworkForward } from "types/network";
+import { queryKeys } from "util/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ConfirmationButton,
+  Icon,
+  useNotify,
+} from "@canonical/react-components";
+import { deleteNetworkForward } from "api/network-forwards";
+
+interface Props {
+  network: LxdNetwork;
+  forward: LxdNetworkForward;
+  project: string;
+}
+
+const DeleteNetworkForwardBtn: FC<Props> = ({ network, forward, project }) => {
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+
+  const handleDelete = () => {
+    setLoading(true);
+    deleteNetworkForward(network, forward, project)
+      .then(() => {
+        notify.success(`Network forward for ${forward.listen_address} deleted`);
+        void queryClient.invalidateQueries({
+          predicate: (query) =>
+            query.queryKey[0] === queryKeys.projects &&
+            query.queryKey[1] === project &&
+            query.queryKey[2] === queryKeys.networks &&
+            query.queryKey[3] === network.name,
+        });
+      })
+      .catch((e) => {
+        setLoading(false);
+        notify.failure("Network forward deletion failed", e);
+      });
+  };
+
+  return (
+    <ConfirmationButton
+      appearance="base"
+      onHoverText="Delete network forward"
+      confirmationModalProps={{
+        title: "Confirm delete",
+        confirmButtonAppearance: "negative",
+        confirmButtonLabel: "Delete",
+        children: (
+          <p>
+            Are you sure you want to delete the network forward with listen
+            address {forward.listen_address}?<br />
+          </p>
+        ),
+        onConfirm: handleDelete,
+      }}
+      className="u-no-margin--bottom has-icon"
+      loading={isLoading}
+      shiftClickEnabled
+      showShiftClickHint
+    >
+      <Icon name="delete" />
+    </ConfirmationButton>
+  );
+};
+
+export default DeleteNetworkForwardBtn;

--- a/src/pages/networks/forms/NetworkForwardForm.tsx
+++ b/src/pages/networks/forms/NetworkForwardForm.tsx
@@ -1,0 +1,185 @@
+import React, { FC, useEffect } from "react";
+import {
+  Button,
+  Col,
+  Form,
+  Icon,
+  Input,
+  Notification,
+  Row,
+  useNotify,
+} from "@canonical/react-components";
+import { FormikProps } from "formik/dist/types";
+import * as Yup from "yup";
+import { LxdNetworkForward } from "types/network";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchNetwork } from "api/networks";
+import { testValidIp, testValidPort } from "util/networks";
+import NotificationRow from "components/NotificationRow";
+import NetworkForwardFormPorts, {
+  NetworkForwardPortFormValues,
+} from "pages/networks/forms/NetworkForwardFormPorts";
+
+export const toNetworkForward = (
+  values: NetworkForwardFormValues,
+): LxdNetworkForward => {
+  return {
+    listen_address: values.listenAddress,
+    description: values.description,
+    config: {
+      target_address: values.defaultTargetAddress,
+    },
+    ports: values.ports.map((port) => ({
+      listen_port: port.listenPort?.toString(),
+      protocol: port.protocol,
+      target_address: port.targetAddress?.toString(),
+      target_port: port.targetPort?.toString(),
+    })),
+  };
+};
+
+export const NetworkForwardSchema = Yup.object().shape({
+  listenAddress: Yup.string()
+    .test("valid-ip", "Invalid IP address", testValidIp)
+    .required("Listen address is required"),
+  ports: Yup.array().of(
+    Yup.object().shape({
+      listenPort: Yup.string()
+        .test("valid-port", "Invalid port number", testValidPort)
+        .required("Listen port required"),
+      protocol: Yup.string().required("Protocol is required"),
+      targetAddress: Yup.string()
+        .test("valid-ip", "Invalid IP address", testValidIp)
+        .required("Target address is required"),
+      targetPort: Yup.string()
+        .nullable()
+        .test("valid-port", "Invalid port number", testValidPort),
+    }),
+  ),
+});
+
+export interface NetworkForwardFormValues {
+  listenAddress: string;
+  defaultTargetAddress?: string;
+  description?: string;
+  ports: NetworkForwardPortFormValues[];
+}
+
+interface Props {
+  formik: FormikProps<NetworkForwardFormValues>;
+  isEdit?: boolean;
+  networkName: string;
+  project: string;
+}
+
+const NetworkForwardForm: FC<Props> = ({
+  formik,
+  isEdit,
+  networkName,
+  project,
+}) => {
+  const notify = useNotify();
+
+  const { data: network } = useQuery({
+    queryKey: [queryKeys.projects, project, queryKeys.networks, networkName],
+    queryFn: () => fetchNetwork(networkName ?? "", project ?? ""),
+  });
+
+  const updateFormHeight = () => {
+    updateMaxHeight("form-contents", "p-bottom-controls");
+  };
+  useEffect(updateFormHeight, [notify.notification?.message]);
+  useEventListener("resize", updateFormHeight);
+
+  const addPort = () => {
+    void formik.setFieldValue("ports", [
+      ...formik.values.ports,
+      {
+        protocol: "tcp",
+      },
+    ]);
+
+    const name = `ports.${formik.values.ports.length}.listenPort`;
+    setTimeout(() => document.getElementById(name)?.focus(), 100);
+  };
+
+  return (
+    <Form className="form network-forwards-form" onSubmit={formik.handleSubmit}>
+      <Row className="form-contents">
+        <Col size={12}>
+          {/* hidden submit to enable enter key in inputs */}
+          <Input type="submit" hidden />
+          <Row className="p-form__group p-form-validation">
+            <NotificationRow />
+            <Notification severity="information" title="Network information">
+              Name: {network?.name}
+              <br />
+              {network?.config["ipv4.address"] && (
+                <>
+                  IPv4 subnet: {network?.config["ipv4.address"]}
+                  <br />
+                </>
+              )}
+              {network?.config["ipv6.address"] && (
+                <>IPv6 subnet: {network?.config["ipv6.address"]}</>
+              )}
+            </Notification>
+          </Row>
+          <Input
+            {...formik.getFieldProps("listenAddress")}
+            id="listenAddress"
+            type="text"
+            label="Listen address"
+            placeholder="Enter IP address"
+            autoFocus
+            required
+            stacked
+            disabled={isEdit}
+            help="Any address routed to LXD."
+            error={
+              formik.touched.listenAddress
+                ? formik.errors.listenAddress
+                : undefined
+            }
+          />
+          <Input
+            {...formik.getFieldProps("defaultTargetAddress")}
+            id="defaultTargetAddress"
+            type="text"
+            label="Default target address"
+            help={
+              <>
+                Fallback target for traffic that does not match a port specified
+                below.
+                <br />
+                Must be from the network <b>{network?.name}</b>.
+              </>
+            }
+            placeholder="Enter IP address"
+            stacked
+          />
+          <Input
+            {...formik.getFieldProps("description")}
+            id="description"
+            type="text"
+            label="Description"
+            placeholder="Enter description"
+            stacked
+          />
+          {formik.values.ports.length > 0 && (
+            <NetworkForwardFormPorts formik={formik} network={network} />
+          )}
+          <Button hasIcon onClick={addPort} type="button">
+            <Icon name="plus" />
+            <span>Add port</span>
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+};
+
+export default NetworkForwardForm;

--- a/src/pages/networks/forms/NetworkForwardFormPorts.tsx
+++ b/src/pages/networks/forms/NetworkForwardFormPorts.tsx
@@ -1,0 +1,169 @@
+import React, { FC } from "react";
+import {
+  Button,
+  Icon,
+  Input,
+  Label,
+  Select,
+} from "@canonical/react-components";
+import { FormikProps } from "formik/dist/types";
+import { NetworkForwardFormValues } from "pages/networks/forms/NetworkForwardForm";
+import { LxdNetwork } from "types/network";
+
+export interface NetworkForwardPortFormValues {
+  listenPort: string;
+  protocol: "tcp" | "udp";
+  targetAddress: string;
+  targetPort?: string;
+}
+
+interface Props {
+  formik: FormikProps<NetworkForwardFormValues>;
+  network?: LxdNetwork;
+}
+
+const NetworkForwardFormPorts: FC<Props> = ({ formik, network }) => {
+  return (
+    <table className="u-no-margin--bottom forward-ports">
+      <thead>
+        <tr>
+          <th className="listen-port">
+            <Label
+              required
+              forId="ports.0.listenPort"
+              className="u-no-margin--bottom"
+            >
+              Listen port
+            </Label>
+          </th>
+          <th className="protocol">
+            <Label
+              required
+              forId="ports.0.protocol"
+              className="u-no-margin--bottom"
+            >
+              Protocol
+            </Label>
+          </th>
+          <th className="target-address">
+            <Label
+              required
+              forId="ports.0.targetAddress"
+              className="u-no-margin--bottom"
+            >
+              Target address
+            </Label>
+          </th>
+          <th className="target-port">
+            <Label forId="ports.0.targetPort" className="u-no-margin--bottom">
+              Target port
+            </Label>
+          </th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {formik.values.ports.map((_port, index) => {
+          const portError = formik.errors.ports?.[
+            index
+          ] as NetworkForwardPortFormValues | null;
+
+          return (
+            <tr key={index}>
+              <td className="listen-port">
+                <Input
+                  {...formik.getFieldProps(`ports.${index}.listenPort`)}
+                  id={`ports.${index}.listenPort`}
+                  type="text"
+                  label="Listen port"
+                  labelClassName="u-off-screen"
+                  placeholder="Port number(s)"
+                  help={
+                    index === formik.values.ports.length - 1 && (
+                      <>e.g. 80,90-99.</>
+                    )
+                  }
+                  error={
+                    formik.touched.ports?.[index]?.listenPort
+                      ? portError?.listenPort
+                      : undefined
+                  }
+                />
+              </td>
+              <td className="protocol">
+                <Select
+                  {...formik.getFieldProps(`ports.${index}.protocol`)}
+                  id={`ports.${index}.protocol`}
+                  options={[
+                    { label: "TCP", value: "tcp" },
+                    { label: "UDP", value: "udp" },
+                  ]}
+                  label="Protocol"
+                  labelClassName="u-off-screen"
+                />
+              </td>
+              <td className="target-address">
+                <Input
+                  {...formik.getFieldProps(`ports.${index}.targetAddress`)}
+                  id={`ports.${index}.targetAddress`}
+                  type="text"
+                  label="Target address"
+                  labelClassName="u-off-screen"
+                  placeholder="Enter IP address"
+                  help={
+                    index === formik.values.ports.length - 1 && (
+                      <>
+                        Must be from the network <b>{network?.name}</b>.
+                      </>
+                    )
+                  }
+                  error={
+                    formik.touched.ports?.[index]?.targetAddress
+                      ? portError?.targetAddress
+                      : undefined
+                  }
+                />
+              </td>
+              <td className="target-port">
+                <Input
+                  {...formik.getFieldProps(`ports.${index}.targetPort`)}
+                  id={`ports.${index}.targetPort`}
+                  type="text"
+                  label="Target port"
+                  labelClassName="u-off-screen"
+                  placeholder="Port number(s)"
+                  help={
+                    index === formik.values.ports.length - 1 &&
+                    "Same as listen port if empty"
+                  }
+                  error={
+                    formik.touched.ports?.[index]?.targetPort
+                      ? portError?.targetPort
+                      : undefined
+                  }
+                />
+              </td>
+              <td>
+                <Button
+                  onClick={() =>
+                    formik.setFieldValue("ports", [
+                      ...formik.values.ports.slice(0, index),
+                      ...formik.values.ports.slice(index + 1),
+                    ])
+                  }
+                  hasIcon
+                  className="u-no-margin--bottom"
+                  type="button"
+                >
+                  <Icon name="delete" />
+                </Button>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default NetworkForwardFormPorts;

--- a/src/sass/_network_forwards_form.scss
+++ b/src/sass/_network_forwards_form.scss
@@ -1,0 +1,32 @@
+.network-forwards-form {
+  .form-contents > div {
+    margin-left: 0;
+    max-width: 67rem !important;
+  }
+
+  .forward-ports {
+    .listen-port,
+    .protocol,
+    .target-address,
+    .target-port {
+      width: 15rem;
+    }
+
+    @media screen and (width <= 1337px) {
+      .listen-port,
+      .protocol,
+      .target-address,
+      .target-port {
+        width: 13rem;
+      }
+    }
+
+    @media screen and (width <= 1190px) {
+      .listen-port,
+      .protocol,
+      .target-port {
+        width: 8rem;
+      }
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -67,6 +67,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "instance_list";
 @import "network_detail_overview";
 @import "network_form";
+@import "network_forwards_form";
 @import "meter";
 @import "network_map";
 @import "no_match";
@@ -265,4 +266,10 @@ $border-thin: 1px solid $color-mid-light !default;
 .auto-expanding-textarea {
   overflow: hidden;
   resize: none;
+}
+
+.network-forwards-table {
+  .actions {
+    max-width: 8rem;
+  }
 }

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -90,3 +90,21 @@ export interface LxdNetworkState {
   type: string;
   vlan?: string;
 }
+
+export interface LxdNetworkForwardPort {
+  description?: string;
+  listen_port: string;
+  protocol: "tcp" | "udp";
+  target_address: string;
+  target_port?: string;
+}
+
+export interface LxdNetworkForward {
+  listen_address: string;
+  config: {
+    target_address?: string;
+  };
+  description?: string;
+  location?: string;
+  ports: LxdNetworkForwardPort[];
+}

--- a/src/util/networks.spec.tsx
+++ b/src/util/networks.spec.tsx
@@ -1,4 +1,4 @@
-import { areNetworksEqual } from "./networks";
+import { areNetworksEqual, testValidIp, testValidPort } from "./networks";
 import { LxdNetwork } from "types/network";
 
 describe("areNetworksEqual", () => {
@@ -57,5 +57,59 @@ describe("areNetworksEqual", () => {
     };
 
     expect(areNetworksEqual(a, b)).toBe(false);
+  });
+});
+
+describe("testValidIp", () => {
+  it("accepts ipv4", () => {
+    const result = testValidIp("1.2.3.4");
+    expect(result).toBe(true);
+  });
+
+  it("rejects invalid ipv4", () => {
+    const result = testValidIp("1.2.3");
+    expect(result).toBe(false);
+  });
+
+  it("rejects invalid ipv4", () => {
+    const result = testValidIp("1.2.3.300");
+    expect(result).toBe(false);
+  });
+
+  it("accepts ipv6", () => {
+    const result = testValidIp("fd42:36de:45cd:3460::1");
+    expect(result).toBe(true);
+  });
+});
+
+describe("testValidPort", () => {
+  it("accepts single port", () => {
+    const result = testValidPort("23");
+    expect(result).toBe(true);
+  });
+
+  it("accepts port list", () => {
+    const result = testValidPort("23,443");
+    expect(result).toBe(true);
+  });
+
+  it("accepts port range", () => {
+    const result = testValidPort("8000-8080");
+    expect(result).toBe(true);
+  });
+
+  it("accepts port range and list", () => {
+    const result = testValidPort("23,8000-8080");
+    expect(result).toBe(true);
+  });
+
+  it("rejects high number", () => {
+    const result = testValidPort("77777");
+    expect(result).toBe(false);
+  });
+
+  it("rejects invalid range", () => {
+    const result = testValidPort("23-");
+    expect(result).toBe(false);
   });
 });

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -1,6 +1,7 @@
 import { LxdInstance } from "types/instance";
 import { LxdNetwork, LxdNetworkConfig } from "types/network";
 import { ConfigRowMetadata } from "util/configInheritance";
+import { AnyObject, TestFunction } from "yup";
 
 export const getIpAddresses = (
   instance: LxdInstance,
@@ -76,4 +77,29 @@ export const areNetworksEqual = (
   );
 
   return !hasMainKeyDiff;
+};
+
+export const testValidIp: TestFunction<string | null | undefined, AnyObject> = (
+  ip,
+) => {
+  const expression =
+    /((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))/;
+
+  if (!ip) {
+    return false;
+  }
+  return expression.test(ip);
+};
+
+export const testValidPort: TestFunction<
+  string | null | undefined,
+  AnyObject
+> = (port) => {
+  const expression =
+    /^(([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])[-,]){0,9}([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/;
+
+  if (!port) {
+    return true;
+  }
+  return expression.test(port);
 };

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -2,6 +2,7 @@ export const queryKeys = {
   certificates: "certificates",
   cluster: "cluster",
   configOptions: "configOptions",
+  forwards: "forwards",
   groups: "groups",
   images: "images",
   instances: "instances",

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -42,3 +42,36 @@ export const editNetwork = async (page: Page, network: string) => {
   await page.getByTestId("tab-link-Configuration").click();
   await page.getByRole("button", { name: "Edit network" }).click();
 };
+
+export const createNetworkForward = async (page: Page, network: string) => {
+  await visitNetwork(page, network);
+
+  await page.getByTestId("tab-link-Configuration").click();
+  await page.getByRole("button", { name: "Edit network" }).click();
+  const networkSubnet = await page.inputValue("input#ipv4_address");
+
+  const listenAddress = networkSubnet.replace("1/24", "1");
+  const targetAddress = networkSubnet.replace("1/24", "3");
+
+  await page.getByTestId("tab-link-Forwards").click();
+  await page.getByRole("link", { name: "Create forward" }).click();
+  await page.getByLabel("Listen address").fill(listenAddress);
+
+  await page.getByRole("button", { name: "Add port" }).click();
+  await page.getByLabel("Listen port").fill("80");
+  await page.getByLabel("Target address", { exact: true }).fill(targetAddress);
+  await page.getByRole("button", { name: "Add port" }).click();
+  await page
+    .getByRole("textbox", { name: "Listen port", exact: true })
+    .fill("23,443-455");
+  await page
+    .getByRole("textbox", { name: "Target address", exact: true })
+    .fill(targetAddress);
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await page.getByText(`Network forward ${listenAddress} created.`).click();
+  await page.getByText(`:80 → ${targetAddress}:80 (tcp)`).click();
+  await page
+    .getByText(`:23,443-455 → ${targetAddress}:23,443-455 (tcp)`)
+    .click();
+};

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import {
   createNetwork,
+  createNetworkForward,
   deleteNetwork,
   editNetwork,
   randomNetworkName,
@@ -91,5 +92,12 @@ test("network edit basic details", async ({ page }) => {
   await assertReadMode(page, "IPv6 DHCP expiry", "3h");
   await assertReadMode(page, "IPv6 DHCP stateful", "true");
 
+  await deleteNetwork(page, network);
+});
+
+test("network forwards", async ({ page }) => {
+  const network = randomNetworkName();
+  await createNetwork(page, network);
+  await createNetworkForward(page, network);
   await deleteNetwork(page, network);
 });


### PR DESCRIPTION
## Done

- add forwards tab under network detail page
- added create network forward in the new tab
- added edit network forward in the new tab
- added Network name and subnet details to the create/edit forward screens
- removed html5 tooltips from required fields/edit forward screens
- changed help text for ports
- added description for forward

Fixes WD-7876

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a network forward
    - edit a network forward with ports