### PR TITLE
fix: create instance from custom iso

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -314,12 +314,12 @@ const CreateInstance: FC = () => {
     }
     void formik.setFieldValue("devices", devices);
 
-    if (type) {
-      void formik.setFieldValue("instanceType", type);
-    } else if (isVmOnlyImage(image)) {
+    if (isVmOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "virtual-machine");
     } else if (isContainerOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "container");
+    } else if (type) {
+      void formik.setFieldValue("instanceType", type);
     }
   };
 


### PR DESCRIPTION
## Done

- Fixed issue when creating an instance from the custom ISO list, the redirect may result in invalid instance type locked for the instance creation page.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - upload foo.iso (from test fixtures), go to Storage -> Custom ISOs and try create an instance from the uploaded custom iso. No error should show (i.e. invalid instance type) when the instance gets created.