### PR TITLE
Make code snippet in `ErrorPage` scrollable, keeping rest of the page fixed

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import {
   CodeSnippet,
   CodeSnippetBlockAppearance,
   Notification,
   Strip,
 } from "@canonical/react-components";
+import { updateMaxHeight } from "util/updateMaxHeight";
+import useEventListener from "@use-it/event-listener";
 
 type Props = {
   error?: Error;
@@ -12,12 +14,18 @@ type Props = {
 
 const ErrorPage: FC<Props> = ({ error }) => {
   const body = encodeURIComponent(
-    `\`\`\`\n${error?.stack ?? "No stack track"}\n\`\`\``,
+    `\`\`\`\n${error?.stack ?? "No stack trace"}\n\`\`\``,
   );
   const url = `https://github.com/canonical/lxd-ui/issues/new?labels=bug&title=Error%20report&body=${body}`;
 
+  const updateHeight = () => {
+    updateMaxHeight("error-info", undefined, 0, "max-height");
+  };
+  useEffect(updateHeight, []);
+  useEventListener("resize", updateHeight);
+
   return (
-    <Strip>
+    <Strip className="u-no-padding--bottom">
       <Notification severity="negative" title="Error">
         Something has gone wrong. If this issue persists,{" "}
         <a href={url} rel="noopener noreferrer" target="_blank">
@@ -25,6 +33,7 @@ const ErrorPage: FC<Props> = ({ error }) => {
         </a>
       </Notification>
       <CodeSnippet
+        className="error-info u-no-margin--bottom"
         blocks={[
           ...(error?.message
             ? [

--- a/src/sass/_error_page.scss
+++ b/src/sass/_error_page.scss
@@ -1,0 +1,3 @@
+.error-info {
+  overflow: auto;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -56,6 +56,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "detail_panels";
 @import "disk_device_form";
 @import "empty_state";
+@import "error_page";
 @import "file_row";
 @import "forms";
 @import "images";


### PR DESCRIPTION
## Done

- Improved responsiveness of the `ErrorPage` component by making the code snippet in it scrollable, and keeping everything else fixed.

## QA

1. Run the LXD-UI:
    - ~On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.~ **Not applicable** - you need to craft an error in the code to see the changes in action.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Craft an error in the body of any main-content FC (e.g. `InstanceList`) or of the `Navigation` FC, and check that the error boundary works correctly. Example code to achieve this: `throw new Error("foo");`
    - Resize the window height and check that the code snippet containing the stack trace can be properly scrolled.