### PR TITLE
fix: remove linuxcontainers images

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -41,10 +41,6 @@ const minimalJson =
   "https://cloud-images.ubuntu.com/minimal/releases/streams/v1/com.ubuntu.cloud:released:download.json";
 const minimalServer = "https://cloud-images.ubuntu.com/minimal/releases/";
 
-const linuxContainersJson =
-  "https://images.linuxcontainers.org/streams/v1/images.json";
-const linuxContainersServer = "https://images.linuxcontainers.org";
-
 const ANY = "any";
 const CONTAINER = "container";
 const VM = "virtual-machine";
@@ -76,11 +72,6 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
 
   const { data: settings, isLoading: isSettingsLoading } = useSettings();
 
-  const { data: linuxContainerImages = [] } = useQuery({
-    queryKey: [queryKeys.images, linuxContainersServer],
-    queryFn: () => loadImages(linuxContainersJson, linuxContainersServer),
-  });
-
   const { data: canonicalImages = [], isLoading: isCiLoading } = useQuery({
     queryKey: [queryKeys.images, canonicalServer],
     queryFn: () => loadImages(canonicalJson, canonicalServer),
@@ -108,7 +99,6 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
         .map(localLxdToRemoteImage)
         .concat([...minimalImages].reverse().sort(byLtsFirst))
         .concat([...canonicalImages].reverse().sort(byLtsFirst))
-        .concat(linuxContainerImages)
         .filter((image) => archSupported.includes(image.arch));
 
   const archAll = [...new Set(images.map((item) => item.arch))]
@@ -214,9 +204,6 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
         }
         if (item.server === minimalServer) {
           return "Ubuntu Minimal";
-        }
-        if (item.server === linuxContainersServer) {
-          return "Linux Containers";
         }
       };
 

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -21,10 +21,11 @@ export const createInstance = async (
   await page.getByLabel("Instance name").fill(instance);
   await page.getByRole("button", { name: "Browse images" }).click();
   await page.getByPlaceholder("Search an image").click();
-  await page.getByPlaceholder("Search an image").fill("alpine");
+  await page.getByPlaceholder("Search an image").fill("jammy");
   await page
-    .getByRole("row", {
-      name: "Distribution Release Variant Type Alias Source Action",
+    .getByRole("row")
+    .filter({
+      hasText: "Ubuntu Minimal",
     })
     .getByRole("button", { name: "Select" })
     .last()


### PR DESCRIPTION
## Done

- Removed linux containers images for selection when creating instances. This is due to the linuxcontainers image server no longer accepts lxd users.
- Fixed tests to use ubuntu jammy image instead of alpine

## QA
- Check only images from ubuntu or ubuntu minimal servers are available for selection when creating an instance