### PR TITLE
Show change counts on save buttons for edit forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,8 +48,8 @@ const StoragePools = lazy(() => import("pages/storage/StoragePools"));
 const StorageVolumes = lazy(() => import("pages/storage/StorageVolumes"));
 const CustomIsoList = lazy(() => import("pages/storage/CustomIsoList"));
 const StoragePoolDetail = lazy(() => import("pages/storage/StoragePoolDetail"));
-const StorageVolumeCreate = lazy(
-  () => import("pages/storage/forms/StorageVolumeCreate"),
+const CreateStorageVolume = lazy(
+  () => import("pages/storage/forms/CreateStorageVolume"),
 );
 const StorageVolumeDetail = lazy(
   () => import("pages/storage/StorageVolumeDetail"),
@@ -305,7 +305,7 @@ const App: FC = () => {
           path="/ui/project/:project/storage/volumes/create"
           element={
             <ProtectedRoute
-              outlet={<ProjectLoader outlet={<StorageVolumeCreate />} />}
+              outlet={<ProjectLoader outlet={<CreateStorageVolume />} />}
             />
           }
         />

--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -103,20 +103,17 @@ export const getConfigurationRow = ({
             })}
           </div>,
         )}
-        {
-          <div>
-            <Button
-              onClick={toggleDefault}
-              type="button"
-              appearance="base"
-              title={disabled ? disabledReason : "Clear override"}
-              disabled={disabled}
-              hasIcon
-            >
-              <Icon name="close" className="clear-configuration-icon" />
-            </Button>
-          </div>
-        }
+        <Button
+          onClick={toggleDefault}
+          type="button"
+          appearance="base"
+          title={disabled ? disabledReason : "Clear override"}
+          disabled={disabled}
+          hasIcon
+          className="u-no-margin--bottom"
+        >
+          <Icon name="close" className="clear-configuration-icon" />
+        </Button>
       </div>
     );
   };

--- a/src/components/forms/FormSubmitBtn.tsx
+++ b/src/components/forms/FormSubmitBtn.tsx
@@ -1,0 +1,30 @@
+import { FC } from "react";
+import { ActionButton } from "@canonical/react-components";
+import { pluralize } from "util/instanceBulkActions";
+import { ConfigurationRowFormikProps } from "components/ConfigurationRow";
+import { getFormChangeCount } from "util/formChangeCount";
+
+interface Props {
+  formik: ConfigurationRowFormikProps;
+  disabled: boolean;
+  isYaml?: boolean;
+}
+
+const FormSubmitBtn: FC<Props> = ({ formik, disabled, isYaml = false }) => {
+  const changeCount = getFormChangeCount(formik);
+
+  return (
+    <ActionButton
+      appearance="positive"
+      loading={formik.isSubmitting}
+      disabled={!formik.isValid || disabled || changeCount === 0}
+      onClick={() => void formik.submitForm()}
+    >
+      {changeCount === 0 || isYaml
+        ? "Save changes"
+        : `Save ${changeCount} ${pluralize("change", changeCount)}`}
+    </ActionButton>
+  );
+};
+
+export default FormSubmitBtn;

--- a/src/components/forms/GPUDeviceInput.tsx
+++ b/src/components/forms/GPUDeviceInput.tsx
@@ -10,7 +10,7 @@ interface Props {
 const GpuDeviceInput: FC<Props> = ({ device, onChange }) => {
   const [type, setType] = useState(device.pci ? "pci" : "id");
   const isPci = type === "pci";
-  const key = `device.${device.id}.${isPci ? "pci" : "id"}`;
+  const key = `device.${device.name}.${isPci ? "pci" : "id"}`;
 
   return (
     <>

--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -152,7 +152,7 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
     );
 
     Object.keys(item.device).forEach((key) => {
-      if (key === "name" || key === "type") {
+      if (key === "name") {
         return null;
       }
 

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -1,11 +1,5 @@
-import { FC, useEffect, useState } from "react";
-import {
-  ActionButton,
-  Button,
-  Col,
-  Form,
-  Row,
-} from "@canonical/react-components";
+import React, { FC, useEffect, useState } from "react";
+import { Button, Col, Form, Row } from "@canonical/react-components";
 import { useFormik } from "formik";
 import { updateInstance } from "api/instances";
 import { useQueryClient } from "@tanstack/react-query";
@@ -68,6 +62,7 @@ import OtherDeviceForm from "components/forms/OtherDeviceForm";
 import YamlSwitch from "components/forms/YamlSwitch";
 import YamlNotification from "components/forms/YamlNotification";
 import ProxyDeviceForm from "components/forms/ProxyDeviceForm";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 export interface InstanceEditDetailsFormValues {
   name: string;
@@ -117,6 +112,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
   const formik = useFormik<EditInstanceFormValues>({
     initialValues: getInstanceEditValues(instance),
     validationSchema: InstanceEditSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       const instancePayload = (
         values.yaml
@@ -240,7 +236,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
             )}
 
             {section === slugify(CLOUD_INIT) && (
-              <CloudInitForm formik={formik} />
+              <CloudInitForm key={`yaml-form-${version}`} formik={formik} />
             )}
 
             {section === slugify(YAML_CONFIGURATION) && (
@@ -278,18 +274,11 @@ const EditInstance: FC<Props> = ({ instance }) => {
             >
               Cancel
             </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={
-                !formik.isValid ||
-                hasDiskError(formik) ||
-                hasNetworkError(formik)
-              }
-              onClick={() => void formik.submitForm()}
-            >
-              Save changes
-            </ActionButton>
+            <FormSubmitBtn
+              formik={formik}
+              isYaml={section === slugify(YAML_CONFIGURATION)}
+              disabled={hasDiskError(formik) || hasNetworkError(formik)}
+            />
           </>
         )}
       </FormFooterLayout>

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -1,10 +1,5 @@
 import { FC, useState } from "react";
-import {
-  ActionButton,
-  Button,
-  Notification,
-  useNotify,
-} from "@canonical/react-components";
+import { Button, Notification, useNotify } from "@canonical/react-components";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useQueryClient } from "@tanstack/react-query";
@@ -21,10 +16,14 @@ import { dump as dumpYaml } from "js-yaml";
 import { toNetworkFormValues } from "util/networkForm";
 import { slugify } from "util/slugify";
 import { useNavigate, useParams } from "react-router-dom";
-import { MAIN_CONFIGURATION } from "pages/networks/forms/NetworkFormMenu";
+import {
+  MAIN_CONFIGURATION,
+  YAML_CONFIGURATION,
+} from "pages/networks/forms/NetworkFormMenu";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
 import YamlSwitch from "components/forms/YamlSwitch";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 interface Props {
   network: LxdNetwork;
@@ -144,14 +143,11 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
             >
               Cancel
             </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid || !formik.values.name}
-              onClick={() => void formik.submitForm()}
-            >
-              Save changes
-            </ActionButton>
+            <FormSubmitBtn
+              formik={formik}
+              isYaml={section === slugify(YAML_CONFIGURATION)}
+              disabled={!formik.values.name}
+            />
           </>
         )}
       </FormFooterLayout>

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from "react";
 import {
-  ActionButton,
   Button,
   Col,
   Form,
@@ -67,6 +66,7 @@ import YamlSwitch from "components/forms/YamlSwitch";
 import YamlNotification from "components/forms/YamlNotification";
 import { PROXY_DEVICES } from "pages/instances/forms/InstanceFormMenu";
 import ProxyDeviceForm from "components/forms/ProxyDeviceForm";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &
@@ -111,6 +111,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
   const formik = useFormik<EditProfileFormValues>({
     initialValues: getProfileEditValues(profile),
     validationSchema: ProfileSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       const profilePayload = (
         values.yaml
@@ -221,7 +222,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
             )}
 
             {section === slugify(CLOUD_INIT) && (
-              <CloudInitForm formik={formik} />
+              <CloudInitForm key={`yaml-form-${version}`} formik={formik} />
             )}
 
             {section === slugify(YAML_CONFIGURATION) && (
@@ -259,18 +260,11 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
             >
               Cancel
             </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={
-                !formik.isValid ||
-                hasDiskError(formik) ||
-                hasNetworkError(formik)
-              }
-              onClick={() => void formik.submitForm()}
-            >
-              Save changes
-            </ActionButton>
+            <FormSubmitBtn
+              formik={formik}
+              isYaml={section === slugify(YAML_CONFIGURATION)}
+              disabled={hasDiskError(formik) || hasNetworkError(formik)}
+            />
           </>
         )}
       </FormFooterLayout>

--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -82,8 +82,9 @@ const ProfileSelector: FC<Props> = ({
                 "Each profile overrides the settings specified in previous profiles"
               }
               onChange={(e) => {
-                selected[index] = e.target.value;
-                setSelected(selected);
+                const newValues = [...selected];
+                newValues[index] = e.target.value;
+                setSelected(newValues);
               }}
               options={profiles
                 .filter(

--- a/src/pages/projects/EditProject.tsx
+++ b/src/pages/projects/EditProject.tsx
@@ -1,5 +1,5 @@
 import { FC, useEffect } from "react";
-import { ActionButton, Button, useNotify } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import { updateProject } from "api/projects";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
@@ -21,6 +21,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { slugify } from "util/slugify";
 import { useToastNotification } from "context/toastNotificationProvider";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 interface Props {
   project: LxdProject;
@@ -51,6 +52,7 @@ const EditProject: FC<Props> = ({ project }) => {
   const formik: FormikProps<ProjectFormValues> = useFormik({
     initialValues: initialValues,
     validationSchema: ProjectSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       if (!hasProjectsNetworksZones) {
         values.features_networks_zones = undefined;
@@ -110,14 +112,7 @@ const EditProject: FC<Props> = ({ project }) => {
               >
                 Cancel
               </Button>
-              <ActionButton
-                appearance="positive"
-                loading={formik.isSubmitting}
-                disabled={!formik.isValid || !formik.values.name}
-                onClick={() => void formik.submitForm()}
-              >
-                Save changes
-              </ActionButton>
+              <FormSubmitBtn formik={formik} disabled={!formik.values.name} />
             </>
           )}
         </FormFooterLayout>

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { ActionButton, Button, useNotify } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   fetchStoragePool,
@@ -29,6 +29,7 @@ import { yamlToObject } from "util/yaml";
 import { useSettings } from "context/useSettings";
 import { getSupportedStorageDrivers } from "util/storageOptions";
 import YamlSwitch from "components/forms/YamlSwitch";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 interface Props {
   pool: LxdStoragePool;
@@ -67,6 +68,7 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
   const formik = useFormik<StoragePoolFormValues>({
     initialValues: toStoragePoolFormValues(pool),
     validationSchema: StoragePoolSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       const savedPool = values.yaml
         ? (yamlToObject(values.yaml) as LxdStoragePool)
@@ -137,14 +139,11 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
             >
               Cancel
             </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid}
-              onClick={() => void formik.submitForm()}
-            >
-              Save changes
-            </ActionButton>
+            <FormSubmitBtn
+              formik={formik}
+              isYaml={section === slugify(YAML_CONFIGURATION)}
+              disabled={!formik.values.name}
+            />
           </>
         )}
       </FormFooterLayout>

--- a/src/pages/storage/StorageVolumeDetail.tsx
+++ b/src/pages/storage/StorageVolumeDetail.tsx
@@ -7,7 +7,7 @@ import Loader from "components/Loader";
 import NotificationRow from "components/NotificationRow";
 import StorageVolumeHeader from "pages/storage/StorageVolumeHeader";
 import StorageVolumeOverview from "pages/storage/StorageVolumeOverview";
-import StorageVolumeEdit from "pages/storage/forms/StorageVolumeEdit";
+import EditStorageVolume from "pages/storage/forms/EditStorageVolume";
 import TabLinks from "components/TabLinks";
 import CustomLayout from "components/CustomLayout";
 import StorageVolumeSnapshots from "./StorageVolumeSnapshots";
@@ -83,7 +83,7 @@ const StorageVolumeDetail: FC = () => {
 
         {activeTab === "configuration" && (
           <div role="tabpanel" aria-labelledby="configuration">
-            <StorageVolumeEdit volume={volume} />
+            <EditStorageVolume volume={volume} />
           </div>
         )}
 

--- a/src/pages/storage/forms/CreateStorageVolume.tsx
+++ b/src/pages/storage/forms/CreateStorageVolume.tsx
@@ -20,7 +20,7 @@ import { POOL } from "../StorageVolumesFilter";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
 
-const StorageVolumeCreate: FC = () => {
+const CreateStorageVolume: FC = () => {
   const navigate = useNavigate();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -109,4 +109,4 @@ const StorageVolumeCreate: FC = () => {
   );
 };
 
-export default StorageVolumeCreate;
+export default CreateStorageVolume;

--- a/src/pages/storage/forms/EditStorageVolume.tsx
+++ b/src/pages/storage/forms/EditStorageVolume.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { ActionButton, Button, useNotify } from "@canonical/react-components";
+import { Button, useNotify } from "@canonical/react-components";
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useQueryClient } from "@tanstack/react-query";
@@ -16,12 +16,13 @@ import { MAIN_CONFIGURATION } from "pages/storage/forms/StorageVolumeFormMenu";
 import { slugify } from "util/slugify";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import { useToastNotification } from "context/toastNotificationProvider";
+import FormSubmitBtn from "components/forms/FormSubmitBtn";
 
 interface Props {
   volume: LxdStorageVolume;
 }
 
-const StorageVolumeEdit: FC<Props> = ({ volume }) => {
+const EditStorageVolume: FC<Props> = ({ volume }) => {
   const navigate = useNavigate();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -40,6 +41,7 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
   const formik = useFormik<StorageVolumeFormValues>({
     initialValues: getStorageVolumeEditValues(volume),
     validationSchema: StorageVolumeSchema,
+    enableReinitialize: true,
     onSubmit: (values) => {
       const saveVolume = volumeFormToPayload(values, project, volume);
       updateStorageVolume(values.pool, project, {
@@ -94,14 +96,7 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
             >
               Cancel
             </Button>
-            <ActionButton
-              appearance="positive"
-              loading={formik.isSubmitting}
-              disabled={!formik.isValid || !formik.values.name}
-              onClick={() => void formik.submitForm()}
-            >
-              Save changes
-            </ActionButton>
+            <FormSubmitBtn formik={formik} disabled={!formik.values.name} />
           </>
         )}
       </FormFooterLayout>
@@ -109,4 +104,4 @@ const StorageVolumeEdit: FC<Props> = ({ volume }) => {
   );
 };
 
-export default StorageVolumeEdit;
+export default EditStorageVolume;

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -216,6 +216,29 @@
     margin-bottom: $spv--x-large;
   }
 
+  .cloud-init {
+    .configuration {
+      width: 9rem;
+    }
+
+    .inherited {
+      width: auto;
+    }
+
+    .override {
+      width: auto;
+    }
+
+    .override-form {
+      align-items: flex-end;
+      flex-direction: column;
+
+      > :first-child {
+        width: 100%;
+      }
+    }
+  }
+
   .device-form {
     .configuration {
       padding-left: 0;
@@ -275,17 +298,6 @@
 
   .yaml-switch {
     margin-left: $sph--x-large;
-  }
-}
-
-.cloud-init {
-  .override-form {
-    align-items: flex-end;
-    flex-direction: column-reverse;
-
-    > :first-child {
-      width: 100%;
-    }
   }
 }
 

--- a/src/util/formChangeCount.spec.ts
+++ b/src/util/formChangeCount.spec.ts
@@ -1,0 +1,154 @@
+import { getFormChangeCount } from "util/formChangeCount";
+import { ConfigurationRowFormikProps } from "components/ConfigurationRow";
+
+describe("formChangeCount", () => {
+  it("counts reordering of profiles", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["homer", "bart"],
+      },
+      values: {
+        profiles: ["bart", "homer"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(2);
+  });
+
+  it("counts adding of a profile", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart"],
+      },
+      values: {
+        profiles: ["bart", "homer"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("counts removal of a profile", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart", "homer"],
+      },
+      values: {
+        profiles: ["bart"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("counts replacement of a profile", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart", "homer"],
+      },
+      values: {
+        profiles: ["bart", "marge"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("counts adding and replacement of a profile", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart", "homer"],
+      },
+      values: {
+        profiles: ["bart", "marge", "lisa"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(2);
+  });
+
+  it("counts adding and replacement of two profiles", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart", "homer"],
+      },
+      values: {
+        profiles: ["marge", "lisa", "maggy"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(3);
+  });
+
+  it("counts removal and replacement of a profile", () => {
+    const formik = {
+      initialValues: {
+        profiles: ["bart", "homer"],
+      },
+      values: {
+        profiles: ["marge"],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(2);
+  });
+
+  it("value added", () => {
+    const formik = {
+      initialValues: {
+        name: undefined,
+      },
+      values: {
+        name: "value",
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("value removed", () => {
+    const formik = {
+      initialValues: {
+        name: "value",
+      },
+      values: {
+        name: undefined,
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("value changed", () => {
+    const formik = {
+      initialValues: {
+        name: "value",
+      },
+      values: {
+        name: "new",
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+});

--- a/src/util/formChangeCount.tsx
+++ b/src/util/formChangeCount.tsx
@@ -1,0 +1,137 @@
+import {
+  ConfigurationRowFormikProps,
+  ConfigurationRowFormikValues,
+} from "components/ConfigurationRow";
+import { FormDevice, FormDeviceValues } from "util/formDevices";
+import { ResourceLimitsFormValues } from "components/forms/ResourceLimitsForm";
+import { InstanceEditDetailsFormValues } from "pages/instances/EditInstance";
+
+const getPrimitiveFieldChanges = (
+  formik: ConfigurationRowFormikProps,
+): number => {
+  let changeCount = 0;
+
+  const ignoredFields = new Set([
+    "readOnly",
+    "profiles",
+    "limits_cpu",
+    "limits_memory",
+    "devices",
+    "barePool",
+  ]);
+
+  for (const key in formik.values) {
+    if (ignoredFields.has(key)) {
+      continue;
+    }
+    const keyType = key as keyof ConfigurationRowFormikValues;
+    if (formik.values[keyType] !== formik.initialValues[keyType]) {
+      changeCount++;
+    }
+  }
+
+  return changeCount;
+};
+
+const getProfileChanges = (formik: ConfigurationRowFormikProps): number => {
+  if (!Object.hasOwn(formik.values, "profiles")) {
+    return 0;
+  }
+
+  const initProfiles = (formik.initialValues as InstanceEditDetailsFormValues)
+    .profiles;
+  const profiles = (formik.values as InstanceEditDetailsFormValues).profiles;
+
+  let changeCount = Math.abs(profiles.length - initProfiles.length);
+  initProfiles.forEach((initProfile, index) => {
+    if (profiles.length > index && initProfile !== profiles[index]) {
+      changeCount++;
+    }
+  });
+
+  return changeCount;
+};
+
+const stringifyWithOrder = (value?: object): string => {
+  return JSON.stringify(value, Object.keys(value ?? {}).sort());
+};
+
+const getLimitChanges = (formik: ConfigurationRowFormikProps): number => {
+  let changeCount = 0;
+
+  ["limits_cpu", "limits_memory"].forEach((key) => {
+    if (!Object.hasOwn(formik.values, key)) {
+      return;
+    }
+
+    const keyType = key as "limits_memory" | "limits_cpu";
+
+    const init = (formik.initialValues as ResourceLimitsFormValues)[keyType];
+    const value = (formik.values as ResourceLimitsFormValues)[keyType];
+
+    if (stringifyWithOrder(init) !== stringifyWithOrder(value)) {
+      changeCount++;
+    }
+  });
+
+  return changeCount;
+};
+
+const getDevicePairFieldChanges = (a: FormDevice, b: FormDevice): number => {
+  let changeCount = 0;
+
+  for (const key in a) {
+    const keyType = key as keyof FormDevice;
+    if (JSON.stringify(a[keyType]) !== JSON.stringify(b[keyType])) {
+      changeCount++;
+    }
+  }
+  return changeCount;
+};
+
+const getDeviceChanges = (formik: ConfigurationRowFormikProps): number => {
+  let changeCount = 0;
+
+  if (!Object.hasOwn(formik.values, "devices")) {
+    return 0;
+  }
+
+  const initDevices = (formik.initialValues as FormDeviceValues).devices;
+  const devices = (formik.values as FormDeviceValues).devices;
+
+  const initNames = initDevices.map((item) => item.name);
+  const names = devices.map((item) => item.name);
+
+  let addCount = 0;
+  let removeCount = 0;
+
+  initNames.forEach((init, initIndex) => {
+    const valueIndex = names.indexOf(init);
+    if (valueIndex === -1) {
+      removeCount++;
+    } else {
+      changeCount += getDevicePairFieldChanges(
+        initDevices[initIndex],
+        devices[valueIndex],
+      );
+    }
+  });
+
+  names.forEach((init) => {
+    const oldIndex = initNames.indexOf(init);
+    if (oldIndex === -1) {
+      addCount++;
+    }
+  });
+
+  return addCount + removeCount + changeCount;
+};
+
+export const getFormChangeCount = (formik: ConfigurationRowFormikProps) => {
+  return (
+    getPrimitiveFieldChanges(formik) +
+    getProfileChanges(formik) +
+    getLimitChanges(formik) +
+    getDeviceChanges(formik)
+  );
+};

--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -38,7 +38,7 @@ test("instance attach custom volumes and detach inherited volumes", async ({
   await page.getByText("Disk", { exact: true }).click();
   await detachVolume(page, "volume-1");
   await attachVolume(page, instanceVolume, "/baz");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 3);
 
   await assertTextVisible(page, "Reattach");
   await assertTextVisible(page, "/baz");
@@ -68,7 +68,7 @@ test("profile edit custom volumes", async ({ page }) => {
   await page.getByRole("gridcell", { name: "/foo" }).click();
 
   await detachVolume(page, "volume-1");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
 
   await page.getByRole("row", { name: "Size 3GiB" }).click();
 
@@ -99,7 +99,7 @@ test("profile edit networks", async ({ page }) => {
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.locator("[id='devices.1.network']").selectOption({ index: 1 });
   await page.locator("[id='devices.1.name']").fill("eth1");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
 
   await page.getByRole("gridcell", { name: "eth0" }).click();
   await page.getByRole("gridcell", { name: "eth1" }).click();

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -63,8 +63,14 @@ export const editInstance = async (page: Page, instance: string) => {
   await page.getByTestId("tab-link-Configuration").click();
 };
 
-export const saveInstance = async (page: Page, instance: string) => {
-  await page.getByRole("button", { name: "Save changes" }).click();
+export const saveInstance = async (
+  page: Page,
+  instance: string,
+  changeCount: number,
+) => {
+  const name =
+    changeCount === 1 ? "Save 1 change" : `Save ${changeCount} changes`;
+  await page.getByRole("button", { name }).click();
   await page.waitForSelector(`text=Instance ${instance} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };

--- a/tests/helpers/profile.ts
+++ b/tests/helpers/profile.ts
@@ -69,8 +69,14 @@ export const renameProfile = async (
   await page.waitForSelector(`text=Profile ${oldName} renamed to ${newName}.`);
 };
 
-export const saveProfile = async (page: Page, profile: string) => {
-  await page.getByRole("button", { name: "Save changes" }).click();
+export const saveProfile = async (
+  page: Page,
+  profile: string,
+  changeCount: number,
+) => {
+  const name =
+    changeCount === 1 ? "Save 1 change" : `Save ${changeCount} changes`;
+  await page.getByRole("button", { name }).click();
   await page.waitForSelector(`text=Profile ${profile} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -39,7 +39,7 @@ export const editPool = async (page: Page, pool: string) => {
 };
 
 export const savePool = async (page: Page, pool: string) => {
-  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.getByRole("button", { name: "Save 1 change" }).click();
   await page.waitForSelector(`text=Storage pool ${pool} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 };

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -50,6 +50,6 @@ export const editVolume = async (page: Page, volume: string) => {
 };
 
 export const saveVolume = async (page: Page, volume: string) => {
-  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.getByRole("button", { name: "Save 1 change" }).click();
   await page.waitForSelector(`text=Storage volume ${volume} updated.`);
 };

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -90,7 +90,7 @@ test("instance edit basic details", async ({ page }) => {
   await page.locator("#profile-1").selectOption(profile);
   await page.getByRole("button", { name: "move profile up" }).last().click();
 
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 3);
 
   await assertTextVisible(page, "DescriptionA-new-description");
   await expect(page.locator("#profile-0")).toHaveValue(profile);
@@ -101,23 +101,23 @@ test("instance cpu and memory", async ({ page }) => {
   await visitInstance(page, instance);
 
   await setCpuLimit(page, "number", "42");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 1);
   await assertReadMode(page, "Exposed CPU limit", "42");
 
   await setCpuLimit(page, "fixed", "1,2,3,4");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 1);
   await assertReadMode(page, "Exposed CPU limit", "1,2,3,4");
 
   await setCpuLimit(page, "fixed", "1-23");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 1);
   await assertReadMode(page, "Exposed CPU limit", "1-23");
 
   await setMemLimit(page, "percentage", "2");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 1);
   await assertReadMode(page, "Memory limit", "2%");
 
   await setMemLimit(page, "absolute", "3");
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 1);
   await assertReadMode(page, "Memory limit", "3GiB");
 });
 
@@ -129,7 +129,7 @@ test("instance edit resource limits", async ({ page }) => {
   await setOption(page, "Disk priority", "1");
   await setInput(page, "Max number of processes", "Enter number", "42");
 
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 3);
 
   await assertReadMode(page, "Memory swap (Containers only)", "Allow");
   await assertReadMode(page, "Disk priority", "1");
@@ -149,7 +149,7 @@ test("instance edit security policies", async ({ page }) => {
   await setOption(page, "Allow /dev/lxd in the instance", "true");
   await setOption(page, "Make /1.0/images API available", "true");
 
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 8);
 
   await assertReadMode(page, "Protect deletion", "No");
   await assertReadMode(page, "Privileged (Containers only)", "Allow");
@@ -181,7 +181,7 @@ test("instance edit snapshot configuration", async ({ page, lxdVersion }) => {
   await setOption(page, "Snapshot stopped instances", "true");
   await setSchedule(page, "@daily", lxdVersion);
 
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 4);
 
   await assertReadMode(page, "Snapshot name pattern", "snap123");
   await assertReadMode(page, "Expire after", "3m");
@@ -197,7 +197,7 @@ test("instance edit cloud init configuration", async ({ page }) => {
   await setCodeInput(page, "User data", "bar:\n" + " - def");
   await setCodeInput(page, "Vendor data", "baz:\n" + " - ghi");
 
-  await saveInstance(page, instance);
+  await saveInstance(page, instance, 3);
 
   await assertCode(page, "Network config", "foo:");
   await assertCode(page, "User data", "bar:");
@@ -215,7 +215,7 @@ test("instance create vm", async ({ page }) => {
   await page.getByText("Security policies").click();
   await setOption(page, "Enable secureboot (VMs only)", "true");
 
-  await saveInstance(page, vmInstance);
+  await saveInstance(page, vmInstance, 1);
 
   await assertReadMode(page, "Enable secureboot (VMs only)", "true");
 });
@@ -238,7 +238,8 @@ test("instance yaml edit", async ({ page }) => {
   await page.keyboard.press("End");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.type("A-new-description");
-  await saveInstance(page, vmInstance);
+  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.waitForSelector(`text=Instance ${vmInstance} updated.`);
 
   await page.getByText("YAML Configuration").click();
   await assertTextVisible(page, "DescriptionA-new-description");

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -46,7 +46,7 @@ test("profile edit basic details", async ({ page }) => {
 
   await page.getByPlaceholder("Enter description").fill("A-new-description");
 
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
 
   await assertTextVisible(page, "DescriptionA-new-description");
 });
@@ -55,23 +55,23 @@ test("profile cpu and memory", async ({ page }) => {
   await visitProfile(page, profile);
 
   await setCpuLimit(page, "number", "42");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
   await assertReadMode(page, "Exposed CPU limit", "42");
 
   await setCpuLimit(page, "fixed", "1,2,3,4");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
   await assertReadMode(page, "Exposed CPU limit", "1,2,3,4");
 
   await setCpuLimit(page, "fixed", "1-23");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
   await assertReadMode(page, "Exposed CPU limit", "1-23");
 
   await setMemLimit(page, "percentage", "2");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
   await assertReadMode(page, "Memory limit", "2%");
 
   await setMemLimit(page, "absolute", "3");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 1);
   await assertReadMode(page, "Memory limit", "3GiB");
 });
 
@@ -82,7 +82,7 @@ test("profile resource limits", async ({ page }) => {
   await setOption(page, "Memory swap", "true");
   await setOption(page, "Disk priority", "1");
   await setInput(page, "Max number of processes", "Enter number", "2");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 3);
 
   await assertReadMode(page, "Memory swap (Containers only)", "Allow");
   await assertReadMode(page, "Disk priority", "1");
@@ -102,7 +102,7 @@ test("profile security policies", async ({ page }) => {
   await setOption(page, "Allow /dev/lxd in the instance", "true");
   await setOption(page, "Make /1.0/images API available", "true");
   await setOption(page, "Enable secureboot", "true");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 9);
 
   await assertReadMode(page, "Protect deletion", "Yes");
   await assertReadMode(page, "Privileged (Containers only)", "Allow");
@@ -132,7 +132,7 @@ test("profile snapshots", async ({ page, lxdVersion }) => {
   await setOption(page, "Snapshot stopped instances", "true");
   await setSchedule(page, "@daily", lxdVersion);
 
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 4);
 
   await assertReadMode(page, "Snapshot name pattern", "snap123");
   await assertReadMode(page, "Expire after", "3m");
@@ -147,7 +147,7 @@ test("profile cloud init", async ({ page }) => {
   await setCodeInput(page, "Network config", "foo:\n" + " - abc");
   await setCodeInput(page, "User data", "bar:\n" + " - def");
   await setCodeInput(page, "Vendor data", "baz:\n" + " - ghi");
-  await saveProfile(page, profile);
+  await saveProfile(page, profile, 3);
 
   await assertCode(page, "Network config", "foo:");
   await assertCode(page, "User data", "bar:");
@@ -165,7 +165,8 @@ test("profile yaml edit", async ({ page }) => {
 description: 'A-new-description'
 devices: {}
 name: ${profile}`);
-  await saveProfile(page, profile);
+  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.waitForSelector(`text=Profile ${profile} updated.`);
 
   await page.locator("#form-footer").getByText("YAML Configuration").click();
   await assertTextVisible(page, "DescriptionA-new-description");

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -95,7 +95,8 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setTextarea(page, "Network uplinks", "lxcbr0");
   await setTextarea(page, "Network zones", "foo,bar");
 
-  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.getByRole("button", { name: "Save 35 changes" }).click();
+
   await page.waitForSelector(`text=Project ${project} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 

--- a/tests/readme-screenshots.spec.ts
+++ b/tests/readme-screenshots.spec.ts
@@ -38,7 +38,7 @@ test("instance list screen", async ({ page }) => {
   await page.getByTestId("tab-link-Configuration").click();
   await page.getByText("Disk", { exact: true }).click();
   await page.getByRole("button", { name: "Create override" }).click();
-  await page.getByRole("button", { name: "Save changes" }).click();
+  await page.getByRole("button", { name: "Save 1 change" }).click();
   const instances = [
     "comic-glider",
     "deciding-flounder",


### PR DESCRIPTION
## Done

- Show change counts on save buttons for edit forms
- added a function to count the pending changes for any edit form
- align naming of create/edit storage pool components. they have been renamed.
- change instance/profile configuration > cloud init forms. to improve the design in them. 
- fix gpu device input. on change of gpu that is specified by id, we should not unfocus the field when typing into it
- show type of inherited devices of type "other"

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit instance, profile, project, network, storage pool and storage volume
    - ensure the save button shows the right number for all possible edits.