### PR TITLE
Replace admonition markup in help texts

### DIFF
--- a/src/util/config.spec.ts
+++ b/src/util/config.spec.ts
@@ -99,6 +99,20 @@ describe("toConfigFields and replaceDocLinks", () => {
       'the value of <a href="https://docs.example.org/reference/storage_zfs/#storage-zfs-volume-conf:zfs.block_mode" target="_blank" rel="noreferrer">zfs.block_mode</a>,<br>the specified',
     );
   });
+
+  it("converts admonition markup to html bold tag", () => {
+    const input = "Foo bar baz.  ```{important}  Some important addition.```";
+
+    const result = configDescriptionToHtml(
+      input,
+      "https://docs.example.org",
+      objectsInvTxt.split("\n"),
+    );
+
+    expect(result).toBe(
+      "Foo bar baz.  <b>Important</b>  Some important addition.",
+    );
+  });
 });
 
 const objectsInvTxt =

--- a/src/util/config.tsx
+++ b/src/util/config.tsx
@@ -35,6 +35,11 @@ export const configDescriptionToHtml = (
     .replaceAll(">", "&gt;")
     .replaceAll("\n", "<br>");
 
+  // replace admonition markup
+  result = result
+    .replaceAll("```", "")
+    .replaceAll("{important}", "<b>Important</b>");
+
   // documentation links
   if (objectsInvTxt) {
     // tags like {ref}`instance-options-qemu` can be in the input string
@@ -66,11 +71,6 @@ export const configDescriptionToHtml = (
   while (result.includes("`") && count++ < maxCodeblockReplacementCount) {
     result = result.replace("`", "<code>").replace("`", "</code>");
   }
-
-  // remove invalid placeholders
-  result = result
-    .replaceAll("```", "")
-    .replaceAll("{{snapshot_pattern_detail}}", "");
 
   return result;
 };


### PR DESCRIPTION
## Done

- add rules to replace admonition markup
- remove cleanup of `{{snapshot_pattern_detail}}`, was fixed upstream.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check project configuration > restrictions > device usage > disk devices > activate override and validate help text below the input
    - Check storage volume configuration > snapshots > pattern > activate override and validate help text below the input