### PR TITLE
fix(app) disable configurations when entity creation is blocked [WD-7489]

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -347,7 +347,7 @@ const CreateInstance: FC = () => {
           active={section}
           setActive={updateSection}
           isConfigDisabled={!formik.values.image}
-          isConfigOpen={isConfigOpen}
+          isConfigOpen={!!formik.values.image && isConfigOpen}
           toggleConfigOpen={toggleMenu}
           hasDiskError={diskError || hasNoRootDisk(formik.values, profiles)}
           hasNetworkError={networkError}

--- a/src/pages/networks/forms/NetworkFormMenu.tsx
+++ b/src/pages/networks/forms/NetworkFormMenu.tsx
@@ -46,7 +46,9 @@ const NetworkFormMenu: FC<Props> = ({ active, setActive, formik }) => {
             <Button
               type="button"
               className="p-side-navigation__accordion-button"
-              aria-expanded={isAdvancedOpen ? "true" : "false"}
+              aria-expanded={
+                !disableReason && isAdvancedOpen ? "true" : "false"
+              }
               onClick={() => setAdvancedOpen(!isAdvancedOpen)}
               disabled={Boolean(disableReason)}
               title={disableReason}
@@ -55,7 +57,9 @@ const NetworkFormMenu: FC<Props> = ({ active, setActive, formik }) => {
             </Button>
             <ul
               className="p-side-navigation__list"
-              aria-expanded={isAdvancedOpen ? "true" : "false"}
+              aria-expanded={
+                !disableReason && isAdvancedOpen ? "true" : "false"
+              }
             >
               <MenuItem
                 label={BRIDGE}

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -162,7 +162,7 @@ const CreateProfile: FC = () => {
         <ProfileFormMenu
           active={section}
           setActive={updateSection}
-          isConfigOpen={isConfigOpen}
+          isConfigOpen={Boolean(formik.values.name) && isConfigOpen}
           toggleConfigOpen={toggleMenu}
           hasName={Boolean(formik.values.name)}
           formik={formik}

--- a/src/pages/storage/forms/StorageVolumeFormMenu.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMenu.tsx
@@ -55,7 +55,9 @@ const StorageVolumeFormMenu: FC<Props> = ({
             <Button
               type="button"
               className="p-side-navigation__accordion-button"
-              aria-expanded={isAdvancedOpen ? "true" : "false"}
+              aria-expanded={
+                !disableReason && isAdvancedOpen ? "true" : "false"
+              }
               onClick={() => setAdvancedOpen(!isAdvancedOpen)}
               disabled={Boolean(disableReason)}
               title={disableReason}
@@ -64,7 +66,9 @@ const StorageVolumeFormMenu: FC<Props> = ({
             </Button>
             <ul
               className="p-side-navigation__list"
-              aria-expanded={isAdvancedOpen ? "true" : "false"}
+              aria-expanded={
+                !disableReason && isAdvancedOpen ? "true" : "false"
+              }
             >
               <MenuItem
                 label={SNAPSHOTS}


### PR DESCRIPTION
## Done

- Fixed the issue with configuration side navigation items remaining accessible even when entity creation (i.e. instance, network, profile or storage volume) is blocked due to invalid form entries.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - While creating an instance, select a base image so that configurations becomes available. Click on the Advanced drop down, then deselect the base image. The drop down should collapse and become disabled.
    - While creating a profile, enter a name for the profile so that configurations becomes available. Click on the Advanced drop down, then clear the profile name input field. The drop down should collapse and become disabled.
    - While creating a network, enter a name for the network so that configurations becomes available. Click on the Advanced drop down, then clear the network name input field. The drop down should collapse and become disabled.
    - While creating a storage volume, enter a name for the volume so that configurations becomes available. Click on the Advanced drop down, then clear the volume name input field. The drop down should collapse and become disabled.
