### PR TITLE
Filter volume snapshots on selecting custom volume 

### DIFF
--- a/src/context/loadCustomVolumes.tsx
+++ b/src/context/loadCustomVolumes.tsx
@@ -1,28 +1,21 @@
-import { fetchStoragePools, fetchStorageVolumes } from "api/storage-pools";
 import { LxdStorageVolume } from "types/storage";
+import { isSnapshot } from "util/storageVolume";
+import { loadVolumes } from "context/loadIsoVolumes";
 
 export const loadCustomVolumes = async (
   project: string,
+  hasStorageVolumesAll: boolean,
 ): Promise<LxdStorageVolume[]> => {
   const result: LxdStorageVolume[] = [];
 
-  const pools = await fetchStoragePools(project);
-  const volumePromises = pools.map(async (pool) =>
-    fetchStorageVolumes(pool.name, project),
-  );
-  const poolVolumes = await Promise.all(volumePromises);
-
-  poolVolumes.forEach((volumes, index) => {
-    const pool = pools[index];
-    volumes.forEach((volume) => {
-      const contentTypes = ["filesystem", "block"];
-      const isFilesystemOrBlock = contentTypes.includes(volume.content_type);
-      const isCustom = volume.type === "custom";
-
-      if (isCustom && isFilesystemOrBlock) {
-        result.push({ ...volume, pool: pool.name });
-      }
-    });
+  const volumes = await loadVolumes(project, hasStorageVolumesAll);
+  volumes.forEach((volume) => {
+    const contentTypes = ["filesystem", "block"];
+    const isFilesystemOrBlock = contentTypes.includes(volume.content_type);
+    const isCustom = volume.type === "custom";
+    if (isCustom && isFilesystemOrBlock && !isSnapshot(volume)) {
+      result.push(volume);
+    }
   });
 
   return result;

--- a/src/context/loadIsoVolumes.tsx
+++ b/src/context/loadIsoVolumes.tsx
@@ -42,9 +42,14 @@ export const collectAllStorageVolumes = async (
     pools.map(async (pool) => fetchStorageVolumes(pool.name, project)),
   );
 
-  poolVolumes.forEach((result) => {
+  poolVolumes.forEach((result, index) => {
     if (result.status === "fulfilled") {
-      allVolumes.push(...result.value);
+      const pool = pools[index];
+      const volumes = result.value.map((volume) => ({
+        ...volume,
+        pool: pool.name,
+      }));
+      allVolumes.push(...volumes);
     } else {
       throw new Error("Failed to load iso images");
     }

--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -8,6 +8,7 @@ import ScrollableTable from "components/ScrollableTable";
 import { LxdStorageVolume } from "types/storage";
 import NotificationRow from "components/NotificationRow";
 import { renderContentType } from "util/storageVolume";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   project: string;
@@ -25,6 +26,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
   onCreate,
 }) => {
   const notify = useNotify();
+  const { hasStorageVolumesAll } = useSupportedFeatures();
 
   const {
     data: volumes = [],
@@ -34,7 +36,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
   } = useQuery({
     queryKey: [queryKeys.customVolumes],
     refetchOnMount: (query) => query.state.isInvalidated,
-    queryFn: () => loadCustomVolumes(project),
+    queryFn: () => loadCustomVolumes(project, hasStorageVolumesAll),
   });
 
   if (error) {


### PR DESCRIPTION
## Done

- Filter volume snapshots on selecting custom volume  to add to an instance or profile. only show the custom volumes to select from.

Fixes #777

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a custom storage volume
    - Create snapshots of the volume
    - Go to configure instance, add disk device, select volume. Ensure the storage volume is available, but the snapshot is not.