### PR TITLE
fix: merge playwright reports with assets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps ${{ matrix.browser }}
@@ -165,18 +165,18 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Download blob reports from GitHub Actions Artifacts
       uses: actions/download-artifact@v4
       with:
-        path: playwright-report
+        path: blob-reports
         pattern: blob-report-*
         merge-multiple: true
     
     # NOTE: there is no need to install playwright dependencies since we only need to merge reports here
     - name: Merge into HTML Report
-      run: npx playwright merge-reports --reporter html ./playwright-report
+      run: npx playwright merge-reports --reporter html ./blob-reports
 
     - name: Save additional test information
       if: always()


### PR DESCRIPTION
## Done

- Fixed issue where assets (videos/traces) are not attached to the html playwright report

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @lorumic or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes
    - Ensure videos and traces are in failing tests
