### PR TITLE
Rely on actual project list for selection of default project

### DIFF
--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -3,9 +3,9 @@ import { LxdProject } from "types/project";
 import { LxdApiResponse } from "types/apiResponse";
 import { LxdOperationResponse } from "types/operation";
 
-export const fetchProjects = (recursion: number): Promise<LxdProject[]> => {
+export const fetchProjects = (): Promise<LxdProject[]> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/projects?recursion=${recursion}`)
+    fetch(`/1.0/projects?recursion=1`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdProject[]>) => resolve(data.metadata))
       .catch(reject);

--- a/src/pages/profiles/ProfileInstances.tsx
+++ b/src/pages/profiles/ProfileInstances.tsx
@@ -39,8 +39,8 @@ const ProfileInstances: FC<Props> = ({
 
   if (isDefaultProject) {
     const { data: projects = [] } = useQuery({
-      queryKey: [queryKeys.projects, 1],
-      queryFn: () => fetchProjects(1),
+      queryKey: [queryKeys.projects],
+      queryFn: fetchProjects,
     });
     projects
       .filter((project) => project.config["features.profiles"] === "false")

--- a/src/pages/projects/ProjectSelector.tsx
+++ b/src/pages/projects/ProjectSelector.tsx
@@ -21,8 +21,8 @@ const ProjectSelector: FC<Props> = ({ activeProject }): JSX.Element => {
   const searchRef = useRef<HTMLInputElement>(null);
 
   const { data: projects = [] } = useQuery({
-    queryKey: [queryKeys.projects, 1],
-    queryFn: () => fetchProjects(1),
+    queryKey: [queryKeys.projects],
+    queryFn: fetchProjects,
   });
 
   projects.sort(defaultFirst);

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -4,7 +4,7 @@ type LXDAuthMethods = "tls" | "oidc" | "unix";
 
 export interface LxdSettings {
   api_status: string;
-  config: LxdConfigPair;
+  config?: LxdConfigPair;
   environment?: {
     architectures: string[];
     os_name?: string;

--- a/src/util/title.tsx
+++ b/src/util/title.tsx
@@ -5,7 +5,7 @@ export const setTitle = () => {
   const { data: settings } = useSettings();
 
   useEffect(() => {
-    const host = settings?.config["user.ui_title"] ?? location.hostname;
+    const host = settings?.config?.["user.ui_title"] ?? location.hostname;
     document.title = `${host} | LXD UI`;
   }, [settings?.config]);
 };


### PR DESCRIPTION
## Done

- Rely on actual project list for selection of default project
- fix invalid object access for restricted users

Fixes #575

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - try access to the UI with a restricted user (`lxc config trust list` then `lxc config trust edit $id` then change `restricted: true` and add a project which is or is not the default project)
    - The restricted user should be redirected to a project they have access to (i.e. non-default) when opening the `/ui` url in a browser.