### PR TITLE
fix: avoid empty label for a11y compliance

### DIFF
--- a/src/pages/networks/forms/IpAddressSelector.tsx
+++ b/src/pages/networks/forms/IpAddressSelector.tsx
@@ -26,7 +26,7 @@ const IpAddressSelector: FC<Props> = ({ id, address, setAddress }) => {
       </div>
       <div className="ip-address-selector ip-address-custom">
         <RadioInput
-          label=""
+          label="Custom"
           aria-label="custom"
           checked={isCustom}
           onChange={() => setAddress("")}

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -150,6 +150,10 @@
       margin-left: -65px;
       margin-top: -5px;
     }
+
+    .p-radio__label {
+      font-size: 0;
+    }
   }
 
   .snapshot-schedule {


### PR DESCRIPTION
## Done

- Resolved empty label a11y issue for ip address selector 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that the label is not visible for the ip address selector
    - Check wave evaluation tool that no a11y empty label warning is reported when the ip address selector is visible on the page