### PR TITLE
Remove storage volume detail page and snapshots for custom ISOs

### DIFF
--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -3,52 +3,42 @@ import { FC } from "react";
 import { Link } from "react-router-dom";
 import { LxdStorageVolume } from "types/storage";
 import classnames from "classnames";
+import {
+  generateLinkForVolumeDetail,
+  hasVolumeDetailPage,
+} from "util/storageVolume";
+import { useProject } from "context/project";
 
 interface Props {
   volume: LxdStorageVolume;
-  project: string;
   isExternalLink?: boolean;
   overrideName?: string;
   className?: string;
 }
 
-export const generateLinkForVolumeDetail = (args: {
-  volume: LxdStorageVolume;
-  project: string;
-}) => {
-  const { volume, project } = args;
-  let path = `storage/pool/${volume.pool}/volumes/${volume.type}/${volume.name}`;
-
-  // NOTE: name of a volume created from an instance is exactly the same as the instance name
-  if (volume.type === "container" || volume.type === "virtual-machine") {
-    path = `instance/${volume.name}`;
-  }
-
-  if (volume.type === "image") {
-    path = "images";
-  }
-
-  return `/ui/project/${project}/${path}`;
-};
-
 const StorageVolumeNameLink: FC<Props> = ({
   volume,
-  project,
-  isExternalLink,
   overrideName,
   className,
 }) => {
+  const { project } = useProject();
+  const isExternalLink = !hasVolumeDetailPage(volume);
+  const caption = overrideName ? overrideName : volume.name;
+
   return (
     <div className={classnames("u-flex", className)}>
       <div
         className={classnames("u-truncate", "volume-name-link")}
-        title={`Volume ${volume.name}`}
+        title={caption}
       >
-        <Link to={generateLinkForVolumeDetail({ volume, project })}>
-          {overrideName ? overrideName : volume.name}
+        <Link
+          to={generateLinkForVolumeDetail(volume, project?.name ?? "")}
+          className={isExternalLink ? "has-icon" : undefined}
+        >
+          {caption}
+          {isExternalLink && <Icon name={ICONS.externalLink} />}
         </Link>
       </div>
-      {isExternalLink && <Icon name={ICONS.externalLink} />}
     </div>
   );
 };

--- a/src/pages/storage/actions/CustomStorageVolumeActions.tsx
+++ b/src/pages/storage/actions/CustomStorageVolumeActions.tsx
@@ -5,21 +5,18 @@ import { LxdStorageVolume } from "types/storage";
 import DeleteStorageVolumeBtn from "./DeleteStorageVolumeBtn";
 import VolumeAddSnapshotBtn from "./snapshots/VolumeAddSnapshotBtn";
 import { useToastNotification } from "context/toastNotificationProvider";
+import { isSnapshotsDisabled } from "util/snapshots";
+import { useProject } from "context/project";
 
 interface Props {
   volume: LxdStorageVolume;
-  project: string;
   className?: string;
-  snapshotDisabled?: boolean;
 }
 
-const CustomStorageVolumeActions: FC<Props> = ({
-  volume,
-  className,
-  project,
-  snapshotDisabled,
-}) => {
+const CustomStorageVolumeActions: FC<Props> = ({ volume, className }) => {
   const toastNotify = useToastNotification();
+  const { project } = useProject();
+
   return (
     <List
       inline
@@ -29,12 +26,12 @@ const CustomStorageVolumeActions: FC<Props> = ({
           key="add-snapshot"
           volume={volume}
           isCTA
-          isDisabled={snapshotDisabled}
+          isDisabled={isSnapshotsDisabled(project)}
         />,
         <DeleteStorageVolumeBtn
           key="delete"
           volume={volume}
-          project={project}
+          project={project?.name ?? ""}
           onFinish={() => {
             toastNotify.success(`Storage volume ${volume.name} deleted.`);
           }}

--- a/src/util/storageVolume.tsx
+++ b/src/util/storageVolume.tsx
@@ -120,3 +120,27 @@ export const getSnapshotsPerVolume = (volumes: LxdStorageVolume[]) => {
 const collapsedViewMaxWidth = 1250;
 export const figureCollapsedScreen = (): boolean =>
   window.innerWidth <= collapsedViewMaxWidth;
+
+export const generateLinkForVolumeDetail = (
+  volume: LxdStorageVolume,
+  project: string,
+): string => {
+  // NOTE: name of a volume created from an instance is exactly the same as the instance name
+  if (volume.type === "container" || volume.type === "virtual-machine") {
+    return `/ui/project/${project}/instance/${volume.name}`;
+  }
+
+  if (volume.type === "image") {
+    return `/ui/project/${project}/images`;
+  }
+
+  if (volume.type === "custom" && volume.content_type === "iso") {
+    return `/ui/project/${project}/storage/custom-isos`;
+  }
+
+  return `/ui/project/${project}/storage/pool/${volume.pool}/volumes/${volume.type}/${volume.name}`;
+};
+
+export const hasVolumeDetailPage = (volume: LxdStorageVolume): boolean => {
+  return generateLinkForVolumeDetail(volume, "").includes("/storage/pool/");
+};


### PR DESCRIPTION
## Done

- Remove storage volume detail page and snapshots for custom ISOs

Fixes WD-10867

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check storage volume list:
      - iso volumes should not have a detail page, and no actions. Only link to the iso list
      - same for images and instances (unchanged behaviour)
      - all other volumes should have actions available in the list and a detail page (unchanged behaviour)

## Screenshots

![image](https://github.com/canonical/lxd-ui/assets/1155472/c9c80044-0fe5-4c08-be5a-10ee754d5191)
