### PR TITLE
fix: add type checks in linting script [WD-13573]

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint-scss": "stylelint 'src/**/*.scss'",
     "lint-js-eslint": "eslint 'src/**/*.{json,tsx,ts}' 'tests/**/*.ts' .eslintrc.cjs babel.config.js",
     "lint-js-prettier": "prettier 'src/**/*.{json,tsx,ts}' 'tests/**/*.ts' .eslintrc.cjs babel.config.js --check",
-    "lint-js": "yarn lint-js-eslint && yarn lint-js-prettier",
+    "lint-js": "tsc --noEmit && yarn lint-js-eslint && yarn lint-js-prettier",
     "hooks-add": "husky install",
     "hooks-remove": "husky uninstall",
     "start": "concurrently --kill-others --raw 'vite --host | grep -v 3000' 'yarn serve'",

--- a/src/pages/login/PasswordModal.tsx
+++ b/src/pages/login/PasswordModal.tsx
@@ -17,7 +17,7 @@ const PasswordModal: FC<Props> = ({ onConfirm, onClose }) => {
   const PasswordSchema = Yup.object().shape({
     password: Yup.string(),
     passwordConfirm: Yup.string().oneOf(
-      [Yup.ref("password"), null],
+      [Yup.ref("password"), ""],
       "Passwords must match",
     ),
   });

--- a/src/pages/storage/StorageVolumeSnapshots.tsx
+++ b/src/pages/storage/StorageVolumeSnapshots.tsx
@@ -156,7 +156,7 @@ const StorageVolumeSnapshots: FC<Props> = ({ volume }) => {
               },
             ]),
         {
-          content: isoTimeToString(snapshot.expires_at),
+          content: isoTimeToString(snapshot.expires_at ?? ""),
           role: "rowheader",
           "aria-label": "Expires at",
           className: "expiration",

--- a/src/pages/storage/forms/EditVolumeSnapshotForm.tsx
+++ b/src/pages/storage/forms/EditVolumeSnapshotForm.tsx
@@ -59,13 +59,17 @@ const EditVolumeSnapshotForm: FC<Props> = ({ volume, snapshot, close }) => {
         newName,
       })
         .then((operation) =>
-          eventQueue.set(operation.metadata.id, resolve, (msg) => {
-            toastNotify.failure(
-              `Snapshot ${snapshot.name} rename failed`,
-              new Error(msg),
-            );
-            formik.setSubmitting(false);
-          }),
+          eventQueue.set(
+            operation.metadata.id,
+            () => resolve(),
+            (msg) => {
+              toastNotify.failure(
+                `Snapshot ${snapshot.name} rename failed`,
+                new Error(msg),
+              );
+              formik.setSubmitting(false);
+            },
+          ),
         )
         .catch((e) => {
           notify.failure("Snapshot rename failed", e);


### PR DESCRIPTION
## Done

- Added type checks to the `lint-js` script. This should pick up typescript errors that previously was missed during CI.
- Fixed some Typescript errors that existed in the codebase

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - N/A