### PR TITLE
feat: Add create instance from snapshot feature [WD-14411]

### DIFF
--- a/src/pages/cluster/ClusterMemberSelector.tsx
+++ b/src/pages/cluster/ClusterMemberSelector.tsx
@@ -1,0 +1,38 @@
+import { Select, SelectProps } from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { fetchClusterMembers } from "api/cluster";
+import { useSettings } from "context/useSettings";
+import React, { FC } from "react";
+import { queryKeys } from "util/queryKeys";
+import { isClusteredServer } from "util/settings";
+
+const ClusterMemberSelector: FC<SelectProps> = ({
+  label,
+  disabled,
+  ...props
+}) => {
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
+  const { data: clusterMembers = [], isLoading: clusterMembersLoading } =
+    useQuery({
+      queryKey: [queryKeys.cluster],
+      queryFn: fetchClusterMembers,
+      enabled: isClustered,
+    });
+
+  return isClustered ? (
+    <Select
+      {...props}
+      label={label ?? "Cluster member"}
+      options={clusterMembers.map((clusterMember) => {
+        return {
+          label: clusterMember.server_name,
+          value: clusterMember.server_name,
+        };
+      })}
+      disabled={disabled || clusterMembersLoading}
+    />
+  ) : null;
+};
+
+export default ClusterMemberSelector;

--- a/src/pages/instances/actions/UploadInstanceBtn.tsx
+++ b/src/pages/instances/actions/UploadInstanceBtn.tsx
@@ -68,7 +68,7 @@ const UploadInstanceBtn: FC = () => {
   const handleSuccess = (instanceName: string) => {
     const message = (
       <>
-        Created Instance <strong>{instanceName}</strong>.
+        Created instance <strong>{instanceName}</strong>.
       </>
     );
 

--- a/src/pages/instances/actions/snapshots/CreateInstanceFromSnapshotBtn.tsx
+++ b/src/pages/instances/actions/snapshots/CreateInstanceFromSnapshotBtn.tsx
@@ -1,0 +1,48 @@
+import { FC } from "react";
+import { LxdInstance, LxdInstanceSnapshot } from "types/instance";
+import { Button, Icon } from "@canonical/react-components";
+import usePortal from "react-useportal";
+import CreateInstanceFromSnapshotForm from "../../forms/CreateInstanceFromSnapshotForm";
+
+interface Props {
+  instance: LxdInstance;
+  snapshot: LxdInstanceSnapshot;
+  isDeleting: boolean;
+  isRestoring: boolean;
+}
+
+const CreateInstanceFromSnapshotBtn: FC<Props> = ({
+  instance,
+  snapshot,
+  isDeleting,
+  isRestoring,
+}) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <CreateInstanceFromSnapshotForm
+            close={closePortal}
+            instance={instance}
+            snapshot={snapshot}
+          />
+        </Portal>
+      )}
+      <Button
+        appearance="base"
+        hasIcon
+        dense
+        aria-label="Create instance"
+        disabled={isDeleting || isRestoring}
+        onClick={openPortal}
+        title="Create instance"
+      >
+        <Icon name="plus" />
+      </Button>
+    </>
+  );
+};
+
+export default CreateInstanceFromSnapshotBtn;

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
@@ -13,6 +13,7 @@ import ConfirmationForce from "components/ConfirmationForce";
 import { useEventQueue } from "context/eventQueue";
 import InstanceEditSnapshotBtn from "./InstanceEditSnapshotBtn";
 import CreateImageFromInstanceSnapshotBtn from "pages/instances/actions/snapshots/CreateImageFromInstanceSnapshotBtn";
+import CreateInstanceFromSnapshotBtn from "./CreateInstanceFromSnapshotBtn";
 
 interface Props {
   instance: LxdInstance;
@@ -103,13 +104,6 @@ const InstanceSnapshotActions: FC<Props> = ({
             isDeleting={isDeleting}
             isRestoring={isRestoring}
           />,
-          <CreateImageFromInstanceSnapshotBtn
-            key="publish"
-            instance={instance}
-            snapshot={snapshot}
-            isRestoring={isRestoring}
-            isDeleting={isDeleting}
-          />,
           <ConfirmationButton
             key="restore"
             appearance="base"
@@ -142,6 +136,20 @@ const InstanceSnapshotActions: FC<Props> = ({
           >
             <Icon name="change-version" />
           </ConfirmationButton>,
+          <CreateImageFromInstanceSnapshotBtn
+            key="publish"
+            instance={instance}
+            snapshot={snapshot}
+            isRestoring={isRestoring}
+            isDeleting={isDeleting}
+          />,
+          <CreateInstanceFromSnapshotBtn
+            key="duplicate"
+            instance={instance}
+            snapshot={snapshot}
+            isDeleting={isDeleting}
+            isRestoring={isRestoring}
+          />,
           <ConfirmationButton
             key="delete"
             appearance="base"

--- a/src/sass/_instance_detail_page.scss
+++ b/src/sass/_instance_detail_page.scss
@@ -8,6 +8,7 @@
   }
 }
 
+.create-instance-from-snapshot-modal,
 .duplicate-instances-modal,
 .create-image-from-instance-modal {
   .p-modal__dialog {

--- a/src/sass/_snapshots.scss
+++ b/src/sass/_snapshots.scss
@@ -24,7 +24,7 @@
   }
 
   .actions {
-    width: 240px;
+    width: 280px;
   }
 
   .u-row:hover {

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -57,6 +57,10 @@ interface LxdInstanceSnapshot {
   created_at: string;
   expires_at: string;
   stateful: boolean;
+  ephemeral: boolean;
+  config: {
+    "volatile.base_image"?: string;
+  };
 }
 
 export type LxdInstanceAction =

--- a/src/util/operations.spec.ts
+++ b/src/util/operations.spec.ts
@@ -1,10 +1,10 @@
 import { getInstanceName, getProjectName } from "./operations";
 import { LxdOperation } from "types/operation";
 
-const craftOperation = (url: string) => {
+const craftOperation = (...url: string[]) => {
   return {
     resources: {
-      instances: [url],
+      instances: [...url],
     },
   } as LxdOperation;
 };
@@ -26,22 +26,13 @@ describe("getInstanceName", () => {
     expect(name).toBe("testInstance2");
   });
 
-  it("identifies instance name from snapshot operation", () => {
+  it("identifies instance name from an instance creation operation with snapshot as source", () => {
     const operation = craftOperation(
-      "/1.0/instances/testInstance3/snapshots/testSnap",
+      "/1.0/instances/targetInstanceName",
+      "/1.0/instances/sourceInstanceName/testSnap",
     );
     const name = getInstanceName(operation);
-
-    expect(name).toBe("testInstance3");
-  });
-
-  it("identifies instance name from a snapshot operation in a custom project", () => {
-    const operation = craftOperation(
-      "/1.0/instances/testInstance3/snapshots/testSnap?project=project",
-    );
-    const name = getInstanceName(operation);
-
-    expect(name).toBe("testInstance3");
+    expect(name).toBe("targetInstanceName");
   });
 });
 

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -5,9 +5,18 @@ export const getInstanceName = (operation?: LxdOperation): string => {
   // /1.0/instances/<instance_name>
   // /1.0/instances/<instance_name>?project=<project_name>
   // /1.0/instances/<instance_name>/snapshots/<snapshot_name>
+  // /1.0/instances/<instance_name>/<snapshot_name>
   return (
     operation?.resources?.instances
-      ?.filter((item) => item.startsWith("/1.0/instances/"))
+      ?.filter((item) => {
+        // for snapshots backend returns %2F instead of /, which is not decoded by the browser
+        const itemUrl = decodeURIComponent(item);
+        return (
+          itemUrl.startsWith("/1.0/instances/") &&
+          // exclude snapshots
+          itemUrl.split("/").length <= 4
+        );
+      })
       .map((item) => item.split("/")[3])
       .pop()
       ?.split("?")[0] ?? ""


### PR DESCRIPTION
## Done

- Add duplicate snapshot feature

## Notes
- Currently using the `copy` vanilla icon for the duplicate snapshot button
- Removed the `allowInconsistent` and `instanceOnly` options. These are not relevant for snapshot duplication.
- Stateful copy is only relevant for stateful snapshots
- For a stateful copy of a snapshot, the instance name must remain the same. This means the instance cannot be created in the same project. Tested this in the CLI, it's the same behaviour (see code [ref](https://github.com/canonical/lxd/blob/68e1b1bd544a4973828009fcf4b3d59a9836f46c/lxd/instances_post.go#L580)). Therefore, I added some additional form validation logic. If the Copy stateful option is checked, then validation is performed on instance name (must be the same as the original instance name) and target project (must be a different project to the source instance project). 
![Screenshot from 2024-08-26 13-28-43](https://github.com/user-attachments/assets/3e0ec844-3f4c-4ec6-a55c-fe513e433d0c)


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance
    - Create a stateless snapshot and a stateful snapshot for the instance (`migration.stateful` must be `true` and the instance must be running)
    - Try duplicate both snapshots. Pay close attention to the stateful snapshot form validation.