### PR TITLE
feat: [WD-14389] Combine instance detail page actions

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -99,7 +99,7 @@ const RenameHeader: FC<Props> = ({
               </li>
             ) : (
               <li
-                className="p-heading--4 u-no-margin--bottom name continuous-breadcrumb"
+                className="p-heading--4 u-no-margin--bottom name continuous-breadcrumb u-truncate"
                 onClick={toggleRename}
                 title={`Rename ${name}`}
               >

--- a/src/pages/instances/InstanceDetailActions.tsx
+++ b/src/pages/instances/InstanceDetailActions.tsx
@@ -1,0 +1,73 @@
+import { FC, cloneElement, useState } from "react";
+import DeleteInstanceBtn from "./actions/DeleteInstanceBtn";
+import { LxdInstance } from "types/instance";
+import MigrateInstanceBtn from "./actions/MigrateInstanceBtn";
+import CreateImageFromInstanceBtn from "./actions/CreateImageFromInstanceBtn";
+import DuplicateInstanceBtn from "./actions/DuplicateInstanceBtn";
+import { ContextualMenu } from "@canonical/react-components";
+import { isWidthBelow } from "util/helpers";
+import useEventListener from "@use-it/event-listener";
+
+interface Props {
+  instance: LxdInstance;
+  project: string;
+  isLoading: boolean;
+}
+
+const InstanceDetailActions: FC<Props> = ({ instance, project, isLoading }) => {
+  const [isLargeScreen, setIsLargeScreen] = useState(isWidthBelow(1200));
+
+  useEventListener("resize", () => setIsLargeScreen(isWidthBelow(1200)));
+  const classname = isLargeScreen ? "p-contextual-menu__link" : "";
+
+  const menuElements = [
+    <MigrateInstanceBtn
+      key="migrate"
+      instance={instance}
+      project={project}
+      classname={classname}
+    />,
+    <CreateImageFromInstanceBtn
+      key="publish"
+      instance={instance}
+      classname={classname}
+    />,
+    <DuplicateInstanceBtn
+      key="duplicate"
+      instance={instance}
+      isLoading={isLoading}
+      classname={classname}
+    />,
+    <DeleteInstanceBtn
+      key="delete"
+      instance={instance}
+      classname={classname}
+    />,
+  ];
+
+  return (
+    <>
+      {isLargeScreen ? (
+        <ContextualMenu
+          closeOnOutsideClick={false}
+          toggleLabel="Actions"
+          position="left"
+          hasToggleIcon
+          title="actions"
+        >
+          {(close: () => void) => (
+            <span>
+              {[...menuElements].map((item) =>
+                cloneElement(item, { onClose: close }),
+              )}
+            </span>
+          )}
+        </ContextualMenu>
+      ) : (
+        <>{menuElements}</>
+      )}
+    </>
+  );
+};
+
+export default InstanceDetailActions;

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import DeleteInstanceBtn from "./actions/DeleteInstanceBtn";
 import { LxdInstance } from "types/instance";
 import RenameHeader, { RenameHeaderValues } from "components/RenameHeader";
 import { renameInstance } from "api/instances";
@@ -16,11 +15,7 @@ import {
 } from "util/instances";
 import { getInstanceName } from "util/operations";
 import InstanceLink from "pages/instances/InstanceLink";
-import MigrateInstanceBtn from "./actions/MigrateInstanceBtn";
-import { useSettings } from "context/useSettings";
-import { isClusteredServer } from "util/settings";
-import CreateImageFromInstanceBtn from "./actions/CreateImageFromInstanceBtn";
-import DuplicateInstanceBtn from "./actions/DuplicateInstanceBtn";
+import InstanceDetailActions from "./InstanceDetailActions";
 
 interface Props {
   name: string;
@@ -39,8 +34,6 @@ const InstanceDetailHeader: FC<Props> = ({
   const navigate = useNavigate();
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
-  const { data: settings } = useSettings();
-  const isClustered = isClusteredServer(settings);
 
   const RenameSchema = Yup.object().shape({
     name: instanceNameValidation(project, controllerState, name).required(
@@ -126,18 +119,11 @@ const InstanceDetailHeader: FC<Props> = ({
         }
         controls={
           instance ? (
-            <>
-              {isClustered ? (
-                <MigrateInstanceBtn instance={instance} project={project} />
-              ) : null}
-              <CreateImageFromInstanceBtn key="publish" instance={instance} />
-              <DuplicateInstanceBtn
-                key="duplicate"
-                instance={instance}
-                isLoading={isLoading}
-              />
-              <DeleteInstanceBtn key="delete" instance={instance} />
-            </>
+            <InstanceDetailActions
+              instance={instance}
+              project={project}
+              isLoading={isLoading}
+            />
           ) : null
         }
         isLoaded={Boolean(instance)}

--- a/src/pages/instances/actions/CreateImageFromInstanceBtn.tsx
+++ b/src/pages/instances/actions/CreateImageFromInstanceBtn.tsx
@@ -4,12 +4,19 @@ import { ActionButton } from "@canonical/react-components";
 import usePortal from "react-useportal";
 import CreateImageFromInstanceForm from "../forms/CreateImageFromInstanceForm";
 import { useInstanceLoading } from "context/instanceLoading";
+import classNames from "classnames";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
+  onClose?: () => void;
 }
 
-const CreateImageFromInstanceBtn: FC<Props> = ({ instance }) => {
+const CreateImageFromInstanceBtn: FC<Props> = ({
+  instance,
+  classname,
+  onClose,
+}) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const instanceLoading = useInstanceLoading();
   const prohibitedStatuses = ["Error", "Frozen", "Running"];
@@ -18,18 +25,24 @@ const CreateImageFromInstanceBtn: FC<Props> = ({ instance }) => {
     prohibitedStatuses.includes(instance?.status) ||
     Boolean(instanceLoading.getType(instance));
 
+  const handleClose = () => {
+    closePortal();
+    onClose?.();
+  };
+
   return (
     <>
       {isOpen && (
         <Portal>
           <CreateImageFromInstanceForm
-            close={closePortal}
+            close={handleClose}
             instance={instance}
           />
         </Portal>
       )}
       <ActionButton
         appearance="default"
+        className={classNames("u-no-margin--bottom", classname)}
         onClick={openPortal}
         aria-label="Create image"
         title={

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -4,8 +4,7 @@ import { LxdInstance } from "types/instance";
 import { useNavigate } from "react-router-dom";
 import ItemName from "components/ItemName";
 import { deletableStatuses } from "util/instanceDelete";
-import { useSmallScreen } from "context/useSmallScreen";
-import { ConfirmationButton, Icon } from "@canonical/react-components";
+import { ConfirmationButton } from "@canonical/react-components";
 import classnames from "classnames";
 import { useEventQueue } from "context/eventQueue";
 import { queryKeys } from "util/queryKeys";
@@ -16,11 +15,12 @@ import { useInstanceLoading } from "context/instanceLoading";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
+  onClose?: () => void;
 }
 
-const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
+const DeleteInstanceBtn: FC<Props> = ({ instance, classname, onClose }) => {
   const eventQueue = useEventQueue();
-  const isDeleteIcon = useSmallScreen();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const instanceLoading = useInstanceLoading();
@@ -74,12 +74,11 @@ const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
   return (
     <ConfirmationButton
       onHoverText={getHoverText()}
-      appearance={isDeleteIcon ? "base" : "default"}
-      className={classnames("u-no-margin--bottom", {
-        "has-icon": isDeleteIcon,
-      })}
+      appearance="default"
+      className={classnames("u-no-margin--bottom", classname)}
       loading={isLoading}
       confirmationModalProps={{
+        close: onClose,
         title: "Confirm delete",
         children: (
           <p>
@@ -95,8 +94,7 @@ const DeleteInstanceBtn: FC<Props> = ({ instance }) => {
       shiftClickEnabled
       showShiftClickHint
     >
-      {isDeleteIcon && <Icon name="delete" />}
-      {!isDeleteIcon && <span>Delete instance</span>}
+      <span>Delete instance</span>
     </ConfirmationButton>
   );
 };

--- a/src/pages/instances/actions/DuplicateInstanceBtn.tsx
+++ b/src/pages/instances/actions/DuplicateInstanceBtn.tsx
@@ -3,26 +3,39 @@ import { LxdInstance } from "types/instance";
 import { Button } from "@canonical/react-components";
 import usePortal from "react-useportal";
 import DuplicateInstanceForm from "../forms/DuplicateInstanceForm";
+import classNames from "classnames";
 
 interface Props {
   instance: LxdInstance;
   isLoading: boolean;
+  classname?: string;
+  onClose?: () => void;
 }
 
-const DuplicateInstanceBtn: FC<Props> = ({ instance, isLoading }) => {
+const DuplicateInstanceBtn: FC<Props> = ({
+  instance,
+  isLoading,
+  classname,
+  onClose,
+}) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  const handleClose = () => {
+    closePortal();
+    onClose?.();
+  };
 
   return (
     <>
       {isOpen && (
         <Portal>
-          <DuplicateInstanceForm close={closePortal} instance={instance} />
+          <DuplicateInstanceForm close={handleClose} instance={instance} />
         </Portal>
       )}
       <Button
         appearance="default"
         aria-label="Duplicate instance"
-        className="u-no-margin--bottom"
+        className={classNames("u-no-margin--bottom", classname)}
         disabled={isLoading}
         onClick={openPortal}
         title="Duplicate instance"

--- a/src/sass/_rename_header.scss
+++ b/src/sass/_rename_header.scss
@@ -11,7 +11,7 @@
 
     .name {
       margin-right: $sph--large;
-      max-width: 33vw;
+      max-width: 26vw;
       overflow: clip !important;
 
       > span > span {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -206,7 +206,7 @@ body {
     margin-bottom: 0;
 
     .continuous-breadcrumb {
-      display: inline;
+      display: inline-block;
     }
   }
 


### PR DESCRIPTION
## Done

- Moving buttons into InstanceDetailHeaderDropdown component.
- Minor scss changes
- Changed DeleteInstanceBtn to no longer use an icon as the situation in which this exists (when page is minimised) has changed.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to instance detail page on a medium+ sized screen and view the instance buttons in a row.
    - Then, minimise screen (Can use inspect element displayed vertically to achieve this) and refresh the page/render the page for the first time to see the icons as a dropdown.

## Screenshots
Medium Screen:
![image](https://github.com/user-attachments/assets/4647d0bf-8c15-4927-9046-bf5106bf7213)
![image](https://github.com/user-attachments/assets/c4b99e61-f225-48e9-a094-b14223d6e681)

Large screen:
![image](https://github.com/user-attachments/assets/2483a249-b5f9-4963-ac07-03bab411624c)
