### PR TITLE
Keep covarge on navigation

### DIFF
--- a/tests/fixtures/coverage.ts
+++ b/tests/fixtures/coverage.ts
@@ -12,7 +12,10 @@ export const startCoverage = async (
   if (!hasCoverage) {
     return;
   }
-  await page.coverage.startJSCoverage();
+  await page.coverage.startJSCoverage({
+    reportAnonymousScripts: true,
+    resetOnNavigation: false,
+  });
 };
 
 export const finishCoverage = async (

--- a/tests/fixtures/coverage.ts
+++ b/tests/fixtures/coverage.ts
@@ -5,26 +5,14 @@ import v8ToIstanbul from "v8-to-istanbul";
 import { CoverageMapData } from "istanbul-lib-coverage";
 import { generateUUID } from "util/helpers";
 
-export const startCoverage = async (
-  page: Page,
-  hasCoverage: boolean,
-): Promise<void> => {
-  if (!hasCoverage) {
-    return;
-  }
+export const startCoverage = async (page: Page): Promise<void> => {
   await page.coverage.startJSCoverage({
     reportAnonymousScripts: true,
     resetOnNavigation: false,
   });
 };
 
-export const finishCoverage = async (
-  page: Page,
-  hasCoverage: boolean,
-): Promise<void> => {
-  if (!hasCoverage) {
-    return;
-  }
+export const finishCoverage = async (page: Page): Promise<void> => {
   const coverage = await page.coverage.stopJSCoverage();
   for (const entry of coverage) {
     if (entry.url.endsWith(".css")) {

--- a/tests/fixtures/lxd-test.ts
+++ b/tests/fixtures/lxd-test.ts
@@ -13,9 +13,13 @@ export const test = base.extend<TestOptions>({
   hasCoverage: [false, { option: true }],
   runCoverage: [
     async ({ page, hasCoverage }, use) => {
-      await startCoverage(page, hasCoverage);
-      await use(page);
-      await finishCoverage(page, hasCoverage);
+      if (hasCoverage) {
+        await startCoverage(page);
+        await use(page);
+        await finishCoverage(page);
+      } else {
+        await use(page);
+      }
     },
     { auto: true },
   ],

--- a/tests/instance-panel.spec.ts
+++ b/tests/instance-panel.spec.ts
@@ -11,24 +11,19 @@ import {
   startInstanceFromPanel,
   stopInstanceFromPanel,
 } from "./helpers/instancePanel";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let instance = randomInstanceName();
 
-test.beforeAll(async ({ browserName, browser, hasCoverage }) => {
+test.beforeAll(async ({ browserName, browser }) => {
   instance = `${browserName}-${instance}`;
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await createInstance(page, instance);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteInstance(page, instance);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -25,32 +25,27 @@ import {
   deleteProfile,
   randomProfileName,
 } from "./helpers/profile";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let instance = randomInstanceName();
 let vmInstance = randomInstanceName();
 let profile = randomProfileName();
 
-test.beforeAll(async ({ browser, browserName, hasCoverage }) => {
+test.beforeAll(async ({ browser, browserName }) => {
   instance = `${browserName}-${instance}`;
   vmInstance = `${browserName}-${vmInstance}`;
   profile = `${browserName}-${profile}`;
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await createProfile(page, profile);
   await createInstance(page, instance);
   await createInstance(page, vmInstance, "virtual-machine");
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteInstance(page, instance);
   await deleteInstance(page, vmInstance);
   await deleteProfile(page, profile);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -13,25 +13,20 @@ import {
   assertReadMode,
   setOption,
 } from "./helpers/configuration";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let network = randomNetworkName();
 
-test.beforeAll(async ({ browser, browserName, hasCoverage }) => {
+test.beforeAll(async ({ browser, browserName }) => {
   // network names can only be 15 characters long
   network = `${browserName.substring(0, 2)}-${network}`;
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await createNetwork(page, network);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteNetwork(page, network);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 

--- a/tests/notification.spec.ts
+++ b/tests/notification.spec.ts
@@ -15,24 +15,19 @@ import {
   toggleNotificationList,
   dismissFirstNotificationFromList,
 } from "./helpers/notification";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let instance = randomInstanceName();
 
-test.beforeAll(async ({ browserName, browser, hasCoverage }) => {
+test.beforeAll(async ({ browserName, browser }) => {
   instance = `${browserName}-${instance}`;
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await createInstance(page, instance);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteInstance(page, instance);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -18,24 +18,19 @@ import {
   saveProfile,
   visitProfile,
 } from "./helpers/profile";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let profile = randomProfileName();
 
-test.beforeAll(async ({ browserName, browser, hasCoverage }) => {
+test.beforeAll(async ({ browserName, browser }) => {
   profile = `${browserName}-${profile}`;
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await createProfile(page, profile);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteProfile(page, profile);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -16,24 +16,19 @@ import {
 } from "./helpers/storageVolume";
 import { activateOverride, setInput } from "./helpers/configuration";
 import { randomSnapshotName } from "./helpers/snapshots";
-import { finishCoverage, startCoverage } from "./fixtures/coverage";
 
 let volume = randomVolumeName();
 
-test.beforeAll(async ({ browser, browserName, hasCoverage }) => {
+test.beforeAll(async ({ browser, browserName }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   volume = `${browserName}-${volume}`;
   await createVolume(page, volume);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 
-test.afterAll(async ({ browser, hasCoverage }) => {
+test.afterAll(async ({ browser }) => {
   const page = await browser.newPage();
-  await startCoverage(page, hasCoverage);
   await deleteVolume(page, volume);
-  await finishCoverage(page, hasCoverage);
   await page.close();
 });
 


### PR DESCRIPTION
## Done

- fix coverage to also include components after navigation
- i.e. delete project navigates and clears all previous pages covered, leading to [create and edit project](https://canonical.github.io/lxd-ui/coverage/lxd-ui/src/api/projects.tsx.html) API functions to appear uncovered. Same with the [project configuration form subcomponents](https://canonical.github.io/lxd-ui/coverage/lxd-ui/src/pages/projects/forms/index.html)
- simplify coverage to be used in one place only
- QA in [this job on a fork](https://github.com/edlerd/lxd-ui/actions/runs/8048133388)
