### PR TITLE
feature(storage): support ceph storage pool [WD-7968]

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -13,18 +13,21 @@ import { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
 import { NetworkFormValues } from "pages/networks/forms/NetworkForm";
 import { ProjectFormValues } from "pages/projects/CreateProject";
 import { getConfigRowMetadata } from "util/configInheritance";
+import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 
 export type ConfigurationRowFormikValues =
   | InstanceAndProfileFormValues
   | StorageVolumeFormValues
   | NetworkFormValues
-  | ProjectFormValues;
+  | ProjectFormValues
+  | StoragePoolFormValues;
 
 type ConfigurationRowFormikProps =
   | InstanceAndProfileFormikProps
   | FormikProps<NetworkFormValues>
   | FormikProps<ProjectFormValues>
-  | FormikProps<StorageVolumeFormValues>;
+  | FormikProps<StorageVolumeFormValues>
+  | FormikProps<StoragePoolFormValues>;
 
 interface Props {
   formik: ConfigurationRowFormikProps;

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -8,12 +8,12 @@ import SubmitButton from "components/SubmitButton";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useNavigate, useParams } from "react-router-dom";
-import { LxdStoragePool } from "types/storage";
 import { queryKeys } from "util/queryKeys";
-import { zfsDriver, btrfsDriver } from "util/storageOptions";
+import { zfsDriver } from "util/storageOptions";
 import { testDuplicateStoragePoolName } from "util/storagePool";
 import StoragePoolForm, {
   StoragePoolFormValues,
+  storagePoolFormToPayload,
 } from "./forms/StoragePoolForm";
 import { useClusterMembers } from "context/useClusterMembers";
 import FormFooterLayout from "components/forms/FormFooterLayout";
@@ -45,20 +45,11 @@ const CreateStoragePool: FC = () => {
       driver: zfsDriver,
       source: "",
       size: "",
+      entityType: "storagePool",
     },
     validationSchema: CreateStoragePoolSchema,
-    onSubmit: ({ name, description, driver, source, size }) => {
-      const hasValidSize = size.match(/^\d/);
-      const storagePool: LxdStoragePool = {
-        name,
-        description,
-        driver,
-        source: driver !== btrfsDriver ? source : undefined,
-        config: {
-          size: hasValidSize ? size : undefined,
-        },
-      };
-
+    onSubmit: (values) => {
+      const storagePool = storagePoolFormToPayload(values);
       const mutation =
         clusterMembers.length > 0
           ? () => createClusteredPool(storagePool, project, clusterMembers)

--- a/src/pages/storage/StoragePoolSize.tsx
+++ b/src/pages/storage/StoragePoolSize.tsx
@@ -21,11 +21,11 @@ const StoragePoolSize: FC<Props> = ({ pool }) => {
   }
 
   const total = resources.space.total;
-  const used = resources.space.used;
+  const used = resources.space.used || 0;
 
   return (
     <Meter
-      percentage={(100 / total) * used}
+      percentage={(100 / total) * used || 0}
       text={`${humanFileSize(used)} of ${humanFileSize(total)} used`}
     />
   );

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -2,10 +2,16 @@ import React, { FC, useEffect, useState } from "react";
 import { Form, Input, Row, Col, useNotify } from "@canonical/react-components";
 import { FormikProps } from "formik";
 import StoragePoolFormMain from "./StoragePoolFormMain";
-import StoragePoolFormMenu from "./StoragePoolFormMenu";
-import { MAIN_CONFIGURATION } from "./StorageVolumeFormMenu";
+import StoragePoolFormMenu, {
+  CEPH_CONFIGURATION,
+  MAIN_CONFIGURATION,
+} from "./StoragePoolFormMenu";
 import useEventListener from "@use-it/event-listener";
 import { updateMaxHeight } from "util/updateMaxHeight";
+import { LxdStoragePool } from "types/storage";
+import { btrfsDriver, cephDriver } from "util/storageOptions";
+import { getCephConfigKey } from "util/storagePool";
+import StoragePoolFormCeph from "./StoragePoolFormCeph";
 
 export interface StoragePoolFormValues {
   isCreating: boolean;
@@ -14,16 +20,55 @@ export interface StoragePoolFormValues {
   description: string;
   driver: string;
   source: string;
-  size: string;
+  entityType: "storagePool";
+  size?: string;
+  ceph_cluster_name?: string;
+  ceph_osd_pg_num?: string;
+  ceph_rbd_clone_copy?: string;
+  ceph_user_name?: string;
+  ceph_rbd_features?: string;
 }
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
+export const storagePoolFormToPayload = (
+  values: StoragePoolFormValues,
+): LxdStoragePool => {
+  const isCephDriver = values.driver === cephDriver;
+  const hasValidSize = values.size?.match(/^\d/);
+
+  const getConfig = () => {
+    if (isCephDriver) {
+      return {
+        [getCephConfigKey("ceph_cluster_name")]: values.ceph_cluster_name,
+        [getCephConfigKey("ceph_osd_pg_num")]:
+          values.ceph_osd_pg_num?.toString(),
+        [getCephConfigKey("ceph_rbd_clone_copy")]: values.ceph_rbd_clone_copy,
+        [getCephConfigKey("ceph_user_name")]: values.ceph_user_name,
+        [getCephConfigKey("ceph_rbd_features")]: values.ceph_rbd_features,
+        source: values.source,
+      };
+    } else {
+      return {
+        size: hasValidSize ? values.size : undefined,
+      };
+    }
+  };
+
+  return {
+    name: values.name,
+    description: values.description,
+    driver: values.driver,
+    source: values.driver !== btrfsDriver ? values.source : undefined,
+    config: getConfig(),
+  };
+};
+
 const StoragePoolForm: FC<Props> = ({ formik }) => {
-  const notify = useNotify();
   const [section, setSection] = useState(MAIN_CONFIGURATION);
+  const notify = useNotify();
 
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
@@ -35,11 +80,18 @@ const StoragePoolForm: FC<Props> = ({ formik }) => {
     <Form className="form storage-pool-form" onSubmit={formik.handleSubmit}>
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden />
-      <StoragePoolFormMenu active={section} setActive={setSection} />
+      <StoragePoolFormMenu
+        active={section}
+        setActive={setSection}
+        formik={formik}
+      />
       <Row className="form-contents" key={section}>
         <Col size={12}>
           {section === MAIN_CONFIGURATION && (
             <StoragePoolFormMain formik={formik} />
+          )}
+          {section === CEPH_CONFIGURATION && (
+            <StoragePoolFormCeph formik={formik} />
           )}
         </Col>
       </Row>

--- a/src/pages/storage/forms/StoragePoolFormCeph.tsx
+++ b/src/pages/storage/forms/StoragePoolFormCeph.tsx
@@ -1,0 +1,67 @@
+import { FormikProps } from "formik";
+import React, { FC } from "react";
+import { StoragePoolFormValues } from "./StoragePoolForm";
+import ConfigurationTable from "components/ConfigurationTable";
+import { getConfigurationRow } from "components/ConfigurationRow";
+import { Input, Select } from "@canonical/react-components";
+import { optionTrueFalse } from "util/instanceOptions";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+}
+
+const StoragePoolFormCeph: FC<Props> = ({ formik }) => {
+  return (
+    <ConfigurationTable
+      rows={[
+        getConfigurationRow({
+          formik,
+          label: "Cluster name",
+          name: "ceph_cluster_name",
+          defaultValue: "",
+          help: "Name of the Ceph cluster in which to create new storage pools",
+          children: <Input type="text" placeholder="Enter cluster name" />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Placement groups",
+          name: "ceph_osd_pg_num",
+          defaultValue: "",
+          help: "Number of placement groups for the OSD storage pool",
+          children: (
+            <Input
+              type="number"
+              placeholder="Enter number of placement groups"
+            />
+          ),
+        }),
+        getConfigurationRow({
+          formik,
+          label: "RBD clone copy",
+          name: "ceph_rbd_clone_copy",
+          defaultValue: "",
+          help: "Whether to use RBD lightweight clones rather than full dataset copies",
+          children: <Select options={optionTrueFalse} />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Ceph user name",
+          name: "ceph_user_name",
+          defaultValue: "",
+          help: "The Ceph user to use when creating storage pools and volumes",
+          children: <Input type="text" placeholder="Enter Ceph user name" />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "RBD features",
+          name: "ceph_rbd_features",
+          defaultValue: "",
+          help: "Comma-separated list of RBD features to enable on the volumes",
+          children: <Input type="text" placeholder="Enter RBD features" />,
+        }),
+      ]}
+    />
+  );
+};
+
+export default StoragePoolFormCeph;

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -7,10 +7,12 @@ import {
   dirDriver,
   btrfsDriver,
   getSourceHelpForDriver,
+  cephDriver,
 } from "util/storageOptions";
 import { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
+import { cephStoragePoolDefaults } from "util/storagePool";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -29,85 +31,99 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
     };
   };
 
+  const isCephDriver = formik.values.driver === cephDriver;
+  const isDirDriver = formik.values.driver === dirDriver;
+
   return (
-    <Row>
-      <Col size={12}>
-        <Input
-          {...getFormProps("name")}
-          type="text"
-          label="Name"
-          required
-          disabled={!formik.values.isCreating || formik.values.readOnly}
-          help={
-            !formik.values.isCreating
-              ? "Cannot rename storage pools"
-              : undefined
-          }
-        />
-        <AutoExpandingTextArea
-          {...getFormProps("description")}
-          label="Description"
-          disabled={formik.values.readOnly}
-          dynamicHeight
-        />
-        <Select
-          id="driver"
-          name="driver"
-          help={
-            !formik.values.isCreating
-              ? "Driver can't be changed"
-              : formik.values.driver === zfsDriver
-                ? "ZFS gives best performance and reliability"
+    <>
+      <Row>
+        <Col size={12}>
+          <Input
+            {...getFormProps("name")}
+            type="text"
+            label="Name"
+            required
+            disabled={!formik.values.isCreating || formik.values.readOnly}
+            help={
+              !formik.values.isCreating
+                ? "Cannot rename storage pools"
                 : undefined
-          }
-          label="Driver"
-          options={storageDrivers}
-          onChange={(target) => {
-            const val = target.target.value;
-            if (val === dirDriver) {
-              void formik.setFieldValue("size", "");
             }
-            if (val === btrfsDriver) {
-              void formik.setFieldValue("source", "");
+          />
+          <AutoExpandingTextArea
+            {...getFormProps("description")}
+            label="Description"
+            disabled={formik.values.readOnly}
+            dynamicHeight
+          />
+          <Select
+            id="driver"
+            name="driver"
+            help={
+              !formik.values.isCreating
+                ? "Driver can't be changed"
+                : formik.values.driver === zfsDriver
+                  ? "ZFS gives best performance and reliability"
+                  : undefined
             }
-            void formik.setFieldValue("driver", val);
-          }}
-          value={formik.values.driver}
-          required
-          disabled={!formik.values.isCreating || formik.values.readOnly}
-        />
-        <DiskSizeSelector
-          label="Size"
-          value={formik.values.size}
-          help={
-            formik.values.driver === dirDriver
-              ? "Not available"
-              : "When left blank, defaults to 20% of free disk space. Default will be between 5GiB and 30GiB"
-          }
-          setMemoryLimit={(val?: string) =>
-            void formik.setFieldValue("size", val)
-          }
-          disabled={
-            formik.values.driver === dirDriver || formik.values.readOnly
-          }
-        />
-        <Input
-          {...getFormProps("source")}
-          type="text"
-          disabled={
-            formik.values.driver === btrfsDriver ||
-            !formik.values.isCreating ||
-            formik.values.readOnly
-          }
-          help={
-            formik.values.isCreating
-              ? getSourceHelpForDriver(formik.values.driver)
-              : "Source can't be changed"
-          }
-          label="Source"
-        />
-      </Col>
-    </Row>
+            label="Driver"
+            options={storageDrivers}
+            onChange={(target) => {
+              const val = target.target.value;
+              if (val === dirDriver) {
+                void formik.setFieldValue("size", "");
+              }
+              if (val === btrfsDriver) {
+                void formik.setFieldValue("source", "");
+              }
+              if (val !== cephDriver) {
+                const cephConfigFields = Object.keys(cephStoragePoolDefaults);
+                for (const field of cephConfigFields) {
+                  void formik.setFieldValue(field, undefined);
+                }
+              }
+
+              void formik.setFieldValue("driver", val);
+            }}
+            value={formik.values.driver}
+            required
+            disabled={!formik.values.isCreating || formik.values.readOnly}
+          />
+          {!isCephDriver && !isDirDriver && (
+            <DiskSizeSelector
+              label="Size"
+              value={formik.values.size}
+              help={
+                formik.values.driver === dirDriver
+                  ? "Not available"
+                  : "When left blank, defaults to 20% of free disk space. Default will be between 5GiB and 30GiB"
+              }
+              setMemoryLimit={(val?: string) =>
+                void formik.setFieldValue("size", val)
+              }
+              disabled={
+                formik.values.driver === dirDriver || formik.values.readOnly
+              }
+            />
+          )}
+          <Input
+            {...getFormProps("source")}
+            type="text"
+            disabled={
+              formik.values.driver === btrfsDriver ||
+              !formik.values.isCreating ||
+              formik.values.readOnly
+            }
+            help={
+              formik.values.isCreating
+                ? getSourceHelpForDriver(formik.values.driver)
+                : "Source can't be changed"
+            }
+            label="Source"
+          />
+        </Col>
+      </Row>
+    </>
   );
 };
 

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -3,20 +3,31 @@ import MenuItem from "components/forms/FormMenuItem";
 import { useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
+import { FormikProps } from "formik";
+import { StoragePoolFormValues } from "./StoragePoolForm";
+import { cephDriver } from "util/storageOptions";
 
 export const MAIN_CONFIGURATION = "Main configuration";
+export const CEPH_CONFIGURATION = "Ceph";
 
 interface Props {
   active: string;
   setActive: (val: string) => void;
+  formik: FormikProps<StoragePoolFormValues>;
 }
 
-const StoragePoolFormMenu: FC<Props> = ({ active, setActive }) => {
+const StoragePoolFormMenu: FC<Props> = ({ formik, active, setActive }) => {
   const notify = useNotify();
   const menuItemProps = {
     active,
     setActive,
   };
+
+  const isCephDriver = formik.values.driver === cephDriver;
+  const hasName = formik.values.name.length > 0;
+  const disableReason = hasName
+    ? undefined
+    : "Please enter a storage pool name to enable this section";
 
   const resize = () => {
     updateMaxHeight("form-navigation", "p-bottom-controls");
@@ -28,6 +39,13 @@ const StoragePoolFormMenu: FC<Props> = ({ active, setActive }) => {
       <nav aria-label="Storage pool form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+          {isCephDriver && (
+            <MenuItem
+              label={CEPH_CONFIGURATION}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
         </ul>
       </nav>
     </div>

--- a/src/pages/storage/forms/StorageVolumeFormMenu.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMenu.tsx
@@ -6,6 +6,7 @@ import useEventListener from "@use-it/event-listener";
 import { FormikProps } from "formik/dist/types";
 import { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
 import { LxdStorageVolumeContentType } from "types/storage";
+import { driversWithFilesystemSupport, zfsDriver } from "util/storageOptions";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const SNAPSHOTS = "Snapshots";
@@ -76,14 +77,14 @@ const StorageVolumeFormMenu: FC<Props> = ({
                 disableReason={disableReason}
               />
               {contentType === "filesystem" &&
-                ["zfs", "lvm", "ceph"].includes(poolDriver) && (
+                driversWithFilesystemSupport.includes(poolDriver) && (
                   <MenuItem
                     label={FILESYSTEM}
                     {...menuItemProps}
                     disableReason={disableReason}
                   />
                 )}
-              {poolDriver === "zfs" && (
+              {poolDriver === zfsDriver && (
                 <MenuItem
                   label={ZFS}
                   {...menuItemProps}

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -1,5 +1,5 @@
 export interface LxdStoragePool {
-  config?: {
+  config: {
     size?: string;
     source?: string;
   } & Record<string, string | undefined>;
@@ -63,7 +63,7 @@ export interface LxdStoragePoolResources {
     total: number;
   };
   space: {
-    used: number;
+    used?: number;
     total: number;
   };
 }

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -19,6 +19,7 @@ import { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
 import { fetchStoragePool } from "api/storage-pools";
 import { getStorageVolumeDefault, getVolumeKey } from "util/storageVolume";
 import { getNetworkDefault } from "util/networks";
+import { getCephStoragePoolDefault } from "./storagePool";
 
 export interface ConfigRowMetadata {
   value?: string;
@@ -40,6 +41,8 @@ export const getConfigRowMetadata = (
       return getStorageVolumeRowMetadata(values, name);
     case "network":
       return getNetworkRowMetadata(name);
+    case "storagePool":
+      return getStoragePoolRowMetadata(name);
   }
 };
 
@@ -116,6 +119,11 @@ const getStorageVolumeRowMetadata = (
 
 const getNetworkRowMetadata = (name: string): ConfigRowMetadata => {
   return getNetworkDefault(name);
+};
+
+// NOTE: this is only relevant for Ceph RBD storage pools at the moment
+const getStoragePoolRowMetadata = (name: string): ConfigRowMetadata => {
+  return getCephStoragePoolDefault(name);
 };
 
 const getInstanceProfileProjectDefaults = (

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -2,6 +2,7 @@ export const dirDriver = "dir";
 export const btrfsDriver = "btrfs";
 export const lvmDriver = "lvm";
 export const zfsDriver = "zfs";
+export const cephDriver = "ceph";
 
 export const storageDrivers = [
   {
@@ -20,12 +21,17 @@ export const storageDrivers = [
     label: "ZFS",
     value: zfsDriver,
   },
+  {
+    label: "Ceph",
+    value: cephDriver,
+  },
 ];
 
 const storageDriverToSourceHelp: Record<string, string> = {
   dir: "Optional, path to an existing directory",
   lvm: "Optional, path to an existing block device, loop file or LVM volume group",
   zfs: "Optional, path to an existing block device, loop file or ZFS dataset/pool",
+  ceph: "Optional, OSD pool name",
 };
 
 export const getSourceHelpForDriver = (driver: string) => {
@@ -34,3 +40,5 @@ export const getSourceHelpForDriver = (driver: string) => {
   }
   return "Not available";
 };
+
+export const driversWithFilesystemSupport = [zfsDriver, lvmDriver, cephDriver];

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -1,5 +1,38 @@
 import { AbortControllerState, checkDuplicateName } from "util/helpers";
 import { AnyObject, TestFunction } from "yup";
+import { ConfigRowMetadata } from "./configInheritance";
+
+export const cephStoragePoolDefaults: Record<string, string> = {
+  ceph_cluster_name: "ceph",
+  ceph_osd_pg_num: "32",
+  ceph_rbd_clone_copy: "true",
+  ceph_user_name: "admin",
+  ceph_rbd_features: "layering",
+};
+
+export const getCephStoragePoolDefault = (
+  formField: string,
+): ConfigRowMetadata => {
+  if (formField in cephStoragePoolDefaults) {
+    return { value: cephStoragePoolDefaults[formField], source: "LXD" };
+  }
+  return { value: "", source: "LXD" };
+};
+
+const cephStoragePoolFormFieldToPayloadName: Record<string, string> = {
+  ceph_cluster_name: "ceph.cluster_name",
+  ceph_osd_pg_num: "ceph.osd.pg_num",
+  ceph_rbd_clone_copy: "ceph.rbd.clone_copy",
+  ceph_user_name: "ceph.user.name",
+  ceph_rbd_features: "ceph.rbd.features",
+};
+
+export const getCephConfigKey = (key: string): string => {
+  if (key in cephStoragePoolFormFieldToPayloadName) {
+    return cephStoragePoolFormFieldToPayloadName[key];
+  }
+  return key;
+};
 
 export const testDuplicateStoragePoolName = (
   project: string,

--- a/src/util/storagePoolEdit.tsx
+++ b/src/util/storagePoolEdit.tsx
@@ -1,0 +1,22 @@
+import { LxdStoragePool } from "types/storage";
+import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
+
+export const getStoragePoolEditValues = (
+  pool: LxdStoragePool,
+): StoragePoolFormValues => {
+  return {
+    readOnly: true,
+    isCreating: false,
+    name: pool.name,
+    description: pool.description,
+    driver: pool.driver,
+    source: pool.config.source || "",
+    size: pool.config.size || "GiB",
+    entityType: "storagePool",
+    ceph_cluster_name: pool.config["ceph.cluster_name"],
+    ceph_osd_pg_num: pool.config["ceph.osd.pg_num"],
+    ceph_rbd_clone_copy: pool.config["ceph.rbd.clone_copy"],
+    ceph_user_name: pool.config["ceph.user.name"],
+    ceph_rbd_features: pool.config["ceph.rbd.features"],
+  };
+};


### PR DESCRIPTION
## Done

### Things required code changes
- CRUD storage pool with ceph (RBD) driver
- CRUD storage pool with ceph (RBD) driver in LXD cluster
- Prevent ceph storage volumes from being attached to more than one instance

### Things that didn't require code changes but tested locally
- Add, edit and delete custom storage volumes in ceph storage pool
- Add, edit, delete and restore snapshots for ceph custom storage volumes

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Setup a Ceph cluster using LXD VMs and microceph
    - Create, edit and delete storage pool with ceph driver
    - Create, edit and delete custom storage volume in ceph storage pool
    - Create, edit, delete and restore snapshots for ceph custom storage volumes
    - Create and run instances in ceph storage pool
    - Create and run instances with ceph custom storage volumes attached