### PR TITLE
Add scrolling for network forwards

### DIFF
--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -16,6 +16,7 @@ import DeleteNetworkForwardBtn from "pages/networks/actions/DeleteNetworkForward
 import { Link } from "react-router-dom";
 import ExpandableList from "components/ExpandableList";
 import NetworkForwardPort from "pages/networks/NetworkForwardPort";
+import ScrollableTable from "components/ScrollableTable";
 
 interface Props {
   network: LxdNetwork;
@@ -129,23 +130,30 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
       </Link>
       <Row>
         {hasNetworkForwards && (
-          <MainTable
-            headers={headers}
-            expanding
-            rows={rows}
-            paginate={30}
-            sortable
-            defaultSort="listenAddress"
-            defaultSortDirection="ascending"
-            className="u-table-layout--auto network-forwards-table"
-            emptyStateMsg={
-              isLoading ? (
-                <Loader text="Loading network forwards..." />
-              ) : (
-                "No data to display"
-              )
-            }
-          />
+          <ScrollableTable
+            dependencies={forwards}
+            tableId="network-forwards-table"
+            belowIds={["status-bar"]}
+          >
+            <MainTable
+              id="network-forwards-table"
+              headers={headers}
+              expanding
+              rows={rows}
+              paginate={30}
+              sortable
+              defaultSort="listenAddress"
+              defaultSortDirection="ascending"
+              className="u-table-layout--auto network-forwards-table"
+              emptyStateMsg={
+                isLoading ? (
+                  <Loader text="Loading network forwards..." />
+                ) : (
+                  "No data to display"
+                )
+              }
+            />
+          </ScrollableTable>
         )}
         {!isLoading && !hasNetworkForwards && (
           <EmptyState


### PR DESCRIPTION
## Done

- make network forwards page scroll only table content

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check network forwards page with many forwards