### PR TITLE
chore: clean up test report publish gh action

### DIFF
--- a/.github/workflows/cla_check.yml
+++ b/.github/workflows/cla_check.yml
@@ -1,0 +1,26 @@
+name: Check CLA
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  commits:
+    permissions:
+      pull-requests: read   # to get list of commits from the PR
+    name: Canonical CLA signed and Signed-off-by (DCO)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v1
+
+      - name: Get PR Commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check that all commits are signed-off
+        uses: tim-actions/dco@master
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/delete_test_reports.yml
+++ b/.github/workflows/delete_test_reports.yml
@@ -3,9 +3,6 @@ on:
     pull_request_target:
         types:
             - closed
-    pull_request:
-        types:
-            - closed
 
 jobs:
     delete_reports:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,47 +1,12 @@
 name: PR checks
-on: [pull_request_target, pull_request]
+on: pull_request_target
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  continue-workflow:
-    name: Check valid PR action trigger
-    runs-on: ubuntu-latest
-    outputs:
-      # we don't want forked PR to trigger two action runs
-      continue: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) }}
-    steps:
-      - name: "Check if PR is triggered locally or from forked repo"
-        run: |
-          echo "Event type -> ${{ github.event_name }}; Base repo -> ${{ github.repository }}; PR origin repo -> ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Continue workflow? ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) }}"
-
-  commits:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
-    permissions:
-      pull-requests: read   # to get list of commits from the PR
-    name: Canonical CLA signed and Signed-off-by (DCO)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
-
-      - name: Get PR Commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check that all commits are signed-off
-        uses: tim-actions/dco@master
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
 
   lint-scss:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -54,8 +19,6 @@ jobs:
         run: yarn lint-scss
 
   lint-js:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -68,8 +31,6 @@ jobs:
         run: yarn lint-js
 
   check-inclusive-naming:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -84,8 +45,6 @@ jobs:
           fail-on-error: true
 
   e2e:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     name: e2e-tests
     runs-on: ubuntu-latest
     outputs:
@@ -162,8 +121,6 @@ jobs:
           retention-days: 30
 
   js-tests:
-    needs: continue-workflow
-    if: ${{ needs.continue-workflow.outputs.continue == 'true' }}
     name: js-tests
     runs-on: ubuntu-latest
     steps:
@@ -183,6 +140,8 @@ jobs:
         run: dotrun test-js
 
   publish_report:
+    permissions:
+      contents: write
     name: publish-e2e-report
     # if job is cancelled we should skip this
     if: success() || needs.e2e.outputs.job_status == 'failure'


### PR DESCRIPTION
## Done

- Cleanup pr action and removed the `pull_request` event trigger.
- Narrowed permissions so that only the `publish_report` job has write access for contents