### PR TITLE
Ensure cache is cleared on image upload after the alias is created

### DIFF
--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -28,7 +28,7 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
           operation.metadata.id,
           () => {
             void queryClient.invalidateQueries({
-              queryKey: [queryKeys.images],
+              predicate: (query) => query.queryKey[0] === queryKeys.images,
             });
             void queryClient.invalidateQueries({
               queryKey: [queryKeys.projects, project],

--- a/src/pages/images/actions/forms/UploadImageForm.tsx
+++ b/src/pages/images/actions/forms/UploadImageForm.tsx
@@ -58,6 +58,12 @@ const UploadImageForm: FC<Props> = ({ close, project }) => {
     }
   };
 
+  const clearCache = () => {
+    void queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[0] === queryKeys.images,
+    });
+  };
+
   const formik = useFormik<{
     alias: string;
     isPublic: boolean;
@@ -94,11 +100,11 @@ const UploadImageForm: FC<Props> = ({ close, project }) => {
               (event) => {
                 const fingerprint = event.metadata.metadata?.fingerprint ?? "";
                 if (values.alias) {
-                  void createImageAlias(fingerprint, values.alias);
+                  void createImageAlias(fingerprint, values.alias).then(
+                    clearCache,
+                  );
                 }
-                void queryClient.invalidateQueries({
-                  queryKey: [queryKeys.images, project],
-                });
+                clearCache();
                 notifySuccess();
               },
               (msg) => {


### PR DESCRIPTION
## Done

- ensure cache is cleared on image upload after the alias is created
- this is to fix a ux issue and to make the image upload test more stable
- ensure we clear all the images caches, as we fetch images for all projects in permission components and need to clear those as well on update or deletion

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - upload an image, ensure the new image appears in the image list with the alias specified.