### PR TITLE
Auto name instance networks

### DIFF
--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -18,9 +18,10 @@ import { EditInstanceFormValues } from "pages/instances/EditInstance";
 import { getConfigurationRowBase } from "components/ConfigurationRow";
 import Loader from "components/Loader";
 import { getInheritedNetworks } from "util/configInheritance";
-import { CustomNetworkDevice } from "util/formDevices";
+import { CustomNetworkDevice, deduplicateName } from "util/formDevices";
 import { isNicDeviceNameMissing } from "util/instanceValidation";
 import { ensureEditMode } from "util/instanceEdit";
+import { getExistingDeviceNames } from "util/devices";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -71,9 +72,15 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
     void formik.setFieldValue("devices", copy);
   };
 
+  const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);
+
   const addNetwork = () => {
     const copy = [...formik.values.devices];
-    copy.push({ type: "nic", name: "", network: networks[0]?.name ?? "" });
+    copy.push({
+      type: "nic",
+      name: deduplicateName("eth", 1, existingDeviceNames),
+      network: networks[0]?.name ?? "",
+    });
     void formik.setFieldValue("devices", copy);
 
     focusNetwork(copy.length - 1);


### PR DESCRIPTION
## Done

- Auto name instance networks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - configure an instance (create or edit)
    - add a network
    - see the generated name