### PR TITLE
fix(actions): github actions for test report publishig failing

### DIFF
--- a/.github/workflows/delete_test_reports.yml
+++ b/.github/workflows/delete_test_reports.yml
@@ -1,5 +1,8 @@
 name: Delete playwright test reports
 on:
+    pull_request_target:
+        types:
+            - closed
     pull_request:
         types:
             - closed

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,31 +1,47 @@
 name: PR checks
-on: pull_request
+on: [pull_request_target, pull_request]
 
 permissions:
   contents: write
 
 jobs:
+  continue-workflow:
+    name: Check valid PR action trigger
+    runs-on: ubuntu-latest
+    outputs:
+      # we don't want forked PR to trigger two action runs
+      continue: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) }}
+    steps:
+      - name: "Check if PR is triggered locally or from forked repo"
+        run: |
+          echo "Event type -> ${{ github.event_name }}; Base repo -> ${{ github.repository }}; PR origin repo -> ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Continue workflow? ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) }}"
+
   commits:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     permissions:
       pull-requests: read   # to get list of commits from the PR
     name: Canonical CLA signed and Signed-off-by (DCO)
     runs-on: ubuntu-latest
     steps:
-    - name: Check if CLA signed
-      uses: canonical/has-signed-canonical-cla@v1
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1
 
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get PR Commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Check that all commits are signed-off
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+      - name: Check that all commits are signed-off
+        uses: tim-actions/dco@master
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
 
   lint-scss:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -38,6 +54,8 @@ jobs:
         run: yarn lint-scss
 
   lint-js:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -50,6 +68,8 @@ jobs:
         run: yarn lint-js
 
   check-inclusive-naming:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -64,6 +84,8 @@ jobs:
           fail-on-error: true
 
   e2e:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     name: e2e-tests
     runs-on: ubuntu-latest
     outputs:
@@ -140,6 +162,8 @@ jobs:
           retention-days: 30
 
   js-tests:
+    needs: continue-workflow
+    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     name: js-tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Done

- Fixed issue with github actions using GITHUB_TOKEN authentication failing on PRs opened from forked repos. See [gh docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories-2) for reference.