### PR TITLE
Use bibyte everywhere and avoid the MB or GB reportings

### DIFF
--- a/src/components/forms/MemoryLimitSelector.tsx
+++ b/src/components/forms/MemoryLimitSelector.tsx
@@ -86,7 +86,7 @@ const MemoryLimitSelector: FC<Props> = ({ memoryLimit, setMemoryLimit }) => {
       return "";
     }
     if (memoryLimit.unit === "%") {
-      return humanFileSize(maxMemory, true);
+      return humanFileSize(maxMemory);
     }
     const formattedValue = getFormattedMaxValue(memoryLimit.unit) ?? 0;
     if (formattedValue < 1) {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -99,18 +99,16 @@ export const handleTextResponse = async (
   return response.text();
 };
 
-export const humanFileSize = (bytes: number, toBibyte = false): string => {
+export const humanFileSize = (bytes: number): string => {
   if (Math.abs(bytes) < 1000) {
     return `${bytes} B`;
   }
 
-  const units = toBibyte
-    ? ["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
-    : ["kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const units = ["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
   let u = -1;
 
   do {
-    bytes /= toBibyte ? 1024 : 1000;
+    bytes /= 1024;
     ++u;
   } while (
     Math.round(Math.abs(bytes) * 10) / 10 >= 1000 &&


### PR DESCRIPTION
## Done

- to align with the cli, use GiB and alike everywhere instead of GB.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance overview > disk usage on a running instance
    - check usage on a storage pool