### PR TITLE
Fix a11y for network forward edit icon

### DIFF
--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -90,6 +90,7 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
               <Link
                 className="p-button--base u-no-margin--bottom has-icon"
                 to={`/ui/project/${project}/networks/detail/${network.name}/forwards/${forward.listen_address}/edit`}
+                title="Edit network forward"
               >
                 <Icon name="edit" />
               </Link>

--- a/src/pages/networks/forms/NetworkForwardForm.tsx
+++ b/src/pages/networks/forms/NetworkForwardForm.tsx
@@ -111,10 +111,7 @@ const NetworkForwardForm: FC<Props> = ({
     <Form className="form network-forwards-form" onSubmit={formik.handleSubmit}>
       <Row className="form-contents">
         <Col size={12}>
-          <ScrollableForm
-            dependencies={[notify.notification]}
-            belowId="form-footer"
-          >
+          <ScrollableForm>
             {/* hidden submit to enable enter key in inputs */}
             <Input type="submit" hidden />
             <Row className="p-form__group p-form-validation">

--- a/src/util/networks.spec.tsx
+++ b/src/util/networks.spec.tsx
@@ -5,7 +5,7 @@ describe("areNetworksEqual", () => {
   it("accepts matches", () => {
     const a: Partial<LxdNetwork> & Required<Pick<LxdNetwork, "config">> = {
       config: {
-        "bridge.mode": "standard",
+        "bridge.driver": "native",
         "ipv4.address": "auto",
         "ipv6.address": "fd42:2c50:bf9f:52b1::1/64",
         "ipv6.nat": "true",
@@ -17,7 +17,7 @@ describe("areNetworksEqual", () => {
     };
     const b: Partial<LxdNetwork> & Required<Pick<LxdNetwork, "config">> = {
       config: {
-        "bridge.mode": "standard",
+        "bridge.driver": "native",
         "ipv4.address": "10.191.170.1/24",
         "ipv6.address": "fd42:2c50:bf9f:52b1::1/64",
         "ipv6.nat": "true",
@@ -47,12 +47,12 @@ describe("areNetworksEqual", () => {
   it("rejects config diff", () => {
     const a: Partial<LxdNetwork> & Required<Pick<LxdNetwork, "config">> = {
       config: {
-        "bridge.mode": "standard",
+        "bridge.driver": "native",
       },
     };
     const b: Partial<LxdNetwork> & Required<Pick<LxdNetwork, "config">> = {
       config: {
-        "bridge.mode": "fan",
+        "bridge.driver": "openvswitch",
       },
     };
 

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -1,7 +1,6 @@
 import { LxdInstance } from "types/instance";
 import { LxdNetwork, LxdNetworkConfig } from "types/network";
 import { ConfigRowMetadata } from "util/configInheritance";
-import { AnyObject, TestFunction } from "yup";
 
 export const getIpAddresses = (
   instance: LxdInstance,
@@ -79,9 +78,7 @@ export const areNetworksEqual = (
   return !hasMainKeyDiff;
 };
 
-export const testValidIp: TestFunction<string | null | undefined, AnyObject> = (
-  ip,
-) => {
+export const testValidIp = (ip: string | null | undefined) => {
   const expression =
     /((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))/;
 
@@ -91,10 +88,7 @@ export const testValidIp: TestFunction<string | null | undefined, AnyObject> = (
   return expression.test(ip);
 };
 
-export const testValidPort: TestFunction<
-  string | null | undefined,
-  AnyObject
-> = (port) => {
+export const testValidPort = (port: string | null | undefined) => {
   const expression =
     /^(([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])[-,]){0,9}([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/;
 


### PR DESCRIPTION
## Done

- made network forward edit button a11y
- fixed usage of ScrollableForm
- fixed types for network port and ip check functions

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Edit a network forward