### PR TITLE
Ensure instance type is derived from image type

### DIFF
--- a/src/pages/images/CustomIsoModal.tsx
+++ b/src/pages/images/CustomIsoModal.tsx
@@ -7,7 +7,7 @@ import { IsoImage } from "types/iso";
 
 interface Props {
   onClose: () => void;
-  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelect: (image: RemoteImage, type?: LxdImageType) => void;
 }
 
 const SELECT_ISO = "selectIso";

--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -12,7 +12,7 @@ import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   primaryImage: IsoImage | null;
-  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelect: (image: RemoteImage, type?: LxdImageType) => void;
   onUpload: () => void;
   onCancel: () => void;
 }

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -29,7 +29,7 @@ import { fetchImageList } from "api/images";
 import { useParams } from "react-router-dom";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelect: (image: RemoteImage, type?: LxdImageType) => void;
   onClose: () => void;
 }
 
@@ -53,7 +53,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [os, setOs] = useState<string>("");
   const [release, setRelease] = useState<string>("");
   const [arch, setArch] = useState<string>("amd64");
-  const [type, setType] = useState<LxdImageType | null>(null);
+  const [type, setType] = useState<LxdImageType | undefined>(undefined);
   const [variant, setVariant] = useState<string>(ANY);
   const { project } = useParams<{ project: string }>();
 

--- a/src/pages/images/actions/SelectImageBtn.tsx
+++ b/src/pages/images/actions/SelectImageBtn.tsx
@@ -5,13 +5,13 @@ import { LxdImageType, RemoteImage } from "types/image";
 import ImageSelector from "pages/images/ImageSelector";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelect: (image: RemoteImage, type?: LxdImageType) => void;
 }
 
 const SelectImageBtn: FC<Props> = ({ onSelect }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
-  const handleSelect = (image: RemoteImage, type: LxdImageType | null) => {
+  const handleSelect = (image: RemoteImage, type?: LxdImageType) => {
     closePortal();
     onSelect(image, type);
   };

--- a/src/pages/images/actions/UseCustomIsoBtn.tsx
+++ b/src/pages/images/actions/UseCustomIsoBtn.tsx
@@ -5,13 +5,13 @@ import { LxdImageType, RemoteImage } from "types/image";
 import CustomIsoModal from "pages/images/CustomIsoModal";
 
 interface Props {
-  onSelect: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelect: (image: RemoteImage, type?: LxdImageType) => void;
 }
 
 const UseCustomIsoBtn: FC<Props> = ({ onSelect }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
-  const handleSelect = (image: RemoteImage, type: LxdImageType | null) => {
+  const handleSelect = (image: RemoteImage, type?: LxdImageType) => {
     closePortal();
     onSelect(image, type);
   };

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -302,7 +302,7 @@ const CreateInstance: FC = () => {
 
   const isLocalIsoImage = formik.values.image?.server === LOCAL_ISO;
 
-  const handleSelectImage = (image: RemoteImage, type: LxdImageType | null) => {
+  const handleSelectImage = (image: RemoteImage, type?: LxdImageType) => {
     void formik.setFieldValue("image", image);
 
     const devices = formik.values.devices.filter(
@@ -314,21 +314,19 @@ const CreateInstance: FC = () => {
     }
     void formik.setFieldValue("devices", devices);
 
-    if (isVmOnlyImage(image)) {
+    if (type) {
+      void formik.setFieldValue("instanceType", type);
+    } else if (isVmOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "virtual-machine");
     } else if (isContainerOnlyImage(image)) {
       void formik.setFieldValue("instanceType", "container");
-    } else if (type) {
-      void formik.setFieldValue("instanceType", type);
     }
   };
 
   useEffect(() => {
-    if (location.state?.selectedImage) {
-      const type = location.state.selectedImage.volume
-        ? "iso-volume"
-        : location.state.selectedImage.type ?? null;
-      handleSelectImage(location.state.selectedImage, type);
+    const imageFromLink = location.state?.selectedImage;
+    if (imageFromLink) {
+      handleSelectImage(imageFromLink, imageFromLink.type);
     }
   }, [location.state?.selectedImage]);
 

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -73,7 +73,7 @@ export const instanceDetailPayload = (values: CreateInstanceFormValues) => {
 
 interface Props {
   formik: FormikProps<CreateInstanceFormValues>;
-  onSelectImage: (image: RemoteImage, type: LxdImageType | null) => void;
+  onSelectImage: (image: RemoteImage, type?: LxdImageType) => void;
   project: string;
 }
 

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -1,6 +1,6 @@
 import { LxdStorageVolume } from "types/storage";
 
-export type LxdImageType = "container" | "virtual-machine" | "iso-volume";
+export type LxdImageType = "container" | "virtual-machine";
 
 interface LxdImageAlias {
   name: string;

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -2,7 +2,7 @@ import { LxdImage, RemoteImage } from "types/image";
 import { LxdStorageVolume } from "types/storage";
 
 export const isVmOnlyImage = (image: RemoteImage): boolean | undefined => {
-  if (image.server === LOCAL_ISO) {
+  if (image.server === LOCAL_ISO || image.type === "virtual-machine") {
     return true;
   }
   return image.variant?.includes("desktop");
@@ -32,6 +32,7 @@ export const isoToRemoteImage = (volume: LxdStorageVolume): RemoteImage => {
     pool: volume.pool,
     release: "-",
     server: LOCAL_ISO,
+    type: "virtual-machine",
     variant: "iso",
     created_at: new Date(volume.created_at).getTime(),
     volume: volume,


### PR DESCRIPTION
## Done

- fix instance creation quicklinks:
- for custom images created from an instance snapshot. The instance creation flow should select the correct instance type, depending on the type of the custom image (vm or container)
- Keep supporting iso volume quick links from storage -> iso volumes

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - publish an image from a vm and from a container snapshot
    - create an instance from the quick links in images 1. from the vm snapshot 2. from the container snapshot
    - upload an iso-volume, create an instance from the link in storage > iso volumes