### PR TITLE
fix architecture filtering on image selection

### DIFF
--- a/src/util/architectures.spec.ts
+++ b/src/util/architectures.spec.ts
@@ -1,0 +1,33 @@
+import { getArchitectureAliases } from "./architectures";
+
+describe("getArchitectureAliases", () => {
+  it("resolves s390x", () => {
+    const result = getArchitectureAliases(["s390x"]);
+
+    expect(result.length).toBe(1);
+    expect(result.includes("s390x")).toBe(true);
+  });
+
+  it("resolves amd64", () => {
+    const result = getArchitectureAliases(["x86_64"]);
+
+    expect(result.length).toBe(3);
+    expect(result.includes("amd64")).toBe(true);
+    expect(result.includes("generic_64")).toBe(true);
+    expect(result.includes("x86_64")).toBe(true);
+  });
+
+  it("resolves riscv64", () => {
+    const result = getArchitectureAliases(["riscv64"]);
+
+    expect(result.length).toBe(1);
+    expect(result.includes("riscv64")).toBe(true);
+  });
+
+  it("resolves unknown architecture", () => {
+    const result = getArchitectureAliases(["unknown-arch"]);
+
+    expect(result.length).toBe(1);
+    expect(result.includes("unknown-arch")).toBe(true);
+  });
+});

--- a/src/util/architectures.tsx
+++ b/src/util/architectures.tsx
@@ -40,13 +40,14 @@ const ARCHITECTURE_ALIASES: Record<string, string[]> = {
 
 export const getArchitectureAliases = (names: string[]): string[] => {
   const aliases: string[] = [];
+  const nameKeys = Object.keys(ARCHITECTURE_NAMES);
+
   names.map((value) => {
-    const key = Object.keys(ARCHITECTURE_NAMES).find(
-      (key) => ARCHITECTURE_NAMES[key] === value,
-    );
-    if (key) {
-      aliases.push(...ARCHITECTURE_ALIASES[key]);
+    const nameKey = nameKeys.find((key) => ARCHITECTURE_NAMES[key] === value);
+    if (nameKey && nameKey in ARCHITECTURE_ALIASES) {
+      aliases.push(...ARCHITECTURE_ALIASES[nameKey]);
     }
+    aliases.push(value);
   });
   return aliases;
 };


### PR DESCRIPTION


## Done

- fix architecture filtering on image selection, it needs to deal with non-aliased architectures
- adding test for architecture alias loading

Fixes #753 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - browse images on instance create. Ensure the same architecture filters on the left are available as before.