### PR TITLE
Case insensitive search in image list on instance launch

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -171,10 +171,10 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
         return true;
       }
       return (
-        item.aliases.includes(query) ||
-        item.arch.includes(query) ||
-        item.os.includes(query) ||
-        item.release.includes(query)
+        item.aliases.toLowerCase().includes(query) ||
+        item.arch.toLowerCase().includes(query) ||
+        item.os.toLowerCase().includes(query) ||
+        item.release.toLowerCase().includes(query)
       );
     })
     .map((item) => {
@@ -414,12 +414,11 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 name="search-image"
                 type="text"
                 onChange={(value) => {
-                  setQuery(value);
+                  setQuery(value.toLowerCase());
                   setOs("");
                   setRelease("");
                 }}
                 placeholder="Search an image"
-                value={query}
               />
             </div>
           </div>


### PR DESCRIPTION
## Done

- Case insensitive search in image list on instance launch

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instance > browse image > search for "ubuntu" and "Ubuntu", it should bring up the same result. Before this would differ.