### PR TITLE
fix: remove workaround for extracting instance name from snapshot operation [WD-14541]

### DIFF
--- a/src/types/operation.d.ts
+++ b/src/types/operation.d.ts
@@ -15,6 +15,7 @@ export interface LxdOperation {
   may_cancel: boolean;
   resources?: {
     instances?: string[];
+    instances_snapshots?: string[];
   };
   status: LxdOperationStatus;
   status_code: string;

--- a/src/util/operations.spec.ts
+++ b/src/util/operations.spec.ts
@@ -2,9 +2,21 @@ import { getInstanceName, getProjectName } from "./operations";
 import { LxdOperation } from "types/operation";
 
 const craftOperation = (...url: string[]) => {
+  const instances: string[] = [];
+  const instances_snapshots: string[] = [];
+  for (const u of url) {
+    const segments = u.split("/");
+    if (segments.length > 4) {
+      instances_snapshots.push(u);
+    } else {
+      instances.push(u);
+    }
+  }
+
   return {
     resources: {
-      instances: [...url],
+      instances,
+      instances_snapshots,
     },
   } as LxdOperation;
 };

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -4,19 +4,9 @@ export const getInstanceName = (operation?: LxdOperation): string => {
   // the url can be one of below formats
   // /1.0/instances/<instance_name>
   // /1.0/instances/<instance_name>?project=<project_name>
-  // /1.0/instances/<instance_name>/snapshots/<snapshot_name>
-  // /1.0/instances/<instance_name>/<snapshot_name>
   return (
     operation?.resources?.instances
-      ?.filter((item) => {
-        // for snapshots backend returns %2F instead of /, which is not decoded by the browser
-        const itemUrl = decodeURIComponent(item);
-        return (
-          itemUrl.startsWith("/1.0/instances/") &&
-          // exclude snapshots
-          itemUrl.split("/").length <= 4
-        );
-      })
+      ?.filter((item) => item.startsWith("/1.0/instances/"))
       .map((item) => item.split("/")[3])
       .pop()
       ?.split("?")[0] ?? ""


### PR DESCRIPTION
## Done

- previously, an operation for creating an instance from a snapshot would include the snapshot name in the instances resource field within the operation response metadata. We had to include a workaround to filter out the snapshots in order to extract the instance name.
- with this upstream [PR](https://github.com/canonical/lxd/pull/14139) merged, we can now remove the workaround

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance from a snapshot
    - Make sure that the operation shows the new instance name