### PR TITLE
simpler one click edit mode for edit forms

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -14,6 +14,7 @@ import { NetworkFormValues } from "pages/networks/forms/NetworkForm";
 import { ProjectFormValues } from "pages/projects/CreateProject";
 import { getConfigRowMetadata } from "util/configInheritance";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
+import { ensureEditMode } from "util/instanceEdit";
 
 export type ConfigurationRowFormikValues =
   | InstanceAndProfileFormValues
@@ -22,7 +23,7 @@ export type ConfigurationRowFormikValues =
   | ProjectFormValues
   | StoragePoolFormValues;
 
-type ConfigurationRowFormikProps =
+export type ConfigurationRowFormikProps =
   | InstanceAndProfileFormikProps
   | FormikProps<NetworkFormValues>
   | FormikProps<ProjectFormValues>
@@ -60,12 +61,20 @@ export const getConfigurationRow = ({
   const overrideValue = readOnlyRenderer(value === "" ? "-" : value);
   const metadata = getConfigRowMetadata(formik.values, name);
 
+  const enableOverride = () => {
+    void formik.setFieldValue(name, defaultValue);
+  };
+
+  const focusOverride = () => {
+    setTimeout(() => document.getElementById(name)?.focus(), 100);
+  };
+
   const toggleDefault = () => {
     if (isOverridden) {
       void formik.setFieldValue(name, undefined);
     } else {
-      void formik.setFieldValue(name, defaultValue);
-      setTimeout(() => document.getElementById(name)?.focus(), 100);
+      enableOverride();
+      focusOverride();
     }
   };
 
@@ -132,7 +141,29 @@ export const getConfigurationRow = ({
 
   const renderOverride = (): ReactNode => {
     if (formik.values.readOnly) {
-      return overrideValue;
+      return (
+        <>
+          {overrideValue}
+          {!disabled && (
+            <Button
+              onClick={() => {
+                ensureEditMode(formik);
+                if (!isOverridden) {
+                  enableOverride();
+                }
+                focusOverride();
+              }}
+              className="u-no-margin--bottom"
+              type="button"
+              appearance="base"
+              title={isOverridden ? "Edit" : "Create override"}
+              hasIcon
+            >
+              <Icon name="edit" />
+            </Button>
+          )}
+        </>
+      );
     }
     if (isOverridden) {
       return getForm();

--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -10,6 +10,7 @@ import { MainTableRow } from "@canonical/react-components/dist/components/MainTa
 import classnames from "classnames";
 import { removeDevice } from "util/formDevices";
 import DetachDiskDeviceBtn from "pages/instances/actions/DetachDiskDeviceBtn";
+import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -53,23 +54,27 @@ const DiskDeviceFormInherited: FC<Props> = ({ formik, inheritedVolumes }) => {
           </div>
         ),
         inherited: "",
-        override: readOnly ? (
-          isNoneDevice ? (
-            <>Detached</>
-          ) : null
-        ) : isNoneDevice ? (
+        override: isNoneDevice ? (
           <Button
             appearance="base"
             type="button"
             title="Reattach volume"
-            onClick={() => removeDevice(noneDeviceId, formik)}
+            onClick={() => {
+              ensureEditMode(formik);
+              removeDevice(noneDeviceId, formik);
+            }}
             className="has-icon u-no-margin--bottom"
           >
             <Icon name="connected"></Icon>
             <span>Reattach</span>
           </Button>
         ) : (
-          <DetachDiskDeviceBtn onDetach={() => addNoneDevice(item.key)} />
+          <DetachDiskDeviceBtn
+            onDetach={() => {
+              ensureEditMode(formik);
+              addNoneDevice(item.key);
+            }}
+          />
         ),
       }),
     );

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -13,6 +13,7 @@ import { LxdStoragePool } from "types/storage";
 import { LxdProfile } from "types/profile";
 import { removeDevice } from "util/formDevices";
 import { hasNoRootDisk } from "util/instanceValidation";
+import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -64,33 +65,37 @@ const DiskDeviceFormRoot: FC<Props> = ({
             className: "override-with-form",
             configuration: <b className="device-name">Root storage</b>,
             inherited: "",
-            override:
-              !readOnly &&
-              (hasRootStorage ? (
-                <div>
-                  <Button
-                    onClick={() => removeDevice(rootIndex, formik)}
-                    type="button"
-                    appearance="base"
-                    title="Clear override"
-                    hasIcon
-                    className="u-no-margin--bottom"
-                  >
-                    <Icon name="close" className="clear-configuration-icon" />
-                  </Button>
-                </div>
-              ) : (
+            override: hasRootStorage ? (
+              <div>
                 <Button
-                  onClick={addRootStorage}
+                  onClick={() => {
+                    ensureEditMode(formik);
+                    removeDevice(rootIndex, formik);
+                  }}
                   type="button"
                   appearance="base"
-                  title="Create override"
-                  className="u-no-margin--bottom"
+                  title="Clear override"
                   hasIcon
+                  className="u-no-margin--bottom"
                 >
-                  <Icon name="edit" />
+                  <Icon name="close" className="clear-configuration-icon" />
                 </Button>
-              )),
+              </div>
+            ) : (
+              <Button
+                onClick={() => {
+                  ensureEditMode(formik);
+                  addRootStorage();
+                }}
+                type="button"
+                appearance="base"
+                title="Create override"
+                className="u-no-margin--bottom"
+                hasIcon
+              >
+                <Icon name="edit" />
+              </Button>
+            ),
           }),
 
           getDiskDeviceRow({

--- a/src/components/forms/RenameDiskDeviceInput.tsx
+++ b/src/components/forms/RenameDiskDeviceInput.tsx
@@ -5,25 +5,10 @@ interface Props {
   name: string;
   index: number;
   setName: (val: string) => void;
-  readOnly: boolean;
 }
 
-const RenameDiskDeviceInput: FC<Props> = ({
-  name,
-  index,
-  setName,
-  readOnly,
-}) => {
+const RenameDiskDeviceInput: FC<Props> = ({ name, index, setName }) => {
   const [isEditing, setEditing] = useState(false);
-
-  if (readOnly) {
-    return (
-      <div className="rename-disk-device device-name">
-        <b>{name}</b>
-      </div>
-    );
-  }
-
   return (
     <div className="rename-disk-device device-name">
       {isEditing ? (

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -450,7 +450,6 @@ const CreateInstance: FC = () => {
 
             {section === YAML_CONFIGURATION && (
               <YamlForm
-                key={`yaml-form-${formik.values.readOnly}`}
                 yaml={getYaml()}
                 setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
               >

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -46,6 +46,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import DiskDeviceForm from "components/forms/DiskDeviceForm";
 import NetworkDevicesForm from "components/forms/NetworkDevicesForm";
 import {
+  ensureEditMode,
   getInstanceEditValues,
   getInstancePayload,
   InstanceEditSchema,
@@ -95,6 +96,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [isConfigOpen, setConfigOpen] = useState(true);
+  const [version, setVersion] = useState(0);
 
   if (!project) {
     return <>Missing project</>;
@@ -230,10 +232,12 @@ const EditInstance: FC<Props> = ({ instance }) => {
 
             {section === slugify(YAML_CONFIGURATION) && (
               <YamlForm
-                key={`yaml-form-${formik.values.readOnly}-${getYaml()}`}
+                key={`yaml-form-${version}`}
                 yaml={getYaml()}
-                setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
-                readOnly={readOnly}
+                setYaml={(yaml) => {
+                  ensureEditMode(formik);
+                  void formik.setFieldValue("yaml", yaml);
+                }}
               >
                 <Notification severity="information" title="YAML Configuration">
                   This is the YAML representation of the instance.
@@ -252,20 +256,14 @@ const EditInstance: FC<Props> = ({ instance }) => {
         </Row>
       </Form>
       <FormFooterLayout>
-        {readOnly ? (
-          <Button
-            appearance="positive"
-            onClick={() => {
-              void formik.setFieldValue("readOnly", false);
-            }}
-          >
-            Edit instance
-          </Button>
-        ) : (
+        {readOnly ? null : (
           <>
             <Button
               appearance="base"
-              onClick={() => formik.setValues(getInstanceEditValues(instance))}
+              onClick={() => {
+                void formik.setValues(getInstanceEditValues(instance));
+                setVersion((old) => old + 1);
+              }}
             >
               Cancel
             </Button>

--- a/src/pages/instances/forms/EditInstanceDetails.tsx
+++ b/src/pages/instances/forms/EditInstanceDetails.tsx
@@ -1,12 +1,13 @@
 import { FC } from "react";
 import { Col, Input, Row } from "@canonical/react-components";
-import ProfileSelect from "pages/profiles/ProfileSelector";
+import ProfileSelector from "pages/profiles/ProfileSelector";
 import { FormikProps } from "formik/dist/types";
 import { EditInstanceFormValues } from "pages/instances/EditInstance";
 import { useSettings } from "context/useSettings";
 import { isClusteredServer } from "util/settings";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
+import { ensureEditMode } from "util/instanceEdit";
 
 export const instanceEditDetailPayload = (values: EditInstanceFormValues) => {
   return {
@@ -23,7 +24,6 @@ interface Props {
 }
 
 const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
-  const readOnly = formik.values.readOnly;
   const { data: settings } = useSettings();
   const isClustered = isClusteredServer(settings);
 
@@ -51,10 +51,12 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
             label="Description"
             placeholder="Enter description"
             onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
+            onChange={(e) => {
+              ensureEditMode(formik);
+              formik.handleChange(e);
+            }}
             value={formik.values.description}
             dynamicHeight
-            disabled={readOnly}
           />
         </Col>
       </Row>
@@ -73,11 +75,13 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
           </Col>
         </Row>
       )}
-      <ProfileSelect
+      <ProfileSelector
         project={project}
         selected={formik.values.profiles}
-        setSelected={(value) => void formik.setFieldValue("profiles", value)}
-        readOnly={readOnly}
+        setSelected={(value) => {
+          ensureEditMode(formik);
+          void formik.setFieldValue("profiles", value);
+        }}
       />
     </ScrollableForm>
   );

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -7,7 +7,7 @@ import {
   Row,
   Select,
 } from "@canonical/react-components";
-import ProfileSelect from "pages/profiles/ProfileSelector";
+import ProfileSelector from "pages/profiles/ProfileSelector";
 import SelectImageBtn from "pages/images/actions/SelectImageBtn";
 import {
   isContainerOnlyImage,
@@ -170,7 +170,7 @@ const InstanceCreateDetailsForm: FC<Props> = ({
           <InstanceLocationSelect formik={formik} />
         </Col>
       </Row>
-      <ProfileSelect
+      <ProfileSelector
         project={project}
         selected={formik.values.profiles}
         setSelected={(value) => void formik.setFieldValue("profiles", value)}

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -38,6 +38,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
   const { section } = useParams<{ section?: string }>();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+  const [version, setVersion] = useState(0);
 
   if (!network?.managed) {
     return (
@@ -118,20 +119,17 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
         project={project}
         section={section ?? slugify(MAIN_CONFIGURATION)}
         setSection={setSection}
+        version={version}
       />
       <FormFooterLayout>
-        {readOnly ? (
-          <Button
-            appearance="positive"
-            onClick={() => void formik.setFieldValue("readOnly", false)}
-          >
-            Edit network
-          </Button>
-        ) : (
+        {readOnly ? null : (
           <>
             <Button
               appearance="base"
-              onClick={() => formik.setValues(toNetworkFormValues(network))}
+              onClick={() => {
+                setVersion((old) => old + 1);
+                void formik.setValues(toNetworkFormValues(network));
+              }}
             >
               Cancel
             </Button>

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -37,6 +37,7 @@ import { useDocs } from "context/useDocs";
 import YamlConfirmation from "components/forms/YamlConfirmation";
 import { getHandledNetworkConfigKeys, getNetworkKey } from "util/networks";
 import NetworkFormOvn from "pages/networks/forms/NetworkFormOvn";
+import { ensureEditMode } from "util/instanceEdit";
 
 export interface NetworkFormValues {
   readOnly: boolean;
@@ -159,6 +160,7 @@ interface Props {
   project: string;
   section: string;
   setSection: (section: string) => void;
+  version?: number;
 }
 
 const NetworkForm: FC<Props> = ({
@@ -167,6 +169,7 @@ const NetworkForm: FC<Props> = ({
   project,
   section,
   setSection,
+  version = 0,
 }) => {
   const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const docBaseLink = useDocs();
@@ -219,10 +222,12 @@ const NetworkForm: FC<Props> = ({
           {section === slugify(OVN) && <NetworkFormOvn formik={formik} />}
           {section === slugify(YAML_CONFIGURATION) && (
             <YamlForm
-              key={`yaml-form-${formik.values.readOnly}`}
+              key={`yaml-form-${version}`}
               yaml={getYaml()}
-              setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
-              readOnly={formik.values.readOnly}
+              setYaml={(yaml) => {
+                ensureEditMode(formik);
+                void formik.setFieldValue("yaml", yaml);
+              }}
             >
               <Notification severity="information" title="YAML Configuration">
                 This is the YAML representation of the network.

--- a/src/pages/networks/forms/NetworkFormMain.tsx
+++ b/src/pages/networks/forms/NetworkFormMain.tsx
@@ -11,6 +11,7 @@ import { optionTrueFalse } from "util/instanceOptions";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
 import NetworkParentSelector from "pages/networks/forms/NetworkParentSelector";
+import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: FormikProps<NetworkFormValues>;
@@ -23,7 +24,10 @@ const NetworkFormMain: FC<Props> = ({ formik, project }) => {
       id: id,
       name: id,
       onBlur: formik.handleBlur,
-      onChange: formik.handleChange,
+      onChange: (e: unknown) => {
+        ensureEditMode(formik);
+        formik.handleChange(e);
+      },
       value: formik.values[id] ?? "",
       error: formik.touched[id] ? (formik.errors[id] as ReactNode) : null,
       placeholder: `Enter ${id.replaceAll("_", " ")}`,
@@ -50,22 +54,14 @@ const NetworkFormMain: FC<Props> = ({ formik, project }) => {
           <AutoExpandingTextArea
             {...getFormProps("description")}
             label="Description"
-            disabled={formik.values.readOnly}
             dynamicHeight
           />
           {formik.values.networkType === "ovn" && (
-            <UplinkSelector
-              props={getFormProps("network")}
-              project={project}
-              isDisabled={formik.values.readOnly}
-            />
+            <UplinkSelector props={getFormProps("network")} project={project} />
           )}
           {formik.values.networkType === "physical" &&
             formik.values.isCreating && (
-              <NetworkParentSelector
-                props={getFormProps("parent")}
-                isDisabled={formik.values.readOnly}
-              />
+              <NetworkParentSelector props={getFormProps("parent")} />
             )}
         </Col>
       </Row>

--- a/src/pages/networks/forms/NetworkParentSelector.tsx
+++ b/src/pages/networks/forms/NetworkParentSelector.tsx
@@ -7,11 +7,10 @@ import { fetchNetworks } from "api/networks";
 import { useParams } from "react-router-dom";
 
 interface Props {
-  isDisabled: boolean;
   props?: Record<string, unknown>;
 }
 
-const NetworkParentSelector: FC<Props> = ({ isDisabled, props }) => {
+const NetworkParentSelector: FC<Props> = ({ props }) => {
   const { project } = useParams<{ project: string }>();
 
   if (!project) {
@@ -44,7 +43,6 @@ const NetworkParentSelector: FC<Props> = ({ isDisabled, props }) => {
     <Select
       label="Parent"
       help="Existing interface to use for network"
-      disabled={isDisabled}
       options={options}
       required
       {...props}

--- a/src/pages/networks/forms/UplinkSelector.tsx
+++ b/src/pages/networks/forms/UplinkSelector.tsx
@@ -9,16 +9,11 @@ import { fetchProject } from "api/projects";
 const UPLINK_NETWORK_TYPES = ["bridge", "physical"];
 
 interface Props {
-  isDisabled: boolean;
   project: string;
   props?: Record<string, unknown>;
 }
 
-const UplinkSelector: FC<Props> = ({
-  isDisabled,
-  project: projectName,
-  props,
-}) => {
+const UplinkSelector: FC<Props> = ({ project: projectName, props }) => {
   const { data: networks = [], isLoading: isNetworkLoading } = useQuery({
     queryKey: [queryKeys.networks, "default"],
     queryFn: () => fetchNetworks("default"),
@@ -54,7 +49,6 @@ const UplinkSelector: FC<Props> = ({
     <Select
       label="Uplink"
       help="Uplink network to use for external network access"
-      disabled={isDisabled}
       options={options}
       required
       {...props}

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -208,7 +208,6 @@ const CreateProfile: FC = () => {
 
             {section === YAML_CONFIGURATION && (
               <YamlForm
-                key={`yaml-form-${formik.values.readOnly}`}
                 yaml={getYaml()}
                 setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
               >

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -49,7 +49,7 @@ import NetworkDevicesForm from "components/forms/NetworkDevicesForm";
 import ProfileDetailsForm, {
   ProfileDetailsFormValues,
 } from "pages/profiles/forms/ProfileDetailsForm";
-import { getProfileEditValues } from "util/instanceEdit";
+import { ensureEditMode, getProfileEditValues } from "util/instanceEdit";
 import { slugify } from "util/slugify";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import FormFooterLayout from "components/forms/FormFooterLayout";
@@ -85,6 +85,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [isConfigOpen, setConfigOpen] = useState(true);
+  const [version, setVersion] = useState(0);
 
   if (!project) {
     return <>Missing project</>;
@@ -210,10 +211,12 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
 
             {section === slugify(YAML_CONFIGURATION) && (
               <YamlForm
-                key={`yaml-form-${formik.values.readOnly}`}
+                key={`yaml-form-${version}`}
                 yaml={getYaml()}
-                setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
-                readOnly={readOnly}
+                setYaml={(yaml) => {
+                  ensureEditMode(formik);
+                  void formik.setFieldValue("yaml", yaml);
+                }}
               >
                 <Notification severity="information" title="YAML Configuration">
                   This is the YAML representation of the profile.
@@ -232,19 +235,14 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
         </Row>
       </Form>
       <FormFooterLayout>
-        {readOnly ? (
-          <Button
-            appearance="positive"
-            disabled={!featuresProfiles}
-            onClick={() => void formik.setFieldValue("readOnly", false)}
-          >
-            Edit profile
-          </Button>
-        ) : (
+        {readOnly ? null : (
           <>
             <Button
               appearance="base"
-              onClick={() => formik.setValues(getProfileEditValues(profile))}
+              onClick={() => {
+                setVersion((old) => old + 1);
+                void formik.setValues(getProfileEditValues(profile));
+              }}
             >
               Cancel
             </Button>

--- a/src/pages/profiles/forms/ProfileDetailsForm.tsx
+++ b/src/pages/profiles/forms/ProfileDetailsForm.tsx
@@ -4,6 +4,7 @@ import { FormikProps } from "formik/dist/types";
 import { CreateProfileFormValues } from "pages/profiles/CreateProfile";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
+import { ensureEditMode } from "util/instanceEdit";
 
 export interface ProfileDetailsFormValues {
   name: string;
@@ -25,7 +26,6 @@ interface Props {
 }
 
 const ProfileDetailsForm: FC<Props> = ({ formik, isEdit }) => {
-  const readOnly = formik.values.readOnly;
   const isDefaultProfile = formik.values.name === "default";
 
   return (
@@ -56,9 +56,13 @@ const ProfileDetailsForm: FC<Props> = ({ formik, isEdit }) => {
             label="Description"
             placeholder="Enter description"
             onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
+            onChange={(e) => {
+              if (isEdit) {
+                ensureEditMode(formik);
+              }
+              formik.handleChange(e);
+            }}
             value={formik.values.description}
-            disabled={readOnly}
             dynamicHeight
           />
         </Col>

--- a/src/pages/projects/EditProject.tsx
+++ b/src/pages/projects/EditProject.tsx
@@ -102,16 +102,7 @@ const EditProject: FC<Props> = ({ project }) => {
       />
       {!isRestricted && (
         <FormFooterLayout>
-          {formik.values.readOnly ? (
-            <>
-              <Button
-                appearance="positive"
-                onClick={() => void formik.setFieldValue("readOnly", false)}
-              >
-                Edit configuration
-              </Button>
-            </>
-          ) : (
+          {formik.values.readOnly ? null : (
             <>
               <Button
                 appearance="base"

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -16,6 +16,7 @@ import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import ScrollableForm from "components/ScrollableForm";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { LxdConfigPair } from "types/config";
+import { ensureEditMode } from "util/instanceEdit";
 
 export interface ProjectDetailsFormValues {
   name: string;
@@ -107,7 +108,6 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
   const [features, setFeatures] = useState(figureFeatures());
 
   const isDefaultProject = formik.values.name === "default";
-  const readOnly = formik.values.readOnly;
   const isNonEmpty = project ? !isProjectEmpty(project) : false;
   const hadFeaturesNetwork = project?.config["features.networks"] === "true";
   const hadFeaturesNetworkZones =
@@ -140,9 +140,11 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             label="Description"
             placeholder="Enter description"
             onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
+            onChange={(e) => {
+              ensureEditMode(formik);
+              formik.handleChange(e);
+            }}
             value={formik.values.description}
-            disabled={formik.values.readOnly}
             dynamicHeight
           />
           <Select
@@ -150,6 +152,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             name="features"
             label="Features"
             onChange={(e) => {
+              ensureEditMode(formik);
               setFeatures(e.target.value);
               void formik.setFieldValue("features_images", true);
               void formik.setFieldValue("features_profiles", true);
@@ -170,7 +173,6 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
               },
             ]}
             disabled={
-              readOnly ||
               isDefaultProject ||
               (isNonEmpty && hadFeaturesNetwork) ||
               (isNonEmpty && hadFeaturesNetworkZones)
@@ -183,14 +185,15 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 id="features_images"
                 name="features_images"
                 label="Images"
-                onChange={() =>
+                onChange={() => {
+                  ensureEditMode(formik);
                   void formik.setFieldValue(
                     "features_images",
                     !formik.values.features_images,
-                  )
-                }
+                  );
+                }}
                 checked={formik.values.features_images}
-                disabled={readOnly || isDefaultProject || isNonEmpty}
+                disabled={isDefaultProject || isNonEmpty}
               />
               <CheckboxInput
                 id="features_profiles"
@@ -207,6 +210,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                   </>
                 }
                 onChange={() => {
+                  ensureEditMode(formik);
                   const newValue = !formik.values.features_profiles;
                   void formik.setFieldValue("features_profiles", newValue);
                   if (!newValue) {
@@ -214,37 +218,37 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                   }
                 }}
                 checked={formik.values.features_profiles}
-                disabled={readOnly || isDefaultProject || isNonEmpty}
+                disabled={isDefaultProject || isNonEmpty}
               />
               <CheckboxInput
                 id="features_networks"
                 name="features_networks"
                 label="Networks"
-                onChange={() =>
+                onChange={() => {
+                  ensureEditMode(formik);
                   void formik.setFieldValue(
                     "features_networks",
                     !formik.values.features_networks,
-                  )
-                }
+                  );
+                }}
                 checked={formik.values.features_networks}
-                disabled={readOnly || isDefaultProject || isNonEmpty}
+                disabled={isDefaultProject || isNonEmpty}
               />
               {hasProjectsNetworksZones && (
                 <CheckboxInput
                   id="features_networks_zones"
                   name="features_networks_zones"
                   label="Network zones"
-                  onChange={() =>
+                  onChange={() => {
+                    ensureEditMode(formik);
                     void formik.setFieldValue(
                       "features_networks_zones",
                       !formik.values.features_networks_zones,
-                    )
-                  }
+                    );
+                  }}
                   checked={formik.values.features_networks_zones}
                   disabled={
-                    readOnly ||
-                    isDefaultProject ||
-                    (isNonEmpty && hadFeaturesNetworkZones)
+                    isDefaultProject || (isNonEmpty && hadFeaturesNetworkZones)
                   }
                 />
               )}
@@ -253,28 +257,30 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                   id="features_storage_buckets"
                   name="features_storage_buckets"
                   label="Storage buckets"
-                  onChange={() =>
+                  onChange={() => {
+                    ensureEditMode(formik);
                     void formik.setFieldValue(
                       "features_storage_buckets",
                       !formik.values.features_storage_buckets,
-                    )
-                  }
+                    );
+                  }}
                   checked={formik.values.features_storage_buckets}
-                  disabled={readOnly || isDefaultProject || isNonEmpty}
+                  disabled={isDefaultProject || isNonEmpty}
                 />
               )}
               <CheckboxInput
                 id="features_storage_volumes"
                 name="features_storage_volumes"
                 label="Storage volumes"
-                onChange={() =>
+                onChange={() => {
+                  ensureEditMode(formik);
                   void formik.setFieldValue(
                     "features_storage_volumes",
                     !formik.values.features_storage_volumes,
-                  )
-                }
+                  );
+                }}
                 checked={formik.values.features_storage_volumes}
-                disabled={readOnly || isDefaultProject || isNonEmpty}
+                disabled={isDefaultProject || isNonEmpty}
               />
             </>
           )}
@@ -293,14 +299,17 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 </Tooltip>
               </>
             }
-            onChange={() =>
-              void formik.setFieldValue("restricted", !formik.values.restricted)
-            }
+            onChange={() => {
+              ensureEditMode(formik);
+              void formik.setFieldValue(
+                "restricted",
+                !formik.values.restricted,
+              );
+            }}
             checked={formik.values.restricted}
             disabled={
-              formik.values.readOnly ||
-              (formik.values.features_profiles === false &&
-                features === "customised")
+              formik.values.features_profiles === false &&
+              features === "customised"
             }
           />
         </Col>

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -45,6 +45,7 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
   }>();
   const controllerState = useState<AbortController | null>(null);
   const { data: clusterMembers = [] } = useClusterMembers();
+  const [version, setVersion] = useState(0);
 
   if (!project) {
     return <>Missing project</>;
@@ -116,20 +117,17 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
         formik={formik}
         section={section ?? defaultFormSection}
         setSection={updateSection}
+        version={version}
       />
       <FormFooterLayout>
-        {formik.values.readOnly ? (
-          <Button
-            appearance="positive"
-            onClick={() => void formik.setFieldValue("readOnly", false)}
-          >
-            Edit pool
-          </Button>
-        ) : (
+        {formik.values.readOnly ? null : (
           <>
             <Button
               appearance="base"
-              onClick={() => formik.setValues(toStoragePoolFormValues(pool))}
+              onClick={() => {
+                setVersion((old) => old + 1);
+                void formik.setValues(toStoragePoolFormValues(pool));
+              }}
             >
               Cancel
             </Button>

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -37,6 +37,7 @@ import StoragePoolFormCeph from "./StoragePoolFormCeph";
 import StoragePoolFormPowerflex from "./StoragePoolFormPowerflex";
 import StoragePoolFormZFS from "./StoragePoolFormZFS";
 import { useSettings } from "context/useSettings";
+import { ensureEditMode } from "util/instanceEdit";
 
 export interface StoragePoolFormValues {
   isCreating: boolean;
@@ -72,6 +73,7 @@ interface Props {
   formik: FormikProps<StoragePoolFormValues>;
   section: string;
   setSection: (section: string) => void;
+  version?: number;
 }
 
 export const toStoragePool = (
@@ -157,7 +159,12 @@ export const toStoragePool = (
   };
 };
 
-const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
+const StoragePoolForm: FC<Props> = ({
+  formik,
+  section,
+  setSection,
+  version = 0,
+}) => {
   const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const docBaseLink = useDocs();
   const { data: settings } = useSettings();
@@ -222,10 +229,12 @@ const StoragePoolForm: FC<Props> = ({ formik, section, setSection }) => {
           )}
           {section === slugify(YAML_CONFIGURATION) && (
             <YamlForm
-              key={`yaml-form-${formik.values.readOnly}`}
+              key={`yaml-form-${version}`}
               yaml={getYaml()}
-              setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
-              readOnly={formik.values.readOnly}
+              setYaml={(yaml) => {
+                ensureEditMode(formik);
+                void formik.setFieldValue("yaml", yaml);
+              }}
             >
               <Notification severity="information" title="YAML Configuration">
                 {`${isSupportedStorageDriver ? "" : `The ${formik.values.driver} driver is not fully supported in the web interface. `}This is the YAML representation of the storage pool.`}

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -16,6 +16,7 @@ import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import { getCephPoolFormFields } from "util/storagePool";
 import { useSettings } from "context/useSettings";
 import ScrollableForm from "components/ScrollableForm";
+import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -50,7 +51,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
             type="text"
             label="Name"
             required
-            disabled={!formik.values.isCreating || formik.values.readOnly}
+            disabled={!formik.values.isCreating}
             help={
               !formik.values.isCreating
                 ? "Cannot rename storage pools"
@@ -60,8 +61,11 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
           <AutoExpandingTextArea
             {...getFormProps("description")}
             label="Description"
-            disabled={formik.values.readOnly}
             dynamicHeight
+            onChange={(e) => {
+              ensureEditMode(formik);
+              formik.handleChange(e);
+            }}
           />
           <Select
             id="driver"
@@ -94,7 +98,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
             }}
             value={formik.values.driver}
             required
-            disabled={!formik.values.isCreating || formik.values.readOnly}
+            disabled={!formik.values.isCreating}
           />
           {!isCephDriver && !isDirDriver && !isPowerFlexDriver && (
             <DiskSizeSelector
@@ -105,12 +109,11 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                   ? "Not available"
                   : "When left blank, defaults to 20% of free disk space. Default will be between 5GiB and 30GiB"
               }
-              setMemoryLimit={(val?: string) =>
-                void formik.setFieldValue("size", val)
-              }
-              disabled={
-                formik.values.driver === dirDriver || formik.values.readOnly
-              }
+              setMemoryLimit={(val?: string) => {
+                ensureEditMode(formik);
+                void formik.setFieldValue("size", val);
+              }}
+              disabled={formik.values.driver === dirDriver}
             />
           )}
           {!isPowerFlexDriver && (
@@ -119,8 +122,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
               type="text"
               disabled={
                 formik.values.driver === btrfsDriver ||
-                !formik.values.isCreating ||
-                formik.values.readOnly
+                !formik.values.isCreating
               }
               help={
                 formik.values.isCreating
@@ -138,6 +140,10 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 label="Powerflex pool"
                 placeholder="Enter powerflex pool"
                 help="ID or name of the remote PowerFlex storage pool"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
                 required
               />
               <Input
@@ -146,6 +152,10 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 label="Domain"
                 placeholder="Enter domain"
                 help="Name of the PowerFlex protection domain. Required if the Powerflex pool is a name."
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
               />
               <Input
                 {...formik.getFieldProps("powerflex_gateway")}
@@ -153,6 +163,10 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 label="Gateway"
                 placeholder="Enter gateway"
                 help="Address of the PowerFlex Gateway"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
                 required
               />
               <Input
@@ -166,6 +180,10 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                     <code>admin</code> if left empty.
                   </>
                 }
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
               />
               <Input
                 {...formik.getFieldProps("powerflex_user_password")}
@@ -173,6 +191,10 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 label="Password"
                 placeholder="Enter password"
                 help="Password for PowerFlex Gateway authentication"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
                 required
               />
             </>

--- a/src/pages/storage/forms/StorageVolumeEdit.tsx
+++ b/src/pages/storage/forms/StorageVolumeEdit.tsx
@@ -84,14 +84,7 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
         setSection={setSection}
       />
       <FormFooterLayout>
-        {formik.values.readOnly ? (
-          <Button
-            appearance="positive"
-            onClick={() => void formik.setFieldValue("readOnly", false)}
-          >
-            Edit volume
-          </Button>
-        ) : (
+        {formik.values.readOnly ? null : (
           <>
             <Button
               appearance="base"

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -11,6 +11,7 @@ import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import { optionTrueFalse } from "util/instanceOptions";
 import StoragePoolSelector from "pages/storage/StoragePoolSelector";
 import ScrollableForm from "components/ScrollableForm";
+import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
@@ -39,7 +40,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
             {...getFormProps(formik, "name")}
             type="text"
             label="Name"
-            disabled={formik.values.readOnly || !formik.values.isCreating}
+            disabled={!formik.values.isCreating}
             required={formik.values.isCreating}
             help={
               formik.values.isCreating
@@ -55,12 +56,11 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
                 ? "Size of storage volume. If empty, volume will not have a size limit within its storage pool."
                 : "Size is immutable for non-custom volumes."
             }
-            setMemoryLimit={(val?: string) =>
-              void formik.setFieldValue("size", val)
-            }
-            disabled={
-              formik.values.readOnly || formik.values.volumeType !== "custom"
-            }
+            setMemoryLimit={(val?: string) => {
+              ensureEditMode(formik);
+              void formik.setFieldValue("size", val);
+            }}
+            disabled={formik.values.volumeType !== "custom"}
           />
           <Select
             {...getFormProps(formik, "content_type")}
@@ -90,7 +90,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
               }
               void formik.setFieldValue("content_type", e.target.value);
             }}
-            disabled={formik.values.readOnly || !formik.values.isCreating}
+            disabled={!formik.values.isCreating}
           />
         </Col>
       </Row>

--- a/src/sass/_disk_device_form.scss
+++ b/src/sass/_disk_device_form.scss
@@ -43,6 +43,14 @@
     }
   }
 
+  .custom-disk-read-mode {
+    display: flex;
+
+    .custom-disk-value {
+      flex-grow: 1;
+    }
+  }
+
   .custom-disk-volume-source,
   .custom-disk-device-limits {
     align-items: center;

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -349,6 +349,7 @@
   .bottom-btns {
     margin-top: 1rem;
     max-width: 72rem;
+    min-height: 3.5rem;
     padding-right: 1.5rem;
   }
 }
@@ -361,5 +362,6 @@
   .bottom-btns {
     margin-top: 1rem;
     max-width: 70.5rem;
+    min-height: 3.5rem;
   }
 }

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -13,6 +13,7 @@ import { EditInstanceFormValues } from "pages/instances/EditInstance";
 import * as Yup from "yup";
 import { EditProfileFormValues } from "pages/profiles/EditProfile";
 import { migrationPayload } from "components/forms/MigrationForm";
+import { ConfigurationRowFormikProps } from "components/ConfigurationRow";
 
 const getEditValues = (
   item: LxdProfile | LxdInstance,
@@ -118,3 +119,9 @@ export const InstanceEditSchema: Yup.ObjectSchema<{
   name: Yup.string().required("Instance name is required"),
   instanceType: Yup.string().required("Instance type is required"),
 });
+
+export const ensureEditMode = (formik: ConfigurationRowFormikProps) => {
+  if (formik.values.readOnly) {
+    void formik.setFieldValue("readOnly", false);
+  }
+};

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -41,7 +41,7 @@ test("instance attach custom volumes and detach inherited volumes", async ({
   await attachVolume(page, instanceVolume, "/baz");
   await saveInstance(page, instance);
 
-  await page.getByRole("gridcell", { name: "Detached" }).click();
+  await assertTextVisible(page, "Reattach");
   await assertTextVisible(page, "/baz");
 
   await deleteInstance(page, instance);
@@ -69,7 +69,6 @@ test("profile edit custom volumes", async ({ page }) => {
   await page.getByRole("gridcell", { name: volume }).click();
   await page.getByRole("gridcell", { name: "/foo" }).click();
 
-  await page.getByRole("button", { name: "Edit profile" }).click();
   await detachVolume(page, "volume-1");
   await saveProfile(page, profile);
 
@@ -100,7 +99,6 @@ test("profile edit networks", async ({ page }) => {
   await page.getByText("Network devices").click();
   await page.getByRole("gridcell", { name: "eth0" }).click();
 
-  await page.getByRole("button", { name: "Edit profile" }).click();
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.locator("[id='devices.1.network']").selectOption({ index: 1 });
   await page.locator("[id='devices.1.name']").fill("eth1");

--- a/tests/doc-links.spec.ts
+++ b/tests/doc-links.spec.ts
@@ -132,7 +132,6 @@ test("Ensure the documentation link text and link targets are present: Project >
   const project = randomProjectName();
   await createProject(page, project);
   await page.getByRole("link", { name: "Configuration" }).click();
-  await page.getByRole("button", { name: "Edit configuration" }).click();
   await page.getByText("Allow custom restrictions on a project level").click();
 
   await page.getByText("Resource limits").click();

--- a/tests/helpers/configuration.ts
+++ b/tests/helpers/configuration.ts
@@ -54,7 +54,6 @@ export const setCpuLimit = async (
 ) => {
   await page.getByTestId("tab-link-Configuration").click();
   await page.getByText("Resource limits").click();
-  await page.getByRole("button", { name: "Edit" }).click();
   await activateOverride(page, "Exposed CPU limit");
   await page.getByText(type).first().click();
   const placeholder =
@@ -73,7 +72,6 @@ export const setMemLimit = async (
 ) => {
   await page.getByTestId("tab-link-Configuration").click();
   await page.getByText("Resource limits").click();
-  await page.getByRole("button", { name: "Edit" }).click();
   await activateOverride(page, "Memory limit");
   await page.getByRole("row", { name: "Memory limit" }).getByText(type).click();
   const text = type === "percentage" ? "Enter percentage" : "Enter value";
@@ -104,10 +102,24 @@ export const setSchedule = async (
 
 export const activateOverride = async (page: Page, field: string) => {
   if (
-    !(await page
+    await page
       .getByRole("row", { name: field })
-      .getByRole("button", { name: "Clear override" })
-      .isVisible())
+      .getByRole("button", { name: "Edit" })
+      .isVisible()
+  ) {
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Edit" })
+      .click();
+
+    return;
+  }
+
+  if (
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Create override" })
+      .isVisible()
   ) {
     await page
       .getByRole("row", { name: field })

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -53,7 +53,6 @@ export const visitInstance = async (
 export const editInstance = async (page: Page, instance: string) => {
   await visitInstance(page, instance);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByRole("button", { name: "Edit instance" }).click();
 };
 
 export const saveInstance = async (page: Page, instance: string) => {

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -44,16 +44,6 @@ export const visitNetwork = async (page: Page, network: string) => {
   await page.getByTestId("tab-link-Configuration").click();
 };
 
-export const saveNetwork = async (page: Page, network: string) => {
-  await page.getByRole("button", { name: "Save changes" }).click();
-  await page.waitForSelector(`text=Network ${network} updated.`);
-  await page.getByRole("button", { name: "Close notification" }).click();
-};
-
-export const editNetwork = async (page: Page) => {
-  await page.getByRole("button", { name: "Edit network" }).click();
-};
-
 export const prepareNetworkTabEdit = async (
   page: Page,
   tabLocation: string,
@@ -64,7 +54,6 @@ export const prepareNetworkTabEdit = async (
     .getByLabel("Network form navigation")
     .getByText(tabLocation)
     .click();
-  await editNetwork(page);
   await activateAllTableOverrides(page);
 };
 
@@ -84,7 +73,7 @@ export const visitNetworkConfiguration = async (page: Page, tab: string) => {
 export const createNetworkForward = async (page: Page, network: string) => {
   await createNetwork(page, network);
   await visitNetwork(page, network);
-  await editNetwork(page);
+  await page.getByRole("gridcell", { name: "/24" }).getByRole("button").click();
 
   const networkSubnet = await page.inputValue("input#ipv4_address");
 

--- a/tests/helpers/profile.ts
+++ b/tests/helpers/profile.ts
@@ -78,5 +78,4 @@ export const saveProfile = async (page: Page, profile: string) => {
 export const editProfile = async (page: Page, profile: string) => {
   await visitProfile(page, profile);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByRole("button", { name: "Edit profile" }).click();
 };

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -36,7 +36,6 @@ export const visitPool = async (page: Page, pool: string) => {
 export const editPool = async (page: Page, pool: string) => {
   await visitPool(page, pool);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByRole("button", { name: "Edit pool" }).click();
 };
 
 export const savePool = async (page: Page, pool: string) => {

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -47,7 +47,6 @@ export const visitVolume = async (page: Page, volume: string) => {
 export const editVolume = async (page: Page, volume: string) => {
   await visitVolume(page, volume);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByRole("button", { name: "Edit volume" }).click();
 };
 
 export const saveVolume = async (page: Page, volume: string) => {

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -8,7 +8,6 @@ import {
   createNetwork,
   createNetworkForward,
   deleteNetwork,
-  editNetwork,
   prepareNetworkTabEdit,
   randomNetworkName,
   visitNetwork,
@@ -40,7 +39,6 @@ test.describe("bridge type", () => {
 
   test("configure main bridge network settings", async ({ page }) => {
     await visitNetwork(page, network);
-    await editNetwork(page);
 
     const DESCRIPTION = "A-new-description";
     await page.getByPlaceholder("Enter description").fill(DESCRIPTION);

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -34,7 +34,6 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await createProject(page, project);
 
   await page.getByRole("link", { name: "Configuration" }).click();
-  await page.getByRole("button", { name: "Edit configuration" }).click();
   await page.getByPlaceholder("Enter description").fill("A-new-description");
   await page
     .getByRole("combobox", { name: "Features" })

--- a/tests/readme-screenshots.spec.ts
+++ b/tests/readme-screenshots.spec.ts
@@ -36,7 +36,6 @@ test("instance list screen", async ({ page }) => {
   await createProject(page, project);
   await visitProfile(page, "default", project);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByRole("button", { name: "Edit profile" }).click();
   await page.getByText("Disk devices").click();
   await page.getByRole("button", { name: "Create override" }).click();
   await page.getByRole("button", { name: "Save changes" }).click();


### PR DESCRIPTION
## Done

- simpler one click edit mode for edit forms on instances, profiles networks, storage pools, storage volumes and projects

Fixes WD-14393

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check edit and creation of instances, profiles networks, storage pools, storage volumes and projects