### PR TITLE
fix: playwright coverage report showing incorrect results [WD-9070]

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig<TestOptions> = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 3,
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/tests/fixtures/coverage.ts
+++ b/tests/fixtures/coverage.ts
@@ -33,6 +33,9 @@ export const finishCoverage = async (
     if (entry.url.includes("spice")) {
       continue;
     }
+    if (entry.url.includes("node_modules")) {
+      continue;
+    }
     const fileMatcher = entry.url.match(/http(s)*:\/\/.*:8407\/(?<file>.*)/);
     if (!fileMatcher?.groups) {
       continue;

--- a/tests/fixtures/lxd-test.ts
+++ b/tests/fixtures/lxd-test.ts
@@ -1,23 +1,24 @@
-import { test as base } from "@playwright/test";
+import { Page, test as base } from "@playwright/test";
 import { finishCoverage, startCoverage } from "./coverage";
 
 export type LxdVersions = "5.0-stable" | "latest-edge";
 export type TestOptions = {
   lxdVersion: LxdVersions;
   hasCoverage: boolean;
+  runCoverage: Page;
 };
 
 export const test = base.extend<TestOptions>({
   lxdVersion: ["latest-edge", { option: true }],
   hasCoverage: [false, { option: true }],
-});
-
-test.beforeEach(async ({ page, hasCoverage }) => {
-  await startCoverage(page, hasCoverage);
-});
-
-test.afterEach(async ({ page, hasCoverage }) => {
-  await finishCoverage(page, hasCoverage);
+  runCoverage: [
+    async ({ page, hasCoverage }, use) => {
+      await startCoverage(page, hasCoverage);
+      await use(page);
+      await finishCoverage(page, hasCoverage);
+    },
+    { auto: true },
+  ],
 });
 
 export const expect = test.expect;


### PR DESCRIPTION
## Done

- Resolved issue with playwright coverage report not displaying all results.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run the test coverage script locally and inspect that the report produced is now correct