### PR TITLE
Avoid prompt on navigation away from terminal after session close

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -143,6 +143,7 @@ const InstanceTerminal: FC<Props> = ({ instance }) => {
         );
       }
       setDataWs(null);
+      setUserInteracted(false);
     };
 
     data.binaryType = "arraybuffer";

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -118,6 +118,7 @@ const InstanceTextConsole: FC<Props> = ({
         onFailure("Error", event.reason, getWsErrorMsg(event.code));
       }
       setDataWs(null);
+      setUserInteracted(false);
     };
 
     data.binaryType = "arraybuffer";


### PR DESCRIPTION
## Done

- Avoid prompt on navigation away from terminal when the websocket for the terminal is closed

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create & start instance
    - open instance detail page > terminal, interact with terminal, try to navigate by clicking and ensure a warning is displayed, and you can stay on the page with the warning. Stop the instance directly or in another tab. Ensure the warning on navigation is not displayed after the terminal was interacted with.
    - repeat test for text console