### PR TITLE
fix: adjust copy for project form

### DIFF
--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -178,7 +178,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
           />
           {features === "customised" && (
             <>
-              Allow the following features:
+              Isolate the following features:
               <CheckboxInput
                 id="features_images"
                 name="features_images"


### PR DESCRIPTION
## Done

- Updated copy on project creation form for better understanding. When we set features for a new lxd project, it means we either restrict the feature resources to the project or inherit from the default project. Therefore "Isloate the following features" makes more sense than "Allowing the following features".

Fixes #828 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new project -> on the project form, select the customised option -> check the wording displays "Isolate the following features"

## Screenshots
![Screenshot from 2024-08-05 09-32-26](https://github.com/user-attachments/assets/e5af056a-c54e-492e-8f1a-c365b0416540)
