### PR TITLE
List minimal images after standard images

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -110,8 +110,8 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     : localImages
         .filter((image) => !image.cached)
         .map(localLxdToRemoteImage)
-        .concat([...minimalImages].reverse().sort(byLtsFirst))
         .concat([...canonicalImages].reverse().sort(byLtsFirst))
+        .concat([...minimalImages].reverse().sort(byLtsFirst))
         .concat([...imagesLxdImages])
         .filter((image) => archSupported.includes(image.arch));
 


### PR DESCRIPTION
## Done

- List minimal images after standard images in image selection modal

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Start instance creation
    - Ensure in Image selection modal the minimal images are listed after the standard images.