### PR TITLE
Include yaml editor code in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log *.log build/ .jekyll-metadata .bundle playwright-report test-results haproxy-local.cfg coverage",
     "build-html": "cp build/ui/index.html build/index.html",
-    "build": "npx vite build && yarn build-html",
+    "build-monaco": "mkdir build/ui/monaco-editor && cp -R node_modules/monaco-editor/min build/ui/monaco-editor",
+    "build": "npx vite build && yarn build-html && yarn build-monaco",
     "format-js-eslint": "eslint 'src/**/*.{json,jsx,tsx,ts}' 'tests/**/*.ts' --fix",
     "format-js-prettier": "prettier 'src/**/*.{json,jsx,tsx,ts}' 'tests/**/*.ts' --write",
     "format-js": "yarn format-js-eslint && yarn format-js-prettier",

--- a/src/components/forms/YamlForm.tsx
+++ b/src/components/forms/YamlForm.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode, useEffect, useRef, useState } from "react";
-import Editor from "@monaco-editor/react";
+import Editor, { loader } from "@monaco-editor/react";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { editor } from "monaco-editor/esm/vs/editor/editor.api";
@@ -27,6 +27,8 @@ const YamlForm: FC<Props> = ({
 }) => {
   const [editor, setEditor] = useState<IStandaloneCodeEditor | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  loader.config({ paths: { vs: "/ui/monaco-editor/min/vs" } });
 
   const updateFormHeight = () => {
     if (!editor || !containerRef.current) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/ui/, ""),
         secure: false,
       },
+      "/ui/monaco-editor": {
+        target: "https://localhost:8407/node_modules",
+        rewrite: (path) => path.replace(/^\/ui/, ""),
+        secure: false,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Done

- Include yaml editor code in build process
- Avoid to rely on external domain cdn.jsdelivr.net to load editor code

Fixes WD-9954

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure CI passes
    - after merge and LXD edge/latest is build, ensure the editor works in the nightly build as well.