### PR TITLE
feat: [WD-14769] Move custom storage volume to another storage pool.

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -363,3 +363,21 @@ export const deleteStorageVolume = (
       .catch(reject);
   });
 };
+
+export const migrateStorageVolume = (
+  volume: Partial<LxdStorageVolume>,
+  targetPool: string,
+): Promise<LxdOperationResponse> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/storage-pools/${volume.pool}/volumes/custom/${volume.name}`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: volume.name,
+        pool: targetPool,
+      }),
+    })
+      .then(handleResponse)
+      .then(resolve)
+      .catch(reject);
+  });
+};

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -1,0 +1,134 @@
+import { FC, useState } from "react";
+import { ActionButton, Icon } from "@canonical/react-components";
+import usePortal from "react-useportal";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useEventQueue } from "context/eventQueue";
+import ItemName from "components/ItemName";
+import { useToastNotification } from "context/toastNotificationProvider";
+import { LxdStorageVolume } from "types/storage";
+import MigrateVolumeModal from "./MigrateVolumeModal";
+import { migrateStorageVolume } from "api/storage-pools";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  storageVolume: LxdStorageVolume;
+  project: string;
+  classname?: string;
+  onClose?: () => void;
+}
+
+const MigrateVolumeBtn: FC<Props> = ({
+  storageVolume,
+  project,
+  classname,
+  onClose,
+}) => {
+  const eventQueue = useEventQueue();
+  const toastNotify = useToastNotification();
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [isVolumeLoading, setVolumeLoading] = useState(false);
+
+  const handleSuccess = (
+    newTarget: string,
+    storageVolume: LxdStorageVolume,
+  ) => {
+    toastNotify.success(
+      <>
+        Volume <ItemName item={{ name: storageVolume.name }} bold />{" "}
+        successfully migrated to pool{" "}
+        <ItemName item={{ name: newTarget }} bold />
+      </>,
+    );
+
+    const oldVolumeUrl = `/ui/project/${storageVolume.project}/storage/pool/${storageVolume.pool}/volumes/${storageVolume.type}/${storageVolume.name}`;
+    const newVolumeUrl = `/ui/project/${storageVolume.project}/storage/pool/${newTarget}/volumes/${storageVolume.type}/${storageVolume.name}`;
+    if (window.location.pathname.startsWith(oldVolumeUrl)) {
+      navigate(newVolumeUrl);
+    }
+  };
+
+  const notifyFailure = (
+    e: unknown,
+    storageVolume: string,
+    targetPool: string,
+  ) => {
+    setVolumeLoading(false);
+    toastNotify.failure(
+      `Migration failed for volume ${storageVolume} to pool ${targetPool}`,
+      e,
+    );
+  };
+
+  const handleFailure = (
+    msg: string,
+    storageVolume: string,
+    targetPool: string,
+  ) => {
+    notifyFailure(new Error(msg), storageVolume, targetPool);
+  };
+
+  const handleFinish = () => {
+    void queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, storageVolume.name],
+    });
+    setVolumeLoading(false);
+  };
+
+  const handleMigrate = (targetPool: string) => {
+    setVolumeLoading(true);
+    migrateStorageVolume(storageVolume, targetPool)
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () => handleSuccess(targetPool, storageVolume),
+          (err) => handleFailure(err, storageVolume.name, targetPool),
+          handleFinish,
+        );
+        toastNotify.info(
+          `Migration started for volume ${storageVolume.name} to pool ${targetPool}`,
+        );
+        void queryClient.invalidateQueries({
+          queryKey: [queryKeys.storage, storageVolume.name, project],
+        });
+        handleClose();
+      })
+      .catch((e) => {
+        notifyFailure(e, storageVolume.name, targetPool);
+      });
+  };
+
+  const handleClose = () => {
+    closePortal();
+    onClose?.();
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <MigrateVolumeModal
+            close={handleClose}
+            migrate={handleMigrate}
+            storageVolume={storageVolume}
+          />
+        </Portal>
+      )}
+      <ActionButton
+        onClick={openPortal}
+        type="button"
+        className={classname}
+        loading={isVolumeLoading}
+        disabled={isVolumeLoading}
+        title="Migrate volume"
+      >
+        <Icon name="machines" />
+        <span>Migrate</span>
+      </ActionButton>
+    </>
+  );
+};
+
+export default MigrateVolumeBtn;

--- a/src/pages/storage/MigrateVolumeModal.tsx
+++ b/src/pages/storage/MigrateVolumeModal.tsx
@@ -1,0 +1,187 @@
+import { FC, KeyboardEvent, useState } from "react";
+import {
+  ActionButton,
+  Button,
+  MainTable,
+  Modal,
+} from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import ScrollableTable from "components/ScrollableTable";
+import { LxdStorageVolume } from "types/storage";
+import { fetchStoragePools } from "api/storage-pools";
+import StoragePoolSize from "./StoragePoolSize";
+
+interface Props {
+  close: () => void;
+  migrate: (target: string) => void;
+  storageVolume: LxdStorageVolume;
+}
+
+const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
+  const { data: pools = [] } = useQuery({
+    queryKey: [queryKeys.storage],
+    queryFn: () => fetchStoragePools(storageVolume.project),
+  });
+
+  const [selectedPool, setSelectedPool] = useState("");
+
+  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Escape") {
+      close();
+    }
+  };
+
+  const handleCancel = () => {
+    if (selectedPool) {
+      setSelectedPool("");
+      return;
+    }
+
+    close();
+  };
+
+  const headers = [
+    { content: "Name", sortKey: "name" },
+    { content: "Driver", sortKey: "driver" },
+    { content: "Status", sortKey: "status" },
+    { content: "Size", sortKey: "size" },
+    { "aria-label": "Actions", className: "actions" },
+  ];
+
+  const rows = pools.map((pool) => {
+    const disableReason =
+      pool.name === storageVolume.pool
+        ? "Volume is located on this cluster member"
+        : "";
+
+    const selectPool = () => {
+      if (disableReason) {
+        return;
+      }
+
+      setSelectedPool(pool.name);
+    };
+
+    return {
+      className: "u-row",
+      columns: [
+        {
+          content: (
+            <div className="u-truncate migrate-instance-name" title={pool.name}>
+              {pool.name}
+            </div>
+          ),
+          role: "cell",
+          "aria-label": "Name",
+          onClick: selectPool,
+        },
+        {
+          content: pool.driver,
+          role: "cell",
+          "aria-label": "Driver",
+          onClick: selectPool,
+        },
+        {
+          content: pool.status,
+          role: "cell",
+          "aria-label": "Status",
+          onClick: selectPool,
+        },
+        {
+          content: <StoragePoolSize pool={pool} />,
+          role: "cell",
+          "aria-label": "Size",
+          onClick: selectPool,
+        },
+        {
+          content: (
+            <Button
+              onClick={selectPool}
+              dense
+              title={disableReason}
+              disabled={Boolean(disableReason)}
+            >
+              Select
+            </Button>
+          ),
+          role: "cell",
+          "aria-label": "Actions",
+          className: "u-align--right",
+          onClick: selectPool,
+        },
+      ],
+      sortData: {
+        name: pool.name.toLowerCase(),
+        driver: pool.driver.toLowerCase(),
+        status: pool.status?.toLowerCase(),
+        size: pool.config.size?.toLowerCase(),
+      },
+    };
+  });
+
+  const modalTitle = selectedPool
+    ? "Confirm migration"
+    : `Choose storage pool for volume ${storageVolume.name}`;
+
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate volume <strong>{storageVolume.name}</strong> to
+        storage pool <b>{selectedPool}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <Modal
+      close={close}
+      className="migrate-instance-modal"
+      title={modalTitle}
+      buttonRow={
+        <div id="migrate-instance-actions">
+          <Button
+            className="u-no-margin--bottom"
+            type="button"
+            aria-label="cancel migrate"
+            appearance="base"
+            onClick={handleCancel}
+          >
+            Cancel
+          </Button>
+          <ActionButton
+            appearance="positive"
+            className="u-no-margin--bottom"
+            onClick={() => migrate(selectedPool)}
+            disabled={!selectedPool}
+          >
+            Migrate
+          </ActionButton>
+        </div>
+      }
+      onKeyDown={handleEscKey}
+    >
+      {selectedPool ? (
+        summary
+      ) : (
+        <div className="migrate-instance-table u-selectable-table-rows">
+          <ScrollableTable
+            dependencies={[]}
+            tableId="migrate-instance-table"
+            belowIds={["status-bar", "migrate-instance-actions"]}
+          >
+            <MainTable
+              id="migrate-instance-table"
+              headers={headers}
+              rows={rows}
+              sortable
+              className="u-table-layout--auto"
+            />
+          </ScrollableTable>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default MigrateVolumeModal;

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -14,6 +14,8 @@ interface Props {
   setValue: (value: string) => void;
   selectProps?: SelectProps;
   hidePoolsWithUnsupportedDrivers?: boolean;
+  disabled?: boolean;
+  help?: string;
 }
 
 const StoragePoolSelector: FC<Props> = ({
@@ -22,6 +24,8 @@ const StoragePoolSelector: FC<Props> = ({
   setValue,
   selectProps,
   hidePoolsWithUnsupportedDrivers = false,
+  disabled,
+  help,
 }) => {
   const notify = useNotify();
   const { data: settings } = useSettings();
@@ -82,6 +86,8 @@ const StoragePoolSelector: FC<Props> = ({
       onChange={(e) => setValue(e.target.value)}
       value={value}
       {...selectProps}
+      disabled={disabled}
+      help={help}
     />
   );
 };

--- a/src/pages/storage/StorageVolumeHeader.tsx
+++ b/src/pages/storage/StorageVolumeHeader.tsx
@@ -9,6 +9,7 @@ import { testDuplicateStorageVolumeName } from "util/storageVolume";
 import { useNotify } from "@canonical/react-components";
 import DeleteStorageVolumeBtn from "pages/storage/actions/DeleteStorageVolumeBtn";
 import { useToastNotification } from "context/toastNotificationProvider";
+import MigrateVolumeBtn from "./MigrateVolumeBtn";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -66,6 +67,8 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
     },
   });
 
+  const classname = "p-segmented-control__button";
+
   return (
     <RenameHeader
       name={volume.name}
@@ -75,17 +78,27 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
         </Link>,
       ]}
       controls={
-        <DeleteStorageVolumeBtn
-          label="Delete volume"
-          volume={volume}
-          project={project}
-          appearance=""
-          hasIcon={false}
-          onFinish={() => {
-            navigate(`/ui/project/${project}/storage/volumes`);
-            toastNotify.success(`Storage volume ${volume.name} deleted.`);
-          }}
-        />
+        <div className="p-segmented-control">
+          <div className="p-segmented-control__list">
+            <MigrateVolumeBtn
+              storageVolume={volume}
+              project={project}
+              classname={classname}
+            />
+            <DeleteStorageVolumeBtn
+              label="Delete"
+              volume={volume}
+              project={project}
+              appearance=""
+              hasIcon={true}
+              onFinish={() => {
+                navigate(`/ui/project/${project}/storage/volumes`);
+                toastNotify.success(`Storage volume ${volume.name} deleted.`);
+              }}
+              classname={classname}
+            />
+          </div>
+        </div>
       }
       isLoaded={true}
       formik={formik}

--- a/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
@@ -16,6 +16,7 @@ interface Props {
   appearance?: string;
   hasIcon?: boolean;
   label?: string;
+  classname?: string;
 }
 
 const DeleteStorageVolumeBtn: FC<Props> = ({
@@ -25,6 +26,7 @@ const DeleteStorageVolumeBtn: FC<Props> = ({
   appearance = "base",
   hasIcon = true,
   label,
+  classname,
 }) => {
   const notify = useNotify();
   const [isLoading, setLoading] = useState(false);
@@ -98,14 +100,14 @@ const DeleteStorageVolumeBtn: FC<Props> = ({
         onConfirm: handleDelete,
       }}
       appearance={appearance}
-      className="has-icon u-no-margin--bottom"
+      className={classname}
       shiftClickEnabled
       showShiftClickHint
       disabled={Boolean(disabledReason)}
       onHoverText={disabledReason}
     >
-      {label && <span>{label}</span>}
       {hasIcon && <Icon name="delete" />}
+      {label && <span>{label}</span>}
     </ConfirmationButton>
   );
 };

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -23,19 +23,24 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
     <ScrollableForm>
       <Row>
         <Col size={12}>
-          {formik.values.isCreating && (
-            <>
-              <Label forId="storage-pool-selector" required>
-                Storage pool
-              </Label>
-              <StoragePoolSelector
-                project={project}
-                value={formik.values.pool}
-                setValue={(val) => void formik.setFieldValue("pool", val)}
-                hidePoolsWithUnsupportedDrivers
-              />
-            </>
-          )}
+          <Label
+            forId="storage-pool-selector"
+            required={formik.values.isCreating ? true : false}
+          >
+            Storage pool
+          </Label>
+          <StoragePoolSelector
+            project={project}
+            value={formik.values.pool}
+            setValue={(val) => void formik.setFieldValue("pool", val)}
+            hidePoolsWithUnsupportedDrivers
+            disabled={!formik.values.isCreating}
+            help={
+              formik.values.isCreating
+                ? undefined
+                : "Use the migrate button in the header to move the volume to a different storage pool."
+            }
+          />
           <Input
             {...getFormProps(formik, "name")}
             type="text"
@@ -45,7 +50,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
             help={
               formik.values.isCreating
                 ? undefined
-                : "Click the name in the header to rename the volume"
+                : "Click the name in the header to rename the volume."
             }
           />
           <DiskSizeSelector

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -10,6 +10,7 @@ import {
   createVolume,
   deleteVolume,
   editVolume,
+  migrateVolume,
   randomVolumeName,
   saveVolume,
   visitVolume,
@@ -55,6 +56,18 @@ test("storage volume create, edit and remove", async ({ page }) => {
 
   await page.getByTestId("tab-link-Overview").click();
   await assertTextVisible(page, "size2GiB");
+});
+
+test("storage volume migrate", async ({ page }) => {
+  const pool2 = randomPoolName();
+  await createPool(page, pool2);
+
+  await migrateVolume(page, volume, pool2);
+  await expect(page.getByRole("link", { name: pool2 })).toBeVisible();
+
+  //Migrate back to default so that the Pool can be deleted
+  await migrateVolume(page, volume, "default");
+  await deletePool(page, pool2);
 });
 
 test("storage volume edit snapshot configuration", async ({


### PR DESCRIPTION
## Done

- Implemented a button that opens a modal to migrate Custom storage volumes between different storage pools.
- Used Segmented-Controls css/ui for the Custom storage volume detail page.
- Created api endpoint 'migrateStorageVolume'.
- Added test for storage volume migration in storage.spec.ts.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to a custom storage volume and view the Migrate button at the top-right of the page.
    - Attempt to change the storage pool of the volume.

## Screenshots
![image](https://github.com/user-attachments/assets/4cfdabc2-30f2-4a27-a60e-ef00cfa3b52b)
![image](https://github.com/user-attachments/assets/f38f6fda-27fb-47ba-bb3a-a0f51c93b64f)
![image](https://github.com/user-attachments/assets/02099572-65b8-4be3-be17-5a1f4c71b62f)
