### PR TITLE
Fix storage pool navigation on create form

### DIFF
--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -86,7 +86,7 @@ const CreateStoragePool: FC = () => {
       <StoragePoolForm
         formik={formik}
         section={section}
-        setSection={setSection}
+        setSection={(newSection) => setSection(slugify(newSection))}
       />
       <FormFooterLayout>
         <Button


### PR DESCRIPTION
## Done

- Fix storage pool navigation on create form

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a storage pool, choose ceph as a provider, switch between the two sections. Previously you would get only blank pages, but not the create form sections.