### PR TITLE
Fix CI: enforce older version of requests library when installing dotrun

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Dotrun
         run: |
-          sudo pip3 install dotrun
+          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Restore cached keys
         uses: actions/cache/restore@v3
@@ -161,7 +161,7 @@ jobs:
 
       - name: Install Dotrun
         run: |
-          sudo pip3 install dotrun
+          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install LXD-UI dependencies
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install Dotrun
         run: |
-          sudo pip3 install dotrun
+          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Restore cached keys
         uses: actions/cache/restore@v3
@@ -221,7 +221,7 @@ jobs:
 
       - name: Install Dotrun
         run: |
-          sudo pip3 install dotrun
+          sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install LXD-UI dependencies
         run: |


### PR DESCRIPTION
## Done

- fix ci, work around a recently introduced bug in requests library

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure ci is passing