### PR TITLE
fix: infinite api call loop when duplicating instance

### DIFF
--- a/src/pages/instances/forms/DuplicateInstanceForm.tsx
+++ b/src/pages/instances/forms/DuplicateInstanceForm.tsx
@@ -14,7 +14,7 @@ import * as Yup from "yup";
 import { createInstance, fetchInstances } from "api/instances";
 import { isClusteredServer } from "util/settings";
 import { useSettings } from "context/useSettings";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { fetchStoragePools } from "api/storage-pools";
 import { fetchClusterMembers } from "api/cluster";
@@ -47,7 +47,6 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
   const controllerState = useState<AbortController | null>(null);
   const navigate = useNavigate();
   const eventQueue = useEventQueue();
-  const queryClient = useQueryClient();
 
   const { data: projects = [], isLoading: projectsLoading } = useQuery({
     queryKey: [queryKeys.projects],
@@ -102,11 +101,6 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
       }
       return `${newInstanceName}-${count}`;
     }
-    void queryClient.invalidateQueries({
-      predicate: (query) => {
-        return query.queryKey[0] === queryKeys.instances;
-      },
-    });
 
     return newInstanceName;
   };


### PR DESCRIPTION
## Done

- The duplicate instance form currently gets stuck in a infinite loop of api calls as the query cache is being invalidated in `getDuplicatedInstanceName`. This PR resolves the issue.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check network calls when the duplicate instance form is open.