### PR TITLE
[WD-13254] test: network forms

### DIFF
--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -70,12 +70,16 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
   const formik = useFormik<NetworkFormValues>({
     initialValues: toNetworkFormValues(network),
     validationSchema: NetworkSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       const yaml = values.yaml ? values.yaml : getYaml();
       const saveNetwork = yamlToObject(yaml) as LxdNetwork;
       updateNetwork({ ...saveNetwork, etag: network.etag }, project)
         .then(() => {
-          void formik.setValues(toNetworkFormValues(saveNetwork));
+          formik.resetForm({
+            values: toNetworkFormValues(saveNetwork),
+          });
+
           void queryClient.invalidateQueries({
             queryKey: [
               queryKeys.projects,

--- a/tests/helpers/configuration.ts
+++ b/tests/helpers/configuration.ts
@@ -20,12 +20,7 @@ export const setInput = async (
   await page.getByPlaceholder(placeholder).last().fill(value);
 };
 
-export const setTextarea = async (
-  page: Page,
-  field: string,
-  placeholder: string,
-  value: string,
-) => {
+export const setTextarea = async (page: Page, field: string, value: string) => {
   await activateOverride(page, field);
   await page.getByRole("row", { name: field }).getByRole("textbox").click();
   await page.getByRole("textbox", { name: field }).fill(value);
@@ -134,4 +129,25 @@ export const assertReadMode = async (
     .getByRole("gridcell", { name: value, exact: true })
     .getByText(value)
     .click();
+};
+
+export const activateAllTableOverrides = async (page: Page) => {
+  const overrideButtons = await page
+    .locator('td[role="gridcell"].override button')
+    .all();
+
+  for (const button of overrideButtons) {
+    await button.click();
+  }
+};
+
+export const checkAllOptions = async (
+  page: Page,
+  name: string,
+  options: string[],
+) => {
+  await activateOverride(page, name);
+  for (const option of options) {
+    await page.getByRole("combobox", { name: name }).selectOption(option);
+  }
 };

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -92,14 +92,9 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
     .getByRole("navigation", { name: "Project form navigation" })
     .getByText("Networks")
     .click();
-  await setTextarea(
-    page,
-    "Available networks",
-    "Enter network names",
-    "lxcbr0",
-  );
-  await setTextarea(page, "Network uplinks", "Enter network names", "lxcbr0");
-  await setTextarea(page, "Network zones", "Enter network zones", "foo,bar");
+  await setTextarea(page, "Available networks", "lxcbr0");
+  await setTextarea(page, "Network uplinks", "lxcbr0");
+  await setTextarea(page, "Network zones", "foo,bar");
 
   await page.getByRole("button", { name: "Save changes" }).click();
   await page.waitForSelector(`text=Project ${project} updated.`);


### PR DESCRIPTION
## Done

- E2E tests for editing networks
- Fixed bug that didn't reset "edit network" form after clicking override and not making a change
- Removed unused parameter "placeholder" in "setTextArea" helper function

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - To replicate the bug, edit a network, click override, do not make a change and submit the form. This is shown in the screenshots with the "dash" appearing after no changes being made. After refreshing the page the "dash" disappears
    - E2E tests need to be ran with playwright

## Screenshots
![image](https://github.com/user-attachments/assets/8b5ebdb3-8df8-47c5-b506-cddcfad2dead)
![image](https://github.com/user-attachments/assets/4c10aa91-b6c6-4333-9cd4-1d53ae14f71c)
