### PR TITLE
move yaml switch to the footer of forms and flatten navigation

### DIFF
--- a/src/components/forms/YamlConfirmation.tsx
+++ b/src/components/forms/YamlConfirmation.tsx
@@ -9,7 +9,8 @@ interface Props {
 const YamlConfirmation: FC<Props> = ({ onConfirm, close }) => {
   return (
     <ConfirmationModal
-      confirmButtonLabel="Discard changes"
+      confirmButtonLabel="Leave without saving"
+      cancelButtonLabel="Continue editing"
       onConfirm={onConfirm}
       close={close}
       title="Confirm"

--- a/src/components/forms/YamlNotification.tsx
+++ b/src/components/forms/YamlNotification.tsx
@@ -1,0 +1,50 @@
+import { FC, useState } from "react";
+import { Notification } from "@canonical/react-components";
+import { pluralize } from "util/instanceBulkActions";
+
+const loadClosed = (entity: string) => {
+  const saved = localStorage.getItem(`yamlNotificationClosed${entity}`);
+  return Boolean(saved);
+};
+
+const saveClosed = (entity: string) => {
+  localStorage.setItem(`yamlNotificationClosed${entity}`, "yes");
+};
+
+interface Props {
+  entity: string;
+  href: string;
+}
+
+const YamlNotification: FC<Props> = ({ entity, href }) => {
+  const [closed, setClosed] = useState(loadClosed(entity));
+
+  if (closed) {
+    return null;
+  }
+
+  const handleClose = () => {
+    saveClosed(entity);
+    setClosed(true);
+    setTimeout(() => {
+      window.dispatchEvent(new Event("resize"));
+      // ensure the Yaml editor is resized after the notification is closed
+    }, 250);
+  };
+
+  return (
+    <Notification
+      severity="information"
+      title="YAML Configuration"
+      onDismiss={handleClose}
+    >
+      This is the YAML representation of the {entity}.
+      <br />
+      <a href={href} target="_blank" rel="noopener noreferrer">
+        Learn more about {pluralize(entity, 2)}
+      </a>
+    </Notification>
+  );
+};
+
+export default YamlNotification;

--- a/src/components/forms/YamlSwitch.tsx
+++ b/src/components/forms/YamlSwitch.tsx
@@ -1,0 +1,66 @@
+import { FC, FormEvent } from "react";
+import { Switch } from "@canonical/react-components";
+import YamlConfirmation from "components/forms/YamlConfirmation";
+import { slugify } from "util/slugify";
+import {
+  MAIN_CONFIGURATION,
+  YAML_CONFIGURATION,
+} from "pages/instances/forms/InstanceFormMenu";
+import usePortal from "react-useportal";
+import { FormikProps } from "formik/dist/types";
+import classnames from "classnames";
+
+interface Props {
+  section?: string;
+  setSection: (section: string) => void;
+  formik: unknown;
+  disableReason?: string;
+}
+
+const YamlSwitch: FC<Props> = ({
+  section,
+  setSection,
+  formik,
+  disableReason,
+}) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const yamlFormik = formik as FormikProps<{ yaml: string }>;
+
+  const isChecked = slugify(section ?? "") === slugify(YAML_CONFIGURATION);
+
+  const handleSwitch = (e: FormEvent) => {
+    if (yamlFormik.values.yaml) {
+      return openPortal(e);
+    }
+
+    const newSection = isChecked ? MAIN_CONFIGURATION : YAML_CONFIGURATION;
+    setSection(newSection);
+  };
+
+  const handleConfirm = () => {
+    void yamlFormik.setFieldValue("yaml", undefined);
+    closePortal();
+    setSection(MAIN_CONFIGURATION);
+  };
+
+  return (
+    <div
+      title={disableReason}
+      className={classnames("u-float-left", { "is-disabled": disableReason })}
+    >
+      {isOpen && (
+        <Portal>
+          <YamlConfirmation onConfirm={handleConfirm} close={closePortal} />
+        </Portal>
+      )}
+      <Switch
+        label="YAML Configuration"
+        checked={isChecked}
+        onChange={handleSwitch}
+        disabled={disableReason !== undefined}
+      />
+    </div>
+  );
+};
+
+export default YamlSwitch;

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Col,
   Form,
-  Notification,
   Row,
 } from "@canonical/react-components";
 import { useFormik } from "formik";
@@ -32,13 +31,13 @@ import YamlForm, { YamlFormValues } from "components/forms/YamlForm";
 import EditInstanceDetails from "pages/instances/forms/EditInstanceDetails";
 import InstanceFormMenu, {
   CLOUD_INIT,
+  DISK_DEVICES,
   MAIN_CONFIGURATION,
   MIGRATION,
   NETWORK_DEVICES,
   RESOURCE_LIMITS,
   SECURITY_POLICIES,
   SNAPSHOTS,
-  DISK_DEVICES,
   YAML_CONFIGURATION,
 } from "pages/instances/forms/InstanceFormMenu";
 import useEventListener from "@use-it/event-listener";
@@ -61,6 +60,8 @@ import { useDocs } from "context/useDocs";
 import MigrationForm, {
   MigrationFormValues,
 } from "components/forms/MigrationForm";
+import YamlSwitch from "components/forms/YamlSwitch";
+import YamlNotification from "components/forms/YamlNotification";
 
 export interface InstanceEditDetailsFormValues {
   name: string;
@@ -95,7 +96,6 @@ const EditInstance: FC<Props> = ({ instance }) => {
   }>();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [isConfigOpen, setConfigOpen] = useState(true);
   const [version, setVersion] = useState(0);
 
   if (!project) {
@@ -162,10 +162,6 @@ const EditInstance: FC<Props> = ({ instance }) => {
       : navigate(`${baseUrl}/${slugify(newSection)}`);
   };
 
-  const toggleMenu = () => {
-    setConfigOpen((old) => !old);
-  };
-
   const getYaml = () => {
     const exclude = new Set([
       "backups",
@@ -186,16 +182,15 @@ const EditInstance: FC<Props> = ({ instance }) => {
   return (
     <div className="edit-instance">
       <Form onSubmit={formik.handleSubmit} className="form">
-        <InstanceFormMenu
-          active={section ?? slugify(MAIN_CONFIGURATION)}
-          setActive={updateSection}
-          isConfigDisabled={false}
-          isConfigOpen={isConfigOpen}
-          toggleConfigOpen={toggleMenu}
-          hasDiskError={hasDiskError(formik)}
-          hasNetworkError={hasNetworkError(formik)}
-          formik={formik}
-        />
+        {section !== slugify(YAML_CONFIGURATION) && (
+          <InstanceFormMenu
+            active={section ?? slugify(MAIN_CONFIGURATION)}
+            setActive={updateSection}
+            isConfigDisabled={false}
+            hasDiskError={hasDiskError(formik)}
+            hasNetworkError={hasNetworkError(formik)}
+          />
+        )}
         <Row className="form-contents" key={section}>
           <Col size={12}>
             {(section === slugify(MAIN_CONFIGURATION) || !section) && (
@@ -239,23 +234,21 @@ const EditInstance: FC<Props> = ({ instance }) => {
                   void formik.setFieldValue("yaml", yaml);
                 }}
               >
-                <Notification severity="information" title="YAML Configuration">
-                  This is the YAML representation of the instance.
-                  <br />
-                  <a
-                    href={`${docBaseLink}/instances`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Learn more about instances
-                  </a>
-                </Notification>
+                <YamlNotification
+                  entity="instance"
+                  href={`${docBaseLink}/instances`}
+                />
               </YamlForm>
             )}
           </Col>
         </Row>
       </Form>
       <FormFooterLayout>
+        <YamlSwitch
+          formik={formik}
+          section={section}
+          setSection={updateSection}
+        />
         {readOnly ? null : (
           <>
             <Button

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -1,10 +1,8 @@
-import { FC, ReactNode, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useNotify } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
-import YamlConfirmation from "components/forms/YamlConfirmation";
-import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk devices";
@@ -17,48 +15,27 @@ export const CLOUD_INIT = "Cloud init";
 export const YAML_CONFIGURATION = "YAML configuration";
 
 interface Props {
-  isConfigOpen: boolean;
   isConfigDisabled: boolean;
-  toggleConfigOpen: () => void;
   active: string;
   setActive: (val: string) => void;
   hasDiskError: boolean;
   hasNetworkError: boolean;
-  formik: InstanceAndProfileFormikProps;
 }
 
 const InstanceFormMenu: FC<Props> = ({
-  isConfigOpen,
   isConfigDisabled,
-  toggleConfigOpen,
   active,
   setActive,
   hasDiskError,
   hasNetworkError,
-  formik,
 }) => {
   const notify = useNotify();
-  const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const menuItemProps = {
     active,
-    setActive: (val: string) => {
-      if (Boolean(formik.values.yaml) && val !== YAML_CONFIGURATION) {
-        const handleConfirm = () => {
-          void formik.setFieldValue("yaml", undefined);
-          setConfirmModal(null);
-          setActive(val);
-        };
-
-        setConfirmModal(
-          <YamlConfirmation
-            onConfirm={handleConfirm}
-            close={() => setConfirmModal(null)}
-          />,
-        );
-      } else {
-        setActive(val);
-      }
-    },
+    setActive,
+    disableReason: isConfigDisabled
+      ? "Please select an image before adding custom configuration"
+      : undefined,
   };
 
   const resize = () => {
@@ -69,59 +46,24 @@ const InstanceFormMenu: FC<Props> = ({
 
   return (
     <div className="p-side-navigation--accordion form-navigation">
-      {confirmModal}
       <nav aria-label="Instance form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={isConfigOpen ? "true" : "false"}
-              onClick={toggleConfigOpen}
-              disabled={isConfigDisabled}
-              title={
-                isConfigDisabled
-                  ? "Please select an image before adding custom configuration"
-                  : ""
-              }
-            >
-              Advanced
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={isConfigOpen ? "true" : "false"}
-            >
-              <MenuItem
-                label={DISK_DEVICES}
-                hasError={hasDiskError}
-                {...menuItemProps}
-              />
-              <MenuItem
-                label={NETWORK_DEVICES}
-                hasError={hasNetworkError}
-                {...menuItemProps}
-              />
-              <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
-              <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
-              <MenuItem label={SNAPSHOTS} {...menuItemProps} />
-              <MenuItem label={MIGRATION} {...menuItemProps} />
-              <MenuItem label={CLOUD_INIT} {...menuItemProps} />
-            </ul>
-          </li>
-          {isConfigDisabled ? (
-            <li className="p-side-navigation__item">
-              <Button
-                className="p-side-navigation__link p-button--base"
-                disabled={true}
-                title="Please select an image before adding custom configuration"
-              >
-                {YAML_CONFIGURATION}
-              </Button>
-            </li>
-          ) : (
-            <MenuItem label={YAML_CONFIGURATION} {...menuItemProps} />
-          )}
+          <MenuItem
+            label={DISK_DEVICES}
+            hasError={hasDiskError}
+            {...menuItemProps}
+          />
+          <MenuItem
+            label={NETWORK_DEVICES}
+            hasError={hasNetworkError}
+            {...menuItemProps}
+          />
+          <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
+          <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
+          <MenuItem label={SNAPSHOTS} {...menuItemProps} />
+          <MenuItem label={MIGRATION} {...menuItemProps} />
+          <MenuItem label={CLOUD_INIT} {...menuItemProps} />
         </ul>
       </nav>
     </div>

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -23,6 +23,7 @@ import { MAIN_CONFIGURATION } from "pages/networks/forms/NetworkFormMenu";
 import { slugify } from "util/slugify";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
+import YamlSwitch from "components/forms/YamlSwitch";
 
 const CreateNetwork: FC = () => {
   const navigate = useNavigate();
@@ -119,6 +120,18 @@ const CreateNetwork: FC = () => {
         setSection={updateSection}
       />
       <FormFooterLayout>
+        <div className="yaml-switch">
+          <YamlSwitch
+            formik={formik}
+            section={section}
+            setSection={updateSection}
+            disableReason={
+              formik.values.name
+                ? undefined
+                : "Please enter a network name to enable this section"
+            }
+          />
+        </div>
         <Button
           appearance="base"
           onClick={() => navigate(`/ui/project/${project}/networks`)}

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -24,6 +24,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { MAIN_CONFIGURATION } from "pages/networks/forms/NetworkFormMenu";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
+import YamlSwitch from "components/forms/YamlSwitch";
 
 interface Props {
   network: LxdNetwork;
@@ -122,6 +123,16 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
         version={version}
       />
       <FormFooterLayout>
+        <YamlSwitch
+          formik={formik}
+          section={section}
+          setSection={setSection}
+          disableReason={
+            formik.values.name
+              ? undefined
+              : "Please enter a network name to enable this section"
+          }
+        />
         {readOnly ? null : (
           <>
             <Button

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -1,12 +1,5 @@
-import { FC, ReactNode, useEffect, useState } from "react";
-import {
-  Col,
-  Form,
-  Input,
-  Notification,
-  Row,
-  useNotify,
-} from "@canonical/react-components";
+import { FC, useEffect } from "react";
+import { Col, Form, Input, Row, useNotify } from "@canonical/react-components";
 import {
   LxdNetwork,
   LxdNetworkBridgeDriver,
@@ -34,9 +27,9 @@ import NetworkFormIpv4 from "pages/networks/forms/NetworkFormIpv4";
 import NetworkFormIpv6 from "pages/networks/forms/NetworkFormIpv6";
 import { slugify } from "util/slugify";
 import { useDocs } from "context/useDocs";
-import YamlConfirmation from "components/forms/YamlConfirmation";
 import { getHandledNetworkConfigKeys, getNetworkKey } from "util/networks";
 import NetworkFormOvn from "pages/networks/forms/NetworkFormOvn";
+import YamlNotification from "components/forms/YamlNotification";
 import { ensureEditMode } from "util/instanceEdit";
 
 export interface NetworkFormValues {
@@ -171,7 +164,6 @@ const NetworkForm: FC<Props> = ({
   setSection,
   version = 0,
 }) => {
-  const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const docBaseLink = useDocs();
   const notify = useNotify();
 
@@ -181,35 +173,17 @@ const NetworkForm: FC<Props> = ({
   useEffect(updateFormHeight, [notify.notification?.message, section]);
   useEventListener("resize", updateFormHeight);
 
-  const handleSetActive = (val: string) => {
-    if (Boolean(formik.values.yaml) && val !== YAML_CONFIGURATION) {
-      const handleConfirm = () => {
-        void formik.setFieldValue("yaml", undefined);
-        setConfirmModal(null);
-        setSection(val);
-      };
-
-      setConfirmModal(
-        <YamlConfirmation
-          onConfirm={handleConfirm}
-          close={() => setConfirmModal(null)}
-        />,
-      );
-    } else {
-      setSection(val);
-    }
-  };
-
   return (
     <Form className="form network-form" onSubmit={formik.handleSubmit}>
-      {confirmModal}
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden value="Hidden input" />
-      <NetworkFormMenu
-        active={section}
-        setActive={handleSetActive}
-        formik={formik}
-      />
+      {section !== slugify(YAML_CONFIGURATION) && (
+        <NetworkFormMenu
+          active={section}
+          setActive={setSection}
+          formik={formik}
+        />
+      )}
       <Row className="form-contents" key={section}>
         <Col size={12}>
           {section === slugify(MAIN_CONFIGURATION) && (
@@ -229,17 +203,10 @@ const NetworkForm: FC<Props> = ({
                 void formik.setFieldValue("yaml", yaml);
               }}
             >
-              <Notification severity="information" title="YAML Configuration">
-                This is the YAML representation of the network.
-                <br />
-                <a
-                  href={`${docBaseLink}/explanation/networks/#managed-networks`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Learn more about networks
-                </a>
-              </Notification>
+              <YamlNotification
+                entity="network"
+                href={`${docBaseLink}/explanation/networks/#managed-networks`}
+              />
             </YamlForm>
           )}
         </Col>

--- a/src/pages/networks/forms/NetworkFormMenu.tsx
+++ b/src/pages/networks/forms/NetworkFormMenu.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useNotify } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { FormikProps } from "formik/dist/types";
@@ -22,7 +22,6 @@ interface Props {
 
 const NetworkFormMenu: FC<Props> = ({ active, setActive, formik }) => {
   const notify = useNotify();
-  const [isAdvancedOpen, setAdvancedOpen] = useState(!formik.values.isCreating);
   const menuItemProps = {
     active,
     setActive,
@@ -50,65 +49,39 @@ const NetworkFormMenu: FC<Props> = ({ active, setActive, formik }) => {
       <nav aria-label="Network form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={
-                !disableReason && isAdvancedOpen ? "true" : "false"
-              }
-              onClick={() => setAdvancedOpen(!isAdvancedOpen)}
-              disabled={Boolean(disableReason)}
-              title={disableReason}
-            >
-              Advanced
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={
-                !disableReason && isAdvancedOpen ? "true" : "false"
-              }
-            >
-              {formik.values.networkType !== "physical" && (
-                <MenuItem
-                  label={BRIDGE}
-                  {...menuItemProps}
-                  disableReason={disableReason}
-                />
-              )}
-              <MenuItem
-                label={DNS}
-                {...menuItemProps}
-                disableReason={disableReason}
-              />
-              {formik.values.ipv4_address !== "none" && (
-                <MenuItem
-                  label={IPV4}
-                  {...menuItemProps}
-                  disableReason={disableReason}
-                />
-              )}
-              {formik.values.ipv6_address !== "none" && (
-                <MenuItem
-                  label={IPV6}
-                  {...menuItemProps}
-                  disableReason={disableReason}
-                />
-              )}
-              {formik.values.networkType === "physical" && (
-                <MenuItem
-                  label={OVN}
-                  {...menuItemProps}
-                  disableReason={disableReason}
-                />
-              )}
-            </ul>
-          </li>
+          {formik.values.networkType !== "physical" && (
+            <MenuItem
+              label={BRIDGE}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
           <MenuItem
-            label={YAML_CONFIGURATION}
+            label={DNS}
             {...menuItemProps}
             disableReason={disableReason}
           />
+          {formik.values.ipv4_address !== "none" && (
+            <MenuItem
+              label={IPV4}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
+          {formik.values.ipv6_address !== "none" && (
+            <MenuItem
+              label={IPV6}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
+          {formik.values.networkType === "physical" && (
+            <MenuItem
+              label={OVN}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
         </ul>
       </nav>
     </div>

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Col,
   Form,
-  Notification,
   Row,
   useNotify,
 } from "@canonical/react-components";
@@ -64,6 +63,8 @@ import MigrationForm, {
   MigrationFormValues,
   migrationPayload,
 } from "components/forms/MigrationForm";
+import YamlSwitch from "components/forms/YamlSwitch";
+import YamlNotification from "components/forms/YamlNotification";
 
 export type CreateProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -83,7 +84,6 @@ const CreateProfile: FC = () => {
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
   const [section, setSection] = useState(MAIN_CONFIGURATION);
-  const [isConfigOpen, setConfigOpen] = useState(false);
 
   if (!project) {
     return <>Missing project</>;
@@ -157,10 +157,6 @@ const CreateProfile: FC = () => {
     setSection(newItem);
   };
 
-  const toggleMenu = () => {
-    setConfigOpen((old) => !old);
-  };
-
   function getYaml() {
     const payload = getCreationPayload(formik.values);
     return dumpYaml(payload);
@@ -169,14 +165,14 @@ const CreateProfile: FC = () => {
   return (
     <BaseLayout title="Create a profile" contentClassName="create-profile">
       <Form onSubmit={formik.handleSubmit} className="form">
-        <ProfileFormMenu
-          active={section}
-          setActive={updateSection}
-          isConfigOpen={Boolean(formik.values.name) && isConfigOpen}
-          toggleConfigOpen={toggleMenu}
-          hasName={Boolean(formik.values.name)}
-          formik={formik}
-        />
+        {section !== YAML_CONFIGURATION && (
+          <ProfileFormMenu
+            active={section}
+            setActive={updateSection}
+            hasName={Boolean(formik.values.name)}
+            formik={formik}
+          />
+        )}
         <Row className="form-contents" key={section}>
           <Col size={12}>
             <NotificationRow />
@@ -211,23 +207,28 @@ const CreateProfile: FC = () => {
                 yaml={getYaml()}
                 setYaml={(yaml) => void formik.setFieldValue("yaml", yaml)}
               >
-                <Notification severity="information" title="YAML Configuration">
-                  This is the YAML representation of the profile.
-                  <br />
-                  <a
-                    href={`${docBaseLink}/profiles`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Learn more about profiles
-                  </a>
-                </Notification>
+                <YamlNotification
+                  entity="profile"
+                  href={`${docBaseLink}/profiles`}
+                />
               </YamlForm>
             )}
           </Col>
         </Row>
       </Form>
       <FormFooterLayout>
+        <div className="yaml-switch">
+          <YamlSwitch
+            formik={formik}
+            section={section}
+            setSection={updateSection}
+            disableReason={
+              formik.values.name
+                ? undefined
+                : "Please enter a profile name before adding custom configuration"
+            }
+          />
+        </div>
         <Button
           appearance="base"
           onClick={() => navigate(`/ui/project/${project}/profiles`)}

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -35,11 +35,11 @@ import ProfileFormMenu, {
   DISK_DEVICES,
   MAIN_CONFIGURATION,
   MIGRATION,
+  NETWORK_DEVICES,
   RESOURCE_LIMITS,
   SECURITY_POLICIES,
   SNAPSHOTS,
   YAML_CONFIGURATION,
-  NETWORK_DEVICES,
 } from "pages/profiles/forms/ProfileFormMenu";
 import { LxdProfile } from "types/profile";
 import useEventListener from "@use-it/event-listener";
@@ -59,6 +59,8 @@ import { getProfilePayload } from "util/profileEdit";
 import MigrationForm, {
   MigrationFormValues,
 } from "components/forms/MigrationForm";
+import YamlSwitch from "components/forms/YamlSwitch";
+import YamlNotification from "components/forms/YamlNotification";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -84,7 +86,6 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
   }>();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [isConfigOpen, setConfigOpen] = useState(true);
   const [version, setVersion] = useState(0);
 
   if (!project) {
@@ -138,10 +139,6 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
       : navigate(`${baseUrl}/${slugify(newSection)}`);
   };
 
-  const toggleMenu = () => {
-    setConfigOpen((old) => !old);
-  };
-
   const getYaml = () => {
     const exclude = new Set(["used_by", "etag"]);
     const profilePayload = getProfilePayload(profile, formik.values);
@@ -167,14 +164,14 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
         </Notification>
       )}
       <Form onSubmit={formik.handleSubmit} className="form">
-        <ProfileFormMenu
-          active={section ?? slugify(MAIN_CONFIGURATION)}
-          setActive={updateSection}
-          isConfigOpen={isConfigOpen}
-          toggleConfigOpen={toggleMenu}
-          hasName={true}
-          formik={formik}
-        />
+        {section !== slugify(YAML_CONFIGURATION) && (
+          <ProfileFormMenu
+            active={section ?? slugify(MAIN_CONFIGURATION)}
+            setActive={updateSection}
+            hasName={true}
+            formik={formik}
+          />
+        )}
         <Row className="form-contents" key={section}>
           <Col size={12}>
             {(section === slugify(MAIN_CONFIGURATION) || !section) && (
@@ -218,23 +215,21 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
                   void formik.setFieldValue("yaml", yaml);
                 }}
               >
-                <Notification severity="information" title="YAML Configuration">
-                  This is the YAML representation of the profile.
-                  <br />
-                  <a
-                    href={`${docBaseLink}/profiles`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Learn more about profiles
-                  </a>
-                </Notification>
+                <YamlNotification
+                  entity="profile"
+                  href={`${docBaseLink}/profiles`}
+                />
               </YamlForm>
             )}
           </Col>
         </Row>
       </Form>
       <FormFooterLayout>
+        <YamlSwitch
+          formik={formik}
+          section={section}
+          setSection={updateSection}
+        />
         {readOnly ? null : (
           <>
             <Button

--- a/src/pages/profiles/forms/ProfileFormMenu.tsx
+++ b/src/pages/profiles/forms/ProfileFormMenu.tsx
@@ -1,11 +1,10 @@
-import { FC, ReactNode, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useNotify } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
-import YamlConfirmation from "components/forms/YamlConfirmation";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk devices";
@@ -18,50 +17,22 @@ export const CLOUD_INIT = "Cloud init";
 export const YAML_CONFIGURATION = "YAML configuration";
 
 interface Props {
-  isConfigOpen: boolean;
-  toggleConfigOpen: () => void;
   active: string;
   setActive: (val: string) => void;
   hasName: boolean;
   formik: InstanceAndProfileFormikProps;
 }
 
-const ProfileFormMenu: FC<Props> = ({
-  isConfigOpen,
-  toggleConfigOpen,
-  active,
-  setActive,
-  hasName,
-  formik,
-}) => {
+const ProfileFormMenu: FC<Props> = ({ active, setActive, hasName, formik }) => {
   const notify = useNotify();
-  const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
 
   const menuItemProps = {
     active,
-    setActive: (val: string) => {
-      if (Boolean(formik.values.yaml) && val !== YAML_CONFIGURATION) {
-        const handleConfirm = () => {
-          void formik.setFieldValue("yaml", undefined);
-          setConfirmModal(null);
-          setActive(val);
-        };
-
-        setConfirmModal(
-          <YamlConfirmation
-            onConfirm={handleConfirm}
-            close={() => setConfirmModal(null)}
-          />,
-        );
-      } else {
-        setActive(val);
-      }
-    },
+    setActive,
+    disableReason: hasName
+      ? undefined
+      : "Please enter a name before adding custom configuration",
   };
-
-  const disableReason = hasName
-    ? undefined
-    : "Please enter a profile name to enable this section";
 
   const resize = () => {
     updateMaxHeight("form-navigation", "p-bottom-controls");
@@ -71,47 +42,24 @@ const ProfileFormMenu: FC<Props> = ({
 
   return (
     <div className="p-side-navigation--accordion form-navigation">
-      {confirmModal}
       <nav aria-label="Profile form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={isConfigOpen ? "true" : "false"}
-              onClick={toggleConfigOpen}
-              disabled={Boolean(disableReason)}
-              title={disableReason}
-            >
-              Advanced
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={isConfigOpen ? "true" : "false"}
-            >
-              <MenuItem
-                label={DISK_DEVICES}
-                hasError={hasDiskError(formik)}
-                {...menuItemProps}
-              />
-              <MenuItem
-                label={NETWORK_DEVICES}
-                hasError={hasNetworkError(formik)}
-                {...menuItemProps}
-              />
-              <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
-              <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
-              <MenuItem label={SNAPSHOTS} {...menuItemProps} />
-              <MenuItem label={MIGRATION} {...menuItemProps} />
-              <MenuItem label={CLOUD_INIT} {...menuItemProps} />
-            </ul>
-          </li>
           <MenuItem
-            label={YAML_CONFIGURATION}
-            disableReason={disableReason}
+            label={DISK_DEVICES}
+            hasError={hasDiskError(formik)}
             {...menuItemProps}
           />
+          <MenuItem
+            label={NETWORK_DEVICES}
+            hasError={hasNetworkError(formik)}
+            {...menuItemProps}
+          />
+          <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
+          <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
+          <MenuItem label={SNAPSHOTS} {...menuItemProps} />
+          <MenuItem label={MIGRATION} {...menuItemProps} />
+          <MenuItem label={CLOUD_INIT} {...menuItemProps} />
         </ul>
       </nav>
     </div>

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -24,6 +24,7 @@ import { MAIN_CONFIGURATION } from "./forms/StoragePoolFormMenu";
 import { useToastNotification } from "context/toastNotificationProvider";
 import { yamlToObject } from "util/yaml";
 import { LxdStoragePool } from "types/storage";
+import YamlSwitch from "components/forms/YamlSwitch";
 
 const CreateStoragePool: FC = () => {
   const navigate = useNavigate();
@@ -98,6 +99,18 @@ const CreateStoragePool: FC = () => {
         setSection={updateSection}
       />
       <FormFooterLayout>
+        <div className="yaml-switch">
+          <YamlSwitch
+            formik={formik}
+            section={section}
+            setSection={updateSection}
+            disableReason={
+              formik.values.name
+                ? undefined
+                : "Please enter a storage pool name to enable this section"
+            }
+          />
+        </div>
         <Button
           appearance="base"
           onClick={() => navigate(`/ui/project/${project}/storage/pools`)}

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -28,6 +28,7 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import { yamlToObject } from "util/yaml";
 import { useSettings } from "context/useSettings";
 import { getSupportedStorageDrivers } from "util/storageOptions";
+import YamlSwitch from "components/forms/YamlSwitch";
 
 interface Props {
   pool: LxdStoragePool;
@@ -120,6 +121,11 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
         version={version}
       />
       <FormFooterLayout>
+        <YamlSwitch
+          formik={formik}
+          section={section}
+          setSection={updateSection}
+        />
         {formik.values.readOnly ? null : (
           <>
             <Button

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -1,11 +1,11 @@
-import { FC, ReactNode, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import {
+  Col,
   Form,
   Input,
-  Row,
-  Col,
-  useNotify,
   Notification,
+  Row,
+  useNotify,
 } from "@canonical/react-components";
 import { FormikProps } from "formik";
 import StoragePoolFormMain from "./StoragePoolFormMain";
@@ -31,7 +31,6 @@ import { slugify } from "util/slugify";
 import YamlForm from "components/forms/YamlForm";
 import { dump as dumpYaml } from "js-yaml";
 import { handleConfigKeys } from "util/storagePoolForm";
-import YamlConfirmation from "components/forms/YamlConfirmation";
 import { useDocs } from "context/useDocs";
 import StoragePoolFormCeph from "./StoragePoolFormCeph";
 import StoragePoolFormPowerflex from "./StoragePoolFormPowerflex";
@@ -165,7 +164,6 @@ const StoragePoolForm: FC<Props> = ({
   setSection,
   version = 0,
 }) => {
-  const [confirmModal, setConfirmModal] = useState<ReactNode | null>(null);
   const docBaseLink = useDocs();
   const { data: settings } = useSettings();
   const notify = useNotify();
@@ -178,25 +176,6 @@ const StoragePoolForm: FC<Props> = ({
 
   const getYaml = () => dumpYaml(toStoragePool(formik.values));
 
-  const handleSetActive = (val: string) => {
-    if (Boolean(formik.values.yaml) && val !== YAML_CONFIGURATION) {
-      const handleConfirm = () => {
-        void formik.setFieldValue("yaml", undefined);
-        setConfirmModal(null);
-        setSection(val);
-      };
-
-      setConfirmModal(
-        <YamlConfirmation
-          onConfirm={handleConfirm}
-          close={() => setConfirmModal(null)}
-        />,
-      );
-    } else {
-      setSection(val);
-    }
-  };
-
   const supportedStorageDrivers = getSupportedStorageDrivers(settings);
   const isSupportedStorageDriver = supportedStorageDrivers.has(
     formik.values.driver,
@@ -204,15 +183,16 @@ const StoragePoolForm: FC<Props> = ({
 
   return (
     <Form className="form storage-pool-form" onSubmit={formik.handleSubmit}>
-      {confirmModal}
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden value="Hidden input" />
-      <StoragePoolFormMenu
-        active={section}
-        setActive={handleSetActive}
-        formik={formik}
-        isSupportedStorageDriver={isSupportedStorageDriver}
-      />
+      {section !== slugify(YAML_CONFIGURATION) && (
+        <StoragePoolFormMenu
+          active={section}
+          setActive={setSection}
+          formik={formik}
+          isSupportedStorageDriver={isSupportedStorageDriver}
+        />
+      )}
       <Row className="form-contents" key={section}>
         <Col size={12}>
           {section === slugify(MAIN_CONFIGURATION) && (

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -77,11 +77,6 @@ const StoragePoolFormMenu: FC<Props> = ({
               disableReason={disableReason}
             />
           )}
-          <MenuItem
-            label={YAML_CONFIGURATION}
-            {...menuItemProps}
-            disableReason={disableReason}
-          />
         </ul>
       </nav>
     </div>

--- a/src/pages/storage/forms/StorageVolumeForm.tsx
+++ b/src/pages/storage/forms/StorageVolumeForm.tsx
@@ -179,7 +179,6 @@ const StorageVolumeForm: FC<Props> = ({ formik, section, setSection }) => {
         formik={formik}
         poolDriver={poolDriver}
         contentType={formik.values.content_type}
-        isCreating={formik.values.isCreating}
       />
       <Row className="form-contents">
         <Col size={12}>

--- a/src/pages/storage/forms/StorageVolumeFormMenu.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMenu.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useNotify } from "@canonical/react-components";
+import { useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { FormikProps } from "formik/dist/types";
@@ -19,7 +19,6 @@ interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
   poolDriver: string;
   contentType: LxdStorageVolumeContentType;
-  isCreating: boolean;
 }
 
 const StorageVolumeFormMenu: FC<Props> = ({
@@ -28,10 +27,8 @@ const StorageVolumeFormMenu: FC<Props> = ({
   formik,
   poolDriver,
   contentType,
-  isCreating,
 }) => {
   const notify = useNotify();
-  const [isAdvancedOpen, setAdvancedOpen] = useState(!isCreating);
   const menuItemProps = {
     active,
     setActive,
@@ -52,47 +49,26 @@ const StorageVolumeFormMenu: FC<Props> = ({
       <nav aria-label="Storage volume form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={
-                !disableReason && isAdvancedOpen ? "true" : "false"
-              }
-              onClick={() => setAdvancedOpen(!isAdvancedOpen)}
-              disabled={Boolean(disableReason)}
-              title={disableReason}
-            >
-              Advanced
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={
-                !disableReason && isAdvancedOpen ? "true" : "false"
-              }
-            >
+          <MenuItem
+            label={SNAPSHOTS}
+            {...menuItemProps}
+            disableReason={disableReason}
+          />
+          {contentType === "filesystem" &&
+            driversWithFilesystemSupport.includes(poolDriver) && (
               <MenuItem
-                label={SNAPSHOTS}
+                label={FILESYSTEM}
                 {...menuItemProps}
                 disableReason={disableReason}
               />
-              {contentType === "filesystem" &&
-                driversWithFilesystemSupport.includes(poolDriver) && (
-                  <MenuItem
-                    label={FILESYSTEM}
-                    {...menuItemProps}
-                    disableReason={disableReason}
-                  />
-                )}
-              {poolDriver === zfsDriver && (
-                <MenuItem
-                  label={ZFS}
-                  {...menuItemProps}
-                  disableReason={disableReason}
-                />
-              )}
-            </ul>
-          </li>
+            )}
+          {poolDriver === zfsDriver && (
+            <MenuItem
+              label={ZFS}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
         </ul>
       </nav>
     </div>

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -107,11 +107,11 @@
         margin-top: 2.5rem;
       }
     }
+  }
 
-    .is-disabled {
-      cursor: not-allowed;
-      opacity: 0.33;
-    }
+  .is-disabled {
+    cursor: not-allowed;
+    opacity: 0.33;
   }
 
   @include mobile-and-tablet {
@@ -129,10 +129,6 @@
         margin-right: 0 !important;
       }
     }
-  }
-
-  .code-editor-wrapper {
-    max-width: 54rem;
   }
 
   .read-only .monaco-editor .cursors-layer > .cursor {
@@ -210,6 +206,10 @@
       display: inherit !important;
       margin-left: $sph--x-small;
     }
+  }
+
+  .yaml-switch {
+    margin-left: $sph--x-large;
   }
 }
 
@@ -352,6 +352,14 @@
     min-height: 3.5rem;
     padding-right: 1.5rem;
   }
+
+  .form {
+    max-width: 72rem;
+  }
+
+  .form-contents:has(.code-editor-wrapper) {
+    padding-left: 1.5rem;
+  }
 }
 
 .edit-instance,
@@ -363,5 +371,13 @@
     margin-top: 1rem;
     max-width: 70.5rem;
     min-height: 3.5rem;
+  }
+
+  .form {
+    max-width: 70.5rem;
+  }
+
+  .form-contents:has(.code-editor-wrapper) {
+    padding-left: 0;
   }
 }

--- a/src/sass/_network_form.scss
+++ b/src/sass/_network_form.scss
@@ -4,6 +4,10 @@
     max-width: 54rem !important;
   }
 
+  .form-contents:has(.code-editor-wrapper) > div {
+    max-width: initial !important;
+  }
+
   @media screen and (width <= 1420px) {
     .configuration-table {
       .configuration {

--- a/src/sass/_storage_pool_form.scss
+++ b/src/sass/_storage_pool_form.scss
@@ -3,4 +3,8 @@
     margin-left: 0;
     max-width: 54rem !important;
   }
+
+  .form-contents:has(.code-editor-wrapper) > div {
+    max-width: initial !important;
+  }
 }

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -26,7 +26,6 @@ test("instance attach custom volumes and detach inherited volumes", async ({
   const instanceVolume = randomVolumeName();
 
   await startProfileCreation(page, profile);
-  await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Disk devices").click();
   await attachVolume(page, profileVolume, "/foo");
   await finishProfileCreation(page, profile);
@@ -55,7 +54,6 @@ test("profile edit custom volumes", async ({ page }) => {
   const volume = randomVolumeName();
 
   await startProfileCreation(page, profile);
-  await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Disk devices").click();
   await page.getByRole("button", { name: "Create override" }).click();
   await page.getByPlaceholder("Enter value").fill("3");
@@ -87,7 +85,6 @@ test("profile edit networks", async ({ page }) => {
   const profile = randomProfileName();
 
   await startProfileCreation(page, profile);
-  await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Network devices").click();
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.getByPlaceholder("Enter name").fill("eth0");

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -29,7 +29,6 @@ export const createInstance = async (
     .selectOption(type);
 
   if (project !== "default") {
-    await page.getByRole("button", { name: "Advanced" }).click();
     await page.getByText("Disk devices").click();
     await page.getByRole("button", { name: "Create override" }).click();
   }

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -59,11 +59,6 @@ export const prepareNetworkTabEdit = async (
 
 export const visitNetworkConfiguration = async (page: Page, tab: string) => {
   await page
-    .getByRole("button", {
-      name: "Advanced",
-    })
-    .click();
-  await page
     .getByLabel("Network form navigation")
     .getByText(tab, { exact: true })
     .click();

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -214,6 +214,8 @@ test("instance yaml edit", async ({ page }) => {
   test.skip(Boolean(process.env.CI), "github runners lack vm support");
   await editInstance(page, vmInstance);
   await page.getByText("YAML configuration").click();
+  await page.getByRole("button", { name: "Close notification" }).click();
+
   await page.locator(".view-lines").click();
   await page.getByText("description: ''").click();
   await page.keyboard.press("End");
@@ -221,7 +223,7 @@ test("instance yaml edit", async ({ page }) => {
   await page.keyboard.type("A-new-description");
   await saveInstance(page, vmInstance);
 
-  await page.getByText("Main configuration").click();
+  await page.getByText("YAML Configuration").click();
   await assertTextVisible(page, "DescriptionA-new-description");
 });
 

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -69,7 +69,6 @@ test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
   await page
     .locator(".u-align--right > .p-button--positive", { hasText: "Select" })
     .click();
-  await page.getByRole("button", { name: "Advanced" }).click();
   await page.getByText("Migration").click();
   await activateOverride(page, "Stateful migration");
   await page

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -157,6 +157,7 @@ test("profile cloud init", async ({ page }) => {
 test("profile yaml edit", async ({ page }) => {
   await editProfile(page, profile);
   await page.getByText("YAML configuration").click();
+  await page.getByRole("button", { name: "Close notification" }).click();
 
   await page.locator(".view-lines").click();
   await page.keyboard.press("Control+a");
@@ -166,6 +167,6 @@ devices: {}
 name: ${profile}`);
   await saveProfile(page, profile);
 
-  await page.getByText("Main configuration").click();
+  await page.locator("#form-footer").getByText("YAML Configuration").click();
   await assertTextVisible(page, "DescriptionA-new-description");
 });


### PR DESCRIPTION
## Done

- move yaml switch to the footer of forms for instance, profile, network and storage pool create and edit
- flatten form navigations

Fixes WD-14519

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check yaml switch on instance, profile, network and storage pool creation and editing