### PR TITLE
On permission select, show image names with image type (vm or container)

### DIFF
--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -309,7 +309,7 @@ export const getImageNameLookup = (
   const nameLookup: Record<string, string> = {};
   for (const image of images) {
     nameLookup[image.fingerprint] =
-      image.properties?.description ?? image.fingerprint;
+      `${image.properties?.description} (${image.type})` ?? image.fingerprint;
   }
 
   return nameLookup;


### PR DESCRIPTION
## Done

- On permission select, show image names with image type (vm or container)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - have a cached image locally available for vm and contianer
    - go to permissions > group > create group > add permissions > image
    - ensure the two images (for vm and container) are visible in the selector