### PR TITLE
fix(ui) avoid small caps for keys from key value pairs shown on detail page overview

### DIFF
--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -44,15 +44,15 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">Base image</th>
+                <th className="u-text--muted">Base image</th>
                 <td>{instance.config["image.description"] ?? "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Description</th>
+                <th className="u-text--muted">Description</th>
                 <td>{instance.description ? instance.description : "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Type</th>
+                <th className="u-text--muted">Type</th>
                 <td>
                   {
                     instanceCreationTypes.filter(
@@ -62,23 +62,23 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">IPv4</th>
+                <th className="u-text--muted">IPv4</th>
                 <td>
                   <InstanceIps instance={instance} family="inet" />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">IPv6</th>
+                <th className="u-text--muted">IPv6</th>
                 <td>
                   <InstanceIps instance={instance} family="inet6" />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Architecture</th>
+                <th className="u-text--muted">Architecture</th>
                 <td>{instance.architecture}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Location</th>
+                <th className="u-text--muted">Location</th>
                 <td>
                   {settings?.environment?.server_clustered
                     ? instance.location
@@ -86,15 +86,15 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">PID</th>
+                <th className="u-text--muted">PID</th>
                 <td>{pid}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Date created</th>
+                <th className="u-text--muted">Date created</th>
                 <td>{isoTimeToString(instance.created_at)}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Last used</th>
+                <th className="u-text--muted">Last used</th>
                 <td>{isoTimeToString(instance.last_used_at)}</td>
               </tr>
             </tbody>

--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -50,7 +50,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
         <table>
           <tbody>
             <tr className="metric-row">
-              <th className="p-muted-heading">Memory</th>
+              <th className="u-text--muted">Memory</th>
               <td>
                 {instanceMetrics.memory ? (
                   <div>
@@ -77,7 +77,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
               </td>
             </tr>
             <tr className="metric-row">
-              <th className="p-muted-heading">Disk</th>
+              <th className="u-text--muted">Disk</th>
               <td>
                 {instanceMetrics.disk ? (
                   <div>

--- a/src/pages/instances/InstanceOverviewNetworks.tsx
+++ b/src/pages/instances/InstanceOverviewNetworks.tsx
@@ -34,17 +34,17 @@ const InstanceOverviewNetworks: FC<Props> = ({ instance, onFailure }) => {
   const hasNetworks = instanceNetworks.length > 0;
 
   const networksHeaders = [
-    { content: "Name", sortKey: "name", className: "p-muted-heading" },
+    { content: "Name", sortKey: "name", className: "u-text--muted" },
     {
       content: "Interface",
       sortKey: "interfaceName",
-      className: "p-muted-heading",
+      className: "u-text--muted",
     },
-    { content: "Type", sortKey: "type", className: "p-muted-heading" },
+    { content: "Type", sortKey: "type", className: "u-text--muted" },
     {
       content: "Managed",
       sortKey: "managed",
-      className: "p-muted-heading u-hide--small u-hide--medium",
+      className: "u-text--muted u-hide--small u-hide--medium",
     },
   ];
 

--- a/src/pages/instances/InstanceOverviewProfiles.tsx
+++ b/src/pages/instances/InstanceOverviewProfiles.tsx
@@ -27,11 +27,11 @@ const InstanceOverviewProfiles: FC<Props> = ({ instance, onFailure }) => {
   }
 
   const profileHeaders = [
-    { content: "Name", sortKey: "name", className: "p-muted-heading" },
+    { content: "Name", sortKey: "name", className: "u-text--muted" },
     {
       content: "Description",
       sortKey: "description",
-      className: "p-muted-heading",
+      className: "u-text--muted",
     },
   ];
 

--- a/src/pages/networks/NetworkDetailOverview.tsx
+++ b/src/pages/networks/NetworkDetailOverview.tsx
@@ -67,29 +67,29 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">Name</th>
+                <th className="u-text--muted">Name</th>
                 <td>
                   <ItemName item={network} />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Description</th>
+                <th className="u-text--muted">Description</th>
                 <td>{network.description ? network.description : "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Type</th>
+                <th className="u-text--muted">Type</th>
                 <td>{network.type}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">State</th>
+                <th className="u-text--muted">State</th>
                 <td>{network.status}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">IPv4</th>
+                <th className="u-text--muted">IPv4</th>
                 <td>{network.config["ipv4.address"]}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">IPv6</th>
+                <th className="u-text--muted">IPv6</th>
                 <td>{network.config["ipv6.address"]}</td>
               </tr>
             </tbody>
@@ -105,25 +105,25 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
             <table>
               <tbody>
                 <tr className="list-wrapper">
-                  <th className="p-muted-heading">RX</th>
+                  <th className="u-text--muted">RX</th>
                   <td>
                     {humanFileSize(networkState?.counters.bytes_received ?? 0)}{" "}
                     ({networkState?.counters.packets_received ?? 0} packets)
                   </td>
                 </tr>
                 <tr className="list-wrapper">
-                  <th className="p-muted-heading">TX</th>
+                  <th className="u-text--muted">TX</th>
                   <td>
                     {humanFileSize(networkState?.counters.bytes_sent ?? 0)} (
                     {networkState?.counters.packets_sent ?? 0} packets)
                   </td>
                 </tr>
                 <tr className="list-wrapper">
-                  <th className="p-muted-heading">MAC address</th>
+                  <th className="u-text--muted">MAC address</th>
                   <td>{networkState?.hwaddr ?? "-"}</td>
                 </tr>
                 <tr className="list-wrapper">
-                  <th className="p-muted-heading">MTU</th>
+                  <th className="u-text--muted">MTU</th>
                   <td>{networkState?.mtu ?? "-"}</td>
                 </tr>
               </tbody>
@@ -139,7 +139,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
           <table>
             <tbody>
               <tr className="list-wrapper">
-                <th className="p-muted-heading">
+                <th className="u-text--muted">
                   Instances ({data.instances.length})
                 </th>
                 <td>
@@ -159,7 +159,7 @@ const NetworkDetailOverview: FC<Props> = ({ network }) => {
                 </td>
               </tr>
               <tr className="list-wrapper">
-                <th className="p-muted-heading">
+                <th className="u-text--muted">
                   Profiles ({data.profiles.length})
                 </th>
                 <td>

--- a/src/pages/profiles/ProfileDetailOverview.tsx
+++ b/src/pages/profiles/ProfileDetailOverview.tsx
@@ -62,13 +62,13 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">Name</th>
+                <th className="u-text--muted">Name</th>
                 <td>
                   <ItemName item={profile} />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Description</th>
+                <th className="u-text--muted">Description</th>
                 <td>{profile.description ? profile.description : "-"}</td>
               </tr>
             </tbody>
@@ -83,13 +83,13 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
           <table>
             <tbody>
               <tr className="list-wrapper">
-                <th className="p-muted-heading">Networks</th>
+                <th className="u-text--muted">Networks</th>
                 <td>
                   <ProfileNetworkList profile={profile} />
                 </td>
               </tr>
               <tr className="list-wrapper">
-                <th className="p-muted-heading">Storage</th>
+                <th className="u-text--muted">Storage</th>
                 <td>
                   <ProfileStorageList profile={profile} />
                 </td>
@@ -106,11 +106,11 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">CPU</th>
+                <th className="u-text--muted">CPU</th>
                 <td>{profile.config["limits.cpu"] || "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Memory</th>
+                <th className="u-text--muted">Memory</th>
                 <td>{profile.config["limits.memory"] || "-"}</td>
               </tr>
             </tbody>
@@ -146,7 +146,7 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
                 <ProfileInstances
                   profile={profile}
                   project={project}
-                  headingClassName="p-muted-heading"
+                  headingClassName="u-text--muted"
                 />
               </tbody>
             </table>

--- a/src/pages/storage/StoragePoolOverview.tsx
+++ b/src/pages/storage/StoragePoolOverview.tsx
@@ -28,29 +28,29 @@ const StoragePoolOverview: FC<Props> = ({ pool, project }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">Name</th>
+                <th className="u-text--muted">Name</th>
                 <td>{pool.name}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Status</th>
+                <th className="u-text--muted">Status</th>
                 <td>{pool.status}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Size</th>
+                <th className="u-text--muted">Size</th>
                 <td>
                   <StoragePoolSize pool={pool} />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Source</th>
+                <th className="u-text--muted">Source</th>
                 <td>{pool.config?.source ?? "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Description</th>
+                <th className="u-text--muted">Description</th>
                 <td>{pool.description ? pool.description : "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Driver</th>
+                <th className="u-text--muted">Driver</th>
                 <td>{pool.driver}</td>
               </tr>
             </tbody>

--- a/src/pages/storage/StorageUsedBy.tsx
+++ b/src/pages/storage/StorageUsedBy.tsx
@@ -30,7 +30,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
     <table>
       <tbody>
         <tr>
-          <th className="p-muted-heading">
+          <th className="u-text--muted">
             Instances ({data[INSTANCES].length})
           </th>
           <td>
@@ -45,9 +45,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
           </td>
         </tr>
         <tr>
-          <th className="p-muted-heading">
-            Profiles ({data[PROFILES].length})
-          </th>
+          <th className="u-text--muted">Profiles ({data[PROFILES].length})</th>
           <td>
             <ExpandableList
               items={data[PROFILES].map((item) => (
@@ -62,7 +60,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
           </td>
         </tr>
         <tr>
-          <th className="p-muted-heading">Images ({data[IMAGES].length})</th>
+          <th className="u-text--muted">Images ({data[IMAGES].length})</th>
           <td>
             <ExpandableList
               items={data[IMAGES].map((item) => (
@@ -77,7 +75,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
           </td>
         </tr>
         <tr>
-          <th className="p-muted-heading">
+          <th className="u-text--muted">
             Snapshots ({data[SNAPSHOTS].length})
           </th>
           <td>
@@ -112,7 +110,7 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
           </td>
         </tr>
         <tr>
-          <th className="p-muted-heading">
+          <th className="u-text--muted">
             Custom volumes ({data[CUSTOM_VOLUMES].length})
           </th>
           <td>

--- a/src/pages/storage/StorageVolumeOverview.tsx
+++ b/src/pages/storage/StorageVolumeOverview.tsx
@@ -31,27 +31,27 @@ const StorageVolumeOverview: FC<Props> = ({ project, volume }) => {
           <table>
             <tbody>
               <tr>
-                <th className="p-muted-heading">Name</th>
+                <th className="u-text--muted">Name</th>
                 <td>{volume.name}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Type</th>
+                <th className="u-text--muted">Type</th>
                 <td>{renderVolumeType(volume)}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Content type</th>
+                <th className="u-text--muted">Content type</th>
                 <td>{renderContentType(volume)}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Description</th>
+                <th className="u-text--muted">Description</th>
                 <td>{volume.description ? volume.description : "-"}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Location</th>
+                <th className="u-text--muted">Location</th>
                 <td>{volume.location}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Pool</th>
+                <th className="u-text--muted">Pool</th>
                 <td>
                   <Link
                     to={`/ui/project/${project}/storage/pool/${volume.pool}`}
@@ -61,17 +61,17 @@ const StorageVolumeOverview: FC<Props> = ({ project, volume }) => {
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Date created</th>
+                <th className="u-text--muted">Date created</th>
                 <td>{isoTimeToString(volume.created_at)}</td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Size</th>
+                <th className="u-text--muted">Size</th>
                 <td>
                   <StorageVolumeSize volume={volume} />
                 </td>
               </tr>
               <tr>
-                <th className="p-muted-heading">Custom config</th>
+                <th className="u-text--muted">Custom config</th>
                 <td>
                   {Object.entries(volume.config).length === 0 ? (
                     "-"


### PR DESCRIPTION
## Done

- avoid small caps for keys from key value pairs shown on detail page overview

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check overview pages for instances, networks and storage
