### PR TITLE
Show permissions in navigation also without oidc.audience being set.

### DIFF
--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -360,7 +360,6 @@ export const enablePermissionsFeature = (): boolean => {
     (settings?.config?.["user.show_permissions"] ?? "false") === "true";
 
   const hasOIDCSettings =
-    !!settings?.config?.["oidc.audience"] &&
     !!settings?.config?.["oidc.client.id"] &&
     !!settings?.config?.["oidc.issuer"];
 


### PR DESCRIPTION
## Done

- Show permissions in navigation also without oidc.audience being set. It is optional, after all