### PR TITLE
Enable VM tests and reduce flaky tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,5 +81,7 @@ dist/
 /playwright/.cache/
 /coverage
 tests/screenshots
+tests/fixtures/image.tar.gz
+tests/fixtures/instance.tar.gz
 
 haproxy-local.cfg

--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -103,19 +103,20 @@ export const getConfigurationRow = ({
             })}
           </div>,
         )}
-        {!disabled && (
+        {
           <div>
             <Button
               onClick={toggleDefault}
               type="button"
               appearance="base"
-              title="Clear override"
+              title={disabled ? disabledReason : "Clear override"}
+              disabled={disabled}
               hasIcon
             >
               <Icon name="close" className="clear-configuration-icon" />
             </Button>
           </div>
-        )}
+        }
       </div>
     );
   };
@@ -144,24 +145,29 @@ export const getConfigurationRow = ({
       return (
         <>
           {overrideValue}
-          {!disabled && (
-            <Button
-              onClick={() => {
-                ensureEditMode(formik);
-                if (!isOverridden) {
-                  enableOverride();
-                }
-                focusOverride();
-              }}
-              className="u-no-margin--bottom"
-              type="button"
-              appearance="base"
-              title={isOverridden ? "Edit" : "Create override"}
-              hasIcon
-            >
-              <Icon name="edit" />
-            </Button>
-          )}
+          <Button
+            onClick={() => {
+              ensureEditMode(formik);
+              if (!isOverridden) {
+                enableOverride();
+              }
+              focusOverride();
+            }}
+            className="u-no-margin--bottom"
+            type="button"
+            appearance="base"
+            title={
+              disabled
+                ? disabledReason
+                : isOverridden
+                  ? "Edit"
+                  : "Create override"
+            }
+            disabled={disabled}
+            hasIcon
+          >
+            <Icon name="edit" />
+          </Button>
         </>
       );
     }

--- a/src/components/forms/MigrationForm.tsx
+++ b/src/components/forms/MigrationForm.tsx
@@ -41,6 +41,9 @@ const MigrationForm: FC<Props> = ({ formik }) => {
           name: "migration_stateful",
           defaultValue: "",
           disabled: isVmOnlyDisabled,
+          disabledReason: isVmOnlyDisabled
+            ? "Only available for virtual machines"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionAllowDeny),
           children: (
             <Select options={optionAllowDeny} disabled={isVmOnlyDisabled} />

--- a/src/components/forms/ResourceLimitsForm.tsx
+++ b/src/components/forms/ResourceLimitsForm.tsx
@@ -90,6 +90,9 @@ const ResourceLimitsForm: FC<Props> = ({ formik }) => {
           label: "Memory swap (Containers only)",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionAllowDeny),
           children: (
             <Select
@@ -113,6 +116,9 @@ const ResourceLimitsForm: FC<Props> = ({ formik }) => {
           label: "Max number of processes (Containers only)",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           children: (
             <Input
               placeholder="Enter number"

--- a/src/components/forms/SecurityPoliciesForm.tsx
+++ b/src/components/forms/SecurityPoliciesForm.tsx
@@ -81,6 +81,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_privileged",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionAllowDeny),
           children: (
             <Select
@@ -96,6 +99,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_nesting",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionAllowDeny),
           children: (
             <Select
@@ -111,6 +117,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_protection_shift",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionYesNo),
           children: (
             <Select options={optionYesNo} disabled={isContainerOnlyDisabled} />
@@ -123,6 +132,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_idmap_base",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           children: (
             <Input
               placeholder="Enter ID"
@@ -141,6 +153,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_idmap_size",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           children: (
             <Input
               placeholder="Enter number"
@@ -160,6 +175,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_idmap_isolated",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionYesNo),
           children: (
             <Select options={optionYesNo} disabled={isContainerOnlyDisabled} />
@@ -172,6 +190,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_devlxd",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionYesNo),
           children: (
             <Select options={optionYesNo} disabled={isContainerOnlyDisabled} />
@@ -185,6 +206,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_devlxd_images",
           defaultValue: "",
           disabled: isContainerOnlyDisabled,
+          disabledReason: isContainerOnlyDisabled
+            ? "Only available for containers"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionYesNo),
           children: (
             <Select options={optionYesNo} disabled={isContainerOnlyDisabled} />
@@ -197,6 +221,9 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           name: "security_secureboot",
           defaultValue: "",
           disabled: isVmOnlyDisabled,
+          disabledReason: isVmOnlyDisabled
+            ? "Only available for virtual machines"
+            : undefined,
           readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
           children: (
             <Select options={optionTrueFalse} disabled={isVmOnlyDisabled} />

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -127,13 +127,13 @@ test("instance edit resource limits", async ({ page }) => {
   await page.getByText("Resource limits").click();
   await setOption(page, "Memory swap", "true");
   await setOption(page, "Disk priority", "1");
-  await setInput(page, "Max number of processes", "Enter number", "2");
+  await setInput(page, "Max number of processes", "Enter number", "42");
 
   await saveInstance(page, instance);
 
   await assertReadMode(page, "Memory swap (Containers only)", "Allow");
   await assertReadMode(page, "Disk priority", "1");
-  await assertReadMode(page, "Max number of processes (Containers only)", "2");
+  await assertReadMode(page, "Max number of processes (Containers only)", "42");
 });
 
 test("instance edit security policies", async ({ page }) => {
@@ -231,7 +231,10 @@ test("instance yaml edit", async ({ page }) => {
   await page.getByRole("button", { name: "Close notification" }).click();
 
   await page.locator(".view-lines").click();
-  await page.getByText("description: ''").click();
+  await page.getByLabel("Editor content;Press Alt+F1").press("ControlOrMeta+f");
+  await page.getByPlaceholder("Find").fill("description: ''");
+  await page.getByPlaceholder("Find").press("Escape");
+  await page.getByText("description: ''").first().click();
   await page.keyboard.press("End");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.type("A-new-description");

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -205,7 +205,11 @@ test("instance edit cloud init configuration", async ({ page }) => {
 });
 
 test("instance create vm", async ({ page }) => {
-  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+  test.skip(
+    Boolean(process.env.DISABLE_VM_TESTS),
+    "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+
   await editInstance(page, vmInstance);
 
   await page.getByText("Security policies").click();
@@ -217,7 +221,11 @@ test("instance create vm", async ({ page }) => {
 });
 
 test("instance yaml edit", async ({ page }) => {
-  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+  test.skip(
+    Boolean(process.env.DISABLE_VM_TESTS),
+    "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+
   await editInstance(page, vmInstance);
   await page.getByText("YAML configuration").click();
   await page.getByRole("button", { name: "Close notification" }).click();

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -109,7 +109,11 @@ test("not allowed to launch instance with custom iso for lxd v5.0/edge", async (
   page,
   lxdVersion,
 }) => {
-  test.skip(Boolean(process.env.CI), "github runners lack vm support");
+  test.skip(
+    Boolean(process.env.DISABLE_VM_TESTS),
+    "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+
   test.skip(
     lxdVersion !== "5.0-edge",
     `this test is specific to lxd v5.0/edge, current lxd snap channel is ${lxdVersion}`,


### PR DESCRIPTION
## Done

- use DISABLE_VM_TESTS variable consistently in tests
- add test artefacts to `.gitignore` file
- show disabled override button in edit forms instead of hiding it, when the section is disabled, and we are in read mode
- fix instance tests to not set a config value that prevents the instance from being started.