### PR TITLE
fix(header) ensure instance name is unique and ot matched against previous name

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -35,14 +35,14 @@ const RenameHeader: FC<Props> = ({
   renameDisabledReason,
 }) => {
   const canRename = renameDisabledReason === undefined;
-  const enableRename = () => {
-    window.dispatchEvent(new Event("resize"));
+  const toggleRename = () => {
+    setTimeout(() => window.dispatchEvent(new Event("resize")), 10);
     if (!canRename || !formik) {
       return;
     }
     void formik.setValues({
       ...formik.values,
-      isRenaming: true,
+      isRenaming: !formik.values.isRenaming,
     });
   };
 
@@ -82,9 +82,7 @@ const RenameHeader: FC<Props> = ({
                   <Button
                     appearance="base"
                     className="cancel"
-                    onClick={() =>
-                      void formik.setFieldValue("isRenaming", false)
-                    }
+                    onClick={toggleRename}
                   >
                     Cancel
                   </Button>
@@ -101,7 +99,7 @@ const RenameHeader: FC<Props> = ({
             ) : (
               <li
                 className="p-heading--4 u-no-margin--bottom name continuous-breadcrumb"
-                onClick={enableRename}
+                onClick={toggleRename}
                 title={`Rename ${name}`}
               >
                 <Tooltip

--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -42,6 +42,7 @@ const RenameHeader: FC<Props> = ({
     }
     void formik.setValues({
       ...formik.values,
+      name: name,
       isRenaming: !formik.values.isRenaming,
     });
   };

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -36,7 +36,7 @@ const InstanceDetailHeader: FC<Props> = ({
   const controllerState = useState<AbortController | null>(null);
 
   const RenameSchema = Yup.object().shape({
-    name: instanceNameValidation(project, controllerState).required(
+    name: instanceNameValidation(project, controllerState, name).required(
       "Instance name is required",
     ),
   });

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -30,10 +30,15 @@ export const instanceLinkFromOperation = (args: {
 export const instanceNameValidation = (
   project: string,
   controllerState: AbortControllerState,
+  oldName?: string,
 ): Yup.StringSchema =>
   Yup.string()
-    .test("deduplicate", "An instance with this name already exists", (value) =>
-      checkDuplicateName(value, project, controllerState, "instances"),
+    .test(
+      "deduplicate",
+      "An instance with this name already exists",
+      (value) =>
+        oldName === value ||
+        checkDuplicateName(value, project, controllerState, "instances"),
     )
     .test(
       "size",


### PR DESCRIPTION
## Done

- ensure instance name is unique and not matched against previous name on renaming

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - rename an instance
    - change name to the same name as the current name. Previously it would cause a validation error, now it should be fine.