### PR TITLE
Ensure deps are installed before running the tics report

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -142,6 +142,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Dotrun
+        run: |
+          sudo pip3 install dotrun
+
+      - name: Install LXD-UI dependencies
+        run: |
+          set -x
+          sudo chmod 0777 ../lxd-ui
+          dotrun install
+
       - name: Produce TICS report
         shell: bash
         run: |


### PR DESCRIPTION
## Done

- Ensure deps are installed before running the tics report
