### PR TITLE
Extend data for error reports

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -7,6 +7,7 @@ import {
 } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
+import { UI_VERSION } from "util/version";
 
 type Props = {
   error?: Error;
@@ -14,7 +15,22 @@ type Props = {
 
 const ErrorPage: FC<Props> = ({ error }) => {
   const body = encodeURIComponent(
-    `\`\`\`\n${error?.stack ?? "No stack trace"}\n\`\`\``,
+    `# Description
+
+A brief description of the problem. Should include what you were
+attempting to do, what you did, what happened and what you expected to
+see happen.
+
+# Metadata
+
+UI Version: ${UI_VERSION}
+Path: ${location.pathname}${location.search}
+
+# Stacktrace
+
+\`\`\`
+${error?.stack ?? "No stack trace"}
+\`\`\``,
   );
   const url = `https://github.com/canonical/lxd-ui/issues/new?labels=bug&title=Error%20report&body=${body}`;
 


### PR DESCRIPTION
## Done

- Extend data for error reports: include version and a text asking for context

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - force an error in a component (i.e. add `throw new Error("foo");` into InstanceList.tsx locally) and ensure the github link is working well