### PR TITLE
Fix used by links to snapshots of custom storage volumes

### DIFF
--- a/src/pages/storage/StorageUsedBy.tsx
+++ b/src/pages/storage/StorageUsedBy.tsx
@@ -85,14 +85,30 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
           <td>
             <ExpandableList
               items={data[SNAPSHOTS].map((item) => (
-                <div key={`${item.instance}-${item.name}-${item.project}`}>
-                  <Link
-                    to={`/ui/project/${item.project}/instances/detail/${item.instance}/snapshots`}
-                  >
-                    {`${item.instance} ${item.name}`}
-                  </Link>
-                  {item.project !== project && ` (project ${item.project})`}
-                </div>
+                <>
+                  {item.instance && (
+                    <div key={`${item.instance}-${item.name}-${item.project}`}>
+                      <Link
+                        to={`/ui/project/${item.project}/instances/detail/${item.instance}/snapshots`}
+                      >
+                        {`${item.instance} ${item.name}`}
+                      </Link>
+                      {item.project !== project && ` (project ${item.project})`}
+                    </div>
+                  )}
+                  {item.volume && (
+                    <div
+                      key={`${item.volume}-${item.name}-${item.project}-${item.pool}`}
+                    >
+                      <Link
+                        to={`/ui/project/${item.project}/storage/detail/${item.pool}/volumes/custom/${item.volume}/snapshots`}
+                      >
+                        {`${item.volume} ${item.name}`}
+                      </Link>
+                      {item.project !== project && ` (project ${item.project})`}
+                    </div>
+                  )}
+                </>
               ))}
             />
           </td>

--- a/src/util/usedBy.spec.ts
+++ b/src/util/usedBy.spec.ts
@@ -24,6 +24,7 @@ describe("filterUsedByType", () => {
 
     expect(results[0].name).toBe("my_profile");
     expect(results[0].project).toBe("foo");
+    expect(results[0].instance).toBe(undefined);
   });
 
   it("decodes url encoded volume names", () => {
@@ -34,5 +35,31 @@ describe("filterUsedByType", () => {
 
     expect(results[0].name).toBe("tüdeldü");
     expect(results[0].project).toBe("default");
+    expect(results[0].instance).toBe(undefined);
+  });
+
+  it("finds instance snapshot", () => {
+    const paths = [
+      "/1.0/instances/absolute-jennet/snapshots/snap0?project=Animals",
+    ];
+    const results = filterUsedByType("snapshots", paths);
+
+    expect(results[0].name).toBe("snap0");
+    expect(results[0].project).toBe("Animals");
+    expect(results[0].instance).toBe("absolute-jennet");
+    expect(results[0].volume).toBe(undefined);
+  });
+
+  it("finds volume snapshot", () => {
+    const paths = [
+      "/1.0/storage-pools/poolName/volumes/custom/volumeName/snapshots/snap1?project=fooProject",
+    ];
+    const results = filterUsedByType("snapshots", paths);
+
+    expect(results[0].name).toBe("snap1");
+    expect(results[0].project).toBe("fooProject");
+    expect(results[0].instance).toBe(undefined);
+    expect(results[0].volume).toBe("volumeName");
+    expect(results[0].pool).toBe("poolName");
   });
 });


### PR DESCRIPTION
## Done

- Fix used by links to snapshots of custom storage volumes

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open storage pool detail page, the used by section previously wrongly treated custom storage pool snapshots as instance snapshots, resulting in invalid links. This works now as expected. Previous [error here](https://lxd-ui-678.demos.haus/ui/project/A-very-very-very-very-very-very-very-very-very-very-long-name/storage/detail/pool-dir). Fixed [used by section here](https://lxd-ui-683.demos.haus/ui/project/A-very-very-very-very-very-very-very-very-very-very-long-name/storage/detail/pool-dir)