### PR TITLE
fix(instance) adding a gpu without pci address will fall back to setting the cards drm id

### DIFF
--- a/src/components/forms/GPUDeviceForm.tsx
+++ b/src/components/forms/GPUDeviceForm.tsx
@@ -60,11 +60,14 @@ const GPUDevicesForm: FC<Props> = ({ formik, project }) => {
   const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);
 
   const addGPUCard = (card: GpuCard) => {
+    const drmId = card.drm?.id ? card.drm.id.toString() : undefined;
+
     const copy = [...formik.values.devices];
     copy.push({
       type: "gpu",
       gputype: "physical",
       pci: card.pci_address,
+      id: card.pci_address === undefined ? drmId : undefined,
       name: deduplicateName("gpu", 1, existingDeviceNames),
     });
     void formik.setFieldValue("devices", copy);


### PR DESCRIPTION
## Done

- fix(instance) adding a gpu without pci address will fall back to setting the cards drm id

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - add a gpu that has no pci address, but a drm id