### PR TITLE
fix(disk) preserve devices.root.size.state key on instance configuration update

### DIFF
--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -3,6 +3,7 @@ export interface LxdDiskDevice {
   path?: string;
   pool: string;
   size?: string;
+  "size.state"?: string;
   source?: string;
   "limits.read"?: string;
   "limits.write"?: string;

--- a/src/util/formDevices.spec.ts
+++ b/src/util/formDevices.spec.ts
@@ -8,7 +8,9 @@ const deviceYaml =
   "  root:\n" +
   "    path: /\n" +
   "    pool: big-pool\n" +
+  "    size: 10GiB\n" +
   "    type: disk\n" +
+  "    size.state: 3GiB\n" +
   "  eth0:\n" +
   "    network: lxcbr\n" +
   "    type: nic\n" +

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -41,6 +41,7 @@ export type FormDiskDevice = Partial<LxdDiskDevice> &
       read?: string;
       write?: string;
     };
+    size_state?: string;
   };
 
 export type FormNetworkDevice = Partial<LxdNicDevice> &
@@ -86,6 +87,10 @@ export const formDeviceToPayload = (devices: FormDevice[]) => {
           item["limits.write"] = item.limits.write;
         }
         delete item.limits;
+      }
+      if ("size_state" in item) {
+        item["size.state"] = item.size_state;
+        delete item.size_state;
       }
       if ("size" in item && !item.size?.match(/^\d/)) {
         delete item.size;
@@ -137,6 +142,7 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
           pool: item.pool,
           source: "source" in item ? item.source : undefined,
           size: "size" in item ? item.size : undefined,
+          size_state: "size.state" in item ? item["size.state"] : undefined,
           limits: {
             read: "limits.read" in item ? item["limits.read"] : undefined,
             write: "limits.write" in item ? item["limits.write"] : undefined,


### PR DESCRIPTION
## Done

- preserve devices.root.size.state key on instance configuration update

Fixes WD-13755

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create an instance with the devices.root.size.state key set i.e. to 4GiB
    - edit instance configuration and save
    - ensure the key is persisted on save.