### PR TITLE
fix: invalidate query cache when creating custom storage volume [WD-13879]

### DIFF
--- a/src/pages/storage/forms/StorageVolumeCreate.tsx
+++ b/src/pages/storage/forms/StorageVolumeCreate.tsx
@@ -63,6 +63,9 @@ const StorageVolumeCreate: FC = () => {
             queryKey: [queryKeys.storage],
           });
           void queryClient.invalidateQueries({
+            queryKey: [queryKeys.customVolumes],
+          });
+          void queryClient.invalidateQueries({
             queryKey: [queryKeys.projects, project],
           });
           void queryClient.invalidateQueries({


### PR DESCRIPTION
## Done

- Previously we did not invalidate the query cache for custom volumes when creating a new one. This means when a user navigate back to an instance and try to attach the volume, they will not see the volume in the select modal unless if they refresh the page. This PR resolves this issue.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Instances -> select an instance to go to its detail page -> Configuration ->  Disk devices -> Attach disk divice (don't do anything)
    - Go to Volumes -> Create volume -> create a new volume -> then go back to the volume select modal in the previous step -> make sure that the new volume is in the list