### PR TITLE
fix: allow forked PRs to access repo secrets

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,16 +6,15 @@ on:
 
 jobs:
   e2e-coverage:
-    environment: ci-end-to-end
     name: e2e-test-coverage
     runs-on: ubuntu-latest
     env:
-      LXD_OIDC_CLIENT_ID: ${{ secrets.LXD_OIDC_CLIENT_ID }}
-      LXD_OIDC_ISSUER: ${{ secrets.LXD_OIDC_ISSUER }}
-      LXD_OIDC_AUDIENCE: ${{ secrets.LXD_OIDC_AUDIENCE }}
-      LXD_OIDC_USER: ${{ secrets.LXD_OIDC_USER }}
-      LXD_OIDC_PASSWORD: ${{ secrets.LXD_OIDC_PASSWORD }}
-      LXD_OIDC_GROUPS_CLAIM: ${{ secrets.LXD_OIDC_GROUPS_CLAIM }}
+      LXD_OIDC_CLIENT_ID: "gxj297yfAjmklILK5WqPWDSbtVBAeSQm"
+      LXD_OIDC_ISSUER: "https://dev-xjrvvfikbsv4jxn7.us.auth0.com/"
+      LXD_OIDC_AUDIENCE: "https://dev-xjrvvfikbsv4jxn7.us.auth0.com/api/v2/"
+      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
+      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
+      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,6 @@ jobs:
         
   lint-scss:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +37,6 @@ jobs:
 
   lint-js:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +48,6 @@ jobs:
 
   check-inclusive-naming:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,7 +60,6 @@ jobs:
           fail-on-error: true
 
   browser-e2e-test:
-    environment: ci-end-to-end
     name: e2e-tests
     runs-on: ubuntu-latest
     strategy:
@@ -74,12 +70,12 @@ jobs:
     outputs:
       job_status: ${{job.status}}
     env:
-      LXD_OIDC_CLIENT_ID: ${{ secrets.LXD_OIDC_CLIENT_ID }}
-      LXD_OIDC_ISSUER: ${{ secrets.LXD_OIDC_ISSUER }}
-      LXD_OIDC_AUDIENCE: ${{ secrets.LXD_OIDC_AUDIENCE }}
-      LXD_OIDC_USER: ${{ secrets.LXD_OIDC_USER }}
-      LXD_OIDC_PASSWORD: ${{ secrets.LXD_OIDC_PASSWORD }}
-      LXD_OIDC_GROUPS_CLAIM: ${{ secrets.LXD_OIDC_GROUPS_CLAIM }}
+      LXD_OIDC_CLIENT_ID: "gxj297yfAjmklILK5WqPWDSbtVBAeSQm"
+      LXD_OIDC_ISSUER: "https://dev-xjrvvfikbsv4jxn7.us.auth0.com/"
+      LXD_OIDC_AUDIENCE: "https://dev-xjrvvfikbsv4jxn7.us.auth0.com/api/v2/"
+      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
+      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
+      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Done

- Allow forked PRs to access CI environment secrets. Note secrets are encrypted so they won't leak.