### PR TITLE
feat: provide UI backward compatibility for older lxd versions [WD-8671]

### DIFF
--- a/src/api/server.tsx
+++ b/src/api/server.tsx
@@ -36,7 +36,13 @@ export const fetchResources = (): Promise<LxdResources> => {
   });
 };
 
-export const fetchConfigOptions = (): Promise<LxdConfigOptions> => {
+export const fetchConfigOptions = (
+  hasMetadataConfiguration: boolean,
+): Promise<LxdConfigOptions | null> => {
+  if (!hasMetadataConfiguration) {
+    return new Promise((resolve) => resolve(null));
+  }
+
   return new Promise((resolve, reject) => {
     fetch("/1.0/metadata/configuration")
       .then(handleResponse)
@@ -45,7 +51,13 @@ export const fetchConfigOptions = (): Promise<LxdConfigOptions> => {
   });
 };
 
-export const fetchDocObjects = (): Promise<string[]> => {
+export const fetchDocObjects = (
+  hasDocumentationObject: boolean,
+): Promise<string[]> => {
+  if (!hasDocumentationObject) {
+    return new Promise((resolve) => resolve([]));
+  }
+
   return new Promise((resolve, reject) => {
     fetch("/documentation/objects.inv.txt")
       .then(handleTextResponse)

--- a/src/context/useDocs.tsx
+++ b/src/context/useDocs.tsx
@@ -1,19 +1,12 @@
-import { useSettings } from "context/useSettings";
+import { useSupportedFeatures } from "./useSupportedFeatures";
 
 export const useDocs = (): string => {
   const remoteBase = "https://documentation.ubuntu.com/lxd/en/latest";
   const localBase = "/documentation";
 
-  const { data: settings } = useSettings();
-  const serverVersion = settings?.environment?.server_version;
-  const serverMajor = parseInt(serverVersion?.split(".")[0] ?? "0");
-  const serverMinor = parseInt(serverVersion?.split(".")[1] ?? "0");
+  const { hasLocalDocumentation } = useSupportedFeatures();
 
-  if (
-    !serverVersion ||
-    serverMajor < 5 ||
-    (serverMajor === 5 && serverMinor < 19)
-  ) {
+  if (!hasLocalDocumentation) {
     return remoteBase;
   }
 

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -1,0 +1,24 @@
+import { useSettings } from "./useSettings";
+
+export const useSupportedFeatures = () => {
+  const { data: settings, isLoading, error } = useSettings();
+  const apiExtensions = new Set(settings?.api_extensions);
+
+  const serverVersion = settings?.environment?.server_version;
+  const serverMajor = parseInt(serverVersion?.split(".")[0] ?? "0");
+  const serverMinor = parseInt(serverVersion?.split(".")[1] ?? "0");
+
+  return {
+    settings,
+    isSettingsLoading: isLoading,
+    settingsError: error,
+    hasCustomVolumeIso: apiExtensions.has("custom_volume_iso"),
+    hasProjectsNetworksZones: apiExtensions.has("projects_networks_zones"),
+    hasStorageBuckets: apiExtensions.has("storage_buckets"),
+    hasMetadataConfiguration: apiExtensions.has("metadata_configuration"),
+    hasLocalDocumentation:
+      !!serverVersion && serverMajor >= 5 && serverMinor >= 19,
+    hasDocumentationObject:
+      !!serverVersion && serverMajor >= 5 && serverMinor >= 20,
+  };
+};

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../lib/spice/src/inputs";
 import AttachIsoBtn from "pages/instances/actions/AttachIsoBtn";
 import NotificationRow from "components/NotificationRow";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   instance: LxdInstance;
@@ -28,6 +29,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
   const notify = useNotify();
   const isVm = instance.type === "virtual-machine";
   const [isGraphic, setGraphic] = useState(isVm);
+  const { hasCustomVolumeIso } = useSupportedFeatures();
 
   const isRunning = instance.status === "Running";
 
@@ -76,7 +78,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
           </div>
           {isGraphic && isRunning && (
             <div>
-              <AttachIsoBtn instance={instance} />
+              {hasCustomVolumeIso && <AttachIsoBtn instance={instance} />}
               <Button
                 className="u-no-margin--bottom"
                 onClick={() => handleFullScreen()}

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -18,6 +18,7 @@ import InstanceLocationSelect from "pages/instances/forms/InstanceLocationSelect
 import UseCustomIsoBtn from "pages/images/actions/UseCustomIsoBtn";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export interface InstanceDetailsFormValues {
   name?: string;
@@ -67,6 +68,8 @@ const InstanceCreateDetailsForm: FC<Props> = ({
   onSelectImage,
   project,
 }) => {
+  const { hasCustomVolumeIso } = useSupportedFeatures();
+
   function figureBaseImageName() {
     const image = formik.values.image;
     return image
@@ -123,7 +126,9 @@ const InstanceCreateDetailsForm: FC<Props> = ({
             ) : (
               <>
                 <SelectImageBtn onSelect={onSelectImage} />
-                <UseCustomIsoBtn onSelect={onSelectImage} />
+                {hasCustomVolumeIso && (
+                  <UseCustomIsoBtn onSelect={onSelectImage} />
+                )}
               </>
             )}
           </div>

--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -41,6 +41,7 @@ import BaseLayout from "components/BaseLayout";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { slugify } from "util/slugify";
 import { useToastNotification } from "context/toastNotificationProvider";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export type ProjectFormValues = ProjectDetailsFormValues &
   ProjectResourceLimitsFormValues &
@@ -56,6 +57,8 @@ const CreateProject: FC = () => {
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
   const [section, setSection] = useState(slugify(PROJECT_DETAILS));
+  const { hasProjectsNetworksZones, hasStorageBuckets } =
+    useSupportedFeatures();
 
   const ProjectSchema = Yup.object().shape({
     name: Yup.string()
@@ -88,6 +91,14 @@ const CreateProject: FC = () => {
             ...networkRestrictionPayload(values),
           }
         : {};
+
+      if (!hasProjectsNetworksZones) {
+        values.features_networks_zones = undefined;
+      }
+
+      if (!hasStorageBuckets) {
+        values.features_storage_buckets = undefined;
+      }
 
       createProject(
         JSON.stringify({

--- a/src/pages/projects/EditProject.tsx
+++ b/src/pages/projects/EditProject.tsx
@@ -32,6 +32,7 @@ import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useNavigate, useParams } from "react-router-dom";
 import { slugify } from "util/slugify";
 import { useToastNotification } from "context/toastNotificationProvider";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   project: LxdProject;
@@ -44,6 +45,8 @@ const EditProject: FC<Props> = ({ project }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const { section } = useParams<{ section?: string }>();
+  const { hasProjectsNetworksZones, hasStorageBuckets } =
+    useSupportedFeatures();
 
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
@@ -61,6 +64,14 @@ const EditProject: FC<Props> = ({ project }) => {
     initialValues: initialValues,
     validationSchema: ProjectSchema,
     onSubmit: (values) => {
+      if (!hasProjectsNetworksZones) {
+        values.features_networks_zones = undefined;
+      }
+
+      if (!hasStorageBuckets) {
+        values.features_storage_buckets = undefined;
+      }
+
       const projectPayload = getPayload(values) as LxdProject;
 
       projectPayload.etag = project.etag;

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -14,6 +14,7 @@ import { isProjectEmpty } from "util/projects";
 import { LxdProject } from "types/project";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export interface ProjectDetailsFormValues {
   name: string;
@@ -74,6 +75,9 @@ interface Props {
 }
 
 const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
+  const { hasProjectsNetworksZones, hasStorageBuckets } =
+    useSupportedFeatures();
+
   const figureFeatures = () => {
     if (
       formik.values.features_images === undefined &&
@@ -222,36 +226,40 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 checked={formik.values.features_networks}
                 disabled={readOnly || isDefaultProject || isNonEmpty}
               />
-              <CheckboxInput
-                id="features_networks_zones"
-                name="features_networks_zones"
-                label="Network zones"
-                onChange={() =>
-                  void formik.setFieldValue(
-                    "features_networks_zones",
-                    !formik.values.features_networks_zones,
-                  )
-                }
-                checked={formik.values.features_networks_zones}
-                disabled={
-                  readOnly ||
-                  isDefaultProject ||
-                  (isNonEmpty && hadFeaturesNetworkZones)
-                }
-              />
-              <CheckboxInput
-                id="features_storage_buckets"
-                name="features_storage_buckets"
-                label="Storage buckets"
-                onChange={() =>
-                  void formik.setFieldValue(
-                    "features_storage_buckets",
-                    !formik.values.features_storage_buckets,
-                  )
-                }
-                checked={formik.values.features_storage_buckets}
-                disabled={readOnly || isDefaultProject || isNonEmpty}
-              />
+              {hasProjectsNetworksZones && (
+                <CheckboxInput
+                  id="features_networks_zones"
+                  name="features_networks_zones"
+                  label="Network zones"
+                  onChange={() =>
+                    void formik.setFieldValue(
+                      "features_networks_zones",
+                      !formik.values.features_networks_zones,
+                    )
+                  }
+                  checked={formik.values.features_networks_zones}
+                  disabled={
+                    readOnly ||
+                    isDefaultProject ||
+                    (isNonEmpty && hadFeaturesNetworkZones)
+                  }
+                />
+              )}
+              {hasStorageBuckets && (
+                <CheckboxInput
+                  id="features_storage_buckets"
+                  name="features_storage_buckets"
+                  label="Storage buckets"
+                  onChange={() =>
+                    void formik.setFieldValue(
+                      "features_storage_buckets",
+                      !formik.values.features_storage_buckets,
+                    )
+                  }
+                  checked={formik.values.features_storage_buckets}
+                  disabled={readOnly || isDefaultProject || isNonEmpty}
+                />
+              )}
               <CheckboxInput
                 id="features_storage_volumes"
                 name="features_storage_volumes"

--- a/src/pages/settings/ConfigFieldDescription.tsx
+++ b/src/pages/settings/ConfigFieldDescription.tsx
@@ -3,6 +3,7 @@ import { useDocs } from "context/useDocs";
 import { configDescriptionToHtml } from "util/config";
 import { useQuery } from "@tanstack/react-query";
 import { fetchDocObjects } from "api/server";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   description?: string;
@@ -11,9 +12,10 @@ interface Props {
 
 const ConfigFieldDescription: FC<Props> = ({ description, className }) => {
   const docBaseLink = useDocs();
+  const { hasDocumentationObject } = useSupportedFeatures();
   const objectsInvTxt = useQuery({
     queryKey: ["documentation/objects.inv.txt"],
-    queryFn: fetchDocObjects,
+    queryFn: () => fetchDocObjects(hasDocumentationObject),
   });
 
   return description ? (

--- a/src/pages/storage/Storage.tsx
+++ b/src/pages/storage/Storage.tsx
@@ -10,6 +10,7 @@ import HelpLink from "components/HelpLink";
 import TabLinks from "components/TabLinks";
 import { useDocs } from "context/useDocs";
 import { storageTabs } from "util/projects";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 const Storage: FC = () => {
   const docBaseLink = useDocs();
@@ -17,6 +18,7 @@ const Storage: FC = () => {
     project: string;
     activeTab?: string;
   }>();
+  const { hasCustomVolumeIso } = useSupportedFeatures();
 
   if (!project) {
     return <>Missing project</>;
@@ -37,7 +39,11 @@ const Storage: FC = () => {
       <NotificationRow />
       <Row>
         <TabLinks
-          tabs={storageTabs}
+          tabs={
+            hasCustomVolumeIso
+              ? storageTabs
+              : storageTabs.filter((tab) => tab !== "Custom ISOs")
+          }
           activeTab={activeTab}
           tabUrl={`/ui/project/${project}/storage`}
         />
@@ -54,7 +60,7 @@ const Storage: FC = () => {
           </div>
         )}
 
-        {activeTab === "custom-isos" && (
+        {activeTab === "custom-isos" && hasCustomVolumeIso && (
           <div role="tabpanel">
             <CustomIsoList project={project} />
           </div>

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -21,4 +21,5 @@ export interface LxdSettings {
   auth_methods?: LXDAuthMethods;
   auth_user_method?: LXDAuthMethods;
   auth_user_name?: string;
+  api_extensions?: string[];
 }

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -21,6 +21,7 @@ import { getVolumeKey } from "util/storageVolume";
 import { getNetworkDefault } from "util/networks";
 import { getPoolKey, storagePoolFormDriverToOptionKey } from "./storagePool";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export interface ConfigRowMetadata {
   value?: string;
@@ -47,14 +48,21 @@ export const getConfigRowMetadata = (
   }
 };
 
+const getConfigOptions = () => {
+  const { hasMetadataConfiguration } = useSupportedFeatures();
+  const { data: configOptions } = useQuery({
+    queryKey: [queryKeys.configOptions],
+    queryFn: () => fetchConfigOptions(hasMetadataConfiguration),
+  });
+
+  return configOptions;
+};
+
 const getInstanceRowMetadata = (
   values: InstanceAndProfileFormValues | ProjectFormValues,
   name: string,
 ): ConfigRowMetadata => {
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: fetchConfigOptions,
-  });
+  const configOptions = getConfigOptions();
 
   const configFields = toConfigFields(configOptions?.configs.instance ?? {});
   const configKey = getInstanceKey(name);
@@ -88,10 +96,7 @@ const getProjectRowMetadata = (
   values: ProjectFormValues,
   name: string,
 ): ConfigRowMetadata => {
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: fetchConfigOptions,
-  });
+  const configOptions = getConfigOptions();
 
   const configFields = toConfigFields(configOptions?.configs.project ?? {});
   const configKey = getProjectKey(name);
@@ -115,10 +120,7 @@ const getStorageVolumeRowMetadata = (
     return { value: pool.config[poolField], source: `${pool.name} pool` };
   }
 
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: fetchConfigOptions,
-  });
+  const configOptions = getConfigOptions();
 
   const optionKey = storagePoolFormDriverToOptionKey(pool?.driver ?? "zfs");
   const configFields = toConfigFields(configOptions?.configs[optionKey] ?? {});
@@ -142,10 +144,7 @@ const getStoragePoolRowMetadata = (
   values: StoragePoolFormValues,
   name: string,
 ): ConfigRowMetadata => {
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: fetchConfigOptions,
-  });
+  const configOptions = getConfigOptions();
 
   const optionKey = storagePoolFormDriverToOptionKey(values.driver);
   const configFields = toConfigFields(configOptions?.configs[optionKey] ?? {});


### PR DESCRIPTION
## Done

- Hide iso import functionality for storage volumes if the lxd server does not support the feature. This includes creating an instance based on custom ISO or attaching custom ISO to a running instance.
- Return empty server configs for lxd 5.0 instead of calling the `/1.0/metadata/configuration` endpoint
- Return empty doc string for lxd 5.0 instead of calling the `/documentation` api endpoint
- Remove `features.networks.zones` project config for lxd 5.0
- Remove `features.storage.buckets` project config for lxd 5.0
- Hide warnings page for lxd 5.0

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Downgrade lxd to 5.0/stable first
    - make sure you can't create an instance using a custom ISO, attach a custom ISO to a running instance via the Instance Console and the Custom ISOs tab is not visible on the storage page. 
    - make sure the server settings page does not error out even it's mostly empty and that there is a notification asking users to upgrade to lxd 5.19 or later.
    - check the network tab in the browser inspect tool that on any configuration page, no network requests are made to the `/documentation/objects.inv.txt` endpoint
    - make sure that you can create project successfully, then try edit a project and can save it successfully. On the project details page, main configuration section, you should not see the check boxes for Network zones and storage bucket features.
    - make sure the warnings page is hidden from the side navigation