### PR TITLE
Count removal of instance config override as one changed field on instance edit

### DIFF
--- a/src/util/formChangeCount.spec.ts
+++ b/src/util/formChangeCount.spec.ts
@@ -151,4 +151,17 @@ describe("formChangeCount", () => {
 
     expect(result).toBe(1);
   });
+
+  it("key was removed", () => {
+    const formik = {
+      initialValues: {
+        name: "value",
+      },
+      values: {},
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
 });

--- a/src/util/formChangeCount.tsx
+++ b/src/util/formChangeCount.tsx
@@ -30,6 +30,17 @@ const getPrimitiveFieldChanges = (
     }
   }
 
+  for (const key in formik.initialValues) {
+    if (ignoredFields.has(key) || Object.hasOwn(formik.values, key)) {
+      continue;
+    }
+
+    const keyType = key as keyof ConfigurationRowFormikValues;
+    if (formik.values[keyType] !== formik.initialValues[keyType]) {
+      changeCount++;
+    }
+  }
+
   return changeCount;
 };
 


### PR DESCRIPTION
## Done

- Count removal of instance config override as one changed field on instance edit

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instance and profile with an overridden primitve field (i.e. security > Protect deletion)
    - save instance/profile
    - edit instance/profile only remove the primitive field override
    - ensure the save button is enabled and lists one pending change