### PR TITLE
feat: improve project deletion experience [WD-13431]

### DIFF
--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -288,7 +288,7 @@ body {
 
 .help-link {
   align-items: center;
-  display: flex;
+  display: inline-flex;
 
   .help-link-icon {
     height: 1rem;

--- a/src/util/resourceDetails.tsx
+++ b/src/util/resourceDetails.tsx
@@ -9,6 +9,13 @@ export type ResourceDetail = {
   type: string;
 };
 
+export type ResourceType =
+  | "instance"
+  | "profile"
+  | "snapshot"
+  | "image"
+  | "volume";
+
 // refer to api spec to see how the names can be extracted from resource url
 // https://documentation.ubuntu.com/lxd/en/latest/api/
 export const extractResourceDetailsFromUrl = (

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -1,4 +1,4 @@
-import { extractResourceDetailsFromUrl } from "./resourceDetails";
+import { extractResourceDetailsFromUrl, ResourceType } from "./resourceDetails";
 export interface LxdUsedBy {
   name: string;
   project: string;
@@ -17,7 +17,7 @@ export interface LxdUsedBy {
  * "/1.0/storage-pools/pool-dir/volumes/custom/test/snapshots/snap1?project=bar"
  */
 export const filterUsedByType = (
-  type: "instance" | "profile" | "snapshot" | "image" | "volume",
+  type: ResourceType,
   usedByPaths?: string[],
 ): LxdUsedBy[] => {
   return (


### PR DESCRIPTION
## Done

- Added tooltip for delete project button on the project configurations page
- The tooltip will show number of resources currently using the project, and will link to the page for each resource type

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Make sure you have resources in the project that you are testing with e.g. instances, profiles, images etc
    - Go to the project configuration page, hover over the delete project button
    - You should see a tooltip showing you the resources currently using the project
    - You should be able to click on the resource label in the tooltip and be directed to the relevant page

## Screenshots
![image](https://github.com/user-attachments/assets/cfd64c94-daaa-40ad-9927-f48b73e81315)
