### PR TITLE
fix: publish image from snapshot created in a project that is not the default project

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -81,7 +81,7 @@ export const createImageFromInstanceSnapshot = (
   isPublic: boolean,
 ): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
-    fetch("/1.0/images", {
+    fetch(`/1.0/images?project=${instance.project}`, {
       method: "POST",
       body: JSON.stringify({
         public: isPublic,

--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -14,6 +14,11 @@
 // fix for safari https://warthogs.atlassian.net/browse/WD-7486
 .multiselect-checkbox span.p-checkbox__label {
   padding-left: 0;
+
+  // applying the above style breaks the checkbox in firefox
+  @-moz-document url-prefix() {
+    padding-left: 2rem;
+  }
 }
 
 .selected-row {

--- a/tests/helpers/images.ts
+++ b/tests/helpers/images.ts
@@ -1,0 +1,22 @@
+import { expect } from "../fixtures/lxd-test";
+import { Page } from "@playwright/test";
+
+export const deleteAllImages = async (
+  page: Page,
+  project: string = "default",
+) => {
+  await page.goto(`/ui/project/${project}`);
+  await page.getByRole("link", { name: "Images", exact: true }).first().click();
+  await page
+    .getByRole("columnheader", { name: "select" })
+    .locator("label:has-text('Select all')")
+    .click();
+  await page.getByRole("button", { name: "Delete image" }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  const notification = page.locator(".toast-notification");
+  await expect(notification).toHaveText(/.*deleted.*/);
+};

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -27,6 +27,13 @@ export const createInstance = async (
   await page
     .getByRole("combobox", { name: "Instance type" })
     .selectOption(type);
+
+  if (project !== "default") {
+    await page.getByRole("button", { name: "Advanced" }).click();
+    await page.getByText("Disk devices").click();
+    await page.getByRole("button", { name: "Create override" }).click();
+  }
+
   await page.getByRole("button", { name: "Create" }).first().click();
 
   await page.waitForSelector(`text=Created instance ${instance}.`);

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -5,15 +5,29 @@ export const randomProjectName = (): string => {
   return `playwright-project-${randomNameSuffix()}`;
 };
 
-export const createProject = async (page: Page, project: string) => {
+const openProjectCreationForm = async (page: Page) => {
   await page.goto("/ui/");
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("button", { name: "Create project" }).click();
+};
+
+const submitProjectCreationForm = async (page: Page, project: string) => {
   await page.getByPlaceholder("Enter name").click();
   await page.getByPlaceholder("Enter name").fill(project);
   await page.getByRole("button", { name: "Create" }).click();
   await page.waitForSelector(`text=Project ${project} created.`);
   await page.getByRole("button", { name: "Close notification" }).click();
+};
+
+export const createProject = async (page: Page, project: string) => {
+  await openProjectCreationForm(page);
+  await submitProjectCreationForm(page, project);
+};
+
+export const createCustomProject = async (page: Page, project: string) => {
+  await openProjectCreationForm(page);
+  await page.getByLabel("Features").selectOption("customised");
+  await submitProjectCreationForm(page, project);
 };
 
 export const renameProject = async (

--- a/tests/helpers/snapshots.ts
+++ b/tests/helpers/snapshots.ts
@@ -9,8 +9,10 @@ export const createInstanceSnapshot = async (
   page: Page,
   instance: string,
   snapshot: string,
+  project?: string,
 ) => {
-  await page.goto("/ui/");
+  const route = project ? `/ui/project/${project}/instances` : "/ui";
+  await page.goto(route);
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(instance);
   await page.getByRole("link", { name: instance }).first().click();
@@ -170,4 +172,22 @@ export const deleteStorageVolumeSnapshot = async (
     .click();
 
   await page.waitForSelector(`text=Snapshot ${snapshot} deleted`);
+};
+
+export const createImageFromSnapshot = async (page: Page, snapshot: string) => {
+  await page
+    .getByRole("row", { name: "Name" })
+    .filter({ hasText: snapshot })
+    .hover();
+  await page
+    .getByRole("row", { name: "Name" })
+    .filter({ hasText: snapshot })
+    .getByRole("button", { name: "Create image" })
+    .click();
+  await page
+    .getByLabel("Create image from instance")
+    .getByRole("button", { name: "Create image" })
+    .click();
+
+  await page.waitForSelector(`text=Image created from snapshot ${snapshot}`);
 };

--- a/tests/snapshots.spec.ts
+++ b/tests/snapshots.spec.ts
@@ -1,9 +1,15 @@
 import { test } from "./fixtures/lxd-test";
+import { deleteAllImages } from "./helpers/images";
 import {
   createInstance,
   deleteInstance,
   randomInstanceName,
 } from "./helpers/instances";
+import {
+  createCustomProject,
+  deleteProject,
+  randomProjectName,
+} from "./helpers/projects";
 import {
   createInstanceSnapshot,
   deleteInstanceSnapshot,
@@ -14,6 +20,7 @@ import {
   restoreStorageVolumeSnapshot,
   editStorageVolumeSnapshot,
   deleteStorageVolumeSnapshot,
+  createImageFromSnapshot,
 } from "./helpers/snapshots";
 import {
   createVolume,
@@ -53,4 +60,24 @@ test("custom storage volume snapshot create, restore, edit and remove", async ({
   await deleteStorageVolumeSnapshot(page, newName);
 
   await deleteVolume(page, volume);
+});
+
+test("publish image from instance snapshot in custom project", async ({
+  page,
+}) => {
+  const project = randomProjectName();
+  await createCustomProject(page, project);
+
+  const instance = randomInstanceName();
+  const type = "container";
+  await createInstance(page, instance, type, project);
+
+  const snapshot = randomSnapshotName();
+  await createInstanceSnapshot(page, instance, snapshot, project);
+  await createImageFromSnapshot(page, snapshot);
+
+  await deleteInstanceSnapshot(page, snapshot);
+  await deleteInstance(page, instance, project);
+  await deleteAllImages(page, project);
+  await deleteProject(page, project);
 });


### PR DESCRIPTION
## Done
- Fixed the issue where publishing an image from a instance snapshot created in a non-default project fails

Fixes #824 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new project, use the "Customised" option
    - In the new project, create an instance and then a snapshot for that instance
    - publish an image for that snapshot should work as expected