### PR TITLE
fix(idp-group) deselect idp group after deletion, deselct idp group on cancel of edit panel

### DIFF
--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -27,7 +27,7 @@ import { fetchIdpGroups } from "api/auth-idp-groups";
 import CreateIdpGroupPanel from "./panels/CreateIdpGroupPanel";
 import BulkDeleteIdpGroupsBtn from "./actions/BulkDeleteIdpGroupsBtn";
 import EditIdpGroupPanel from "./panels/EditIdpGroupPanel";
-import DeleteIdepGroupBtn from "./actions/DeleteIdpGroupBtn";
+import DeleteIdpGroupBtn from "./actions/DeleteIdpGroupBtn";
 import { useSettings } from "context/useSettings";
 import { Link } from "react-router-dom";
 
@@ -51,6 +51,15 @@ const PermissionIdpGroups: FC = () => {
   if (error) {
     notify.failure("Loading provider groups failed", error);
   }
+
+  useEffect(() => {
+    const validSelections = selectedGroupNames.filter((name) =>
+      groups.some((group) => group.name === name),
+    );
+    if (validSelections.length !== selectedGroupNames.length) {
+      setSelectedGroupNames(validSelections);
+    }
+  }, [groups]);
 
   useEffect(() => {
     if (panelParams.idpGroup) {
@@ -113,7 +122,7 @@ const PermissionIdpGroups: FC = () => {
                 >
                   <Icon name="edit" />
                 </Button>,
-                <DeleteIdepGroupBtn
+                <DeleteIdpGroupBtn
                   key={`delete-${idpGroup.name}`}
                   idpGroup={idpGroup}
                 />,
@@ -265,7 +274,6 @@ const PermissionIdpGroups: FC = () => {
                   <BulkDeleteIdpGroupsBtn
                     idpGroups={selectedGroups}
                     className="u-no-margin--bottom"
-                    onDelete={() => setSelectedGroupNames([])}
                   />
                 </>
               )}
@@ -293,7 +301,10 @@ const PermissionIdpGroups: FC = () => {
       {panelParams.panel === panels.createIdpGroup && <CreateIdpGroupPanel />}
 
       {panelParams.panel === panels.editIdpGroup && selectedGroups.length && (
-        <EditIdpGroupPanel idpGroup={selectedGroups[0]} />
+        <EditIdpGroupPanel
+          idpGroup={selectedGroups[0]}
+          onClose={() => setSelectedGroupNames([])}
+        />
       )}
     </>
   );

--- a/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
@@ -6,15 +6,10 @@ import DeleteIdpGroupsModal from "./DeleteIdpGroupsModal";
 
 interface Props {
   idpGroups: IdpGroup[];
-  onDelete: () => void;
   className?: string;
 }
 
-const BulkDeleteIdpGroupsBtn: FC<Props> = ({
-  idpGroups,
-  className,
-  onDelete,
-}) => {
+const BulkDeleteIdpGroupsBtn: FC<Props> = ({ idpGroups, className }) => {
   const [confirming, setConfirming] = useState(false);
 
   const handleConfirmDelete = () => {
@@ -22,7 +17,6 @@ const BulkDeleteIdpGroupsBtn: FC<Props> = ({
   };
 
   const handleCloseConfirm = () => {
-    onDelete();
     setConfirming(false);
   };
 

--- a/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
+++ b/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
@@ -8,7 +8,7 @@ interface Props {
   idpGroup: IdpGroup;
 }
 
-const DeleteIdepGroupBtn: FC<Props> = ({ idpGroup }) => {
+const DeleteIdpGroupBtn: FC<Props> = ({ idpGroup }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
 
   return (
@@ -33,4 +33,4 @@ const DeleteIdepGroupBtn: FC<Props> = ({ idpGroup }) => {
   );
 };
 
-export default DeleteIdepGroupBtn;
+export default DeleteIdpGroupBtn;

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -24,9 +24,10 @@ type GroupEditHistory = {
 
 interface Props {
   idpGroup: IdpGroup;
+  onClose?: () => void;
 }
 
-const EditIdpGroupPanel: FC<Props> = ({ idpGroup }) => {
+const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -122,6 +123,7 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup }) => {
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
+    onClose?.();
   };
 
   const saveIdpGroup = (values: IdpGroupFormValues) => {


### PR DESCRIPTION
## Done

- this fixes two issues with idp group selection
- 1. on edit idp group and cancel, we should unselect the group
- 2. on select idp group, then delete the single row, we should remove the deleted group from the selection.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit idp group, in the panel click cancel, ensure the group is unselected
    - select and idp group, delete it from the row (not bulk delete), ensure the group gets unselected
    - bulk delete idp groups, ensure they get unselected.