### PR TITLE
fix: create instance from custom image

### DIFF
--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -9,7 +9,12 @@ import {
 } from "@canonical/react-components";
 import ProfileSelect from "pages/profiles/ProfileSelector";
 import SelectImageBtn from "pages/images/actions/SelectImageBtn";
-import { isContainerOnlyImage, isVmOnlyImage, LOCAL_ISO } from "util/images";
+import {
+  isContainerOnlyImage,
+  isVmOnlyImage,
+  LOCAL_IMAGE,
+  LOCAL_ISO,
+} from "util/images";
 import { instanceCreationTypes } from "util/instanceOptions";
 import { FormikProps } from "formik/dist/types";
 import { CreateInstanceFormValues } from "pages/instances/CreateInstance";
@@ -45,6 +50,15 @@ export const instanceDetailPayload = (values: CreateInstanceFormValues) => {
       type: "image",
     },
   };
+
+  if (values.image?.server === LOCAL_IMAGE) {
+    payload.source = {
+      type: "image",
+      certificate: "",
+      fingerprint: values.image?.fingerprint,
+      allow_inconsistent: false,
+    };
+  }
 
   if (values.image?.server === LOCAL_ISO) {
     payload.source = {

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -60,6 +60,7 @@ export interface RemoteImage {
   server?: string;
   volume?: LxdStorageVolume;
   type?: LxdImageType;
+  fingerprint?: string;
 }
 
 export interface RemoteImageList {

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -38,14 +38,17 @@ export const isoToRemoteImage = (volume: LxdStorageVolume): RemoteImage => {
   };
 };
 
+export const LOCAL_IMAGE = "local-image";
+
 export const localLxdToRemoteImage = (image: LxdImage): RemoteImage => {
   return {
-    aliases: image.update_source?.alias ?? image.fingerprint,
+    aliases: image.update_source?.alias ?? image.aliases?.[0]?.name ?? "",
+    fingerprint: image.fingerprint,
     arch: image.architecture === "x86_64" ? "amd64" : image.architecture,
     os: image.properties?.os ?? "",
     created_at: new Date(image.uploaded_at).getTime(),
     release: image.properties?.release ?? "",
-    server: image.update_source?.server,
+    server: LOCAL_IMAGE,
     type: image.type,
   };
 };


### PR DESCRIPTION
## Done

- fix instance creation from custom images:  needs fingerprint in payload.source

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a custom image locally as described in https://github.com/canonical/lxd-ui/pull/717
    - launch an instance from the custom image, where previously an error was encountered as [described here](https://discourse.ubuntu.com/t/image-not-provided-for-instance-creation/43832), the instance should now be created.