### PR TITLE
Ensure storage volume is active when visiting a volume detail page

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -8,6 +8,7 @@ interface Props {
   children: ReactNode;
   className?: string;
   activeUrlMatches?: string[];
+  ignoreUrlMatches?: string[];
 }
 
 const NavLink: FC<Props & LinkHTMLAttributes<HTMLElement>> = ({
@@ -16,6 +17,7 @@ const NavLink: FC<Props & LinkHTMLAttributes<HTMLElement>> = ({
   children,
   className,
   activeUrlMatches = [],
+  ignoreUrlMatches = [],
   ...linkProps
 }) => {
   const location = useLocation();
@@ -28,6 +30,12 @@ const NavLink: FC<Props & LinkHTMLAttributes<HTMLElement>> = ({
   for (const match of activeUrlMatches) {
     if (location.pathname.includes(match)) {
       isActive = true;
+    }
+  }
+
+  for (const match of ignoreUrlMatches) {
+    if (location.pathname.includes(match)) {
+      isActive = false;
     }
   }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -245,6 +245,7 @@ const Navigation: FC = () => {
                                 title="Pools"
                                 onClick={softToggleMenu}
                                 className="accordion-nav-secondary"
+                                ignoreUrlMatches={["volumes/custom"]}
                               >
                                 Pools
                               </NavLink>
@@ -257,6 +258,7 @@ const Navigation: FC = () => {
                                 title="Volumes"
                                 onClick={softToggleMenu}
                                 className="accordion-nav-secondary"
+                                activeUrlMatches={["volumes/custom"]}
                               >
                                 Volumes
                               </NavLink>


### PR DESCRIPTION
## Done

- Ensure storage volume is active when visiting a volume detail page
- before we would mark the storage pool section active when visiting a volume detail page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to storage > volumes > (filter a custom volume) > detail page, ensure the correct nav entry is active