### PR TITLE
Use fetch all volumes endpoint

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -203,6 +203,19 @@ export const fetchStorageVolumes = (
   });
 };
 
+export const fetchAllStorageVolumes = (
+  project: string,
+): Promise<LxdStorageVolume[]> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/storage-volumes?recursion=1&project=${project}`)
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdStorageVolume[]>) =>
+        resolve(data.metadata),
+      )
+      .catch(reject);
+  });
+};
+
 export const fetchStorageVolume = (
   pool: string,
   project: string,

--- a/src/context/loadIsoVolumes.tsx
+++ b/src/context/loadIsoVolumes.tsx
@@ -1,13 +1,18 @@
-import { fetchStoragePools, fetchStorageVolumes } from "api/storage-pools";
+import {
+  fetchAllStorageVolumes,
+  fetchStoragePools,
+  fetchStorageVolumes,
+} from "api/storage-pools";
 import { isoToRemoteImage } from "util/images";
 import { RemoteImage } from "types/image";
 import { LxdStorageVolume } from "types/storage";
 
 export const loadIsoVolumes = async (
   project: string,
+  hasStorageVolumesAll: boolean,
 ): Promise<RemoteImage[]> => {
   const remoteImages: RemoteImage[] = [];
-  const allVolumes = await loadVolumes(project);
+  const allVolumes = await loadVolumes(project, hasStorageVolumesAll);
   allVolumes.forEach((volume) => {
     if (volume.content_type === "iso") {
       const image = isoToRemoteImage(volume);
@@ -19,6 +24,15 @@ export const loadIsoVolumes = async (
 };
 
 export const loadVolumes = async (
+  project: string,
+  hasStorageVolumesAll: boolean,
+): Promise<LxdStorageVolume[]> => {
+  return hasStorageVolumesAll
+    ? fetchAllStorageVolumes(project)
+    : collectAllStorageVolumes(project);
+};
+
+export const collectAllStorageVolumes = async (
   project: string,
 ): Promise<LxdStorageVolume[]> => {
   const allVolumes: LxdStorageVolume[] = [];

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -16,6 +16,7 @@ export const useSupportedFeatures = () => {
     hasProjectsNetworksZones: apiExtensions.has("projects_networks_zones"),
     hasStorageBuckets: apiExtensions.has("storage_buckets"),
     hasMetadataConfiguration: apiExtensions.has("metadata_configuration"),
+    hasStorageVolumesAll: apiExtensions.has("storage_volumes_all"),
     hasLocalDocumentation:
       !!serverVersion && serverMajor >= 5 && serverMinor >= 19,
     hasDocumentationObject:

--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -8,6 +8,7 @@ import Loader from "components/Loader";
 import { useProject } from "context/project";
 import { LxdImageType, RemoteImage } from "types/image";
 import { IsoImage } from "types/iso";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   primaryImage: IsoImage | null;
@@ -24,10 +25,11 @@ const CustomIsoSelector: FC<Props> = ({
 }) => {
   const { project } = useProject();
   const projectName = project?.name ?? "";
+  const { hasStorageVolumesAll } = useSupportedFeatures();
 
   const { data: images = [], isLoading } = useQuery({
     queryKey: [queryKeys.isoVolumes, project],
-    queryFn: () => loadIsoVolumes(projectName),
+    queryFn: () => loadIsoVolumes(projectName, hasStorageVolumesAll),
   });
 
   const headers = [

--- a/src/pages/storage/CustomIsoList.tsx
+++ b/src/pages/storage/CustomIsoList.tsx
@@ -20,6 +20,7 @@ import { Link } from "react-router-dom";
 import { useDocs } from "context/useDocs";
 import useSortTableData from "util/useSortTableData";
 import { useToastNotification } from "context/toastNotificationProvider";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   project: string;
@@ -27,12 +28,13 @@ interface Props {
 
 const CustomIsoList: FC<Props> = ({ project }) => {
   const docBaseLink = useDocs();
+  const { hasStorageVolumesAll } = useSupportedFeatures();
   const toastNotify = useToastNotification();
   const [query, setQuery] = useState<string>("");
 
   const { data: images = [], isLoading } = useQuery({
     queryKey: [queryKeys.isoVolumes, project],
-    queryFn: () => loadIsoVolumes(project),
+    queryFn: () => loadIsoVolumes(project, hasStorageVolumesAll),
   });
 
   const headers = [

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -49,6 +49,7 @@ import useEventListener from "@use-it/event-listener";
 import { useProject } from "context/project";
 import { isSnapshotsDisabled } from "util/snapshots";
 import useSortTableData from "util/useSortTableData";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 const StorageVolumes: FC = () => {
   const docBaseLink = useDocs();
@@ -56,6 +57,7 @@ const StorageVolumes: FC = () => {
   const { project } = useParams<{ project: string }>();
   const [searchParams] = useSearchParams();
   const [isSmallScreen, setSmallScreen] = useState(figureCollapsedScreen());
+  const { hasStorageVolumesAll } = useSupportedFeatures();
   const resize = () => {
     setSmallScreen(figureCollapsedScreen());
   };
@@ -84,7 +86,7 @@ const StorageVolumes: FC = () => {
     isLoading,
   } = useQuery({
     queryKey: [queryKeys.volumes, project],
-    queryFn: () => loadVolumes(project),
+    queryFn: () => loadVolumes(project, hasStorageVolumesAll),
   });
 
   if (error) {


### PR DESCRIPTION
## Done

- use fetch all volumes endpoint
- we used to fetch all storage pools and then all volumes for each pool, with https://github.com/canonical/lxd/issues/12550 a new endpoint to directly fetch all storage volumes is available, this PR is starting to use it.
- This only works with the latest/edge version of lxd

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure storages -> volumes page is working as before