### PR TITLE
Fix event handling and e2e tests

### DIFF
--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -51,7 +51,9 @@ const Events: FC = () => {
         });
         void refetchOperations();
       }
-      handleEvent(event);
+      // ensure open requests that reply with an operation and register
+      // new handlers in the eventQueue are closed before handling the event
+      setTimeout(() => handleEvent(event), 250);
     };
   };
 


### PR DESCRIPTION
## Done

- ensure open requests that reply with an operation and register new handlers in the `eventQueue` are closed before handling the event as it is reported by the events websocket to be finished