### PR TITLE
feat: update wording on create certificate page

### DIFF
--- a/src/pages/login/BrowserImport.tsx
+++ b/src/pages/login/BrowserImport.tsx
@@ -41,7 +41,7 @@ const BrowserImport: FC<Props> = ({ sendPfx }) => {
 
   const downloadPfx = (
     <li className="p-list__item u-clearfix">
-      Download <code>lxd-ui.pfx</code>
+      Download the <code>.pfx</code> file for importing to your browser.
       {sendPfx && (
         <div className="u-float-right--large">
           <Button onClick={sendPfx}>Download pfx</Button>
@@ -82,9 +82,8 @@ const BrowserImport: FC<Props> = ({ sendPfx }) => {
                 <code>Import</code>.
               </li>
               <li className="p-list__item">
-                Select the <code>lxd-ui.pfx</code> file you just downloaded.
-                Enter your password, or leave the field empty if you have not
-                set one.
+                Select the <code>.pfx</code> file you just downloaded. Enter
+                your password, or leave the field empty if you have not set one.
               </li>
               <li className="p-list__item">
                 Restart the browser and open LXD-UI. Select the LXD-UI

--- a/src/pages/login/CertificateGenerate.tsx
+++ b/src/pages/login/CertificateGenerate.tsx
@@ -142,15 +142,18 @@ const CertificateGenerate: FC = () => {
                 <Col size={3}>
                   <h2 className="p-stepped-list__title p-heading--5">Trust</h2>
                 </Col>
-                <Col size={6}>
+                <Col size={8}>
                   <div className="p-stepped-list__content">
                     <p>
-                      Download <code>lxd-ui.crt</code> and add it to the LXD
-                      trust store
+                      Download <code>{"<certificate-name>"}.crt</code> and add
+                      it to the LXD trust store
                     </p>
                     <div className="p-code-snippet">
                       <pre className="p-code-snippet__block--icon">
-                        <code>lxc config trust add Downloads/lxd-ui.crt</code>
+                        <code>
+                          lxc config trust add Downloads/
+                          {"<certificate-name>"}.crt
+                        </code>
                       </pre>
                     </div>
                   </div>


### PR DESCRIPTION
## Done

- Improved wording for the create certificates page

Fixes #836 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - See below screenshot
    - @edlerd @piperdeck @ru-fu please would you have a look and see if the updated wording is appropriate?

## Screenshots
![Screenshot from 2024-08-15 14-53-49](https://github.com/user-attachments/assets/43b01127-4ada-4d0b-ac3d-5a5e44b5b0c5)
