### PR TITLE
ci: fix coverage report artifact upload

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Playwright Browser
         run: npx playwright install --with-deps chromium
@@ -78,6 +78,7 @@ jobs:
           zip -r coverage/playwright-report/cobertura-coverage.zip coverage/playwright-report/cobertura-coverage.xml
           DOTRUN_CONTAINER_ID=$(docker ps | awk '{print $1}' | tail -n1)
           docker stop $DOTRUN_CONTAINER_ID
+          rm -rf coverage/playwright-report/lxd-ui/ui/monaco-editor/
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
## Done

Fix issue with coverage report artifact upload failing due to build files for `monaco-editor` containing invalid characters.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes