### PR TITLE
Simplify loading state and avoid races on start/stopping of instances

### DIFF
--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -31,15 +31,19 @@ export const InstanceLoadingProvider: FC<Props> = ({ children }) => {
   );
 
   const setLoading = (instance: LxdInstance, loadingType: LoadingTypes) => {
-    const newMap = new Map(instanceStates);
-    newMap.set(instance.name, loadingType);
-    setInstanceStates(newMap);
+    setInstanceStates((oldMap) => {
+      const newMap = new Map(oldMap);
+      newMap.set(instance.name, loadingType);
+      return newMap;
+    });
   };
 
   const setFinish = (instance: LxdInstance) => {
-    const newMap = new Map(instanceStates);
-    newMap.delete(instance.name);
-    setInstanceStates(newMap);
+    setInstanceStates((oldMap) => {
+      const newMap = new Map(oldMap);
+      newMap.delete(instance.name);
+      return newMap;
+    });
   };
 
   return (

--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -134,7 +134,6 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
             expanding
             rows={rows}
             paginate={30}
-            responsive
             sortable
             defaultSort="listenAddress"
             defaultSortDirection="ascending"


### PR DESCRIPTION
## Done

- Simplify loading state and avoid races on start/stopping of instances

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - manually start/stop a bunch of instances quickly after one another (not necessarily bulk actions) to ensure no instance is left in starting/stopping state. This was the broken behaviour before.