### PR TITLE
delay clearing instance cache when an instance state change fails

### DIFF
--- a/src/util/instanceStart.tsx
+++ b/src/util/instanceStart.tsx
@@ -24,6 +24,12 @@ export const useInstanceStart = (instance: LxdInstance) => {
     !enabledStatuses.includes(instance.status) ||
     instanceLoading.getType(instance) === "Migrating";
 
+  const clearCache = () => {
+    void queryClient.invalidateQueries({
+      queryKey: [queryKeys.instances],
+    });
+  };
+
   const handleStart = () => {
     instanceLoading.setLoading(instance, "Starting");
     const mutation =
@@ -32,25 +38,29 @@ export const useInstanceStart = (instance: LxdInstance) => {
       .then((operation) => {
         eventQueue.set(
           operation.metadata.id,
-          () =>
+          () => {
             toastNotify.success(
               <>
                 Instance <InstanceLink instance={instance} /> started.
               </>,
-            ),
-          (msg) =>
+            );
+            clearCache();
+          },
+          (msg) => {
             toastNotify.failure(
               "Instance start failed",
               new Error(msg),
               <>
                 Instance <ItemName item={instance} bold />:
               </>,
-            ),
+            );
+            // Delay clearing the cache, because the instance is reported as RUNNING
+            // when a start operation failed, only shortly after it goes back to STOPPED
+            // and we want to avoid showing the intermediate RUNNING state.
+            setTimeout(clearCache, 1500);
+          },
           () => {
             instanceLoading.setFinish(instance);
-            void queryClient.invalidateQueries({
-              queryKey: [queryKeys.instances],
-            });
           },
         );
       })


### PR DESCRIPTION
## Done

- delay clearing instance cache when an instance state change fails
- avoid reporting wrong intermediate instance status as returned by the api shortly after a state change failure

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create an instance, set "Resource Limits" > "Max number of processes" to 1.
    - Start the instnance
    - Ensure the instance is reported as stopped, not as running on the startup error.