### PR TITLE
Fix workflow: stop dotrun before uploading coverage report

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -76,6 +76,8 @@ jobs:
           sudo chmod -R 0777 ../lxd-ui
           yarn test-coverage
           zip -r coverage/playwright-report/cobertura-coverage.zip coverage/playwright-report/cobertura-coverage.xml
+          DOTRUN_CONTAINER_ID=$(docker ps | awk '{print $1}' | tail -n1)
+          docker stop $DOTRUN_CONTAINER_ID
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
## Done

- Fix workflow: stop dotrun before uploading coverage report to avoid active symlinks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - not needed