### PR TITLE
fix(login) use trust_token as a field name in the payload 

### DIFF
--- a/src/api/certificates.tsx
+++ b/src/api/certificates.tsx
@@ -11,13 +11,17 @@ export const fetchCertificates = (): Promise<LxdCertificate[]> => {
   });
 };
 
-export const addCertificate = (token: string): Promise<void> => {
+export const addCertificate = (
+  token: string,
+  hasExplicitTrustToken: boolean,
+): Promise<void> => {
   return new Promise((resolve, reject) => {
+    const tokenFieldName = hasExplicitTrustToken ? "trust_token" : "password";
     fetch(`/1.0/certificates`, {
       method: "POST",
       body: JSON.stringify({
         type: "client",
-        password: token,
+        [tokenFieldName]: token,
       }),
     })
       .then(handleResponse)

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -22,5 +22,6 @@ export const useSupportedFeatures = () => {
     hasDocumentationObject:
       !!serverVersion && serverMajor >= 5 && serverMinor >= 20,
     hasAccessManagement: apiExtensions.has("access_management"),
+    hasExplicitTrustToken: apiExtensions.has("explicit_trust_token"),
   };
 };

--- a/src/pages/login/CertificateAddForm.tsx
+++ b/src/pages/login/CertificateAddForm.tsx
@@ -1,10 +1,12 @@
 import { FC, useState } from "react";
 import { Button, Form, Textarea, useNotify } from "@canonical/react-components";
 import { addCertificate } from "api/certificates";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 const CertificateAddForm: FC = () => {
   const notify = useNotify();
   const [token, setToken] = useState("");
+  const { hasExplicitTrustToken } = useSupportedFeatures();
 
   const useToken = () => {
     const sanitisedToken =
@@ -13,7 +15,7 @@ const CertificateAddForm: FC = () => {
         .split(/\r?\n|\r|\n/g)
         .at(-1) ?? "";
 
-    addCertificate(sanitisedToken)
+    addCertificate(sanitisedToken, hasExplicitTrustToken)
       .then(() => {
         location.reload();
       })


### PR DESCRIPTION
## Done

- fix(login) use trust_token as a field name in the payload 
- when reusing a certificate in case the explicit_trust_token api extension is present

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure reusing an old certificate works when talking to a 5.21/stable as well as a 6.1/stable and a latest/candidate backend.