### PR TITLE
feat: create instance from backup file [WD-13919]

### DIFF
--- a/src/context/toastNotificationProvider.tsx
+++ b/src/context/toastNotificationProvider.tsx
@@ -4,7 +4,6 @@ import {
   ValueOf,
   failure,
   info,
-  success,
 } from "@canonical/react-components";
 import { NotificationSeverity } from "@canonical/react-components/dist/components/Notification/Notification";
 import ToastNotification from "components/ToastNotification";
@@ -28,7 +27,10 @@ export type ToastNotificationType = NotificationType & {
 
 type ToastNotificationHelper = {
   notifications: ToastNotificationType[];
-  success: (message: ReactNode) => ToastNotificationType;
+  success: (
+    message: ReactNode,
+    actions?: NotificationAction[],
+  ) => ToastNotificationType;
   info: (message: ReactNode, title?: string) => ToastNotificationType;
   failure: (
     title: string,
@@ -165,7 +167,12 @@ const ToastNotificationProvider: FC<PropsWithChildren> = ({ children }) => {
     failure: (title, error, message, actions) =>
       addNotification(failure(title, error, message, actions)),
     info: (message, title) => addNotification(info(message, title)),
-    success: (message) => addNotification(success(message)),
+    success: (message, actions) =>
+      addNotification({
+        message,
+        actions,
+        type: NotificationSeverity.POSITIVE,
+      } as NotificationType),
     clear,
     toggleListView,
     isListView: showList,

--- a/src/pages/images/actions/UploadInstanceBtn.tsx
+++ b/src/pages/images/actions/UploadInstanceBtn.tsx
@@ -1,0 +1,252 @@
+import { ChangeEvent, FC, useCallback, useState } from "react";
+import {
+  ActionButton,
+  Button,
+  Input,
+  Modal,
+} from "@canonical/react-components";
+import { Form, useNavigate } from "react-router-dom";
+import { useFormik } from "formik";
+import * as Yup from "yup";
+import { instanceNameValidation, truncateInstanceName } from "util/instances";
+import { useProject } from "context/project";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { uploadInstance } from "api/instances";
+import { UploadState } from "types/storage";
+import { useEventQueue } from "context/eventQueue";
+import { useToastNotification } from "context/toastNotificationProvider";
+import ProgressBar from "components/ProgressBar";
+import { humanFileSize } from "util/helpers";
+import usePortal from "react-useportal";
+import StoragePoolSelector from "pages/storage/StoragePoolSelector";
+import { AxiosError } from "axios";
+import { LxdSyncResponse } from "types/apiResponse";
+
+export interface UploadInstanceFormValues {
+  instanceFile: File | null;
+  name: string;
+  pool: string;
+}
+
+const UploadInstanceBtn: FC = () => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { project, isLoading: isProjectLoading } = useProject();
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadState, setUploadState] = useState<UploadState | null>(null);
+  const eventQueue = useEventQueue();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [uploadAbort, setUploadAbort] = useState<AbortController | null>(null);
+  const instanceNameAbort = useState<AbortController | null>(null);
+
+  const changeFile = async (e: ChangeEvent<HTMLInputElement>) => {
+    const { onChange } = formik.getFieldProps("instanceFile");
+    onChange(e);
+
+    if (e.currentTarget.files) {
+      const file = e.currentTarget.files[0];
+      const suffix = "-imported";
+      const instanceName = truncateInstanceName(
+        // remove file extension
+        file.name.split(".")[0],
+        suffix,
+      );
+      await formik.setFieldValue("instanceFile", file);
+      await formik.setFieldValue("name", instanceName);
+
+      // validate instance name
+      await formik.validateField("name");
+      void formik.setFieldTouched("name", true, true);
+      if (!formik.errors.name) {
+        formik.setFieldError("name", undefined);
+      }
+    }
+  };
+
+  const handleSuccess = (instanceName: string) => {
+    const message = (
+      <>
+        Created Instance <strong>{instanceName}</strong>.
+      </>
+    );
+
+    const actions = [
+      {
+        label: "Configure",
+        onClick: () =>
+          navigate(
+            `/ui/project/${project?.name}/instance/${instanceName}/configuration`,
+          ),
+      },
+    ];
+
+    toastNotify.success(message, actions);
+  };
+
+  const handleFailure = (msg: string) => {
+    toastNotify.failure("Instance creation failed.", new Error(msg));
+  };
+
+  const handleFinish = () => {
+    void queryClient.invalidateQueries({
+      predicate: (query) => {
+        return query.queryKey[0] === queryKeys.instances;
+      },
+    });
+  };
+
+  const handleUpload = () => {
+    if (!formik.values.instanceFile) {
+      return;
+    }
+
+    setIsUploading(true);
+    const uploadController = new AbortController();
+    setUploadAbort(uploadController);
+
+    const instanceName = formik.values.name;
+    void uploadInstance(
+      formik.values.instanceFile,
+      instanceName,
+      project?.name,
+      formik.values.pool,
+      setUploadState,
+      uploadController,
+    )
+      .then((operation) => {
+        toastNotify.info(
+          <>
+            Upload completed. Now creating instance{" "}
+            <strong>{instanceName}</strong>.
+          </>,
+        );
+
+        eventQueue.set(
+          operation.metadata.id,
+          () => handleSuccess(instanceName),
+          handleFailure,
+          handleFinish,
+        );
+      })
+      .catch((e: AxiosError<LxdSyncResponse<null>>) => {
+        const error = new Error(e.response?.data.error);
+        toastNotify.failure("Instance upload failed", error);
+      })
+      .finally(() => {
+        handleCloseModal();
+        navigate(`/ui/project/${project?.name}/instances`);
+      });
+  };
+
+  const formik = useFormik<UploadInstanceFormValues>({
+    initialValues: {
+      name: "",
+      pool: "",
+      instanceFile: null,
+    },
+    validateOnMount: true,
+    validationSchema: Yup.object().shape({
+      name: instanceNameValidation(
+        project?.name || "",
+        instanceNameAbort,
+      ).optional(),
+    }),
+    onSubmit: handleUpload,
+  });
+
+  const handleCloseModal = useCallback(() => {
+    uploadAbort?.abort();
+    setIsUploading(false);
+    setUploadState(null);
+    setUploadAbort(null);
+    formik.resetForm();
+    closePortal();
+  }, [uploadAbort, formik.resetForm, closePortal]);
+
+  return (
+    <>
+      <Button onClick={openPortal} type="button" id="upload-instance-file">
+        <span>Upload instance</span>
+      </Button>
+      {isOpen && (
+        <Portal>
+          <Modal
+            close={handleCloseModal}
+            className="upload-instance-modal"
+            title="Upload instance"
+            buttonRow={
+              <>
+                <Button
+                  appearance="base"
+                  className="u-no-margin--bottom"
+                  type="button"
+                  onClick={handleCloseModal}
+                >
+                  Cancel
+                </Button>
+                <ActionButton
+                  appearance="positive"
+                  className="u-no-margin--bottom"
+                  loading={formik.isSubmitting || isUploading}
+                  disabled={
+                    !formik.isValid ||
+                    isProjectLoading ||
+                    !formik.values.instanceFile
+                  }
+                  onClick={() => void formik.submitForm()}
+                >
+                  Upload and create
+                </ActionButton>
+              </>
+            }
+          >
+            <Form
+              onSubmit={formik.handleSubmit}
+              className={uploadState ? "u-hide" : ""}
+            >
+              <Input
+                id="instance-file"
+                name="instanceFile"
+                type="file"
+                label="Instance backup file"
+                onChange={(e) => void changeFile(e)}
+              />
+              <Input
+                {...formik.getFieldProps("name")}
+                id="name"
+                type="text"
+                label="New instance name"
+                placeholder="Enter name"
+                error={formik.touched.name ? formik.errors.name : null}
+                disabled={!formik.values.instanceFile}
+              />
+              <StoragePoolSelector
+                project={project?.name || ""}
+                value={formik.values.pool}
+                setValue={(value) => void formik.setFieldValue("pool", value)}
+                selectProps={{
+                  id: "pool",
+                  label: "Root storage pool",
+                  disabled: isProjectLoading || !formik.values.instanceFile,
+                }}
+              />
+            </Form>
+            {uploadState && (
+              <>
+                <ProgressBar percentage={Math.floor(uploadState.percentage)} />
+                <p>
+                  {humanFileSize(uploadState.loaded)} loaded of{" "}
+                  {humanFileSize(uploadState.total ?? 0)}
+                </p>
+              </>
+            )}
+          </Modal>
+        </Portal>
+      )}
+    </>
+  );
+};
+
+export default UploadInstanceBtn;

--- a/src/pages/images/actions/UseCustomIsoBtn.tsx
+++ b/src/pages/images/actions/UseCustomIsoBtn.tsx
@@ -18,12 +18,7 @@ const UseCustomIsoBtn: FC<Props> = ({ onSelect }) => {
 
   return (
     <>
-      <Button
-        appearance="link"
-        onClick={openPortal}
-        type="button"
-        id="select-custom-iso"
-      >
+      <Button onClick={openPortal} type="button" id="select-custom-iso">
         <span>Use custom ISO</span>
       </Button>
       {isOpen && (

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -24,6 +24,7 @@ import UseCustomIsoBtn from "pages/images/actions/UseCustomIsoBtn";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import UploadInstanceBtn from "pages/images/actions/UploadInstanceBtn";
 
 export interface InstanceDetailsFormValues {
   name?: string;
@@ -143,6 +144,7 @@ const InstanceCreateDetailsForm: FC<Props> = ({
                 {hasCustomVolumeIso && (
                   <UseCustomIsoBtn onSelect={onSelectImage} />
                 )}
+                <UploadInstanceBtn />
               </>
             )}
           </div>

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -18,6 +18,8 @@ import UploadCustomImageHint from "pages/storage/UploadCustomImageHint";
 import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import StoragePoolSelector from "./StoragePoolSelector";
+import { AxiosError } from "axios";
+import { LxdSyncResponse } from "types/apiResponse";
 
 interface Props {
   onFinish: (name: string, pool: string) => void;
@@ -83,8 +85,9 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
           },
         ),
       )
-      .catch((e) => {
-        toastNotify.failure("Image import failed", e);
+      .catch((e: AxiosError<LxdSyncResponse<null>>) => {
+        const error = new Error(e.response?.data.error);
+        toastNotify.failure("Image import failed", error);
         setLoading(false);
         setUploadState(null);
       });

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -319,6 +319,7 @@
   .base-image {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
 
     .image-name {
       flex-grow: 1;

--- a/src/sass/_upload_instance_modal.scss
+++ b/src/sass/_upload_instance_modal.scss
@@ -1,0 +1,6 @@
+.upload-instance-modal {
+  .p-modal__dialog {
+    margin: auto;
+    width: 35rem;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -107,6 +107,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "storage";
 @import "tag";
 @import "toast";
+@import "upload_instance_modal";
 @import "upper_controls_bar";
 
 body {

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -51,3 +51,15 @@ export const instanceNameValidation = (
     .matches(/^[A-Za-z].*$/, {
       message: "Instance name must start with a letter",
     });
+
+export const truncateInstanceName = (
+  name: string,
+  suffix: string = "",
+): string => {
+  const instanceNameMaxLength = 63;
+  if (name.length > instanceNameMaxLength - suffix.length) {
+    name = name.slice(0, instanceNameMaxLength - suffix.length);
+  }
+
+  return name + suffix;
+};


### PR DESCRIPTION
## Done

- Allow instance creation from file import

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run `lxc export <instance> <filename>` to export an instance
    - Navigate to Create Instance form
    - Click "Import from file" button
    - Select the exported instance backup file
    - Set an instance name and select a target storage pool
    - Create the instance