### PR TITLE
Add p-breadcrumbs--large class to avoid upstream conflicts

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -48,7 +48,7 @@ const RenameHeader: FC<Props> = ({
         <div className={classnames("p-panel__title", titleClassName)}>
           <nav
             key="breadcrumbs"
-            className="p-breadcrumbs"
+            className="p-breadcrumbs p-breadcrumbs--large"
             aria-label="Breadcrumbs"
           >
             <ol className="p-breadcrumbs__items">

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -171,7 +171,7 @@ $border-thin: 1px solid $color-mid-light !default;
   padding-bottom: $spv--medium;
 }
 
-.p-breadcrumbs {
+.p-breadcrumbs--large {
   margin-bottom: 0;
   width: inherit;
 


### PR DESCRIPTION
## Done

- Added a new breadcrumbs-large class to the breadcrumbs to avoid polluting vanilla classes.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check all the breadcrumbs in detail pages look as they should be.

## Screenshots

[if relevant, include a screenshot or screen capture]