### PR TITLE
fix(volume) custom volume cache key needs to include the current project

### DIFF
--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -59,7 +59,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
             queryKey: [queryKeys.storage],
           });
           void queryClient.invalidateQueries({
-            queryKey: [queryKeys.customVolumes],
+            queryKey: [queryKeys.customVolumes, project],
           });
           notify.success(`Storage volume ${values.name} created.`);
           onFinish(volume);

--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -34,7 +34,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: [queryKeys.customVolumes],
+    queryKey: [queryKeys.customVolumes, project],
     refetchOnMount: (query) => query.state.isInvalidated,
     queryFn: () => loadCustomVolumes(project, hasStorageVolumesAll),
   });

--- a/src/pages/storage/forms/StorageVolumeCreate.tsx
+++ b/src/pages/storage/forms/StorageVolumeCreate.tsx
@@ -63,7 +63,7 @@ const StorageVolumeCreate: FC = () => {
             queryKey: [queryKeys.storage],
           });
           void queryClient.invalidateQueries({
-            queryKey: [queryKeys.customVolumes],
+            queryKey: [queryKeys.customVolumes, project],
           });
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.projects, project],


### PR DESCRIPTION
## Done

- added project to the cache key of the custom volume list
- when switching between projects, the custom volume list needs to be refreshed

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
   - create instance > disk > select custom volume, see currently available volumes (ensure at least one is uploaded). Change project to a project with an isolated storage and ensure the list is different.