### PR TITLE
Link identity and permission counts to the edit panel sections

### DIFF
--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -118,13 +118,31 @@ const PermissionGroups: FC = () => {
           title: group.description,
         },
         {
-          content: allIdentityIds.length,
+          content: (
+            <Button
+              appearance="link"
+              dense
+              onClick={() => panelParams.openEditGroup(group.name, "identity")}
+            >
+              {allIdentityIds.length}
+            </Button>
+          ),
           role: "cell",
           className: "u-align--right identities",
           "aria-label": "Identities in this group",
         },
         {
-          content: group.permissions?.length || 0,
+          content: (
+            <Button
+              appearance="link"
+              dense
+              onClick={() =>
+                panelParams.openEditGroup(group.name, "permission")
+              }
+            >
+              {group.permissions?.length || 0}
+            </Button>
+          ),
           role: "cell",
           className: "u-align--right permissions",
           "aria-label": "Permissions for this group",

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -51,7 +51,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
-  const [subForm, setSubForm] = useState<GroupSubForm>(null);
+  const [subForm, setSubForm] = useState<GroupSubForm>(panelParams.subForm);
   const [confirming, setConfirming] = useState(false);
   const [identities, setIdentities] = useState<FormIdentity[]>(
     getIdentityIdsForGroup(group).map((id) => ({ id: id })) as FormIdentity[],

--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -19,10 +19,10 @@ import classnames from "classnames";
 import { LxdGroup, LxdPermission } from "types/permissions";
 
 export type FormPermission = LxdPermission & {
-  id: string;
+  id?: string;
   isRemoved?: boolean;
   isAdded?: boolean;
-  resourceLabel: string;
+  resourceLabel?: string;
 };
 
 interface Props {
@@ -50,7 +50,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
     }
 
     const groupPermissionIds = getPermissionIds(group?.permissions ?? []);
-    const wasInGroup = groupPermissionIds.includes(newPermission.id);
+    const wasInGroup = groupPermissionIds.includes(newPermission.id ?? "");
     const addMe = { ...newPermission, isAdded: !wasInGroup, isRemoved: false };
 
     if (permissionExists && permissionExists.isRemoved) {
@@ -90,7 +90,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
         return (
           permission.entitlement.includes(search) ||
           permission.entity_type.includes(search) ||
-          permission.resourceLabel.toLowerCase().includes(search)
+          permission.resourceLabel?.toLowerCase().includes(search)
         );
       })
     : permissions;
@@ -166,7 +166,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
                   appearance="base"
                   hasIcon
                   dense
-                  onClick={() => deletePermission(permission.id)}
+                  onClick={() => deletePermission(permission.id ?? "")}
                   type="button"
                   aria-label="Delete permission"
                   title="Delete permission"
@@ -191,7 +191,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
       ],
       sortData: {
         resourceType: permission.entity_type.toLowerCase(),
-        resource: permission.resourceLabel.toLowerCase(),
+        resource: permission.resourceLabel?.toLowerCase(),
         entitlement: permission.entitlement.toLowerCase(),
       },
     };

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -344,8 +344,8 @@ export const permissionSort = (
     resourceTypeSortOrder[permissionA.entity_type] -
     resourceTypeSortOrder[permissionB.entity_type];
 
-  const resourceNameComparison = permissionA.resourceLabel.localeCompare(
-    permissionB.resourceLabel,
+  const resourceNameComparison = permissionA.resourceLabel?.localeCompare(
+    permissionB.resourceLabel ?? "",
   );
 
   const entitlementComparison = permissionA.entitlement.localeCompare(

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -1,4 +1,5 @@
 import { useSearchParams } from "react-router-dom";
+import { GroupSubForm } from "pages/permissions/panels/CreateGroupPanel";
 
 export interface PanelHelper {
   panel: string | null;
@@ -7,6 +8,7 @@ export interface PanelHelper {
   group: string | null;
   idpGroup: string | null;
   identity: string | null;
+  subForm: GroupSubForm;
   project: string;
   clear: () => void;
   openInstanceSummary: (instance: string, project: string) => void;
@@ -14,7 +16,7 @@ export interface PanelHelper {
   openProfileSummary: (profile: string, project: string) => void;
   openIdentityGroups: (identity?: string) => void;
   openCreateGroup: () => void;
-  openEditGroup: (group: string) => void;
+  openEditGroup: (group: string, subForm?: GroupSubForm) => void;
   openGroupIdentities: (group?: string) => void;
   openCreateIdpGroup: () => void;
   openEditIdpGroup: (group: string) => void;
@@ -64,6 +66,7 @@ const usePanelParams = (): PanelHelper => {
     newParams.delete("panel");
     newParams.delete("profile");
     newParams.delete("project");
+    newParams.delete("sub-form");
     setParams(newParams);
     craftResizeEvent();
   };
@@ -76,6 +79,7 @@ const usePanelParams = (): PanelHelper => {
     identity: params.get("identity"),
     group: params.get("group"),
     idpGroup: params.get("idp-group"),
+    subForm: params.get("sub-form") as GroupSubForm,
 
     clear: () => {
       clearParams();
@@ -103,8 +107,12 @@ const usePanelParams = (): PanelHelper => {
       setPanelParams(panels.createGroup);
     },
 
-    openEditGroup: (group) => {
-      setPanelParams(panels.editGroup, { group: group || "" });
+    openEditGroup: (group, subForm) => {
+      const params: ParamMap = { group: group || "" };
+      if (subForm) {
+        params["sub-form"] = subForm;
+      }
+      setPanelParams(panels.editGroup, params);
     },
 
     openGroupIdentities: (group) => {


### PR DESCRIPTION
## Done

- Link identity and permission counts to the edit panel sections

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check permission > groups
    - click on the number of identities or permissions links to the edit panel section