### PR TITLE
Preserve any disk device field on editing of instance or profile config

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -15,6 +15,7 @@ import { ProjectFormValues } from "pages/projects/CreateProject";
 import { getConfigRowMetadata } from "util/configInheritance";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 import { ensureEditMode } from "util/instanceEdit";
+import { focusField } from "util/formFields";
 
 export type ConfigurationRowFormikValues =
   | InstanceAndProfileFormValues
@@ -65,16 +66,12 @@ export const getConfigurationRow = ({
     void formik.setFieldValue(name, defaultValue);
   };
 
-  const focusOverride = () => {
-    setTimeout(() => document.getElementById(name)?.focus(), 100);
-  };
-
   const toggleDefault = () => {
     if (isOverridden) {
       void formik.setFieldValue(name, undefined);
     } else {
       enableOverride();
-      focusOverride();
+      focusField(name);
     }
   };
 
@@ -148,7 +145,7 @@ export const getConfigurationRow = ({
               if (!isOverridden) {
                 enableOverride();
               }
-              focusOverride();
+              focusField(name);
             }}
             className="u-no-margin--bottom"
             type="button"

--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -22,6 +22,7 @@ import {
 import { ensureEditMode } from "util/instanceEdit";
 import { getExistingDeviceNames } from "util/devices";
 import { LxdProfile } from "types/profile";
+import { focusField } from "util/formFields";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -34,10 +35,6 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
   const customVolumes = formik.values.devices
     .filter((item) => item.type === "disk" && !isRootDisk(item))
     .map((device) => device as FormDiskDevice);
-
-  const focusField = (name: string) => {
-    setTimeout(() => document.getElementById(name)?.focus(), 100);
-  };
 
   const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);
 

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -49,9 +49,6 @@ const DiskDeviceFormRoot: FC<Props> = ({
       pool: inheritValue ? inheritValue.pool : (pools[0]?.name ?? undefined),
     });
     void formik.setFieldValue("devices", copy);
-
-    const newDeviceIndex = copy.length - 1;
-    void formik.setFieldValue(`devices.${newDeviceIndex}.size`, "GiB");
   };
 
   const focusField = (name: string) => {

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -14,6 +14,7 @@ import { LxdProfile } from "types/profile";
 import { removeDevice } from "util/formDevices";
 import { hasNoRootDisk, isRootDisk } from "util/instanceValidation";
 import { ensureEditMode } from "util/instanceEdit";
+import { focusField } from "util/formFields";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -49,10 +50,6 @@ const DiskDeviceFormRoot: FC<Props> = ({
       pool: inheritValue ? inheritValue.pool : (pools[0]?.name ?? undefined),
     });
     void formik.setFieldValue("devices", copy);
-  };
-
-  const focusField = (name: string) => {
-    setTimeout(() => document.getElementById(name)?.focus(), 100);
   };
 
   return (

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -54,6 +54,10 @@ const DiskDeviceFormRoot: FC<Props> = ({
     void formik.setFieldValue(`devices.${newDeviceIndex}.size`, "GiB");
   };
 
+  const focusField = (name: string) => {
+    setTimeout(() => document.getElementById(name)?.focus(), 100);
+  };
+
   return (
     <>
       <h2 className="p-heading--4">Root storage</h2>
@@ -126,9 +130,27 @@ const DiskDeviceFormRoot: FC<Props> = ({
               inheritValue?.size ?? (inheritValue ? "unlimited" : ""),
             inheritSource,
             readOnly: readOnly,
-            overrideValue:
-              formRootDevice?.size ?? (hasRootStorage ? "unlimited" : ""),
-            overrideForm: (
+            overrideValue: (
+              <>
+                {formRootDevice?.size ?? (hasRootStorage ? "unlimited" : "")}
+                {hasRootStorage && (
+                  <Button
+                    onClick={() => {
+                      ensureEditMode(formik);
+                      focusField("limits_disk");
+                    }}
+                    type="button"
+                    appearance="base"
+                    title="Edit"
+                    className="u-no-margin--bottom"
+                    hasIcon
+                  >
+                    <Icon name="edit" />
+                  </Button>
+                )}
+              </>
+            ),
+            overrideForm: hasRootStorage && (
               <>
                 <DiskSizeSelector
                   value={formRootDevice?.size ?? "GiB"}

--- a/src/components/forms/InheritedDeviceRow.tsx
+++ b/src/components/forms/InheritedDeviceRow.tsx
@@ -10,7 +10,7 @@ interface Props {
   inheritValue: ReactNode;
   inheritSource?: string;
   readOnly: boolean;
-  overrideValue?: string;
+  overrideValue?: string | ReactNode;
   overrideForm?: ReactNode;
   addOverride?: () => void;
   clearOverride?: () => void;

--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -22,6 +22,7 @@ import { CustomNetworkDevice, deduplicateName } from "util/formDevices";
 import { isNicDeviceNameMissing } from "util/instanceValidation";
 import { ensureEditMode } from "util/instanceEdit";
 import { getExistingDeviceNames } from "util/devices";
+import { focusField } from "util/formFields";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -62,8 +63,7 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
   }
 
   const focusNetwork = (id: number) => {
-    const name = `devices.${id}.name`;
-    setTimeout(() => document.getElementById(name)?.focus(), 100);
+    focusField(`devices.${id}.name`);
   };
 
   const removeNetwork = (index: number) => {

--- a/src/pages/networks/forms/NetworkForwardForm.tsx
+++ b/src/pages/networks/forms/NetworkForwardForm.tsx
@@ -23,6 +23,7 @@ import NetworkForwardFormPorts, {
   NetworkForwardPortFormValues,
 } from "pages/networks/forms/NetworkForwardFormPorts";
 import ScrollableForm from "components/ScrollableForm";
+import { focusField } from "util/formFields";
 
 export const toNetworkForward = (
   values: NetworkForwardFormValues,
@@ -104,7 +105,7 @@ const NetworkForwardForm: FC<Props> = ({
     ]);
 
     const name = `ports.${formik.values.ports.length}.listenPort`;
-    setTimeout(() => document.getElementById(name)?.focus(), 100);
+    focusField(name);
   };
 
   return (

--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -3,6 +3,7 @@ export interface LxdDiskDevice {
   path?: string;
   pool: string;
   size?: string;
+  "boot.priority"?: string;
   "size.state"?: string;
   source?: string;
   "limits.read"?: string;

--- a/src/util/formChangeCount.spec.ts
+++ b/src/util/formChangeCount.spec.ts
@@ -1,5 +1,6 @@
 import { getFormChangeCount } from "util/formChangeCount";
 import { ConfigurationRowFormikProps } from "components/ConfigurationRow";
+import { FormDevice } from "util/formDevices";
 
 describe("formChangeCount", () => {
   it("counts reordering of profiles", () => {
@@ -158,6 +159,85 @@ describe("formChangeCount", () => {
         name: "value",
       },
       values: {},
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("root disk change invisible fields", () => {
+    const formik = {
+      initialValues: {
+        devices: [
+          {
+            name: "root",
+            path: "/",
+            type: "disk",
+            pool: "pool",
+            "boot.priority": "10",
+          },
+        ],
+      },
+      values: {
+        devices: [
+          {
+            name: "root",
+            path: "/",
+            type: "disk",
+            pool: "pool",
+          },
+        ],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(0);
+  });
+
+  it("root disk change visible fields", () => {
+    const formik = {
+      initialValues: {
+        devices: [
+          {
+            name: "root",
+            path: "/",
+            type: "disk",
+            pool: "pool",
+          },
+        ],
+      },
+      values: {
+        devices: [
+          {
+            name: "root",
+            path: "/",
+            type: "disk",
+            pool: "new-pool",
+          },
+        ],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("counts adding none device", () => {
+    const formik = {
+      initialValues: {
+        devices: [] as FormDevice[],
+      },
+      values: {
+        devices: [
+          {
+            name: "eth0",
+            type: "none",
+          },
+        ],
+      },
     } as ConfigurationRowFormikProps;
 
     const result = getFormChangeCount(formik);

--- a/src/util/formChangeCount.tsx
+++ b/src/util/formChangeCount.tsx
@@ -5,6 +5,7 @@ import {
 import { FormDevice, FormDeviceValues } from "util/formDevices";
 import { ResourceLimitsFormValues } from "components/forms/ResourceLimitsForm";
 import { InstanceEditDetailsFormValues } from "pages/instances/EditInstance";
+import { isRootDisk } from "util/instanceValidation";
 
 const getPrimitiveFieldChanges = (
   formik: ConfigurationRowFormikProps,
@@ -93,6 +94,10 @@ const getDevicePairFieldChanges = (a: FormDevice, b: FormDevice): number => {
 
   for (const key in a) {
     const keyType = key as keyof FormDevice;
+    if (isRootDisk(a) && !["size", "pool"].includes(keyType)) {
+      continue;
+    }
+
     if (JSON.stringify(a[keyType]) !== JSON.stringify(b[keyType])) {
       changeCount++;
     }

--- a/src/util/formDevices.spec.ts
+++ b/src/util/formDevices.spec.ts
@@ -11,6 +11,7 @@ const deviceYaml =
   "    size: 10GiB\n" +
   "    type: disk\n" +
   "    size.state: 3GiB\n" +
+  "    boot.priority: 7\n" +
   "  eth0:\n" +
   "    network: lxcbr\n" +
   "    type: nic\n" +

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -44,7 +44,7 @@ export type FormDiskDevice = Partial<LxdDiskDevice> &
       read?: string;
       write?: string;
     };
-    size_state?: string;
+    bare?: LxdDiskDevice;
   };
 
 export type FormNetworkDevice = Partial<LxdNicDevice> &
@@ -94,9 +94,9 @@ export const formDeviceToPayload = (devices: FormDevice[]) => {
         }
         delete item.limits;
       }
-      if ("size_state" in item) {
-        item["size.state"] = item.size_state;
-        delete item.size_state;
+      if (item.type === "disk") {
+        const { bare, ...rest } = item;
+        item = { ...bare, ...rest };
       }
       if ("size" in item && !item.size?.match(/^\d/)) {
         delete item.size;
@@ -148,12 +148,12 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
           pool: item.pool,
           source: "source" in item ? item.source : undefined,
           size: "size" in item ? item.size : undefined,
-          size_state: "size.state" in item ? item["size.state"] : undefined,
           limits: {
             read: "limits.read" in item ? item["limits.read"] : undefined,
             write: "limits.write" in item ? item["limits.write"] : undefined,
           },
           type: "disk",
+          bare: item,
         };
       case "gpu":
       case "proxy":

--- a/src/util/formFields.tsx
+++ b/src/util/formFields.tsx
@@ -34,3 +34,7 @@ export const optionRenderer = (
 
   return "";
 };
+
+export const focusField = (name: string) => {
+  setTimeout(() => document.getElementById(name)?.focus(), 100);
+};


### PR DESCRIPTION
## Done

- Preserve boot.priority field on editing of instance or profile config
- Fix root storage display: Only show size input, if an override exists in edit mode.
- Fix root storage: Show edit button next to size to enable edit mode.

Fixes #919

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a "boot.priority" field on the root disk with value "10" or similar through the yaml editor
    - edit the instance with the guided form
    - ensure the boot priority field is preserved after saving the instance