### PR TITLE
Use doc link titles as link text in case they are available

### DIFF
--- a/src/util/config.spec.ts
+++ b/src/util/config.spec.ts
@@ -81,7 +81,7 @@ describe("toConfigFields and replaceDocLinks", () => {
     );
 
     expect(result).toBe(
-      'Specify a Pongo2 template string that represents the snapshot name.<br>This template is used for scheduled snapshots and for unnamed snapshots.<br><br>See <a href="https://docs.example.org/reference/instance_options/#instance-options-snapshots-names" target="_blank" rel="noopener noreferrer">instance options snapshots names</a> for more information.',
+      'Specify a Pongo2 template string that represents the snapshot name.<br>This template is used for scheduled snapshots and for unnamed snapshots.<br><br>See <a href="https://docs.example.org/reference/instance_options/#instance-options-snapshots-names" target="_blank" rel="noopener noreferrer">Automatic snapshot names</a> for more information.',
     );
   });
 

--- a/src/util/config.tsx
+++ b/src/util/config.tsx
@@ -58,7 +58,13 @@ export const configDescriptionToHtml = (
         return;
       }
       const docPath = line.split(": ")[1];
-      const linkText = token.replaceAll("-", " ");
+      const linkTextCandidate = line
+        .split(":")[0]
+        .replace(/\s\s+/g, " ")
+        .trim();
+      const linkText = linkTextCandidate.includes(" ") // some lines in the object.inv.txt file have a description before the : and a link after
+        ? linkTextCandidate.substring(linkTextCandidate.indexOf(" ") + 1)
+        : token.replaceAll("-", " ");
       const link = `<a href="${docBaseLink}/${docPath}" target="_blank" rel="noopener noreferrer">${linkText}</a>`;
 
       result = result.replaceAll(tag, link);


### PR DESCRIPTION
## Done

- Use doc link titles as link text in case they are available from the object.inv.txt content

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open settings > core.https_address, override it. Under the text input should be written "see How to expose LXD to the network" with a link to the docs
    - ensure other links to docs are correct.