### PR TITLE
update: add support for instance_create_start api extension [WD-13645]

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -25,5 +25,6 @@ export const useSupportedFeatures = () => {
       serverMajor > 5,
     hasAccessManagement: apiExtensions.has("access_management"),
     hasExplicitTrustToken: apiExtensions.has("explicit_trust_token"),
+    hasInstanceCreateStart: apiExtensions.has("instance_create_start"),
   };
 };


### PR DESCRIPTION
## Context
The latest lxd release added a new api extension `instance_create_start`, which introduced the ability to create and start an instance in a single API call. See the [PR](https://github.com/canonical/lxd/issues/13322) for reference. This PR includes the usage of the new api extension, however, the old way of creating and starting instances is kept to maintain compatibility with older lxd versions.

## Done

- added the ability to create and start an instance with single API call to `POST /1.0/instances`
- added new api extension check for `instances_create_start`

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - refresh lxd snap to latest branch `snap refresh lxd --channel=latest/edge`
    - create and start an instance.
    - take note the first info notification informs the user that the instance will be created and started post creation.
    - once the instance is created, only one notification will be shown that indicates the instance has been created and started.
    - then refresh lxd snap to 5.21 `snap refresh lxd --channel=5.21/stable`
    - create and start another instance.
    - take note the first notification will inform instance creation started
    - once the instance is created, a second notification will indicate instance is starting
    - once the instance is started, a third notification will indicate instance has been created and started