### PR TITLE
[WD-11660] LXD-UI e2e test for operations

### DIFF
--- a/tests/helpers/operations.ts
+++ b/tests/helpers/operations.ts
@@ -1,0 +1,12 @@
+import { Page } from "@playwright/test";
+import { expect } from "../fixtures/lxd-test";
+
+export const validateOperation = async (
+  page: Page,
+  title: string,
+  instance: string,
+) => {
+  await expect(
+    page.getByLabel("Action", { exact: true }).getByText(title + instance),
+  ).toBeVisible();
+};

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -1,0 +1,47 @@
+import { test } from "./fixtures/lxd-test";
+import {
+  createInstance,
+  deleteInstance,
+  randomInstanceName,
+  visitAndStartInstance,
+  visitAndStopInstance,
+} from "./helpers/instances";
+import { assertTextVisible } from "./helpers/permissions";
+import {
+  checkNotificationExists,
+  dismissNotification,
+} from "./helpers/notification";
+import { validateOperation } from "./helpers/operations";
+
+test("instance operations are recognised on the Operations page", async ({
+  page,
+}) => {
+  const instance = randomInstanceName();
+  await createInstance(page, instance);
+
+  // validate create operation is in operation list
+  await page.goto("/ui/operations");
+  await validateOperation(page, "Creating Instance", instance);
+
+  // start instance and wait for the notification instance was started
+  await visitAndStartInstance(page, instance);
+  await checkNotificationExists(page);
+  await assertTextVisible(page, "Instance " + instance + " started");
+
+  // click on the “x operations” link in the status bar
+  await dismissNotification(page);
+
+  // validate the operation to start the instance is in the operation list
+  await page.goto("/ui/operations");
+  await validateOperation(page, "Starting Instance", instance);
+
+  // stop instance and validate stop operation is in operation list
+  await visitAndStopInstance(page, instance);
+  await page.goto("/ui/operations");
+  await validateOperation(page, "Stopping Instance", instance);
+
+  // delete instance and validate delete operation is in operation list
+  await deleteInstance(page, instance);
+  await page.goto("/ui/operations");
+  await validateOperation(page, "Deleting Instance", instance);
+});


### PR DESCRIPTION
## Done

Created a test case in the new file ```operations.spec.ts``` to cover the following instance operations:

- create an instance
- validate create operation is in operation list
- start instance
- wait for the notification instance was started
- click on the “x operations” link in the status bar
- validate the operation to start the instance is in the operation list
- on instances page: stop instance
- validate stop operation is in operation list
- delete instance
- validate delete operation is in operation list

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, run as described [here](../HACKING.md#setting-up-for-development).
2. Perform the following QA steps:
    - N/A

## Screenshots

N/A