### PR TITLE
adjust other device copy to align with rest of the configuration

### DIFF
--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -234,28 +234,28 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
             value={device.type}
             options={[
               {
-                label: "Infiniband (container only)",
+                label: "Infiniband (Containers only)",
                 value: "infiniband",
                 disabled: isVm,
               },
               {
-                label: "PCI (VM only)",
+                label: "PCI (VMs only)",
                 value: "pci",
                 disabled: isContainer,
               },
               { label: "TPM", value: "tpm" },
               {
-                label: "Unix Block (container only)",
+                label: "Unix Block (Containers only)",
                 value: "unix-block",
                 disabled: isVm,
               },
               {
-                label: "Unix Char (container only)",
+                label: "Unix Char (Containers only)",
                 value: "unix-char",
                 disabled: isVm,
               },
               {
-                label: "Unix Hotplug (container only)",
+                label: "Unix Hotplug (Containers only)",
                 value: "unix-hotplug",
                 disabled: isVm,
               },


### PR DESCRIPTION
## Done

- adjust other device copy to align with rest of the configuration

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - configure an instance (edit or create one)
    - check the other device type. The copy should be aligned with the other sections of the instance configuration
