### PR TITLE
fix: table pagination margin bottom

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -289,6 +289,6 @@ body {
   }
 }
 
-.items-per-page {
+#pagination {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Done

- Adjusted bottom margin for the table pagination component in lxd-ui

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check there is no bottom margin for the table pagination controls