### PR TITLE
fix: adjust generate certificate page layout

### DIFF
--- a/src/pages/login/CertificateGenerate.tsx
+++ b/src/pages/login/CertificateGenerate.tsx
@@ -78,6 +78,8 @@ const CertificateGenerate: FC = () => {
     downloadLink.click();
   };
 
+  const crtFileName = `lxd-ui-${location.hostname}.crt`;
+
   return (
     <CustomLayout
       mainClassName="certificate-generate"
@@ -144,34 +146,34 @@ const CertificateGenerate: FC = () => {
                 </Col>
                 <Col size={8}>
                   <div className="p-stepped-list__content">
-                    <p>
-                      Download <code>{"<certificate-name>"}.crt</code> and add
-                      it to the LXD trust store
-                    </p>
+                    <Row>
+                      <Col size={6}>
+                        <p>
+                          Download the <code>.crt</code> file and add it to the
+                          LXD trust store
+                        </p>
+                      </Col>
+                      {certs && (
+                        <Col size={2}>
+                          <Button
+                            className="download-crt"
+                            onClick={() => downloadText(crtFileName, certs.crt)}
+                          >
+                            Download&nbsp;crt
+                          </Button>
+                        </Col>
+                      )}
+                    </Row>
                     <div className="p-code-snippet">
                       <pre className="p-code-snippet__block--icon">
                         <code>
                           lxc config trust add Downloads/
-                          {"<certificate-name>"}.crt
+                          {crtFileName}
                         </code>
                       </pre>
                     </div>
                   </div>
                 </Col>
-                {certs && (
-                  <Col size={3}>
-                    <Button
-                      onClick={() =>
-                        downloadText(
-                          `lxd-ui-${location.hostname}.crt`,
-                          certs.crt,
-                        )
-                      }
-                    >
-                      Download crt
-                    </Button>
-                  </Col>
-                )}
               </Row>
             </li>
             <li className="p-stepped-list__item">

--- a/src/sass/_certificates.scss
+++ b/src/sass/_certificates.scss
@@ -15,5 +15,9 @@
     .p-stepped-list__item:first-child::after {
       display: none;
     }
+
+    .p-stepped-list__item {
+      padding-top: $spv--x-small;
+    }
   }
 }


### PR DESCRIPTION
## Done

- Fixed styling for the generate certificate page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - N/A

## Screenshots
![Screenshot from 2024-08-16 15-46-45](https://github.com/user-attachments/assets/15d77296-7178-4d90-bc7a-0b9c42b77b92)
![Screenshot from 2024-08-16 15-47-00](https://github.com/user-attachments/assets/2a2a0937-b99b-4d65-901d-7ecb94d67fb1)
