### PR TITLE
ensure scrolling a vm graphic console is propagated to the parent element

### DIFF
--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -116,7 +116,7 @@ const InstanceGraphicConsole: FC<Props> = ({
   useEffect(handleResize, [notify.notification?.message]);
 
   useEventListener("spice-wheel", (e) => {
-    if (!spiceRef.current?.parentElement || !Object.hasOwn(e, "detail")) {
+    if (!spiceRef.current?.parentElement || !("detail" in e)) {
       return;
     }
     const wheelEvent = (e as SpiceWheelEvent).detail.wheelEvent;


### PR DESCRIPTION
## Done

- ensure scrolling a vm graphic console is propagated to the parent element, so the console content is scrolling on screens with low height.
- this is a follow up to #702 

Fixes #700

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start a vm with a graphic console on a browser window that won't show the full console on the screen.
    - scroll when hovering the console and ensure the console content is scrolling

## Screenshots

see scrollbar, when hovering the black part of the screen and using the mouse wheel, the scrollbar on the right should move up and down.
![image](https://github.com/canonical/lxd-ui/assets/1155472/a084368a-2d02-4add-aa88-1221abdabf3d)
