### PR TITLE
feat(storage) default storage pool for volume creation [WD-7675]

### DIFF
--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -366,6 +366,9 @@ const StorageVolumes: FC = () => {
     return <Loader text="Loading storage volumes..." />;
   }
 
+  const defaultPoolForVolumeCreate =
+    filters.pools.length === 1 ? filters.pools[0] : "";
+
   return volumes.length === 0 ? (
     <EmptyState
       className="empty-state"
@@ -392,7 +395,10 @@ const StorageVolumes: FC = () => {
           <StorageVolumesFilter key={project} volumes={volumes} />
         </div>
         <div>
-          <CreateVolumeBtn project={project} />
+          <CreateVolumeBtn
+            project={project}
+            defaultPool={defaultPoolForVolumeCreate}
+          />
         </div>
       </div>
       <Pagination

--- a/src/pages/storage/actions/CreateVolumeBtn.tsx
+++ b/src/pages/storage/actions/CreateVolumeBtn.tsx
@@ -4,15 +4,19 @@ import { useNavigate } from "react-router-dom";
 
 interface Props {
   project: string;
+  defaultPool?: string;
   className?: string;
 }
 
-const CreateVolumeBtn: FC<Props> = ({ project, className }) => {
+const CreateVolumeBtn: FC<Props> = ({ project, className, defaultPool }) => {
   const navigate = useNavigate();
 
   const handleAdd = () => {
-    navigate(`/ui/project/${project}/storage/volumes/create
-    `);
+    navigate(
+      `/ui/project/${project}/storage/volumes/create${
+        defaultPool ? `?pool=${defaultPool}` : ""
+      }`,
+    );
   };
 
   return (

--- a/src/pages/storage/forms/StorageVolumeCreate.tsx
+++ b/src/pages/storage/forms/StorageVolumeCreate.tsx
@@ -7,7 +7,7 @@ import { queryKeys } from "util/queryKeys";
 import SubmitButton from "components/SubmitButton";
 import { createStorageVolume } from "api/storage-pools";
 import NotificationRow from "components/NotificationRow";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { testDuplicateStorageVolumeName } from "util/storageVolume";
 import BaseLayout from "components/BaseLayout";
 import {
@@ -17,6 +17,7 @@ import {
 import StorageVolumeForm from "pages/storage/forms/StorageVolumeForm";
 import { MAIN_CONFIGURATION } from "pages/storage/forms/StorageVolumeFormMenu";
 import { slugify } from "util/slugify";
+import { POOL } from "../StorageVolumesFilter";
 
 const StorageVolumeCreate: FC = () => {
   const navigate = useNavigate();
@@ -25,6 +26,7 @@ const StorageVolumeCreate: FC = () => {
   const [section, setSection] = useState(slugify(MAIN_CONFIGURATION));
   const controllerState = useState<AbortController | null>(null);
   const { project } = useParams<{ project: string }>();
+  const [searchParams] = useSearchParams();
 
   if (!project) {
     return <>Missing project</>;
@@ -44,7 +46,7 @@ const StorageVolumeCreate: FC = () => {
       type: "custom",
       name: "",
       project: project,
-      pool: "",
+      pool: searchParams.get(POOL) || "",
       size: "GiB",
       isReadOnly: false,
       isCreating: true,


### PR DESCRIPTION
## Done

- When a user creates a new custom storage volume from the volumes list, and if they’ve filtered this list to only show volumes from one storage pool, the volume creation form will now set the storage pool to match the filter by default.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Storage -> Volumes tab. In the search and filter input box, filter volumes by a **single** storage pool. Then try create a volume, the storage pool selection should be defaulted to the filtered storage pool.
    - Now try filter volumes by **multiple** storage pools. Then try create a volume, the storage pool selection should be defaulted to the default storage pool. Same behaviour should be observed if there are no storage pool filters for volumes.