### PR TITLE
Add devices section to bundle all related entries in instance and profile form menu

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -408,7 +408,7 @@ const CreateInstance: FC = () => {
           <InstanceFormMenu
             active={section}
             setActive={updateSection}
-            isConfigDisabled={!formik.values.image}
+            isDisabled={!formik.values.image}
             hasDiskError={diskError || hasNoRootDisk(formik.values, profiles)}
             hasNetworkError={networkError}
           />

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -190,7 +190,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
           <InstanceFormMenu
             active={section ?? slugify(MAIN_CONFIGURATION)}
             setActive={updateSection}
-            isConfigDisabled={false}
+            isDisabled={false}
             hasDiskError={hasDiskError(formik)}
             hasNetworkError={hasNetworkError(formik)}
           />

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -1,14 +1,14 @@
-import { FC, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { useNotify } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 
 export const MAIN_CONFIGURATION = "Main configuration";
-export const DISK_DEVICES = "Disk devices";
-export const NETWORK_DEVICES = "Network devices";
-export const GPU_DEVICES = "GPU devices";
-export const OTHER_DEVICES = "Other devices";
+export const DISK_DEVICES = "Disk";
+export const NETWORK_DEVICES = "Network";
+export const GPU_DEVICES = "GPU";
+export const OTHER_DEVICES = "Other";
 export const RESOURCE_LIMITS = "Resource limits";
 export const SECURITY_POLICIES = "Security policies";
 export const MIGRATION = "Migration";
@@ -17,7 +17,7 @@ export const CLOUD_INIT = "Cloud init";
 export const YAML_CONFIGURATION = "YAML configuration";
 
 interface Props {
-  isConfigDisabled: boolean;
+  isDisabled: boolean;
   active: string;
   setActive: (val: string) => void;
   hasDiskError: boolean;
@@ -25,19 +25,23 @@ interface Props {
 }
 
 const InstanceFormMenu: FC<Props> = ({
-  isConfigDisabled,
+  isDisabled,
   active,
   setActive,
   hasDiskError,
   hasNetworkError,
 }) => {
   const notify = useNotify();
+  const [isDeviceExpanded, setDeviceExpanded] = useState(true);
+
+  const disableReason = isDisabled
+    ? "Please select an image before adding custom configuration"
+    : undefined;
+
   const menuItemProps = {
     active,
     setActive,
-    disableReason: isConfigDisabled
-      ? "Please select an image before adding custom configuration"
-      : undefined,
+    disableReason,
   };
 
   const resize = () => {
@@ -51,18 +55,39 @@ const InstanceFormMenu: FC<Props> = ({
       <nav aria-label="Instance form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <MenuItem
-            label={DISK_DEVICES}
-            hasError={hasDiskError}
-            {...menuItemProps}
-          />
-          <MenuItem
-            label={NETWORK_DEVICES}
-            hasError={hasNetworkError}
-            {...menuItemProps}
-          />
-          <MenuItem label={GPU_DEVICES} {...menuItemProps} />
-          <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+          <li className="p-side-navigation__item">
+            <Button
+              type="button"
+              className="p-side-navigation__accordion-button"
+              aria-expanded={isDeviceExpanded ? "true" : "false"}
+              onClick={() => {
+                if (!isDisabled) {
+                  setDeviceExpanded(!isDeviceExpanded);
+                }
+              }}
+              disabled={isDisabled}
+              title={disableReason}
+            >
+              Devices
+            </Button>
+            <ul
+              className="p-side-navigation__list"
+              aria-expanded={isDeviceExpanded ? "true" : "false"}
+            >
+              <MenuItem
+                label={DISK_DEVICES}
+                hasError={hasDiskError}
+                {...menuItemProps}
+              />
+              <MenuItem
+                label={NETWORK_DEVICES}
+                hasError={hasNetworkError}
+                {...menuItemProps}
+              />
+              <MenuItem label={GPU_DEVICES} {...menuItemProps} />
+              <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+            </ul>
+          </li>
           <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
           <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
           <MenuItem label={SNAPSHOTS} {...menuItemProps} />

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -173,7 +173,7 @@ const CreateProfile: FC = () => {
           <ProfileFormMenu
             active={section}
             setActive={updateSection}
-            hasName={Boolean(formik.values.name)}
+            isDisabled={!formik.values.name}
             formik={formik}
           />
         )}

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -172,7 +172,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
           <ProfileFormMenu
             active={section ?? slugify(MAIN_CONFIGURATION)}
             setActive={updateSection}
-            hasName={true}
+            isDisabled={false}
             formik={formik}
           />
         )}

--- a/src/pages/profiles/forms/ProfileFormMenu.tsx
+++ b/src/pages/profiles/forms/ProfileFormMenu.tsx
@@ -1,16 +1,16 @@
-import { FC, useEffect } from "react";
+import React, { FC, useEffect, useState } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { useNotify } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 
 export const MAIN_CONFIGURATION = "Main configuration";
-export const DISK_DEVICES = "Disk devices";
-export const NETWORK_DEVICES = "Network devices";
-export const GPU_DEVICES = "GPU devices";
-export const OTHER_DEVICES = "Other devices";
+export const DISK_DEVICES = "Disk";
+export const NETWORK_DEVICES = "Network";
+export const GPU_DEVICES = "GPU";
+export const OTHER_DEVICES = "Other";
 export const RESOURCE_LIMITS = "Resource limits";
 export const SECURITY_POLICIES = "Security policies";
 export const SNAPSHOTS = "Snapshots";
@@ -21,19 +21,27 @@ export const YAML_CONFIGURATION = "YAML configuration";
 interface Props {
   active: string;
   setActive: (val: string) => void;
-  hasName: boolean;
+  isDisabled: boolean;
   formik: InstanceAndProfileFormikProps;
 }
 
-const ProfileFormMenu: FC<Props> = ({ active, setActive, hasName, formik }) => {
+const ProfileFormMenu: FC<Props> = ({
+  active,
+  setActive,
+  isDisabled,
+  formik,
+}) => {
   const notify = useNotify();
+  const [isDeviceExpanded, setDeviceExpanded] = useState(true);
+
+  const disableReason = isDisabled
+    ? "Please enter a name before adding custom configuration"
+    : undefined;
 
   const menuItemProps = {
     active,
     setActive,
-    disableReason: hasName
-      ? undefined
-      : "Please enter a name before adding custom configuration",
+    disableReason,
   };
 
   const resize = () => {
@@ -47,18 +55,39 @@ const ProfileFormMenu: FC<Props> = ({ active, setActive, hasName, formik }) => {
       <nav aria-label="Profile form navigation">
         <ul className="p-side-navigation__list">
           <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
-          <MenuItem
-            label={DISK_DEVICES}
-            hasError={hasDiskError(formik)}
-            {...menuItemProps}
-          />
-          <MenuItem
-            label={NETWORK_DEVICES}
-            hasError={hasNetworkError(formik)}
-            {...menuItemProps}
-          />
-          <MenuItem label={GPU_DEVICES} {...menuItemProps} />
-          <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+          <li className="p-side-navigation__item">
+            <Button
+              type="button"
+              className="p-side-navigation__accordion-button"
+              aria-expanded={isDeviceExpanded ? "true" : "false"}
+              onClick={() => {
+                if (!isDisabled) {
+                  setDeviceExpanded(!isDeviceExpanded);
+                }
+              }}
+              disabled={isDisabled}
+              title={disableReason}
+            >
+              Devices
+            </Button>
+            <ul
+              className="p-side-navigation__list"
+              aria-expanded={isDeviceExpanded ? "true" : "false"}
+            >
+              <MenuItem
+                label={DISK_DEVICES}
+                hasError={hasDiskError(formik)}
+                {...menuItemProps}
+              />
+              <MenuItem
+                label={NETWORK_DEVICES}
+                hasError={hasNetworkError(formik)}
+                {...menuItemProps}
+              />
+              <MenuItem label={GPU_DEVICES} {...menuItemProps} />
+              <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+            </ul>
+          </li>
           <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
           <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
           <MenuItem label={SNAPSHOTS} {...menuItemProps} />

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -26,7 +26,7 @@ test("instance attach custom volumes and detach inherited volumes", async ({
   const instanceVolume = randomVolumeName();
 
   await startProfileCreation(page, profile);
-  await page.getByText("Disk devices").click();
+  await page.getByText("Disk", { exact: true }).click();
   await attachVolume(page, profileVolume, "/foo");
   await finishProfileCreation(page, profile);
 
@@ -35,7 +35,7 @@ test("instance attach custom volumes and detach inherited volumes", async ({
   await editInstance(page, instance);
   await page.getByRole("button", { name: "Add profile" }).click();
   await page.locator("#profile-1").selectOption(profile);
-  await page.getByText("Disk devices").click();
+  await page.getByText("Disk", { exact: true }).click();
   await detachVolume(page, "volume-1");
   await attachVolume(page, instanceVolume, "/baz");
   await saveInstance(page, instance);
@@ -54,7 +54,7 @@ test("profile edit custom volumes", async ({ page }) => {
   const volume = randomVolumeName();
 
   await startProfileCreation(page, profile);
-  await page.getByText("Disk devices").click();
+  await page.getByText("Disk", { exact: true }).click();
   await page.getByRole("button", { name: "Create override" }).click();
   await page.getByPlaceholder("Enter value").fill("3");
   await attachVolume(page, volume, "/foo");
@@ -62,7 +62,7 @@ test("profile edit custom volumes", async ({ page }) => {
 
   await visitProfile(page, profile);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByText("Disk devices").click();
+  await page.getByText("Disk", { exact: true }).click();
   await page.getByRole("row", { name: "Size 3GiB" }).click();
   await page.getByRole("gridcell", { name: volume }).click();
   await page.getByRole("gridcell", { name: "/foo" }).click();
@@ -85,7 +85,7 @@ test("profile edit networks", async ({ page }) => {
   const profile = randomProfileName();
 
   await startProfileCreation(page, profile);
-  await page.getByText("Network devices").click();
+  await page.getByText("Network", { exact: true }).click();
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.getByPlaceholder("Enter name").fill("eth0");
   await page.getByLabel("Network").selectOption({ index: 1 });
@@ -93,7 +93,7 @@ test("profile edit networks", async ({ page }) => {
 
   await visitProfile(page, profile);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByText("Network devices").click();
+  await page.getByText("Network", { exact: true }).click();
   await page.getByRole("gridcell", { name: "eth0" }).click();
 
   await page.getByRole("button", { name: "Attach network" }).click();

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -33,7 +33,7 @@ export const createInstance = async (
     .selectOption(type);
 
   if (project !== "default") {
-    await page.getByText("Disk devices").click();
+    await page.getByText("Disk", { exact: true }).click();
     await page.getByRole("button", { name: "Create override" }).click();
   }
 

--- a/tests/readme-screenshots.spec.ts
+++ b/tests/readme-screenshots.spec.ts
@@ -36,7 +36,7 @@ test("instance list screen", async ({ page }) => {
   await createProject(page, project);
   await visitProfile(page, "default", project);
   await page.getByTestId("tab-link-Configuration").click();
-  await page.getByText("Disk devices").click();
+  await page.getByText("Disk", { exact: true }).click();
   await page.getByRole("button", { name: "Create override" }).click();
   await page.getByRole("button", { name: "Save changes" }).click();
   const instances = [


### PR DESCRIPTION
## Done

- Add devices section to bundle all related entries in instance and profile form menu

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instances and profile form menu on create/edit of instances and profiles