### PR TITLE
chore(test): added tests for multiple lxd server versions [WD-8616]

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,6 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        lxd_channel: ["5.0/stable", "latest/edge"]
         browser: ["chromium", "firefox"]
     outputs:
       job_status: ${{job.status}}
@@ -114,7 +115,7 @@ jobs:
       - name: Install LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
-          channel: latest/edge
+          channel: ${{ matrix.lxd_channel }}
 
       - name: Setup LXD
         shell: bash
@@ -132,17 +133,25 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps ${{ matrix.browser }}
 
+      - name: Set lxd channel env variable
+        id: lxd-env
+        run: |
+          # need to change / to - in lxd channel string for report naming
+          LXD_CHANNEL=$(echo '${{ matrix.lxd_channel }}' | sed 's#/#-#g')
+          echo "LXD_CHANNEL=$LXD_CHANNEL" >> $GITHUB_OUTPUT
+
       - name: Run Playwright tests
-        run: npx playwright test --project ${{ matrix.browser }}
+        run: npx playwright test --project ${{ matrix.browser }}:lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}
 
       - name: Rename Playwright report
-        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-report.zip
+        if: always()
+        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}-report.zip
 
-      - name: Upload ${{ matrix.browser }} blob reports to be merged
+      - name: Upload ${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }} blob reports to be merged
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.browser }}
+          name: blob-report-${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}
           path: blob-report
           retention-days: 1
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -90,6 +90,12 @@ All commits are required to be signed off using a GPG key. You can use the follo
 3. To sign commits, you should enter the git command with additional flags as shown in this example: `git commit -s -S -a -m "initial commit"`.
 4. To make your life a little easier, you can setup a git alias for signing commits with `git config alias.sc 'commit -s -S -a'`. Now you can sign your commits with `git sc -m "initial commit"` for example. Note this only enables the alias for your local git configuration.
 
+# Supporting multiple lxd versions
+When making a contribution to this project, please take note that the UI should degrade gracefully for all lxd LTS versions later than v5.0. To acheive this, there are two processes that should be followed:
+
+1. When adding a new feature that introduces lxd api endpoints that are not currently used in the project, make sure you check against `api_extensions` returned by the `GET /1.0/` endpoint if the new endpoints used exists for older lxd versions. If the new endpoints are not supported in an older lxd version, then you should either hide or disable a portion of the new feature for the relevant lxd version. A useful `useSupportedFeatures` hook can be used for this purpose. You can also find a comprehensive list of `api_extensions` refrences in the [lxd documentation](https://documentation.ubuntu.com/lxd/en/latest/api-extensions/).
+2. You should write e2e tests that covers the new feature for all supported lxd versions. For example, if your feature is hidden for an older lxd server version, you should test that it is not displayed in the browser for that lxd version.
+
 # End-to-end tests
 
 Install playwright and its browsers

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "hooks-remove": "husky uninstall",
     "start": "concurrently --kill-others --raw 'vite --host | grep -v 3000' 'yarn serve'",
     "serve": "./entrypoint",
-    "test-js": "vitest --run"
+    "test-js": "vitest --run",
+    "test-e2e-edge": "npx playwright test --project chromium:lxd-latest-edge firefox:lxd-latest-edge",
+    "test-e2e-stable": "npx playwright test --project chromium:lxd-5.0-stable firefox:lxd-5.0-stable"
   },
   "dependencies": {
     "@canonical/react-components": "0.50.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
+import { TestOptions } from "./tests/fixtures/lxd-test";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+const config: PlaywrightTestConfig<TestOptions> = {
   testDir: "./tests",
   /* Maximum time one test can run for. */
   timeout: 120 * 1000,
@@ -42,16 +43,31 @@ const config: PlaywrightTestConfig = {
   /* Configure projects for major browsers */
   projects: [
     {
-      name: "chromium",
+      name: "chromium:lxd-5.0-stable",
       use: {
         ...devices["Desktop Chrome"],
+        lxdVersion: "5.0-stable",
       },
     },
-
     {
-      name: "firefox",
+      name: "firefox:lxd-5.0-stable",
       use: {
         ...devices["Desktop Firefox"],
+        lxdVersion: "5.0-stable",
+      },
+    },
+    {
+      name: "chromium:lxd-latest-edge",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+      },
+    },
+    {
+      name: "firefox:lxd-latest-edge",
+      use: {
+        ...devices["Desktop Firefox"],
+        lxdVersion: "latest-edge",
       },
     },
   ],

--- a/tests/cluster.spec.ts
+++ b/tests/cluster.spec.ts
@@ -1,4 +1,5 @@
-import { Page, test } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import { randomNameSuffix } from "./helpers/name";
 
 test("cluster group create and delete", async ({ page }) => {

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   deleteProfile,
   finishProfileCreation,

--- a/tests/fixtures/lxd-test.ts
+++ b/tests/fixtures/lxd-test.ts
@@ -1,0 +1,10 @@
+import { test as base } from "@playwright/test";
+
+export type LxdVersions = "5.0-stable" | "latest-edge";
+export type TestOptions = {
+  lxdVersion: LxdVersions;
+};
+
+export const test = base.extend<TestOptions>({
+  lxdVersion: ["latest-edge", { option: true }],
+});

--- a/tests/helpers/configuration.ts
+++ b/tests/helpers/configuration.ts
@@ -1,4 +1,5 @@
 import { Page } from "@playwright/test";
+import { LxdVersions } from "../fixtures/lxd-test";
 
 export const setOption = async (page: Page, field: string, value: string) => {
   await activateOverride(page, field);
@@ -89,14 +90,20 @@ export const setMemLimit = async (
   await page.getByPlaceholder(text).fill(limit);
 };
 
-export const setSchedule = async (page: Page, value: string) => {
-  await activateOverride(
-    page,
-    "Schedule Schedule for automatic instance snapshots - From: LXD",
-  );
+export const setSchedule = async (
+  page: Page,
+  value: string,
+  lxdVersion: LxdVersions,
+) => {
+  const scheduleFieldText =
+    lxdVersion === "5.0-stable"
+      ? "Schedule"
+      : "Schedule Schedule for automatic instance snapshots - From: LXD";
+
+  await activateOverride(page, scheduleFieldText);
   await page
     .getByRole("row", {
-      name: "Schedule Schedule for automatic instance snapshots - From: LXD",
+      name: scheduleFieldText,
     })
     .getByText("Cron syntax")
     .click();

--- a/tests/instance-panel.spec.ts
+++ b/tests/instance-panel.spec.ts
@@ -1,4 +1,5 @@
-import { Page, test } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createInstance,
   deleteInstance,

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -1,4 +1,5 @@
-import { Page, expect, test } from "@playwright/test";
+import { Page, expect } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createInstance,
   deleteInstance,
@@ -157,7 +158,7 @@ test("instance edit security policies", async () => {
   );
 });
 
-test("instance edit snapshot configuration", async () => {
+test("instance edit snapshot configuration", async ({ lxdVersion }) => {
   await editInstance(page, instance);
 
   await page
@@ -167,7 +168,7 @@ test("instance edit snapshot configuration", async () => {
   await setInput(page, "Snapshot name", "Enter name pattern", "snap123");
   await setInput(page, "Expire after", "Enter expiry expression", "3m");
   await setOption(page, "Snapshot stopped instances", "true");
-  await setSchedule(page, "@daily");
+  await setSchedule(page, "@daily", lxdVersion);
 
   await saveInstance(page, instance);
 

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -1,4 +1,5 @@
-import { test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import { randomNameSuffix } from "./helpers/name";
 import { deleteInstance, randomInstanceName } from "./helpers/instances";
 
@@ -8,7 +9,11 @@ export const randomIso = (): string => {
   return `playwright-iso-${randomNameSuffix()}`;
 };
 
-test("upload and delete custom iso", async ({ page }) => {
+test("upload and delete custom iso", async ({ page, lxdVersion }) => {
+  test.skip(
+    lxdVersion === "5.0-stable",
+    "custom storage volume iso import not supported in lxd v5.0/stable",
+  );
   const isoName = randomIso();
 
   await page.goto("/ui/");
@@ -39,8 +44,11 @@ test("upload and delete custom iso", async ({ page }) => {
   await page.getByText(`Custom iso ${isoName} deleted.`).click();
 });
 
-test("use custom iso for instance launch", async ({ page }) => {
-  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
+  test.skip(
+    lxdVersion === "5.0-stable",
+    "custom storage volume iso import not supported in lxd v5.0/stable",
+  );
 
   const instance = randomInstanceName();
   const isoName = randomIso();
@@ -57,7 +65,9 @@ test("use custom iso for instance launch", async ({ page }) => {
     .locator("#name")
     .fill(isoName);
   await page.getByRole("button", { name: "Upload", exact: true }).click();
-  await page.locator(".u-align--right > .p-button--positive").click();
+  await page
+    .locator(".u-align--right > .p-button--positive", { hasText: "Select" })
+    .click();
   await page.getByRole("button", { name: "Create" }).click();
 
   await page.waitForSelector(`text=Created instance ${instance}.`);
@@ -70,4 +80,37 @@ test("use custom iso for instance launch", async ({ page }) => {
   await page.getByRole("button", { name: "Delete" }).click();
   await page.getByText("Delete", { exact: true }).click();
   await page.getByText(`Custom iso ${isoName} deleted.`).click();
+});
+
+test("not allowed to upload custom iso for lxd v5.0/stable", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion !== "5.0-stable",
+    `this test is specific to lxd v5.0/stable, current lxd snap channel is ${lxdVersion}`,
+  );
+  await page.goto("/ui/");
+  await page.getByRole("link", { name: "Storage", exact: true }).click();
+  await expect(page.getByTestId("tab-link-Custom ISOs")).toBeHidden();
+});
+
+test("not allowed to launch instance with custom iso for lxd v5.0/stable", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+  test.skip(
+    lxdVersion !== "5.0-stable",
+    `this test is specific to lxd v5.0/stable, current lxd snap channel is ${lxdVersion}`,
+  );
+
+  const instance = randomInstanceName();
+  await page.goto("/ui/");
+  await page.getByRole("link", { name: "Instances", exact: true }).click();
+  await page.getByRole("button", { name: "Create instance" }).click();
+  await page.getByLabel("Instance name").fill(instance);
+  await expect(
+    page.getByRole("button", { name: "Use custom ISO" }),
+  ).toBeHidden();
 });

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -1,4 +1,5 @@
-import { Page, test } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createNetwork,
   createNetworkForward,

--- a/tests/notification.spec.ts
+++ b/tests/notification.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createAndStartInstance,
   createInstance,

--- a/tests/profile-summary-panel.spec.ts
+++ b/tests/profile-summary-panel.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createProfile,
   deleteProfile,

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -1,4 +1,5 @@
-import { Page, test } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   assertCode,
   assertReadMode,
@@ -120,14 +121,14 @@ test("profile security policies", async () => {
   await assertReadMode(page, "Enable secureboot (VMs only)", "true");
 });
 
-test("profile snapshots", async () => {
+test("profile snapshots", async ({ lxdVersion }) => {
   await editProfile(page, profile);
   await page.getByText("Snapshots").click();
 
   await setInput(page, "Snapshot name", "Enter name pattern", "snap123");
   await setInput(page, "Expire after", "Enter expiry expression", "3m");
   await setOption(page, "Snapshot stopped instances", "true");
-  await setSchedule(page, "@daily");
+  await setSchedule(page, "@daily", lxdVersion);
 
   await saveProfile(page, profile);
 

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -1,4 +1,5 @@
-import { test } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   ServerSettingType,
   resetSetting,
@@ -32,10 +33,29 @@ const settings: {
   },
 ];
 
-test("test all non-critical server settings", async ({ page }) => {
+test("test all non-critical server settings", async ({ page, lxdVersion }) => {
+  test.skip(
+    lxdVersion === "5.0-stable",
+    "/1.0/metadata/configuration endpoint not available in lxd v5.0/stable",
+  );
   await visitServerSettings(page);
   for (const setting of settings) {
     await updateSetting(page, setting.name, setting.type, setting.content);
     await resetSetting(page, setting.name, setting.type, setting.default);
   }
+});
+
+test("only user server setting available for lxd v5.0/stable", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion !== "5.0-stable",
+    `this test is specific to lxd v5.0/stable, current lxd snap channel is ${lxdVersion}`,
+  );
+
+  await visitServerSettings(page);
+  await page.waitForSelector(`text=Get more server settings`);
+  const allSettingRows = await page.locator("#settings-table tbody tr").all();
+  expect(allSettingRows.length).toEqual(1);
 });

--- a/tests/snapshots.spec.ts
+++ b/tests/snapshots.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createInstance,
   deleteInstance,

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -1,4 +1,5 @@
-import { Page, test } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { test } from "./fixtures/lxd-test";
 import {
   createPool,
   deletePool,
@@ -54,7 +55,7 @@ test("storage volume create, edit and remove", async () => {
   await page.getByText("size2GiB").click();
 });
 
-test("storage volume edit snapshot configuration", async () => {
+test("storage volume edit snapshot configuration", async ({ lxdVersion }) => {
   await visitVolume(page, volume);
   await page.getByTestId("tab-link-Snapshots").click();
   await page.getByText("See configuration").click();
@@ -67,7 +68,11 @@ test("storage volume edit snapshot configuration", async () => {
     "snap123",
   );
   await setInput(page, "Expire after", "Enter expiry expression", "3m");
-  await activateOverride(page, "Schedule Schedule for automatic");
+  const scheduleFieldText =
+    lxdVersion === "5.0-stable"
+      ? "Schedule"
+      : "Schedule Schedule for automatic volume snapshots";
+  await activateOverride(page, scheduleFieldText);
   await page.getByPlaceholder("Enter cron expression").last().fill("@daily");
   await page.getByRole("button", { name: "Save" }).click();
   await page.waitForSelector(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
     "babel.config.js",
     "playwright.config.ts",
     "webpack.config.js",
-    "./tests/*.ts",
+    "./tests/**/*.ts",
     "vite.config.ts",
     "vitest.config.ts"
   ],


### PR DESCRIPTION
## Done

- Adjusted CI to run e2e tests against multiple lxd server versions
- Added tests for lxd v5.0/stable
- Adjusted existing tests with features that does not exist in  lxd v5.0/stable to be skipped
- Added test fixture to annotate tests with lxd version

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure CI passes
    - check that the output playwright report looks fine