### PR TITLE
feat: enrich permission selector entitlements with descriptions [WD-13431]

### DIFF
--- a/src/api/server.tsx
+++ b/src/api/server.tsx
@@ -1,7 +1,7 @@
 import { handleResponse, handleTextResponse } from "util/helpers";
 import { LxdSettings } from "types/server";
 import { LxdApiResponse } from "types/apiResponse";
-import { LxdConfigOptions, LxdConfigPair } from "types/config";
+import { LxdMetadata, LxdConfigPair } from "types/config";
 import { LxdResources } from "types/resources";
 
 export const fetchSettings = (): Promise<LxdSettings> => {
@@ -38,7 +38,7 @@ export const fetchResources = (): Promise<LxdResources> => {
 
 export const fetchConfigOptions = (
   hasMetadataConfiguration: boolean,
-): Promise<LxdConfigOptions | null> => {
+): Promise<LxdMetadata | null> => {
   if (!hasMetadataConfiguration) {
     return new Promise((resolve) => resolve(null));
   }
@@ -46,7 +46,7 @@ export const fetchConfigOptions = (
   return new Promise((resolve, reject) => {
     fetch("/1.0/metadata/configuration")
       .then(handleResponse)
-      .then((data: LxdApiResponse<LxdConfigOptions>) => resolve(data.metadata))
+      .then((data: LxdApiResponse<LxdMetadata>) => resolve(data.metadata))
       .catch(reject);
   });
 };

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -23,7 +23,16 @@ export interface LxcConfigOptionCategories {
   };
 }
 
-export interface LxdConfigOptions {
+export interface LxdEntitlement {
+  name: string;
+  description: string;
+}
+
+export interface LxdEntityEntitlements {
+  [entity: string]: LxdEntitlement[];
+}
+
+export interface LxdMetadata {
   configs: {
     cluster: LxcConfigOptionCategories;
     instance: LxcConfigOptionCategories;
@@ -43,6 +52,7 @@ export interface LxdConfigOptions {
     "storage-powerflex": LxcConfigOptionCategories;
     "storage-zfs": LxcConfigOptionCategories;
   };
+  entities: LxdEntityEntitlements;
 }
 
-export type LxdConfigOptionsKeys = keyof LxdConfigOptions["configs"];
+export type LxdConfigOptionsKeys = keyof LxdMetadata["configs"];

--- a/src/util/permissions.spec.ts
+++ b/src/util/permissions.spec.ts
@@ -1,3 +1,4 @@
+import { LxdMetadata } from "types/config";
 import {
   generateEntitlementOptions,
   generatePermissionSort,
@@ -69,6 +70,7 @@ describe("General util functions for permissions feature", () => {
         disabled: true,
         label: "Select an option",
         value: "",
+        title: "",
       },
       {
         value: "/1.0/instances/instance-1?project=default",
@@ -85,7 +87,7 @@ describe("General util functions for permissions feature", () => {
     ]);
   });
 
-  it("generateEntitlementOptions", () => {
+  describe("generateEntitlementOptions", () => {
     const resourceType = "server";
     const permissions = [
       {
@@ -110,44 +112,121 @@ describe("General util functions for permissions feature", () => {
       },
     ];
 
-    const entitlementOptions = generateEntitlementOptions(
-      resourceType,
-      permissions,
-    );
+    it("should have description titles in entitlement options if metadata is provided", () => {
+      const metadata: LxdMetadata = {
+        configs: {
+          cluster: {},
+          instance: {},
+          "network-bridge": {},
+          "network-macvlan": {},
+          "network-ovn": {},
+          "network-physical": {},
+          "network-sriov": {},
+          project: {},
+          server: {},
+          "storage-btrfs": {},
+          "storage-ceph": {},
+          "storage-cephfs": {},
+          "storage-cephobject": {},
+          "storage-dir": {},
+          "storage-lvm": {},
+          "storage-powerflex": {},
+          "storage-zfs": {},
+        },
+        entities: {
+          server: [
+            {
+              name: "admin",
+              description: "admin entitlement description",
+            },
+          ],
+        },
+      };
 
-    expect(entitlementOptions).toEqual([
-      {
-        disabled: true,
-        label: "Select an option",
-        value: "",
-      },
-      {
-        disabled: true,
-        label: "Built-in roles",
-        value: "",
-      },
-      {
-        label: "admin",
-        value: "admin",
-      },
-      {
-        label: "viewer",
-        value: "viewer",
-      },
-      {
-        disabled: true,
-        label: "Granular entitlements",
-        value: "",
-      },
-      {
-        label: "can_edit",
-        value: "can_edit",
-      },
-      {
-        label: "can_view",
-        value: "can_view",
-      },
-    ]);
+      const entitlementOptions = generateEntitlementOptions(
+        resourceType,
+        permissions,
+        metadata,
+      );
+
+      expect(entitlementOptions).toEqual([
+        {
+          disabled: true,
+          label: "Select an option",
+          value: "",
+          title: "",
+        },
+        {
+          disabled: true,
+          label: "Built-in roles",
+          value: "",
+        },
+        {
+          label: "admin",
+          value: "admin",
+          title: "admin entitlement description",
+        },
+        {
+          label: "viewer",
+          value: "viewer",
+        },
+        {
+          disabled: true,
+          label: "Granular entitlements",
+          value: "",
+        },
+        {
+          label: "can_edit",
+          value: "can_edit",
+        },
+        {
+          label: "can_view",
+          value: "can_view",
+        },
+      ]);
+    });
+
+    it("should generate entitlement options without metadata", () => {
+      const entitlementOptions = generateEntitlementOptions(
+        resourceType,
+        permissions,
+      );
+
+      expect(entitlementOptions).toEqual([
+        {
+          disabled: true,
+          label: "Select an option",
+          value: "",
+          title: "",
+        },
+        {
+          disabled: true,
+          label: "Built-in roles",
+          value: "",
+        },
+        {
+          label: "admin",
+          value: "admin",
+        },
+        {
+          label: "viewer",
+          value: "viewer",
+        },
+        {
+          disabled: true,
+          label: "Granular entitlements",
+          value: "",
+        },
+        {
+          label: "can_edit",
+          value: "can_edit",
+        },
+        {
+          label: "can_view",
+          value: "can_view",
+        },
+      ]);
+    });
   });
 
   it("generatePermissionSort", () => {


### PR DESCRIPTION
## Done

- Use entities metadata from `/1.0/metadata/configurations` to populate permission selector options
- This is built with backward compatibility in mind since `/1.0/metadata/configuration` endpoint does not exist for some older versions of LXD.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions -> Groups and create a group
    - For the new group, select "Manage Permissions" from the actions list to open up the permissions panel
    - View the options in the resource type selector, make sure all options are displayed correctly
    - Select a resource type, then select a resource. View the options in the entitlement selector, hover over an option and make sure that relevant description is displayed in the tooltip.