### PR TITLE
Add coverage report as zip file

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -75,6 +75,7 @@ jobs:
           set -x
           sudo chmod -R 0777 ../lxd-ui
           yarn test-coverage
+          zip -r coverage/playwright-report/cobertura-coverage.zip coverage/playwright-report/cobertura-coverage.xml
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
## Done

- add coverage report as zip file for externals to consume
- QA is [in this fork build](https://github.com/edlerd/lxd-ui/actions/runs/8008643689/job/21875510900)