### PR TITLE
[WD-11661] feat: Added 2 storage e2e test to increase coverage.

### DIFF
--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -5,13 +5,13 @@ export const randomPoolName = (): string => {
   return `playwright-pool-${randomNameSuffix()}`;
 };
 
-export const createPool = async (page: Page, pool: string) => {
+export const createPool = async (page: Page, pool: string, driver = "dir") => {
   await page.goto("/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Pools" }).click();
   await page.getByRole("button", { name: "Create pool" }).click();
   await page.getByPlaceholder("Enter name").fill(pool);
-  await page.getByLabel("Driver").selectOption("dir");
+  await page.getByLabel("Driver").selectOption(driver);
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await page.waitForSelector(`text=Storage pool ${pool} created.`);
 };

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -5,13 +5,20 @@ export const randomVolumeName = (): string => {
   return `playwright-volume-${randomNameSuffix()}`;
 };
 
-export const createVolume = async (page: Page, volume: string) => {
+export const createVolume = async (
+  page: Page,
+  volume: string,
+  volumeType = "filesystem",
+) => {
   await page.goto("/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Volumes" }).click();
   await page.getByRole("button", { name: "Create volume" }).click();
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByPlaceholder("Enter value").fill("1");
+  await page
+    .getByPlaceholder("Enter content type")
+    .selectOption({ label: volumeType });
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await page.waitForSelector(`text=Storage volume ${volume} created.`);
   await page.getByRole("button", { name: "Close notification" }).click();

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -114,3 +114,28 @@ test("navigate to custom volume via pool used by list", async ({ page }) => {
   await page.getByRole("link", { name: volume }).click();
   await expect(page).toHaveURL(/volumes\/custom\//);
 });
+
+test("storage pool with driver zfs", async ({ page }) => {
+  const pool = randomPoolName();
+  await createPool(page, pool, "ZFS");
+
+  await expect(page.getByRole("link", { name: pool })).toBeVisible();
+
+  await deletePool(page, pool);
+
+  await expect(page.getByRole("link", { name: pool })).toBeHidden();
+});
+
+test("storage volume of type block", async ({ page }) => {
+  const volume = randomVolumeName();
+  await createVolume(page, volume, "block");
+
+  await expect(
+    page
+      .getByRole("row", { name: "Name" })
+      .filter({ hasText: volume })
+      .getByRole("cell", { name: "Content Type" }),
+  ).toHaveText("Block");
+
+  await deleteVolume(page, volume);
+});


### PR DESCRIPTION
- Storage pool with driver zfs
- Storage volume of type block

## Done

- Added 2 new tests as mentioned above.
- Edited createPool in storagePool.ts and createVolume in storageVolume.ts to accommodate different property types.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - N/A

## Screenshots

N/A