### PR TITLE
fix: temporarily disable the sass deprecation for mixed-decls

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,14 @@ import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+        silenceDeprecations: ["mixed-decls"],
+      },
+    },
+  },
   plugins: [tsconfigPaths(), react()],
   server: {
     port: 3000,


### PR DESCRIPTION
## Done
- Recently with the update dependency [PR](https://github.com/canonical/lxd-ui/pull/837) merged, sass was upgraded resulting in the `mixed-decls` deprecation warning polluting the vite dev server logs. Since most of the warning actually originate from upstream vanilla, it should be acceptable to silence the warning for now.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check local vite dev server logs