### PR TITLE
Add link to the authentication setup FAQ from the certificate generation and reuse pages

### DIFF
--- a/src/pages/login/CertificateAdd.tsx
+++ b/src/pages/login/CertificateAdd.tsx
@@ -6,6 +6,7 @@ import Loader from "components/Loader";
 import CertificateAddForm from "pages/login/CertificateAddForm";
 import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
+import HelpLink from "components/HelpLink";
 
 const CertificateAdd: FC = () => {
   const { isAuthenticated, isAuthLoading } = useAuth();
@@ -24,7 +25,14 @@ const CertificateAdd: FC = () => {
       mainClassName="certificate-generate"
       header={
         <div className="p-panel__header is-sticky">
-          <h1 className="p-panel__title">Add existing certificate</h1>
+          <h1 className="p-panel__title">
+            <HelpLink
+              href="https://github.com/canonical/lxd-ui/wiki/Authentication-Setup-FAQ"
+              title="Authentication Setup FAQ"
+            >
+              Add existing certificate
+            </HelpLink>
+          </h1>
         </div>
       }
     >
@@ -33,7 +41,16 @@ const CertificateAdd: FC = () => {
       ) : (
         <Row>
           <Notification severity="caution">
-            A client certificate must be present and selected in your browser
+            A client certificate must be present and selected in your browser.
+            <br />
+            Learn more in the{" "}
+            <a
+              href="https://github.com/canonical/lxd-ui/wiki/Authentication-Setup-FAQ#reusing-certificates"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Authentication Setup FAQ
+            </a>
           </Notification>
         </Row>
       )}

--- a/src/pages/login/CertificateGenerate.tsx
+++ b/src/pages/login/CertificateGenerate.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "context/auth";
 import Loader from "components/Loader";
 import PasswordModal from "pages/login/PasswordModal";
 import CustomLayout from "components/CustomLayout";
+import HelpLink from "components/HelpLink";
 
 interface Certs {
   crt: string;
@@ -82,7 +83,14 @@ const CertificateGenerate: FC = () => {
       mainClassName="certificate-generate"
       header={
         <div className="p-panel__header is-sticky">
-          <h1 className="p-panel__title">Setup LXD UI</h1>
+          <h1 className="p-panel__title">
+            <HelpLink
+              href="https://github.com/canonical/lxd-ui/wiki/Authentication-Setup-FAQ"
+              title="Authentication Setup FAQ"
+            >
+              Setup LXD UI
+            </HelpLink>
+          </h1>
         </div>
       }
     >


### PR DESCRIPTION
## Done

- Add link to the authentication setup FAQ from the certificate generation and reuse pages

Fixes WD-13244 #542

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Access lxd-ui without a valid certificate, the headers in the cert generation and "Add existing certificate" pages should link to the FAQ.

## Screenshots

![image](https://github.com/user-attachments/assets/2f5b893c-cbc1-4118-a7af-3ac7c8935215)
