### PR TITLE
Show error message, when API requests fail

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -54,14 +54,19 @@ export const deleteImageBulk = (
     void Promise.allSettled(
       fingerprints.map((name) => {
         const image = { fingerprint: name } as LxdImage;
-        return deleteImage(image, project).then((operation) => {
-          eventQueue.set(
-            operation.metadata.id,
-            () => pushSuccess(results),
-            (msg) => pushFailure(results, msg),
-            () => continueOrFinish(results, fingerprints.length, resolve),
-          );
-        });
+        return deleteImage(image, project)
+          .then((operation) => {
+            eventQueue.set(
+              operation.metadata.id,
+              () => pushSuccess(results),
+              (msg) => pushFailure(results, msg),
+              () => continueOrFinish(results, fingerprints.length, resolve),
+            );
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, fingerprints.length, resolve);
+          });
       }),
     );
   });

--- a/src/api/instance-snapshots.tsx
+++ b/src/api/instance-snapshots.tsx
@@ -58,16 +58,19 @@ export const deleteInstanceSnapshotBulk = (
   return new Promise((resolve) => {
     void Promise.allSettled(
       snapshotNames.map(async (name) => {
-        return await deleteInstanceSnapshot(instance, { name }).then(
-          (operation) => {
+        return await deleteInstanceSnapshot(instance, { name })
+          .then((operation) => {
             eventQueue.set(
               operation.metadata.id,
               () => pushSuccess(results),
               (msg) => pushFailure(results, msg),
               () => continueOrFinish(results, snapshotNames.length, resolve),
             );
-          },
-        );
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, snapshotNames.length, resolve);
+          });
       }),
     );
   });

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -171,16 +171,19 @@ export const updateInstanceBulkAction = (
   return new Promise((resolve) => {
     void Promise.allSettled(
       actions.map(async ({ name, project, action }) => {
-        return await putInstanceAction(name, project, action, isForce).then(
-          (operation) => {
+        return await putInstanceAction(name, project, action, isForce)
+          .then((operation) => {
             eventQueue.set(
               operation.metadata.id,
               () => pushSuccess(results),
               (msg) => pushFailure(results, msg),
               () => continueOrFinish(results, actions.length, resolve),
             );
-          },
-        );
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, actions.length, resolve);
+          });
       }),
     );
   });
@@ -207,14 +210,19 @@ export const deleteInstanceBulk = (
   return new Promise((resolve) => {
     void Promise.allSettled(
       instances.map(async (instance) => {
-        return await deleteInstance(instance).then((operation) => {
-          eventQueue.set(
-            operation.metadata.id,
-            () => pushSuccess(results),
-            (msg) => pushFailure(results, msg),
-            () => continueOrFinish(results, instances.length, resolve),
-          );
-        });
+        return await deleteInstance(instance)
+          .then((operation) => {
+            eventQueue.set(
+              operation.metadata.id,
+              () => pushSuccess(results),
+              (msg) => pushFailure(results, msg),
+              () => continueOrFinish(results, instances.length, resolve),
+            );
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, instances.length, resolve);
+          });
       }),
     );
   });

--- a/src/api/volume-snapshots.tsx
+++ b/src/api/volume-snapshots.tsx
@@ -59,16 +59,19 @@ export const deleteVolumeSnapshotBulk = (
   return new Promise((resolve) => {
     void Promise.allSettled(
       snapshotNames.map(async (name) => {
-        return await deleteVolumeSnapshot(volume, { name }).then(
-          (operation) => {
+        return await deleteVolumeSnapshot(volume, { name })
+          .then((operation) => {
             eventQueue.set(
               operation.metadata.id,
               () => pushSuccess(results),
               (msg) => pushFailure(results, msg),
               () => continueOrFinish(results, snapshotNames.length, resolve),
             );
-          },
-        );
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, snapshotNames.length, resolve);
+          });
       }),
     );
   });

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -20,26 +20,36 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
 
   const handleDelete = () => {
     setLoading(true);
-    void deleteImage(image, project).then((operation) =>
-      eventQueue.set(
-        operation.metadata.id,
-        () => {
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.images],
-          });
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.projects, project],
-          });
-          toastNotify.success(`Image ${image.properties.description} deleted.`);
-        },
-        (msg) =>
-          toastNotify.failure(
-            `Image ${image.properties.description} deletion failed`,
-            new Error(msg),
-          ),
-        () => setLoading(false),
-      ),
-    );
+    void deleteImage(image, project)
+      .then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () => {
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.images],
+            });
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.projects, project],
+            });
+            toastNotify.success(
+              `Image ${image.properties.description} deleted.`,
+            );
+          },
+          (msg) =>
+            toastNotify.failure(
+              `Image ${image.properties.description} deletion failed`,
+              new Error(msg),
+            ),
+          () => setLoading(false),
+        ),
+      )
+      .catch((e) => {
+        toastNotify.failure(
+          `Image ${image.properties.description} deletion failed`,
+          e,
+        );
+        setLoading(false);
+      });
   };
 
   return (

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -210,13 +210,17 @@ const CreateInstance: FC = () => {
       void startInstance({
         name: instanceName,
         project: project,
-      } as LxdInstance).then((operation) => {
-        eventQueue.set(
-          operation.metadata.id,
-          () => notifyCreatedAndStarted(instanceLink),
-          (msg) => notifyCreatedButStartFailed(instanceLink, new Error(msg)),
-        );
-      });
+      } as LxdInstance)
+        .then((operation) => {
+          eventQueue.set(
+            operation.metadata.id,
+            () => notifyCreatedAndStarted(instanceLink),
+            (msg) => notifyCreatedButStartFailed(instanceLink, new Error(msg)),
+          );
+        })
+        .catch((e: Error) => {
+          notifyCreatedButStartFailed(instanceLink, e);
+        });
     } else {
       const consoleUrl = `/ui/project/${project}/instance/${instanceName}/console`;
       const message = isIsoImage && (

--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -41,34 +41,39 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
       instance,
       values,
     ) as LxdInstance;
-    void updateInstance(instanceMinusIso, project ?? "").then((operation) => {
-      const instanceLink = instanceLinkFromOperation({
-        operation,
-        project,
+    void updateInstance(instanceMinusIso, project ?? "")
+      .then((operation) => {
+        const instanceLink = instanceLinkFromOperation({
+          operation,
+          project,
+        });
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                ISO <b>{attachedIso?.source ?? ""}</b> detached from{" "}
+                {instanceLink}
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Detaching ISO failed.",
+              new Error(msg),
+              instanceLink,
+            ),
+          () => {
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances, instance.name, project],
+            });
+            setLoading(false);
+          },
+        );
+      })
+      .catch((e) => {
+        setLoading(false);
+        toastNotify.failure("Detaching ISO failed.", e);
       });
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              ISO <b>{attachedIso?.source ?? ""}</b> detached from{" "}
-              {instanceLink}
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Detaching ISO failed.",
-            new Error(msg),
-            instanceLink,
-          ),
-        () => {
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances, instance.name, project],
-          });
-          setLoading(false);
-        },
-      );
-    });
   };
 
   const handleSelect = (image: RemoteImage) => {
@@ -78,33 +83,38 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
     const isoDevice = remoteImageToIsoDevice(image);
     values.devices.push(isoDevice);
     const instancePlusIso = getInstancePayload(instance, values) as LxdInstance;
-    void updateInstance(instancePlusIso, project ?? "").then((operation) => {
-      const instanceLink = instanceLinkFromOperation({
-        operation,
-        project,
+    void updateInstance(instancePlusIso, project ?? "")
+      .then((operation) => {
+        const instanceLink = instanceLinkFromOperation({
+          operation,
+          project,
+        });
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                ISO <b>{image.aliases}</b> attached to {instanceLink}
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Attaching ISO failed.",
+              new Error(msg),
+              instanceLink,
+            ),
+          () => {
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances, instance.name, project],
+            });
+            setLoading(false);
+          },
+        );
+      })
+      .catch((e) => {
+        setLoading(false);
+        toastNotify.failure("Attaching ISO failed.", e);
       });
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              ISO <b>{image.aliases}</b> attached to {instanceLink}
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Attaching ISO failed.",
-            new Error(msg),
-            instanceLink,
-          ),
-        () => {
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances, instance.name, project],
-          });
-          setLoading(false);
-        },
-      );
-    });
   };
 
   return attachedIso ? (

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -25,31 +25,38 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
 
   const handleFreeze = () => {
     instanceLoading.setLoading(instance, "Freezing");
-    void freezeInstance(instance).then((operation) => {
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              Instance <InstanceLink instance={instance} /> frozen.
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Instance freeze failed",
-            new Error(msg),
-            <>
-              Instance <ItemName item={instance} bold />:
-            </>,
-          ),
-        () => {
-          instanceLoading.setFinish(instance);
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances],
-          });
-        },
-      );
-    });
+    void freezeInstance(instance)
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                Instance <InstanceLink instance={instance} /> frozen.
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Instance freeze failed",
+              new Error(msg),
+              <InstanceLink instance={instance} />,
+            ),
+          () => {
+            instanceLoading.setFinish(instance);
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances],
+            });
+          },
+        );
+      })
+      .catch((e) => {
+        toastNotify.failure(
+          "Instance freeze failed",
+          e,
+          <InstanceLink instance={instance} />,
+        );
+        instanceLoading.setFinish(instance);
+      });
   };
 
   const isDisabled = isLoading || instance.status !== "Running";

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -27,31 +27,38 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
 
   const handleRestart = () => {
     instanceLoading.setLoading(instance, "Restarting");
-    void restartInstance(instance, isForce).then((operation) => {
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              Instance <InstanceLink instance={instance} /> restarted.
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Instance restart failed",
-            new Error(msg),
-            <>
-              Instance <ItemName item={instance} bold />:
-            </>,
-          ),
-        () => {
-          instanceLoading.setFinish(instance);
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances],
-          });
-        },
-      );
-    });
+    void restartInstance(instance, isForce)
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                Instance <InstanceLink instance={instance} /> restarted.
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Instance restart failed",
+              new Error(msg),
+              <InstanceLink instance={instance} />,
+            ),
+          () => {
+            instanceLoading.setFinish(instance);
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances],
+            });
+          },
+        );
+      })
+      .catch((e) => {
+        toastNotify.failure(
+          "Instance restart failed",
+          e,
+          <InstanceLink instance={instance} />,
+        );
+        instanceLoading.setFinish(instance);
+      });
   };
 
   const disabledStatuses = ["Stopped", "Frozen", "Error"];

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -27,31 +27,38 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
 
   const handleStop = () => {
     instanceLoading.setLoading(instance, "Stopping");
-    void stopInstance(instance, isForce).then((operation) => {
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              Instance <InstanceLink instance={instance} /> stopped.
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Instance stop failed",
-            new Error(msg),
-            <>
-              Instance <ItemName item={instance} bold />:
-            </>,
-          ),
-        () => {
-          instanceLoading.setFinish(instance);
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances],
-          });
-        },
-      );
-    });
+    void stopInstance(instance, isForce)
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                Instance <InstanceLink instance={instance} /> stopped.
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Instance stop failed",
+              new Error(msg),
+              <InstanceLink instance={instance} />,
+            ),
+          () => {
+            instanceLoading.setFinish(instance);
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances],
+            });
+          },
+        );
+      })
+      .catch((e) => {
+        toastNotify.failure(
+          "Instance stop failed",
+          e,
+          <InstanceLink instance={instance} />,
+        );
+        instanceLoading.setFinish(instance);
+      });
   };
 
   return (

--- a/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
@@ -41,19 +41,21 @@ const InstanceConfigureSnapshotModal: FC<Props> = ({
         values,
       ) as LxdInstance;
 
-      void updateInstance(instancePayload, project ?? "").then((operation) => {
-        eventQueue.set(
-          operation.metadata.id,
-          () => onSuccess("Configuration updated."),
-          (msg) => onFailure("Configuration update failed", new Error(msg)),
-          () => {
-            close();
-            void queryClient.invalidateQueries({
-              queryKey: [queryKeys.instances],
-            });
-          },
-        );
-      });
+      void updateInstance(instancePayload, project ?? "")
+        .then((operation) => {
+          eventQueue.set(
+            operation.metadata.id,
+            () => onSuccess("Configuration updated."),
+            (msg) => onFailure("Configuration update failed", new Error(msg)),
+            () => {
+              close();
+              void queryClient.invalidateQueries({
+                queryKey: [queryKeys.instances],
+              });
+            },
+          );
+        })
+        .catch((e) => onFailure("Configuration update failed", e));
     },
   });
 

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
@@ -34,30 +34,35 @@ const InstanceSnapshotActions: FC<Props> = ({
 
   const handleDelete = () => {
     setDeleting(true);
-    void deleteInstanceSnapshot(instance, snapshot).then((operation) =>
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          onSuccess(
-            <>
-              Snapshot <ItemName item={snapshot} bold /> deleted.
-            </>,
-          ),
-        (msg) => onFailure("Snapshot deletion failed", new Error(msg)),
-        () => {
-          setDeleting(false);
-          void queryClient.invalidateQueries({
-            predicate: (query) => query.queryKey[0] === queryKeys.instances,
-          });
-        },
-      ),
-    );
+    void deleteInstanceSnapshot(instance, snapshot)
+      .then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            onSuccess(
+              <>
+                Snapshot <ItemName item={snapshot} bold /> deleted.
+              </>,
+            ),
+          (msg) => onFailure("Snapshot deletion failed", new Error(msg)),
+          () => {
+            setDeleting(false);
+            void queryClient.invalidateQueries({
+              predicate: (query) => query.queryKey[0] === queryKeys.instances,
+            });
+          },
+        ),
+      )
+      .catch((e) => {
+        onFailure("Snapshot deletion failed", e);
+        setDeleting(false);
+      });
   };
 
   const handleRestore = () => {
     setRestoring(true);
-    void restoreInstanceSnapshot(instance, snapshot, restoreState).then(
-      (operation) =>
+    void restoreInstanceSnapshot(instance, snapshot, restoreState)
+      .then((operation) =>
         eventQueue.set(
           operation.metadata.id,
           () =>
@@ -74,7 +79,11 @@ const InstanceSnapshotActions: FC<Props> = ({
             });
           },
         ),
-    );
+      )
+      .catch((e) => {
+        onFailure("Snapshot restore failed", e);
+        setRestoring(false);
+      });
   };
 
   return (

--- a/src/pages/instances/forms/EditInstanceSnapshotForm.tsx
+++ b/src/pages/instances/forms/EditInstanceSnapshotForm.tsx
@@ -56,8 +56,8 @@ const EditInstanceSnapshotForm: FC<Props> = ({
           name: newName,
         } as LxdInstanceSnapshot)
       : snapshot;
-    void updateInstanceSnapshot(instance, targetSnapshot, expiresAt).then(
-      (operation) =>
+    void updateInstanceSnapshot(instance, targetSnapshot, expiresAt)
+      .then((operation) =>
         eventQueue.set(
           operation.metadata.id,
           () => notifyUpdateSuccess(newName ?? snapshot.name),
@@ -69,29 +69,38 @@ const EditInstanceSnapshotForm: FC<Props> = ({
             formik.setSubmitting(false);
           },
         ),
-    );
+      )
+      .catch((e) => {
+        toastNotify.failure("Snapshot update failed", e);
+        formik.setSubmitting(false);
+      });
   };
 
   const rename = (newName: string, expiresAt?: string) => {
-    void renameInstanceSnapshot(instance, snapshot, newName).then((operation) =>
-      eventQueue.set(
-        operation.metadata.id,
-        () => {
-          if (expiresAt) {
-            update(expiresAt, newName);
-          } else {
-            notifyUpdateSuccess(newName);
-          }
-        },
-        (msg) => {
-          toastNotify.failure(
-            `Snapshot rename failed for instance ${instance.name}`,
-            new Error(msg),
-          );
-          formik.setSubmitting(false);
-        },
-      ),
-    );
+    void renameInstanceSnapshot(instance, snapshot, newName)
+      .then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () => {
+            if (expiresAt) {
+              update(expiresAt, newName);
+            } else {
+              notifyUpdateSuccess(newName);
+            }
+          },
+          (msg) => {
+            toastNotify.failure(
+              `Snapshot rename failed for instance ${instance.name}`,
+              new Error(msg),
+            );
+            formik.setSubmitting(false);
+          },
+        ),
+      )
+      .catch((e) => {
+        toastNotify.failure("Snapshot rename failed", e);
+        formik.setSubmitting(false);
+      });
   };
 
   const [expiryDate, expiryTime] =

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -47,24 +47,29 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
         formik.setSubmitting(false);
         return;
       }
-      void renameProject(project.name, values.name).then((operation) =>
-        eventQueue.set(
-          operation.metadata.id,
-          () => {
-            navigate(`/ui/project/${values.name}/configuration`);
-            toastNotify.success(
-              `Project ${project.name} renamed to ${values.name}.`,
-            );
-            void formik.setFieldValue("isRenaming", false);
-          },
-          (msg) =>
-            toastNotify.failure(
-              `Renaming project ${project.name} failed`,
-              new Error(msg),
-            ),
-          () => formik.setSubmitting(false),
-        ),
-      );
+      void renameProject(project.name, values.name)
+        .then((operation) =>
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              navigate(`/ui/project/${values.name}/configuration`);
+              toastNotify.success(
+                `Project ${project.name} renamed to ${values.name}.`,
+              );
+              void formik.setFieldValue("isRenaming", false);
+            },
+            (msg) =>
+              toastNotify.failure(
+                `Renaming project ${project.name} failed`,
+                new Error(msg),
+              ),
+            () => formik.setSubmitting(false),
+          ),
+        )
+        .catch((e) => {
+          formik.setSubmitting(false);
+          toastNotify.failure(`Renaming project ${project.name} failed`, e);
+        });
     },
   });
 

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -85,20 +85,31 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
       projectName,
       setUploadState,
       uploadController,
-    ).then((operation) =>
-      eventQueue.set(
-        operation.metadata.id,
-        () => onFinish(name, pool),
-        (msg) => toastNotify.failure("Image import failed", new Error(msg)),
-        () => {
-          setLoading(false);
-          setUploadState(null);
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.storage, pool, queryKeys.volumes, projectName],
-          });
-        },
-      ),
-    );
+    )
+      .then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () => onFinish(name, pool),
+          (msg) => toastNotify.failure("Image import failed", new Error(msg)),
+          () => {
+            setLoading(false);
+            setUploadState(null);
+            void queryClient.invalidateQueries({
+              queryKey: [
+                queryKeys.storage,
+                pool,
+                queryKeys.volumes,
+                projectName,
+              ],
+            });
+          },
+        ),
+      )
+      .catch((e) => {
+        toastNotify.failure("Image import failed", e);
+        setLoading(false);
+        setUploadState(null);
+      });
   };
 
   const changeFile = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
@@ -33,25 +33,30 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
 
   const handleDelete = () => {
     setDeleting(true);
-    void deleteVolumeSnapshot(volume, snapshot).then((operation) =>
-      eventQueue.set(
-        operation.metadata.id,
-        () => toastNotify.success(`Snapshot ${snapshot.name} deleted`),
-        (msg) =>
-          toastNotify.failure(
-            `Snapshot ${snapshot.name} deletion failed`,
-            new Error(msg),
-          ),
-        () => {
-          setDeleting(false);
-          void queryClient.invalidateQueries({
-            predicate: (query) =>
-              query.queryKey[0] === queryKeys.volumes ||
-              query.queryKey[0] === queryKeys.storage,
-          });
-        },
-      ),
-    );
+    void deleteVolumeSnapshot(volume, snapshot)
+      .then((operation) =>
+        eventQueue.set(
+          operation.metadata.id,
+          () => toastNotify.success(`Snapshot ${snapshot.name} deleted`),
+          (msg) =>
+            toastNotify.failure(
+              `Snapshot ${snapshot.name} deletion failed`,
+              new Error(msg),
+            ),
+          () => {
+            setDeleting(false);
+            void queryClient.invalidateQueries({
+              predicate: (query) =>
+                query.queryKey[0] === queryKeys.volumes ||
+                query.queryKey[0] === queryKeys.storage,
+            });
+          },
+        ),
+      )
+      .catch((e) => {
+        notify.failure("Snapshot deletion failed", e);
+        setDeleting(false);
+      });
   };
 
   const handleRestore = () => {

--- a/src/pages/storage/forms/EditVolumeSnapshotForm.tsx
+++ b/src/pages/storage/forms/EditVolumeSnapshotForm.tsx
@@ -57,15 +57,20 @@ const EditVolumeSnapshotForm: FC<Props> = ({ volume, snapshot, close }) => {
         volume,
         snapshot,
         newName,
-      }).then((operation) =>
-        eventQueue.set(operation.metadata.id, resolve, (msg) => {
-          toastNotify.failure(
-            `Snapshot ${snapshot.name} rename failed`,
-            new Error(msg),
-          );
+      })
+        .then((operation) =>
+          eventQueue.set(operation.metadata.id, resolve, (msg) => {
+            toastNotify.failure(
+              `Snapshot ${snapshot.name} rename failed`,
+              new Error(msg),
+            );
+            formik.setSubmitting(false);
+          }),
+        )
+        .catch((e) => {
+          notify.failure("Snapshot rename failed", e);
           formik.setSubmitting(false);
-        }),
-      );
+        });
     });
   };
 

--- a/src/util/instanceStart.tsx
+++ b/src/util/instanceStart.tsx
@@ -25,31 +25,36 @@ export const useInstanceStart = (instance: LxdInstance) => {
     instanceLoading.setLoading(instance, "Starting");
     const mutation =
       instance.status === "Frozen" ? unfreezeInstance : startInstance;
-    void mutation(instance).then((operation) => {
-      eventQueue.set(
-        operation.metadata.id,
-        () =>
-          toastNotify.success(
-            <>
-              Instance <InstanceLink instance={instance} /> started.
-            </>,
-          ),
-        (msg) =>
-          toastNotify.failure(
-            "Instance start failed",
-            new Error(msg),
-            <>
-              Instance <ItemName item={instance} bold />:
-            </>,
-          ),
-        () => {
-          instanceLoading.setFinish(instance);
-          void queryClient.invalidateQueries({
-            queryKey: [queryKeys.instances],
-          });
-        },
-      );
-    });
+    void mutation(instance)
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () =>
+            toastNotify.success(
+              <>
+                Instance <InstanceLink instance={instance} /> started.
+              </>,
+            ),
+          (msg) =>
+            toastNotify.failure(
+              "Instance start failed",
+              new Error(msg),
+              <>
+                Instance <ItemName item={instance} bold />:
+              </>,
+            ),
+          () => {
+            instanceLoading.setFinish(instance);
+            void queryClient.invalidateQueries({
+              queryKey: [queryKeys.instances],
+            });
+          },
+        );
+      })
+      .catch((e) => {
+        toastNotify.failure("Instance start failed", e);
+        instanceLoading.setFinish(instance);
+      });
   };
   return { handleStart, isLoading, isDisabled };
 };


### PR DESCRIPTION
## Done

- when updating an instance, the request might fail, we should show an error and stop the form from the submitting state
- the same is true for any other api requests, we should catch in case the api returns an error and display the message returned by the api if any is available.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Edit an instance, provoke an error by going to Yaml configuration, add a 2nd profile, that doens't exist. Save changes and ensure an error is displayed.