### PR TITLE
Fix safari regressions [WD-7486]

### DIFF
--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -7,6 +7,11 @@
   }
 }
 
+// fix for safari https://warthogs.atlassian.net/browse/WD-7486
+.multiselect-checkbox span.p-checkbox__label {
+  padding-left: 0;
+}
+
 .selected-row {
   background-color: #e6f2ff;
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -182,7 +182,7 @@ $border-thin: 1px solid $color-mid-light !default;
   .p-breadcrumbs__item {
     font-size: #{map.get($font-sizes, h4-mobile)}rem;
     font-weight: 275;
-    line-height: 2rem;
+    line-height: 1.45rem;
     margin-bottom: 0;
     margin-top: 0;
     padding-top: 0;
@@ -245,6 +245,7 @@ $border-thin: 1px solid $color-mid-light !default;
 }
 
 .help-link {
+  align-items: center;
   display: flex;
 
   .help-link-icon {


### PR DESCRIPTION
## Done

- Decreased line height for breadcrumb items, because safari renders fonts differently than other browsers.
- Removed padding-left from selectable main table's checkbox__label, because the padding left was pushing the arrow on the next row in Safari.
- `align-items: center` to breadcrumb for because info icon was not aligned perfectly with the breadcrumb.

This changes don't show regressions in chrome, but fixes issues in safari.



Fixes WD-7486

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check all breadcrumbs, selectable main tables look okay in safari.

## Screenshots
Before:
The screenshots for "Before" are attached in https://warthogs.atlassian.net/browse/WD-7486

After:
Selectable main table:

<img width="924" alt="Screenshot 2024-01-15 at 5 09 17 PM" src="https://github.com/canonical/lxd-ui/assets/54525904/3ca6641e-e262-4213-970f-63ab440159df">


Breadcrumbs:
<img width="1155" alt="Screenshot 2024-01-15 at 5 08 36 PM" src="https://github.com/canonical/lxd-ui/assets/54525904/c7d88d41-bc12-44c0-8aa2-bc09d3177362">

[Before]: Breadcrumb with info icon:
<img width="1254" alt="image" src="https://github.com/canonical/lxd-ui/assets/54525904/1dfdb916-75e3-4e9e-bdb9-3f019ab7466e">

[After]: Breadcrumb with info icon:
<img width="911" alt="image" src="https://github.com/canonical/lxd-ui/assets/54525904/9b7580d1-8d34-49c4-8584-066bbe955dfa">
