### PR TITLE
fix: resolve playwright report artifact upload conflict

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -135,6 +135,9 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test --project ${{ matrix.browser }}
 
+      - name: Rename Playwright report
+        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-report.zip
+
       - name: Upload ${{ matrix.browser }} blob reports to be merged
         if: always()
         uses: actions/upload-artifact@v4
@@ -186,13 +189,6 @@ jobs:
         FULL_HTML_REPORT_URL=https://canonical.github.io/lxd-ui/$HTML_REPORT_URL_PATH
         echo "::notice title=Published Playwright Test Report::$FULL_HTML_REPORT_URL"
         echo "Please wait a few minute for the reports to get published before accessing the url!"
-    
-    - name: Upload HTML report
-      uses: actions/upload-artifact@v4
-      with:
-        name: html-report--attempt-${{ github.run_attempt }}
-        path: playwright-report
-        retention-days: 14
 
   js-tests:
     name: js-tests

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5 * 1000,
+    timeout: 120 * 1000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/tests/cluster.spec.ts
+++ b/tests/cluster.spec.ts
@@ -1,5 +1,4 @@
 import { Page, test } from "@playwright/test";
-import { TIMEOUT } from "./helpers/constants";
 import { randomNameSuffix } from "./helpers/name";
 
 test("cluster group create and delete", async ({ page }) => {
@@ -18,7 +17,7 @@ test("cluster group add and remove members", async ({ page }) => {
   await page.getByRole("link", { name: "Cluster" }).click();
   await page.getByRole("button", { name: "All cluster groups" }).click();
   await page.getByRole("link", { name: group }).click();
-  await page.waitForSelector(`text=${member}`, TIMEOUT);
+  await page.waitForSelector(`text=${member}`);
 
   await toggleClusterGroupMember(page, group, member);
   await deleteClusterGroup(page, group);
@@ -37,7 +36,7 @@ export const createClusterGroup = async (page: Page, group: string) => {
   await page.getByPlaceholder("Enter name").fill(group);
   await page.getByRole("button", { name: "Create" }).click();
 
-  await page.waitForSelector(`text=Cluster group ${group} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Cluster group ${group} created.`);
 };
 
 export const deleteClusterGroup = async (page: Page, group: string) => {
@@ -48,7 +47,7 @@ export const deleteClusterGroup = async (page: Page, group: string) => {
   await page.getByRole("button", { name: "Delete" }).click();
   await page.getByText("Delete", { exact: true }).click();
 
-  await page.waitForSelector(`text=Cluster group ${group} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Cluster group ${group} deleted.`);
 };
 
 export const toggleClusterGroupMember = async (
@@ -67,7 +66,7 @@ export const toggleClusterGroupMember = async (
     .click();
   await page.getByRole("button", { name: "Save changes" }).click();
 
-  await page.waitForSelector(`text=Cluster group ${group} saved.`, TIMEOUT);
+  await page.waitForSelector(`text=Cluster group ${group} saved.`);
 };
 
 export const getFirstClusterMember = async (page: Page): Promise<string> => {

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,1 +1,0 @@
-export const TIMEOUT = { timeout: 120 * 1000 };

--- a/tests/helpers/instancePanel.ts
+++ b/tests/helpers/instancePanel.ts
@@ -1,5 +1,4 @@
 import { Page, expect } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export const openInstancePanel = async (page: Page, instance: string) => {
   await page.goto("/ui/");
@@ -10,7 +9,7 @@ export const openInstancePanel = async (page: Page, instance: string) => {
   const instanceDetailPanel = page.locator("css=.detail-panel", {
     hasText: "instance summary",
   });
-  await expect(instanceDetailPanel).toBeVisible(TIMEOUT);
+  await expect(instanceDetailPanel).toBeVisible();
 };
 
 export const closeInstancePanel = async (page: Page) => {
@@ -19,7 +18,7 @@ export const closeInstancePanel = async (page: Page) => {
   const instanceDetailPanel = page.locator("css=.detail-panel", {
     hasText: "instance summary",
   });
-  await expect(instanceDetailPanel).toHaveCount(0, TIMEOUT);
+  await expect(instanceDetailPanel).toHaveCount(0);
 };
 
 export const startInstanceFromPanel = async (page: Page, instance: string) => {
@@ -28,7 +27,7 @@ export const startInstanceFromPanel = async (page: Page, instance: string) => {
   });
   const startButton = instanceDetailPanel.locator("css=button[title=Start]");
   await startButton.click();
-  await page.waitForSelector(`text=Instance ${instance} started.`, TIMEOUT);
+  await page.waitForSelector(`text=Instance ${instance} started.`);
 };
 
 export const stopInstanceFromPanel = async (page: Page, instance: string) => {
@@ -43,7 +42,7 @@ export const stopInstanceFromPanel = async (page: Page, instance: string) => {
     hasText: "Stop",
   });
   await confirmStopButton.click();
-  await page.waitForSelector(`text=Instance ${instance} stopped.`, TIMEOUT);
+  await page.waitForSelector(`text=Instance ${instance} stopped.`);
 };
 
 export const navigateToInstanceDetails = async (
@@ -60,5 +59,5 @@ export const navigateToInstanceDetails = async (
   const instanceDetailTitle = page.locator("css=.instance-detail-title", {
     hasText: instance,
   });
-  await expect(instanceDetailTitle).toBeVisible(TIMEOUT);
+  await expect(instanceDetailTitle).toBeVisible();
 };

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -1,5 +1,4 @@
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 import { randomNameSuffix } from "./name";
 
 export const randomInstanceName = (): string => {
@@ -35,7 +34,7 @@ export const createInstance = async (
     .selectOption(type);
   await page.getByRole("button", { name: "Create" }).first().click();
 
-  await page.waitForSelector(`text=Created instance ${instance}.`, TIMEOUT);
+  await page.waitForSelector(`text=Created instance ${instance}.`);
 };
 
 export const visitInstance = async (page: Page, instance: string) => {
@@ -53,7 +52,7 @@ export const editInstance = async (page: Page, instance: string) => {
 
 export const saveInstance = async (page: Page, instance: string) => {
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Instance ${instance} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Instance ${instance} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 
@@ -64,14 +63,14 @@ export const deleteInstance = async (page: Page, instance: string) => {
     await page.keyboard.down("Shift");
     await stopButton.click();
     await page.keyboard.up("Shift");
-    await page.waitForSelector(`text=Instance ${instance} stopped.`, TIMEOUT);
+    await page.waitForSelector(`text=Instance ${instance} stopped.`);
   }
   await page.getByRole("button", { name: "Delete" }).click();
   await page
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
-  await page.waitForSelector(`text=Instance ${instance} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Instance ${instance} deleted.`);
 };
 
 export const hasInstance = async (page: Page, instance: string) => {
@@ -94,10 +93,7 @@ export const renameInstance = async (
   await page.getByRole("textbox").press("Control+a");
   await page.getByRole("textbox").fill(newName);
   await page.getByRole("button", { name: "Save" }).click();
-  await page.waitForSelector(
-    `text=Instance ${oldName} renamed to ${newName}.`,
-    TIMEOUT,
-  );
+  await page.waitForSelector(`text=Instance ${oldName} renamed to ${newName}.`);
 };
 
 export const createAndStartInstance = async (
@@ -129,16 +125,13 @@ export const createAndStartInstance = async (
     .selectOption(type);
   await page.getByRole("button", { name: "Create and start" }).first().click();
 
-  await page.waitForSelector(
-    `text=Created and started instance ${instance}.`,
-    TIMEOUT,
-  );
+  await page.waitForSelector(`text=Created and started instance ${instance}.`);
 };
 
 export const visitAndStartInstance = async (page: Page, instance: string) => {
   await visitInstance(page, instance);
   await page.getByRole("button", { name: "Start", exact: true }).click();
-  await page.waitForSelector(`text=Instance ${instance} started.`, TIMEOUT);
+  await page.waitForSelector(`text=Instance ${instance} started.`);
 };
 
 export const visitAndStopInstance = async (page: Page, instance: string) => {
@@ -148,6 +141,6 @@ export const visitAndStopInstance = async (page: Page, instance: string) => {
     await page.keyboard.down("Shift");
     await stopButton.click();
     await page.keyboard.up("Shift");
-    await page.waitForSelector(`text=Instance ${instance} stopped.`, TIMEOUT);
+    await page.waitForSelector(`text=Instance ${instance} stopped.`);
   }
 };

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -1,5 +1,4 @@
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 import { randomNameSuffix } from "./name";
 
 export const randomNetworkName = (): string => {
@@ -14,7 +13,7 @@ export const createNetwork = async (page: Page, network: string) => {
   await page.getByLabel("Name").click();
   await page.getByLabel("Name").fill(network);
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Network ${network} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Network ${network} created.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 
@@ -25,7 +24,7 @@ export const deleteNetwork = async (page: Page, network: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
-  await page.waitForSelector(`text=Network ${network} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Network ${network} deleted.`);
 };
 
 export const visitNetwork = async (page: Page, network: string) => {
@@ -35,7 +34,7 @@ export const visitNetwork = async (page: Page, network: string) => {
 
 export const saveNetwork = async (page: Page, network: string) => {
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Network ${network} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Network ${network} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 

--- a/tests/helpers/notification.ts
+++ b/tests/helpers/notification.ts
@@ -1,14 +1,13 @@
 import { Page, expect } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export const checkNotificationExists = async (page: Page) => {
   const notification = page.locator(".toast-notification");
-  await expect(notification).toBeVisible(TIMEOUT);
+  await expect(notification).toBeVisible();
 };
 
 export const checkNotificationHidden = async (page: Page) => {
   const notification = page.locator(".toast-notification");
-  await expect(notification).toBeHidden(TIMEOUT);
+  await expect(notification).toBeHidden();
 };
 
 export const dismissNotification = async (page: Page) => {
@@ -16,7 +15,7 @@ export const dismissNotification = async (page: Page) => {
   await notification
     .getByRole("button", { name: "Close notification" })
     .click();
-  await expect(notification).toBeHidden(TIMEOUT);
+  await expect(notification).toBeHidden();
 };
 
 export const toggleNotificationList = async (page: Page) => {

--- a/tests/helpers/profile.ts
+++ b/tests/helpers/profile.ts
@@ -1,5 +1,4 @@
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 import { randomNameSuffix } from "./name";
 
 export const randomProfileName = (): string => {
@@ -20,7 +19,7 @@ export const startProfileCreation = async (page: Page, profile: string) => {
 
 export const finishProfileCreation = async (page: Page, profile: string) => {
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Profile ${profile} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Profile ${profile} created.`);
 };
 
 export const deleteProfile = async (page: Page, profile: string) => {
@@ -30,7 +29,7 @@ export const deleteProfile = async (page: Page, profile: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
-  await page.waitForSelector(`text=Profile ${profile} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Profile ${profile} deleted.`);
 };
 
 export const visitProfile = async (page: Page, profile: string) => {
@@ -54,15 +53,12 @@ export const renameProfile = async (
   await page.getByRole("textbox").press("Control+a");
   await page.getByRole("textbox").fill(newName);
   await page.getByRole("button", { name: "Save" }).click();
-  await page.waitForSelector(
-    `text=Profile ${oldName} renamed to ${newName}.`,
-    TIMEOUT,
-  );
+  await page.waitForSelector(`text=Profile ${oldName} renamed to ${newName}.`);
 };
 
 export const saveProfile = async (page: Page, profile: string) => {
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Profile ${profile} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Profile ${profile} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 

--- a/tests/helpers/profileSummaryPanel.ts
+++ b/tests/helpers/profileSummaryPanel.ts
@@ -1,5 +1,4 @@
 import { Page, expect } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export const openProfileSummaryPanel = async (page: Page, profile: string) => {
   const profileRow = page.locator("css=tr[role=row]", { hasText: profile });
@@ -9,7 +8,7 @@ export const openProfileSummaryPanel = async (page: Page, profile: string) => {
   const profileSummaryPanel = page.locator("css=.detail-panel", {
     hasText: "profile summary",
   });
-  await expect(profileSummaryPanel).toBeVisible(TIMEOUT);
+  await expect(profileSummaryPanel).toBeVisible();
 };
 
 export const closeProfileSummaryPanel = async (page: Page) => {
@@ -18,7 +17,7 @@ export const closeProfileSummaryPanel = async (page: Page) => {
   const profileSummaryPanel = page.locator("css=.detail-panel", {
     hasText: "profile summary",
   });
-  await expect(profileSummaryPanel).toHaveCount(0, TIMEOUT);
+  await expect(profileSummaryPanel).toHaveCount(0);
 };
 
 export const navigateToProfileDetails = async (page: Page, profile: string) => {
@@ -32,5 +31,5 @@ export const navigateToProfileDetails = async (page: Page, profile: string) => {
   const profileDetailTitle = page.locator("css=.p-panel__title", {
     hasText: profile,
   });
-  await expect(profileDetailTitle).toBeVisible(TIMEOUT);
+  await expect(profileDetailTitle).toBeVisible();
 };

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -1,6 +1,5 @@
 import { randomNameSuffix } from "./name";
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export const randomProjectName = (): string => {
   return `playwright-project-${randomNameSuffix()}`;
@@ -13,7 +12,7 @@ export const createProject = async (page: Page, project: string) => {
   await page.getByPlaceholder("Enter name").click();
   await page.getByPlaceholder("Enter name").fill(project);
   await page.getByRole("button", { name: "Create" }).click();
-  await page.waitForSelector(`text=Project ${project} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Project ${project} created.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 
@@ -42,5 +41,5 @@ export const deleteProject = async (page: Page, project: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
-  await page.waitForSelector(`text=Project ${project} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Project ${project} deleted.`);
 };

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,5 +1,4 @@
 import { Locator, Page, expect } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export type ServerSettingType = "checkbox" | "text" | "number" | "password";
 
@@ -23,7 +22,7 @@ export const removePassword = async (
     exact: true,
   });
   await removeButton.click();
-  await page.waitForSelector(`text=Setting ${settingName} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Setting ${settingName} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
   await validateSettingValue(settingRow, "not set");
 };
@@ -44,7 +43,7 @@ export const updateSetting = async (
     await settingInput.fill(content);
   }
   await settingRow.getByRole("button", { name: "Save", exact: true }).click();
-  await page.waitForSelector(`text=Setting ${settingName} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Setting ${settingName} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
   await validateSettingValue(
     settingRow,
@@ -78,7 +77,7 @@ export const resetSetting = async (
     .getByRole("button", { name: "Reset to default", exact: true })
     .click();
   await settingRow.getByRole("button", { name: "Save", exact: true }).click();
-  await page.waitForSelector(`text=Setting ${settingName} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Setting ${settingName} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
   await validateSettingValue(settingRow, defaultValue);
 };

--- a/tests/helpers/snapshots.ts
+++ b/tests/helpers/snapshots.ts
@@ -1,6 +1,5 @@
 import { randomNameSuffix } from "./name";
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 
 export const randomSnapshotName = (): string => {
   return `playwright-snapshot-${randomNameSuffix()}`;
@@ -28,7 +27,6 @@ export const createInstanceSnapshot = async (
 
   await page.waitForSelector(
     `text=Snapshot ${snapshot} created for instance ${instance}.`,
-    TIMEOUT,
   );
 };
 
@@ -47,7 +45,7 @@ export const restoreInstanceSnapshot = async (page: Page, snapshot: string) => {
     .getByRole("button", { name: "Restore" })
     .click();
 
-  await page.waitForSelector(`text=Snapshot ${snapshot} restored.`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} restored.`);
 };
 
 export const editInstanceSnapshot = async (
@@ -93,7 +91,7 @@ export const deleteInstanceSnapshot = async (page: Page, snapshot: string) => {
     .getByRole("button", { name: "Delete" })
     .click();
 
-  await page.waitForSelector(`text=Snapshot ${snapshot} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} deleted.`);
 };
 
 export const createStorageVolumeSnapshot = async (
@@ -108,7 +106,7 @@ export const createStorageVolumeSnapshot = async (
   await page.getByLabel("Snapshot name").click();
   await page.getByLabel("Snapshot name").fill(snapshot);
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Snapshot ${snapshot} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} created.`);
 };
 
 export const restoreStorageVolumeSnapshot = async (
@@ -124,7 +122,7 @@ export const restoreStorageVolumeSnapshot = async (
     .getByRole("dialog", { name: "Confirm restore" })
     .getByRole("button", { name: "Restore" })
     .click();
-  await page.waitForSelector(`text=Snapshot ${snapshot} restored`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} restored`);
 };
 
 export const editStorageVolumeSnapshot = async (
@@ -150,7 +148,7 @@ export const editStorageVolumeSnapshot = async (
   await page.getByRole("button", { name: "Save" }).click();
   await page.getByText(`Snapshot ${newName} saved.`).click();
   await page.getByText("Apr 28, 2093, 12:23 PM").click();
-  await page.waitForSelector(`text=Snapshot ${newName} saved.`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${newName} saved.`);
 };
 
 export const deleteStorageVolumeSnapshot = async (
@@ -171,5 +169,5 @@ export const deleteStorageVolumeSnapshot = async (
     .getByRole("button", { name: "Delete" })
     .click();
 
-  await page.waitForSelector(`text=Snapshot ${snapshot} deleted`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} deleted`);
 };

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -1,5 +1,4 @@
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 import { randomNameSuffix } from "./name";
 
 export const randomPoolName = (): string => {
@@ -13,7 +12,7 @@ export const createPool = async (page: Page, pool: string) => {
   await page.getByPlaceholder("Enter name").fill(pool);
   await page.getByLabel("Driver").selectOption("dir");
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Storage pool ${pool} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage pool ${pool} created.`);
 };
 
 export const deletePool = async (page: Page, pool: string) => {
@@ -23,7 +22,7 @@ export const deletePool = async (page: Page, pool: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete pool" })
     .click();
-  await page.waitForSelector(`text=Storage pool ${pool} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage pool ${pool} deleted.`);
 };
 
 export const visitPool = async (page: Page, pool: string) => {
@@ -40,6 +39,6 @@ export const editPool = async (page: Page, pool: string) => {
 
 export const savePool = async (page: Page, pool: string) => {
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Storage pool ${pool} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage pool ${pool} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -1,5 +1,4 @@
 import { Page } from "@playwright/test";
-import { TIMEOUT } from "./constants";
 import { randomNameSuffix } from "./name";
 
 export const randomVolumeName = (): string => {
@@ -14,7 +13,7 @@ export const createVolume = async (page: Page, volume: string) => {
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByPlaceholder("Enter value").fill("1");
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Storage volume ${volume} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage volume ${volume} created.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 
@@ -25,7 +24,7 @@ export const deleteVolume = async (page: Page, volume: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
-  await page.waitForSelector(`text=Storage volume ${volume} deleted.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage volume ${volume} deleted.`);
 };
 
 export const visitVolume = async (page: Page, volume: string) => {
@@ -46,5 +45,5 @@ export const editVolume = async (page: Page, volume: string) => {
 
 export const saveVolume = async (page: Page, volume: string) => {
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Storage volume ${volume} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Storage volume ${volume} updated.`);
 };

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -25,7 +25,6 @@ import {
   deleteProfile,
   randomProfileName,
 } from "./helpers/profile";
-import { TIMEOUT } from "./helpers/constants";
 
 let instance = randomInstanceName();
 let vmInstance = randomInstanceName();
@@ -51,7 +50,7 @@ test.afterAll(async () => {
 test("instance terminal operations", async () => {
   await visitAndStartInstance(page, instance);
   await page.getByTestId("tab-link-Terminal").click();
-  await expect(page.locator(".xterm-screen")).toBeVisible(TIMEOUT);
+  await expect(page.locator(".xterm-screen")).toBeVisible();
   await page.keyboard.type("lsb_release -a");
   await page.keyboard.press("Enter");
   await expect(page.locator(".xterm-rows")).toContainText("Ubuntu");

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -1,7 +1,6 @@
 import { test } from "@playwright/test";
 import { randomNameSuffix } from "./helpers/name";
 import { deleteInstance, randomInstanceName } from "./helpers/instances";
-import { TIMEOUT } from "./helpers/constants";
 
 const ISO_FILE = "./tests/fixtures/foo.iso";
 
@@ -61,7 +60,7 @@ test("use custom iso for instance launch", async ({ page }) => {
   await page.locator(".u-align--right > .p-button--positive").click();
   await page.getByRole("button", { name: "Create" }).click();
 
-  await page.waitForSelector(`text=Created instance ${instance}.`, TIMEOUT);
+  await page.waitForSelector(`text=Created instance ${instance}.`);
 
   await deleteInstance(page, instance);
   await page.goto("/ui/");

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -11,7 +11,6 @@ import {
   randomProjectName,
   renameProject,
 } from "./helpers/projects";
-import { TIMEOUT } from "./helpers/constants";
 
 test("project create and remove", async ({ page }) => {
   const project = randomProjectName();
@@ -96,7 +95,7 @@ test("project edit configuration", async ({ page }) => {
   await setTextarea(page, "Network zones", "Enter network zones", "foo,bar");
 
   await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Project ${project} updated.`, TIMEOUT);
+  await page.waitForSelector(`text=Project ${project} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 
   await page.getByText("Project details").click();

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -15,7 +15,6 @@ import {
   visitVolume,
 } from "./helpers/storageVolume";
 import { activateOverride, setInput } from "./helpers/configuration";
-import { TIMEOUT } from "./helpers/constants";
 import { randomSnapshotName } from "./helpers/snapshots";
 
 let volume = randomVolumeName();
@@ -73,7 +72,6 @@ test("storage volume edit snapshot configuration", async () => {
   await page.getByRole("button", { name: "Save" }).click();
   await page.waitForSelector(
     `text=Snapshot configuration updated for volume ${volume}.`,
-    TIMEOUT,
   );
 });
 
@@ -94,7 +92,7 @@ test("custom storage volume add snapshot from CTA", async () => {
   await page.getByLabel("Snapshot name").click();
   await page.getByLabel("Snapshot name").fill(snapshot);
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Snapshot ${snapshot} created.`, TIMEOUT);
+  await page.waitForSelector(`text=Snapshot ${snapshot} created.`);
 
   await deleteVolume(page, volume);
 });


### PR DESCRIPTION
## Done

- Removed workflow step that uploads the merged playwright reports for the second time

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes and that the playwright report is visible at the URL produced by the `merge-e2e-report` job
   