### PR TITLE
feat: limit functionalities for storage pool with driver that's not fully supported in the UI [WD-9345]

### DIFF
--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -19,10 +19,15 @@ import { checkDuplicateName } from "util/helpers";
 import { useClusterMembers } from "context/useClusterMembers";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { toStoragePoolFormValues } from "util/storagePoolForm";
-import { MAIN_CONFIGURATION } from "./forms/StoragePoolFormMenu";
+import {
+  MAIN_CONFIGURATION,
+  YAML_CONFIGURATION,
+} from "./forms/StoragePoolFormMenu";
 import { slugify } from "util/slugify";
 import { useToastNotification } from "context/toastNotificationProvider";
 import { yamlToObject } from "util/yaml";
+import { useSettings } from "context/useSettings";
+import { getSupportedStorageDrivers } from "util/storageOptions";
 
 interface Props {
   pool: LxdStoragePool;
@@ -31,6 +36,7 @@ interface Props {
 const EditStoragePool: FC<Props> = ({ pool }) => {
   const navigate = useNavigate();
   const notify = useNotify();
+  const { data: settings } = useSettings();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const { project, section } = useParams<{
@@ -99,11 +105,16 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
       : navigate(`${baseUrl}/${slugify(newSection)}`);
   };
 
+  const supportedStorageDrivers = getSupportedStorageDrivers(settings);
+  const defaultFormSection = supportedStorageDrivers.has(formik.values.driver)
+    ? slugify(MAIN_CONFIGURATION)
+    : slugify(YAML_CONFIGURATION);
+
   return (
     <div className="edit-storage-pool">
       <StoragePoolForm
         formik={formik}
-        section={section ?? slugify(MAIN_CONFIGURATION)}
+        section={section ?? defaultFormSection}
         setSection={updateSection}
       />
       <FormFooterLayout>

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -22,6 +22,7 @@ import { LxdStoragePool } from "types/storage";
 import {
   btrfsDriver,
   cephDriver,
+  getSupportedStorageDrivers,
   powerFlex,
   zfsDriver,
 } from "util/storageOptions";
@@ -35,6 +36,7 @@ import { useDocs } from "context/useDocs";
 import StoragePoolFormCeph from "./StoragePoolFormCeph";
 import StoragePoolFormPowerflex from "./StoragePoolFormPowerflex";
 import StoragePoolFormZFS from "./StoragePoolFormZFS";
+import { useSettings } from "context/useSettings";
 
 export interface StoragePoolFormValues {
   isCreating: boolean;
@@ -158,6 +160,7 @@ export const toStoragePool = (
 const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
   const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const docBaseLink = useDocs();
+  const { data: settings } = useSettings();
   const notify = useNotify();
 
   const updateFormHeight = () => {
@@ -187,6 +190,11 @@ const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
     }
   };
 
+  const supportedStorageDrivers = getSupportedStorageDrivers(settings);
+  const isSupportedStorageDriver = supportedStorageDrivers.has(
+    formik.values.driver,
+  );
+
   return (
     <Form className="form storage-pool-form" onSubmit={formik.handleSubmit}>
       {confirmModal}
@@ -196,6 +204,7 @@ const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
         active={section}
         setActive={handleSetActive}
         formik={formik}
+        isSupportedStorageDriver={isSupportedStorageDriver}
       />
       <Row className="form-contents" key={section}>
         <Col size={12}>
@@ -219,7 +228,7 @@ const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
               readOnly={formik.values.readOnly}
             >
               <Notification severity="information" title="YAML Configuration">
-                This is the YAML representation of the storage pool.
+                {`${isSupportedStorageDriver ? "" : `The ${formik.values.driver} driver is not fully supported in the web interface. `}This is the YAML representation of the storage pool.`}
                 <br />
                 <a
                   href={`${docBaseLink}/explanation/storage/#storage-pools`}

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -18,9 +18,15 @@ interface Props {
   active: string;
   setActive: (val: string) => void;
   formik: FormikProps<StoragePoolFormValues>;
+  isSupportedStorageDriver: boolean;
 }
 
-const StoragePoolFormMenu: FC<Props> = ({ formik, active, setActive }) => {
+const StoragePoolFormMenu: FC<Props> = ({
+  formik,
+  active,
+  setActive,
+  isSupportedStorageDriver,
+}) => {
   const notify = useNotify();
   const menuItemProps = {
     active,
@@ -42,11 +48,14 @@ const StoragePoolFormMenu: FC<Props> = ({ formik, active, setActive }) => {
   };
   useEffect(resize, [notify.notification?.message]);
   useEventListener("resize", resize);
+
   return (
     <div className="p-side-navigation--accordion form-navigation">
       <nav aria-label="Storage pool form navigation">
         <ul className="p-side-navigation__list">
-          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+          {isSupportedStorageDriver && (
+            <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+          )}
           {isCephDriver && (
             <MenuItem
               label={CEPH_CONFIGURATION}

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -31,6 +31,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
                 project={project}
                 value={formik.values.pool}
                 setValue={(val) => void formik.setFieldValue("pool", val)}
+                hidePoolsWithUnsupportedDrivers
               />
             </>
           )}

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -35,6 +35,14 @@ export const getStorageDriverOptions = (
   );
 };
 
+export const getSupportedStorageDrivers = (
+  settings?: LxdSettings,
+): Set<string> => {
+  return new Set(
+    getStorageDriverOptions(settings).map((driver) => driver.value as string),
+  );
+};
+
 const storageDriverToSourceHelp: Record<string, string> = {
   dir: "Optional, path to an existing directory",
   lvm: "Optional, path to an existing block device, loop file or LVM volume group",


### PR DESCRIPTION
## Done

- remove volumes tab in storage detail page when pool driver is not supported
- remove main configuration form menu tab and default to show yaml configs editor when pool driver is not supported
- filter out storage pool selector options with unsupported drivers (applies to creating custom volumes, selecting root storage pool for instance and profile, creating custom volume while creating instance, uploading custom iso)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Setup a ceph cluster for the lxd host server
    - Then run `lxc storage create cephfs-pool cephfs source=my-filesystem cephfs.create_missing=true cephfs.data_pool=my-data cephfs.meta_pool=my-metadata` to create a `cephfs` storage pool.
    - Test visiting storage pool detail configurations page for the `cephfs-pool`. Ensure the volumes tab is gone, ensure main configurations form menu item is gone, try updating the storage pool config using the yaml editor (`cephfs.create_missing` config can be changed without negative consequences)
    - Try create a custom volume, the storage pool selection should not contain `cephfs-pool`.
    - Try upload a custom iso, the storage pool selection should not contain `cephfs-pool`.
    - Try creating an instance or a profile, go to disk devices section, the root storage pool selector should not contain `cephfs-pool` as an option