### PR TITLE
feat: [WD-13703] add export image

### DIFF
--- a/src/pages/images/ImageList.tsx
+++ b/src/pages/images/ImageList.tsx
@@ -28,6 +28,7 @@ import { useDocs } from "context/useDocs";
 import CustomLayout from "components/CustomLayout";
 import PageHeader from "components/PageHeader";
 import CustomIsoBtn from "pages/storage/actions/CustomIsoBtn";
+import ExportImageTarballBtn from "./actions/ExportImageTarballBtn";
 
 const ImageList: FC = () => {
   const docBaseLink = useDocs();
@@ -111,6 +112,7 @@ const ImageList: FC = () => {
             project={project}
             image={localLxdToRemoteImage(image)}
           />,
+          <ExportImageTarballBtn key="export-image" image={image} />,
           <DeleteImageBtn key="delete" image={image} project={project} />,
         ]}
       />

--- a/src/pages/images/actions/ExportImageTarballBtn.tsx
+++ b/src/pages/images/actions/ExportImageTarballBtn.tsx
@@ -1,0 +1,54 @@
+import { FC, useState } from "react";
+import { LxdImage } from "types/image";
+import { ActionButton, Icon } from "@canonical/react-components";
+import { useToastNotification } from "context/toastNotificationProvider";
+
+interface Props {
+  image: LxdImage;
+}
+
+const ExportImageTarballBtn: FC<Props> = ({ image }) => {
+  const toastNotify = useToastNotification();
+  const [isLoading, setLoading] = useState(false);
+  const description = image.properties?.description ?? image.fingerprint;
+  const isUnifiedTarball = image.update_source == null; //Only Split Tarballs have an update_source.
+
+  const handleExport = () => {
+    setLoading(true);
+
+    try {
+      const url = `/1.0/images/${image.fingerprint}/export`;
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "download";
+      a.click();
+      window.URL.revokeObjectURL(url);
+
+      toastNotify.success(
+        `Image ${description} was successfully downloaded. Please check your downloads folder.`,
+      );
+    } catch (e) {
+      toastNotify.failure(`Image ${description} was unable to download.`, e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ActionButton
+      title={
+        isUnifiedTarball ? "Export image" : "Cannot export this image format."
+      }
+      aria-label="export image"
+      loading={isLoading}
+      onClick={handleExport}
+      className="has-icon"
+      appearance="base"
+      disabled={!isUnifiedTarball}
+    >
+      <Icon name="export" />
+    </ActionButton>
+  );
+};
+
+export default ExportImageTarballBtn;


### PR DESCRIPTION
## Work done
- Added ExportImageTarballBtn component
- Added API call to retrieve Image

## Context
- Images from the instance creation process, return as multipart/form-data files, have a **Split tarball** format (Meaning an image is downloaded as two files).
- Images published from snapshots or instances return as application/octetstream files and consequently have a **Unified tarball** image format.
- You can find more information about Image Formats in LXD, [here](https://documentation.ubuntu.com/lxd/en/latest/reference/image_format/#image-tarballs) .

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    #### Test unified tarball (single file download i.e. `content-type: application/octet-stream`)
    - Create an instance (preferably with a base image that's reasonably large e.g. ubuntu jammy). The instance may be container or VM type. 
    - Navigate to the instance detail page after creation.
    - Go to the Snapshots tab.
    - Create a snapshot for the instance.
    - Hover over the snapshot just created, you should see the "Create image" icon button. Click it to create an image from the snapshot. You should give the image an alias for easier reference later.
    - Navigate to Images list
    - Find the image that just got created
    - Export/Download the image. Once the download is complete, you should see a single tarball in the directory where you selected for the download.
    
    #### Test split tarball (two file downloads i.e. `content-type: multipart/form-data` where each part is `content-type: application/octet-stream`) 
    - Create an instance (preferably with a base image that's reasonably large e.g. ubuntu jammy). The instance may be container or VM type.
    - Navigate to Images list
    - The image you selected as the base image for the instance should be present in the list
    - Export/Download the image. Once the download is complete, you should see two tarballs in the directory where you selected for the download. The extension for the downloaded tarballs should be something like `squashfs` and `tar.xz`.

Additional notes:
* The current filepicker we use comes from the dependency, "@types/wicg-file-system-access". This has a limitation where for Split tarballs, we can not save the image directly into a System directory (such as the Documents or Downloads folder). however this can be overcome by creating a folder inside a system directory and then saving the file in there. Discussion should take place over whether this is a feature that should stay implemented or whether we can take an alternative approach to this.
![image](https://github.com/user-attachments/assets/fdff8111-dc33-441b-9497-6dc49ac4ff50)


## Screenshots

![image](https://github.com/user-attachments/assets/12c995d9-0706-4675-a8ad-52a7d187e6a8)

![image](https://github.com/user-attachments/assets/3092c7d3-f6a8-4b92-92f1-29e8a1656cc8)

![image](https://github.com/user-attachments/assets/bad32c6f-8d96-4b4b-b080-8ecc91f01e69)
