### PR TITLE
Add link to storage pool from storage volume

### DIFF
--- a/src/pages/storage/StorageVolumeOverview.tsx
+++ b/src/pages/storage/StorageVolumeOverview.tsx
@@ -7,6 +7,7 @@ import { LxdStorageVolume } from "types/storage";
 import { isoTimeToString } from "util/helpers";
 import StorageVolumeSize from "pages/storage/StorageVolumeSize";
 import { renderContentType, renderVolumeType } from "util/storageVolume";
+import { Link } from "react-router-dom";
 
 interface Props {
   project: string;
@@ -48,6 +49,16 @@ const StorageVolumeOverview: FC<Props> = ({ project, volume }) => {
               <tr>
                 <th className="p-muted-heading">Location</th>
                 <td>{volume.location}</td>
+              </tr>
+              <tr>
+                <th className="p-muted-heading">Pool</th>
+                <td>
+                  <Link
+                    to={`/ui/project/${project}/storage/detail/${volume.pool}`}
+                  >
+                    {volume.pool}
+                  </Link>
+                </td>
               </tr>
               <tr>
                 <th className="p-muted-heading">Date created</th>

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./fixtures/lxd-test";
+import { expect, test } from "./fixtures/lxd-test";
 import {
   createPool,
   deletePool,
@@ -104,4 +104,11 @@ test("custom storage volume add snapshot from CTA", async ({ page }) => {
   await page.waitForSelector(`text=Snapshot ${snapshot} created.`);
 
   await deleteVolume(page, volume);
+});
+
+test("navigate to custom volume via pool used by list", async ({ page }) => {
+  await visitVolume(page, volume);
+  await page.locator(`tr:has-text("Pool")`).getByRole("link").click();
+  await page.getByRole("link", { name: volume }).click();
+  await expect(page).toHaveURL(/volumes\/custom\//);
 });


### PR DESCRIPTION
## Done

- Add link to storage pool from storage volume
- add test for storage pool used by storage volume link 

Fixes WD-8591

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure QA is passing
    - go to detail page of a storage volume, see new link directly to storage pool