### PR TITLE
feat: upgrade to xterm v5 and remove xterm-for-react dependency [WD-8311]

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "react-useportal": "1.0.19",
     "serve": "14.2.1",
     "vanilla-framework": "4.6.0",
-    "xterm-addon-fit": "0.6.0",
-    "xterm-for-react": "1.0.4",
+    "xterm": "5.2.1",
+    "xterm-addon-fit": "0.8.0",
     "yup": "1.3.3"
   },
   "devDependencies": {

--- a/src/components/Xterm.tsx
+++ b/src/components/Xterm.tsx
@@ -1,0 +1,213 @@
+/**
+MIT License
+
+Copyright (c) 2020 Robert Harbison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { Terminal, ITerminalOptions, ITerminalAddon } from "xterm";
+import "xterm/css/xterm.css";
+
+interface Props {
+  /**
+   * Class name to add to the terminal container.
+   */
+  className?: string;
+
+  /**
+   * Options to initialize the terminal with.
+   */
+  options?: ITerminalOptions;
+
+  /**
+   * An array of XTerm addons to load along with the terminal.current.
+   */
+  addons?: Array<ITerminalAddon>;
+
+  /**
+   * Adds an event listener for when a binary event fires. This is used to
+   * enable non UTF-8 conformant binary messages to be sent to the backend.
+   * Currently this is only used for a certain type of mouse reports that
+   * happen to be not UTF-8 compatible.
+   * The event value is a JS string, pass it to the underlying pty as
+   * binary data, e.g. `pty.write(Buffer.from(data, 'binary'))`.
+   */
+  onBinary?(data: string): void;
+
+  /**
+   * Adds an event listener for the cursor moves.
+   */
+  onCursorMove?(): void;
+
+  /**
+   * Adds an event listener for when a data event fires. This happens for
+   * example when the user types or pastes into the terminal.current. The event value
+   * is whatever `string` results, in a typical setup, this should be passed
+   * on to the backing pty.
+   */
+  onData?(data: string): void;
+
+  /**
+   * Adds an event listener for when a key is pressed. The event value contains the
+   * string that will be sent in the data event as well as the DOM event that
+   * triggered it.
+   */
+  onKey?(event: { key: string; domEvent: KeyboardEvent }): void;
+
+  /**
+   * Adds an event listener for when a line feed is added.
+   */
+  onLineFeed?(): void;
+
+  /**
+   * Adds an event listener for when a scroll occurs. The event value is the
+   * new position of the viewport.
+   * @returns an `IDisposable` to stop listening.
+   */
+  onScroll?(newPosition: number): void;
+
+  /**
+   * Adds an event listener for when a selection change occurs.
+   */
+  onSelectionChange?(): void;
+
+  /**
+   * Adds an event listener for when rows are rendered. The event value
+   * contains the start row and end rows of the rendered area (ranges from `0`
+   * to `terminal.current.rows - 1`).
+   */
+  onRender?(event: { start: number; end: number }): void;
+
+  /**
+   * Adds an event listener for when the terminal is resized. The event value
+   * contains the new size.
+   */
+  onResize?(event: { cols: number; rows: number }): void;
+
+  /**
+   * Adds an event listener for when an OSC 0 or OSC 2 title change occurs.
+   * The event value is the new title.
+   */
+  onTitleChange?(newTitle: string): void;
+
+  /**
+   * Attaches a custom key event handler which is run before keys are
+   * processed, giving consumers of xterm.js ultimate control as to what keys
+   * should be processed by the terminal and what keys should not.
+   *
+   * @param event The custom KeyboardEvent handler to attach.
+   * This is a function that takes a KeyboardEvent, allowing consumers to stop
+   * propagation and/or prevent the default action. The function returns
+   * whether the event should be processed by xterm.js.
+   */
+  customKeyEventHandler?(event: KeyboardEvent): boolean;
+
+  /**
+   * This callback porovides an interface for running actions directly after
+   * the terminal is open. Some useful cations includes resizing the terminal
+   * or focusing on the terminal etc.
+   */
+  onOpen?(): void;
+}
+
+export default forwardRef<Terminal, Props>(function Xterm(
+  {
+    options = {},
+    addons,
+    className,
+    onBinary,
+    onCursorMove,
+    onData,
+    onKey,
+    onLineFeed,
+    onScroll,
+    onSelectionChange,
+    onRender,
+    onResize,
+    onTitleChange,
+    customKeyEventHandler,
+    onOpen,
+  }: Props,
+  ref,
+) {
+  const [terminalOpen, setTerminalOpen] = useState(false);
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const xtermRef = useRef<Terminal>(new Terminal(options));
+
+  useImperativeHandle(ref, () => {
+    return xtermRef.current;
+  });
+
+  const initialiseXterm = () => {
+    // Load addons if the prop exists.
+    if (addons) {
+      addons.forEach((addon) => {
+        xtermRef.current?.loadAddon(addon);
+      });
+    }
+
+    // Create Listeners
+    if (onBinary) xtermRef.current.onBinary(onBinary);
+    if (onCursorMove) xtermRef.current.onCursorMove(onCursorMove);
+    if (onData) xtermRef.current.onData(onData);
+    if (onKey) xtermRef.current.onKey(onKey);
+    if (onLineFeed) xtermRef.current.onLineFeed;
+    if (onScroll) xtermRef.current.onScroll(onScroll);
+    if (onSelectionChange)
+      xtermRef.current.onSelectionChange(onSelectionChange);
+    if (onRender) xtermRef.current.onRender(onRender);
+    if (onResize) xtermRef.current.onResize(onResize);
+    if (onTitleChange) xtermRef.current.onTitleChange(onTitleChange);
+
+    // Add Custom Key Event Handler
+    if (customKeyEventHandler) {
+      xtermRef.current.attachCustomKeyEventHandler(customKeyEventHandler);
+    }
+  };
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (terminal) {
+      initialiseXterm();
+      xtermRef.current?.open(terminal);
+      setTerminalOpen(true);
+    }
+
+    return () => {
+      xtermRef.current?.dispose();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (terminalOpen && onOpen) {
+      onOpen();
+    }
+  }, [terminalOpen]);
+
+  return <div className={className} ref={terminalRef} />;
+});

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -65,10 +65,10 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "instance_detail_panel";
 @import "instance_detail_terminal";
 @import "instance_list";
+@import "meter";
 @import "network_detail_overview";
 @import "network_form";
 @import "network_forwards_form";
-@import "meter";
 @import "network_map";
 @import "no_match";
 @import "operation_list";
@@ -86,10 +86,10 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "selectable_main_table";
 @import "settings_page";
 @import "snapshots";
-@import "storage";
 @import "storage_detail_overview";
 @import "storage_pool_form";
 @import "storage_volume_form";
+@import "storage";
 @import "upper_controls_bar";
 
 .p-heading--4 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4910,7 +4910,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
 
-prop-types@15.8.1, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6279,23 +6279,15 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xterm-addon-fit@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.6.0.tgz#142e1ce181da48763668332593fc440349c88c34"
-  integrity sha512-9/7A+1KEjkFam0yxTaHfuk9LEvvTSBi0PZmEkzJqgafXPEXL9pCMAVV7rB09sX6ATRDXAdBpQhZkhKj7CGvYeg==
+xterm-addon-fit@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz#48ca99015385141918f955ca7819e85f3691d35f"
+  integrity sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==
 
-xterm-for-react@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/xterm-for-react/-/xterm-for-react-1.0.4.tgz#6b35b9b037a0f9d979e7b57bb1d7c6ab7565b380"
-  integrity sha512-DCkLR9ZXeW907YyyaCTk/3Ol34VRHfCnf3MAPOkj3dUNA85sDqHvTXN8efw4g7bx7gWdJQRsEpGt2tJOXKG3EQ==
-  dependencies:
-    prop-types "^15.7.2"
-    xterm "^4.5.0"
-
-xterm@^4.5.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.19.0.tgz#c0f9d09cd61de1d658f43ca75f992197add9ef6d"
-  integrity sha512-c3Cp4eOVsYY5Q839dR5IejghRPpxciGmLWWaP9g+ppfMeBChMeLa1DCA+pmX/jyDZ+zxFOmlJL/82qVdayVoGQ==
+xterm@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.2.1.tgz#b3fea7bdb55b9be1d4b31f4cd1091f26ac42afb8"
+  integrity sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Done

- Created a `Xterm` component which directly depends on `xterm.js`. This enabled the removal of `xterm-for-react` dependency and we can now upgrade `xterm` independently. The new Xterm component is a hook based implementation inspired by the [xterm-for-react](https://github.com/robert-harbison/xterm-for-react/blob/master/src/XTerm.tsx) implementation.
- Cleaned up `InstanceTerminal` and `InstanceTextConsole` components, removing unnecessary `useEffect` and `useLayoutEffect` calls.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Visit the details page for a running instance, test the Terminal and Console tabs and make sure the terminal work as expected.