### PR TITLE
fix: prevent settings form input from submitting multiple requests

### DIFF
--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -60,7 +60,7 @@ const SettingFormInput: FC<Props> = ({
       <Button appearance="base" onClick={onCancel}>
         Cancel
       </Button>
-      <Button appearance="positive" onClick={() => onSubmit(value)}>
+      <Button appearance="positive" type="submit">
         Save
       </Button>
       {canBeReset && (


### PR DESCRIPTION
## Done

- Currently clicking the "Save" button in a setting form input will result in two api requests sent to the server. This PR fixes this issue.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to server settings page, edit any config and save. Observe the network tab in the browser and you should only see one request sending the payload to the lxd server.