### PR TITLE
Add error boundaries WD-8089

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -9,29 +9,35 @@ import { InstanceLoadingProvider } from "context/instanceLoading";
 import { ProjectProvider } from "context/project";
 import Events from "pages/instances/Events";
 import App from "./App";
+import ErrorBoundary from "components/ErrorBoundary";
+import ErrorPage from "components/ErrorPage";
 
 const queryClient = new QueryClient();
 
 const Root: FC = () => {
   return (
-    <NotificationProvider>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <ProjectProvider>
-            <InstanceLoadingProvider>
-              <EventQueueProvider>
-                <div className="l-application" role="presentation">
-                  <Navigation />
-                  <App />
-                  <Panels />
-                  <Events />
-                </div>
-              </EventQueueProvider>
-            </InstanceLoadingProvider>
-          </ProjectProvider>
-        </AuthProvider>
-      </QueryClientProvider>
-    </NotificationProvider>
+    <ErrorBoundary fallback={ErrorPage}>
+      <NotificationProvider>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <ProjectProvider>
+              <InstanceLoadingProvider>
+                <EventQueueProvider>
+                  <div className="l-application" role="presentation">
+                    <Navigation />
+                    <ErrorBoundary fallback={ErrorPage}>
+                      <App />
+                      <Panels />
+                      <Events />
+                    </ErrorBoundary>
+                  </div>
+                </EventQueueProvider>
+              </InstanceLoadingProvider>
+            </ProjectProvider>
+          </AuthProvider>
+        </QueryClientProvider>
+      </NotificationProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from "react";
+import type { PropsWithChildren } from "react";
+import { Component } from "react";
+
+type Props = PropsWithChildren & {
+  fallback: FC<{ error?: Error }>;
+};
+
+type State = {
+  error?: Error;
+  hasError: boolean;
+};
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  render() {
+    const { error, hasError } = this.state;
+    const { children, fallback: ErrorComponent } = this.props;
+
+    return hasError ? <ErrorComponent error={error} /> : <>{children}</>;
+  }
+}

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,0 +1,55 @@
+import React, { FC } from "react";
+import {
+  CodeSnippet,
+  CodeSnippetBlockAppearance,
+  Notification,
+  Strip,
+} from "@canonical/react-components";
+
+type Props = {
+  error?: Error;
+};
+
+const ErrorPage: FC<Props> = ({ error }) => {
+  const body = encodeURIComponent(
+    `\`\`\`\n${error?.stack ?? "No stack track"}\n\`\`\``,
+  );
+  const url = `https://github.com/canonical/lxd-ui/issues/new?labels=bug&title=Error%20report&body=${body}`;
+
+  return (
+    <Strip>
+      <Notification severity="negative" title="Error">
+        Something has gone wrong. If this issue persists,{" "}
+        <a href={url} rel="noopener noreferrer" target="_blank">
+          please raise an issue on GitHub.
+        </a>
+      </Notification>
+      <CodeSnippet
+        blocks={[
+          ...(error?.message
+            ? [
+                {
+                  title: "Error",
+                  appearance: CodeSnippetBlockAppearance.NUMBERED,
+                  wrapLines: true,
+                  code: error.message,
+                },
+              ]
+            : []),
+          ...(error?.stack
+            ? [
+                {
+                  title: "Stack trace",
+                  appearance: CodeSnippetBlockAppearance.NUMBERED,
+                  wrapLines: true,
+                  code: error.stack,
+                },
+              ]
+            : []),
+        ]}
+      />
+    </Strip>
+  );
+};
+
+export default ErrorPage;


### PR DESCRIPTION
## Done

- add error boundary component
- apply error boundary to 1) main content and 2) the whole app

Fixes: WD-8089

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - force an error in a nested component and ensure the boundary works (i.e. add `throw new Error("foo");` to `InstanceList.tsx`

## Screenshot

Error in a content component:
![image](https://github.com/canonical/lxd-ui/assets/1155472/571b7628-e7eb-41f9-8a82-5afaa3729728)

Error in navigation or a component higher in the component tree:
![image](https://github.com/canonical/lxd-ui/assets/1155472/b8a740dc-2427-4635-8082-79655291a5f4)
