### PR TITLE
fix(instance): add name length check for instance name (creation/edit)

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -16,7 +16,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { LxdImageType, RemoteImage } from "types/image";
 import { isContainerOnlyImage, isVmOnlyImage, LOCAL_ISO } from "util/images";
-import { checkDuplicateName } from "util/helpers";
 import { dump as dumpYaml } from "js-yaml";
 import { yamlToObject } from "util/yaml";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -75,6 +74,7 @@ import {
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
 import { useDocs } from "context/useDocs";
+import { instanceNameValidation } from "util/instances";
 
 export type CreateInstanceFormValues = InstanceDetailsFormValues &
   FormDeviceValues &
@@ -109,20 +109,7 @@ const CreateInstance: FC = () => {
   }
 
   const InstanceSchema = Yup.object().shape({
-    name: Yup.string()
-      .test(
-        "deduplicate",
-        "An instance with this name already exists",
-        (value) =>
-          checkDuplicateName(value, project, controllerState, "instances"),
-      )
-      .matches(/^[A-Za-z0-9-]+$/, {
-        message: "Only alphanumeric and hyphen characters are allowed",
-      })
-      .matches(/^[A-Za-z].*$/, {
-        message: "Instance name must start with a letter",
-      })
-      .optional(),
+    name: instanceNameValidation(project, controllerState).optional(),
     instanceType: Yup.string().required("Instance type is required"),
   });
 

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -7,12 +7,12 @@ import { renameInstance } from "api/instances";
 import InstanceStateActions from "pages/instances/actions/InstanceStateActions";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import { checkDuplicateName } from "util/helpers";
 import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import {
   instanceLinkFromName,
   instanceLinkFromOperation,
+  instanceNameValidation,
 } from "util/instances";
 import { getInstanceName } from "util/operations";
 import InstanceLink from "pages/instances/InstanceLink";
@@ -30,21 +30,9 @@ const InstanceDetailHeader: FC<Props> = ({ name, instance, project }) => {
   const controllerState = useState<AbortController | null>(null);
 
   const RenameSchema = Yup.object().shape({
-    name: Yup.string()
-      .test(
-        "deduplicate",
-        "An instance with this name already exists",
-        (value) =>
-          instance?.name === value ||
-          checkDuplicateName(value, project, controllerState, "instances"),
-      )
-      .matches(/^[A-Za-z0-9-]+$/, {
-        message: "Only alphanumeric and hyphen characters are allowed",
-      })
-      .matches(/^[A-Za-z].*$/, {
-        message: "Instance name must start with a letter",
-      })
-      .required("Instance name is required"),
+    name: instanceNameValidation(project, controllerState).required(
+      "Instance name is required",
+    ),
   });
 
   const formik = useFormik<RenameHeaderValues>({

--- a/src/sass/_rename_header.scss
+++ b/src/sass/_rename_header.scss
@@ -40,6 +40,14 @@
       .cancel {
         margin-right: $sph--small;
       }
+
+      .p-form-validation__message {
+        font-variant-caps: initial;
+        font-variant-numeric: initial;
+        font-weight: initial;
+        letter-spacing: initial;
+        text-indent: initial;
+      }
     }
   }
 

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -2,6 +2,8 @@ import { LxdOperationResponse } from "types/operation";
 import { getInstanceName } from "./operations";
 import InstanceLink from "pages/instances/InstanceLink";
 import { ReactNode } from "react";
+import { AbortControllerState, checkDuplicateName } from "./helpers";
+import * as Yup from "yup";
 
 export const instanceLinkFromName = (args: {
   instanceName: string;
@@ -24,3 +26,23 @@ export const instanceLinkFromOperation = (args: {
   }
   return <InstanceLink instance={{ name: linkText, project: project || "" }} />;
 };
+
+export const instanceNameValidation = (
+  project: string,
+  controllerState: AbortControllerState,
+): Yup.StringSchema =>
+  Yup.string()
+    .test("deduplicate", "An instance with this name already exists", (value) =>
+      checkDuplicateName(value, project, controllerState, "instances"),
+    )
+    .test(
+      "size",
+      "Instance name must be between 1 and 63 characters",
+      (value) => !value || value.length < 64,
+    )
+    .matches(/^[A-Za-z0-9-]+$/, {
+      message: "Only alphanumeric and hyphen characters are allowed",
+    })
+    .matches(/^[A-Za-z].*$/, {
+      message: "Instance name must start with a letter",
+    });


### PR DESCRIPTION
## Done

- Added length validation check for instance name (creation and edit)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new instance, input some text that is longer than 63 characters in the "Instance name" field, and check that a proper error message appears
    - Edit an existing instance, change the name in the header by inputting some text that is longer than 63 characters and check that a proper error message appears