### PR TITLE
chore: speed up e2e tests [WD-8560]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,11 +62,13 @@ jobs:
           reporter: github-pr-review
           fail-on-error: true
 
-  e2e:
+  browser-e2e-test:
     name: e2e-tests
     runs-on: ubuntu-latest
-    env:
-      HTML_REPORT_URL_PATH: reports/pr-${{ github.event.number }}/${{ github.run_id }}/${{ github.run_attempt }}
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: ["chromium", "firefox"]
     outputs:
       job_status: ${{job.status}}
     steps:
@@ -128,31 +130,69 @@ jobs:
           node-version: 18
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run Playwright tests
-        run: npx playwright test
+        run: npx playwright test --project ${{ matrix.browser }}
 
-      - name: Save additional test information
+      - name: Upload ${{ matrix.browser }} blob reports to be merged
         if: always()
-        run: |
-          touch playwright-report/info.txt
-          echo "HTML_REPORT_URL_PATH:$HTML_REPORT_URL_PATH" >> playwright-report/info.txt
-          cat playwright-report/info.txt
-
-      - uses: actions/upload-artifact@v4
-        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
+          name: blob-report-${{ matrix.browser }}
+          path: blob-report
+          retention-days: 1
 
-      - name: Output Report URL as Worfklow Annotation
-        if: always()
-        run: |
-          FULL_HTML_REPORT_URL=https://canonical.github.io/lxd-ui/$HTML_REPORT_URL_PATH
-          echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
-          echo "Please wait a few minute for the reports to get published before accessing the url!"
+  merge-e2e-reports:
+    if: always()
+    needs: [browser-e2e-test]
+    env:
+      HTML_REPORT_URL_PATH: reports/pr-${{ github.event.number }}/${{ github.run_id }}/${{ github.run_attempt }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: playwright-report
+        pattern: blob-report-*
+        merge-multiple: true
+    
+    # NOTE: there is no need to install playwright dependencies since we only need to merge reports here
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./playwright-report
+
+    - name: Save additional test information
+      if: always()
+      run: |
+        touch playwright-report/info.txt
+        echo "HTML_REPORT_URL_PATH:$HTML_REPORT_URL_PATH" >> playwright-report/info.txt
+        cat playwright-report/info.txt
+    
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 14
+
+    - name: Output Report URL as Worfklow Annotation
+      if: always()
+      run: |
+        FULL_HTML_REPORT_URL=https://canonical.github.io/lxd-ui/$HTML_REPORT_URL_PATH
+        echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
+        echo "Please wait a few minute for the reports to get published before accessing the url!"
+    
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-report--attempt-${{ github.run_attempt }}
+        path: playwright-report
+        retention-days: 14
 
   js-tests:
     name: js-tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : 3,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -36,6 +36,8 @@ const config: PlaywrightTestConfig = {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
   },
+  // Limit the number of failures on CI to save resources
+  maxFailures: process.env.CI ? 3 : undefined,
 
   /* Configure projects for major browsers */
   projects: [

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -140,3 +140,14 @@ export const visitAndStartInstance = async (page: Page, instance: string) => {
   await page.getByRole("button", { name: "Start", exact: true }).click();
   await page.waitForSelector(`text=Instance ${instance} started.`, TIMEOUT);
 };
+
+export const visitAndStopInstance = async (page: Page, instance: string) => {
+  await visitInstance(page, instance);
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+  if (await stopButton.isEnabled()) {
+    await page.keyboard.down("Shift");
+    await stopButton.click();
+    await page.keyboard.up("Shift");
+    await page.waitForSelector(`text=Instance ${instance} stopped.`, TIMEOUT);
+  }
+};

--- a/tests/instance-panel.spec.ts
+++ b/tests/instance-panel.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { Page, test } from "@playwright/test";
 import {
   createInstance,
   deleteInstance,
@@ -13,28 +13,32 @@ import {
   stopInstanceFromPanel,
 } from "./helpers/instancePanel";
 
-test("instance panel open and close", async ({ page }) => {
-  const instance = randomInstanceName();
+let instance = randomInstanceName();
+let page: Page;
+test.beforeAll(async ({ browserName, browser }) => {
+  instance = `${browserName}-${instance}`;
+  page = await browser.newPage();
   await createInstance(page, instance);
-  await openInstancePanel(page, instance);
-  await closeInstancePanel(page);
-  await deleteInstance(page, instance);
 });
 
-test("start and stop instance from panel", async ({ page }) => {
-  const instance = randomInstanceName();
-  await createInstance(page, instance);
+test.afterAll(async () => {
+  await deleteInstance(page, instance);
+  await page.close();
+});
+
+test("instance panel open and close", async () => {
+  await openInstancePanel(page, instance);
+  await closeInstancePanel(page);
+});
+
+test("start and stop instance from panel", async () => {
   await openInstancePanel(page, instance);
   await startInstanceFromPanel(page, instance);
   await stopInstanceFromPanel(page, instance);
   await closeInstancePanel(page);
-  await deleteInstance(page, instance);
 });
 
-test("navigate to instance details from panel", async ({ page }) => {
-  const instance = randomInstanceName();
-  await createInstance(page, instance);
+test("navigate to instance details from panel", async () => {
   await openInstancePanel(page, instance);
   await navigateToInstanceDetails(page, instance);
-  await deleteInstance(page, instance);
 });

--- a/tests/notification.spec.ts
+++ b/tests/notification.spec.ts
@@ -1,9 +1,11 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import {
   createAndStartInstance,
   createInstance,
   deleteInstance,
   randomInstanceName,
+  visitAndStartInstance,
+  visitAndStopInstance,
 } from "./helpers/instances";
 import {
   checkNotificationExists,
@@ -13,32 +15,36 @@ import {
   dismissFirstNotificationFromList,
 } from "./helpers/notification";
 
-test("show notification after user action", async ({ page }) => {
-  const instance = randomInstanceName();
+let instance = randomInstanceName();
+let page: Page;
+test.beforeAll(async ({ browserName, browser }) => {
+  page = await browser.newPage();
+  instance = `${browserName}-${instance}`;
   await createInstance(page, instance);
-  await checkNotificationExists(page);
+});
+
+test.afterAll(async () => {
   await deleteInstance(page, instance);
+  await page.close();
+});
+
+test("show notification after user action", async () => {
+  await visitAndStartInstance(page, instance);
   await checkNotificationExists(page);
 });
 
-test("dismiss one notification", async ({ page }) => {
-  const instance = randomInstanceName();
-  await createInstance(page, instance);
-  await dismissNotification(page);
-  await deleteInstance(page, instance);
+test("dismiss one notification", async () => {
+  await visitAndStopInstance(page, instance);
   await dismissNotification(page);
 });
 
-test("auto hide notification after a timeout", async ({ page }) => {
-  const instance = randomInstanceName();
-  await createInstance(page, instance);
+test("auto hide notification after a timeout", async () => {
+  await visitAndStartInstance(page, instance);
   await page.waitForTimeout(5000);
   await checkNotificationHidden(page);
-  await deleteInstance(page, instance);
-  await dismissNotification(page);
 });
 
-test("notifications list", async ({ page }) => {
+test("notifications list", async () => {
   const instance = randomInstanceName();
   await createAndStartInstance(page, instance);
   await toggleNotificationList(page); // open list

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { Page, test } from "@playwright/test";
 import {
   assertCode,
   assertReadMode,
@@ -19,25 +19,26 @@ import {
   visitProfile,
 } from "./helpers/profile";
 
-test("profile create and remove", async ({ page }) => {
-  const profile = randomProfileName();
+let profile = randomProfileName();
+let page: Page;
+test.beforeAll(async ({ browserName, browser }) => {
+  page = await browser.newPage();
+  profile = `${browserName}-${profile}`;
   await createProfile(page, profile);
-  await deleteProfile(page, profile);
 });
 
-test("profile rename", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test.afterAll(async () => {
+  await deleteProfile(page, profile);
+  await page.close();
+});
 
+test("profile rename", async () => {
   const newName = profile + "-rename";
   await renameProfile(page, profile, newName);
-
-  await deleteProfile(page, newName);
+  profile = newName;
 });
 
-test("profile edit basic details", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile edit basic details", async () => {
   await editProfile(page, profile);
 
   await page.getByPlaceholder("Enter description").fill("A-new-description");
@@ -45,13 +46,9 @@ test("profile edit basic details", async ({ page }) => {
   await saveProfile(page, profile);
 
   await page.getByText("DescriptionA-new-description").click();
-
-  await deleteProfile(page, profile);
 });
 
-test("profile cpu and memory", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile cpu and memory", async () => {
   await visitProfile(page, profile);
 
   await setCpuLimit(page, "number", "42");
@@ -73,13 +70,9 @@ test("profile cpu and memory", async ({ page }) => {
   await setMemLimit(page, "absolute", "3");
   await saveProfile(page, profile);
   await assertReadMode(page, "Memory limit", "3GiB");
-
-  await deleteProfile(page, profile);
 });
 
-test("profile resource limits", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile resource limits", async () => {
   await editProfile(page, profile);
 
   await page.getByText("Resource limits").click();
@@ -91,13 +84,9 @@ test("profile resource limits", async ({ page }) => {
   await assertReadMode(page, "Memory swap (Containers only)", "Allow");
   await assertReadMode(page, "Disk priority", "1");
   await assertReadMode(page, "Max number of processes (Containers only)", "2");
-
-  await deleteProfile(page, profile);
 });
 
-test("profile security policies", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile security policies", async () => {
   await editProfile(page, profile);
   await page.getByText("Security policies").click();
 
@@ -129,13 +118,9 @@ test("profile security policies", async ({ page }) => {
     "Yes",
   );
   await assertReadMode(page, "Enable secureboot (VMs only)", "true");
-
-  await deleteProfile(page, profile);
 });
 
-test("profile snapshots", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile snapshots", async () => {
   await editProfile(page, profile);
   await page.getByText("Snapshots").click();
 
@@ -150,13 +135,9 @@ test("profile snapshots", async ({ page }) => {
   await assertReadMode(page, "Expire after", "3m");
   await assertReadMode(page, "Snapshot stopped instances", "Yes");
   await assertReadMode(page, "Schedule", "@daily");
-
-  await deleteProfile(page, profile);
 });
 
-test("profile cloud init", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile cloud init", async () => {
   await editProfile(page, profile);
   await page.getByText("Cloud init").click();
 
@@ -168,13 +149,9 @@ test("profile cloud init", async ({ page }) => {
   await assertCode(page, "Network config", "foo:");
   await assertCode(page, "User data", "bar:");
   await assertCode(page, "Vendor data", "baz:");
-
-  await deleteProfile(page, profile);
 });
 
-test("profile yaml edit", async ({ page }) => {
-  const profile = randomProfileName();
-  await createProfile(page, profile);
+test("profile yaml edit", async () => {
   await editProfile(page, profile);
   await page.getByText("YAML configuration").click();
 
@@ -188,6 +165,4 @@ name: ${profile}`);
 
   await page.getByText("Main configuration").click();
   await page.getByText("DescriptionA-new-description").click();
-
-  await deleteProfile(page, profile);
 });


### PR DESCRIPTION
## Done

- Adjusted test suites to reuse lxd resources across tests instead of creating new ones for every test.
- Use matrix strategy to run browser specific e2e tests. This splits up the test workload across two runners and essentially should halve the test run time.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure ci passes and test speed improves