### PR TITLE
feat: show cached images for instance creation [WD-14414]

### DIFF
--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -15,6 +15,7 @@ export interface LxdImage {
     os: string;
     release: string;
     variant?: string;
+    version?: string;
   };
   update_source?: {
     alias: string;
@@ -61,6 +62,7 @@ export interface RemoteImage {
   volume?: LxdStorageVolume;
   type?: LxdImageType;
   fingerprint?: string;
+  cached?: boolean;
 }
 
 export interface RemoteImageList {

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -1,5 +1,6 @@
 import { LxdImage, RemoteImage } from "types/image";
 import { LxdStorageVolume } from "types/storage";
+import { capitalizeFirstLetter } from "./helpers";
 
 export const isVmOnlyImage = (image: RemoteImage): boolean | undefined => {
   if (image.server === LOCAL_ISO || image.type === "virtual-machine") {
@@ -46,11 +47,14 @@ export const localLxdToRemoteImage = (image: LxdImage): RemoteImage => {
     aliases: image.update_source?.alias ?? image.aliases?.[0]?.name ?? "",
     fingerprint: image.fingerprint,
     arch: image.architecture === "x86_64" ? "amd64" : image.architecture,
-    os: image.properties?.os ?? "",
+    os: capitalizeFirstLetter(image.properties?.os ?? ""),
     created_at: new Date(image.uploaded_at).getTime(),
     release: image.properties?.release ?? "",
-    server: LOCAL_IMAGE,
+    release_title: image.properties?.version ?? "",
     type: image.type,
+    cached: image.cached,
+    server: image.cached ? image.update_source?.server : LOCAL_IMAGE,
+    variant: image.properties?.variant,
   };
 };
 

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -27,7 +27,12 @@ export const createInstance = async (
   await page.getByRole("button", { name: "Browse images" }).click();
   await page.getByPlaceholder("Search an image").click();
   await page.getByPlaceholder("Search an image").fill(image);
-  await page.getByRole("button", { name: "Select" }).first().click();
+  await page
+    .getByRole("row")
+    .filter({ hasNotText: "cached" })
+    .getByRole("button", { name: "Select" })
+    .first()
+    .click();
   await page
     .getByRole("combobox", { name: "Instance type" })
     .selectOption(type);
@@ -121,7 +126,11 @@ export const createAndStartInstance = async (
   await page.getByRole("button", { name: "Browse images" }).click();
   await page.getByPlaceholder("Search an image").click();
   await page.getByPlaceholder("Search an image").fill("alpine/3.19/cloud");
-  await page.getByRole("button", { name: "Select" }).click();
+  await page
+    .getByRole("row")
+    .filter({ hasNotText: "cached" })
+    .getByRole("button", { name: "Select" })
+    .click();
   await page
     .getByRole("combobox", { name: "Instance type" })
     .selectOption(type);


### PR DESCRIPTION
## Done

- Show cached images when creating instances

Closes #839 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance with a base image from any remote image server to download it for LXD
    - Then try create an instance again, make sure the previously downloaded image is available for selection in the image selection modal

## Screenshots
![Screenshot from 2024-09-16 17-10-44](https://github.com/user-attachments/assets/6e2933c9-f229-498b-9a1e-1ede2aa89730)
