### PR TITLE
ci: remove all monaco-editor directories when uploading coverage report bundle

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -78,7 +78,8 @@ jobs:
           zip -r coverage/playwright-report/cobertura-coverage.zip coverage/playwright-report/cobertura-coverage.xml
           DOTRUN_CONTAINER_ID=$(docker ps | awk '{print $1}' | tail -n1)
           docker stop $DOTRUN_CONTAINER_ID
-          rm -rf coverage/playwright-report/lxd-ui/ui/monaco-editor/
+          # Remove all monaco-editor build files, which causes error in upload-artifact due to invalid characters in file naming
+          find . -type d -name "monaco-editor" -exec rm -r {} +
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
## Done

- The coverage report is failing due to files in `monaco-editor` directory, the path also seems to change. Let's try to remove all `monaco-editor` directories no matter where they are located and see if this works.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes