### PR TITLE
fix(network) allow disabling of dhcp in ipv4/ipv6 network configuration

### DIFF
--- a/src/pages/networks/forms/NetworkFormIpv4.tsx
+++ b/src/pages/networks/forms/NetworkFormIpv4.tsx
@@ -29,14 +29,15 @@ const NetworkFormIpv4: FC<Props> = ({ formik }) => {
           : []),
 
         ...(formik.values.networkType !== "ovn" &&
-        formik.values.networkType !== "physical" &&
-        hasDhcp
+        formik.values.networkType !== "physical"
           ? [
               getConfigurationRow({
                 formik,
                 name: "ipv4_dhcp_expiry",
                 label: "IPv4 DHCP expiry",
                 defaultValue: "",
+                disabled: !hasDhcp,
+                disabledReason: "IPv4 DHCP is disabled",
                 children: <Input type="text" />,
               }),
 
@@ -45,6 +46,8 @@ const NetworkFormIpv4: FC<Props> = ({ formik }) => {
                 name: "ipv4_dhcp_ranges",
                 label: "IPv4 DHCP ranges",
                 defaultValue: "",
+                disabled: !hasDhcp,
+                disabledReason: "IPv4 DHCP is disabled",
                 children: <Textarea />,
               }),
             ]

--- a/src/pages/networks/forms/NetworkFormIpv6.tsx
+++ b/src/pages/networks/forms/NetworkFormIpv6.tsx
@@ -28,8 +28,7 @@ const NetworkFormIpv6: FC<Props> = ({ formik }) => {
             ]
           : []),
 
-        ...(hasDhcp &&
-        formik.values.networkType !== "ovn" &&
+        ...(formik.values.networkType !== "ovn" &&
         formik.values.networkType !== "physical"
           ? [
               getConfigurationRow({
@@ -37,6 +36,8 @@ const NetworkFormIpv6: FC<Props> = ({ formik }) => {
                 name: "ipv6_dhcp_expiry",
                 label: "IPv6 DHCP expiry",
                 defaultValue: "",
+                disabled: !hasDhcp,
+                disabledReason: "IPv6 DHCP is disabled",
                 children: <Input type="text" />,
               }),
 
@@ -45,18 +46,22 @@ const NetworkFormIpv6: FC<Props> = ({ formik }) => {
                 name: "ipv6_dhcp_ranges",
                 label: "IPv6 DHCP ranges",
                 defaultValue: "",
+                disabled: !hasDhcp,
+                disabledReason: "IPv6 DHCP is disabled",
                 children: <Textarea />,
               }),
             ]
           : []),
 
-        ...(hasDhcp && formik.values.networkType !== "physical"
+        ...(formik.values.networkType !== "physical"
           ? [
               getConfigurationRow({
                 formik,
                 name: "ipv6_dhcp_stateful",
                 label: "IPv6 DHCP stateful",
                 defaultValue: "",
+                disabled: !hasDhcp,
+                disabledReason: "IPv6 DHCP is disabled",
                 children: <Select options={optionTrueFalse} />,
               }),
             ]

--- a/src/util/version.tsx
+++ b/src/util/version.tsx
@@ -1,2 +1,2 @@
 export const RECENT_MAJOR_SERVER_VERSION = 5;
-export const UI_VERSION = "0.10";
+export const UI_VERSION = "0.11";


### PR DESCRIPTION
## Done

- fix(network) allow disabling of dhcp in ipv4/ipv6 network configuration
- i.e. on bridge networks. Avoid crash reported in #814

## QA

- test network configuration of a bridge, enable/disable dhcp for ipv4 and ipv6