### PR TITLE
Adjust haproxy config to allow oidc based login

### DIFF
--- a/haproxy-demo.cfg
+++ b/haproxy-demo.cfg
@@ -12,9 +12,11 @@ frontend lxd_frontend
   bind 0.0.0.0:80
   acl is_core path_beg /1.0
   acl is_docs path_beg /documentation
+  acl is_oidc path_beg /oidc
   acl is_backend_allowed hdr_sub(cookie) lxdUiBackend=LXD_UI_BACKEND_SECRET
   use_backend lxd_core if is_core is_backend_allowed
   use_backend lxd_core if is_docs is_backend_allowed
+  use_backend lxd_core if is_oidc is_backend_allowed
   use_backend lxd_core_denied if is_core !is_backend_allowed
   default_backend lxd_ui
 
@@ -22,7 +24,7 @@ backend lxd_ui
   server yarn_serve_port 127.0.0.1:3000
 
 backend lxd_core
-  server lxd_https LXD_UI_BACKEND_IP:8443 ssl verify none crt /srv/key.pem
+  server lxd_https LXD_UI_BACKEND_IP:8443 ssl verify none
 
 backend lxd_core_denied
   mode http


### PR DESCRIPTION
## Done

- remove tls cert

This aims to allow OIDC login. But our backend is not allowed to talk to an external address, so the oidc login flow fails.