### PR TITLE
feat: use supported storage driver options from server settings [WD-8144]

### DIFF
--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -3,22 +3,24 @@ import { Row, Input, Select, Col } from "@canonical/react-components";
 import { FormikProps } from "formik";
 import {
   zfsDriver,
-  storageDrivers,
   dirDriver,
   btrfsDriver,
   getSourceHelpForDriver,
   cephDriver,
+  getStorageDriverOptions,
 } from "util/storageOptions";
 import { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import { cephStoragePoolDefaults } from "util/storagePool";
+import { useSettings } from "context/useSettings";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormMain: FC<Props> = ({ formik }) => {
+  const { data: settings } = useSettings();
   const getFormProps = (id: "name" | "description" | "size" | "source") => {
     return {
       id: id,
@@ -33,6 +35,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
 
   const isCephDriver = formik.values.driver === cephDriver;
   const isDirDriver = formik.values.driver === dirDriver;
+  const storageDriverOptions = getStorageDriverOptions(settings);
 
   return (
     <>
@@ -67,7 +70,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                   : undefined
             }
             label="Driver"
-            options={storageDrivers}
+            options={storageDriverOptions}
             onChange={(target) => {
               const val = target.target.value;
               if (val === dirDriver) {

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -1,6 +1,11 @@
 import { LxdConfigPair } from "./config";
 
 type LXDAuthMethods = "tls" | "oidc" | "unix";
+type SupportedStorageDriver = {
+  Name: string;
+  Version: string;
+  Remote: boolean;
+};
 
 export interface LxdSettings {
   api_status: string;
@@ -10,6 +15,7 @@ export interface LxdSettings {
     os_name?: string;
     server_version: ?string;
     server_clustered: boolean;
+    storage_supported_drivers: SupportedStorageDriver[];
   };
   auth?: "trusted" | "untrusted";
   auth_methods?: LXDAuthMethods;

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -1,31 +1,33 @@
+import { OptionHTMLAttributes } from "react";
+import { LxdSettings } from "types/server";
+
 export const dirDriver = "dir";
 export const btrfsDriver = "btrfs";
 export const lvmDriver = "lvm";
 export const zfsDriver = "zfs";
 export const cephDriver = "ceph";
 
-export const storageDrivers = [
-  {
-    label: "Directory",
-    value: dirDriver,
-  },
-  {
-    label: "Btrfs",
-    value: btrfsDriver,
-  },
-  {
-    label: "LVM",
-    value: lvmDriver,
-  },
-  {
-    label: "ZFS",
-    value: zfsDriver,
-  },
-  {
-    label: "Ceph",
-    value: cephDriver,
-  },
-];
+const storageDriverLabels: { [key: string]: string } = {
+  [dirDriver]: "Directory",
+  [btrfsDriver]: "Btrfs",
+  [lvmDriver]: "LVM",
+  [zfsDriver]: "ZFS",
+  [cephDriver]: "Ceph",
+};
+
+export const getStorageDriverOptions = (settings?: LxdSettings) => {
+  const serverSupportedStorageDrivers =
+    settings?.environment?.storage_supported_drivers || [];
+  const storageDriverOptions: OptionHTMLAttributes<HTMLOptionElement>[] = [];
+  for (const driver of serverSupportedStorageDrivers) {
+    const label = storageDriverLabels[driver.Name];
+    if (label) {
+      storageDriverOptions.push({ label, value: driver.Name });
+    }
+  }
+
+  return storageDriverOptions;
+};
 
 const storageDriverToSourceHelp: Record<string, string> = {
   dir: "Optional, path to an existing directory",


### PR DESCRIPTION
## Done

- Generate storage driver options based on server settings

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a storage pool and check that the storage driver options selector is populated correctly