### PR TITLE
fix: update file conversion source disk size field name [WD-15110]

### DIFF
--- a/src/util/uploadExternalFormatFile.tsx
+++ b/src/util/uploadExternalFormatFile.tsx
@@ -49,7 +49,7 @@ export const uploadExternalFormatFilePayload = (
     },
     type: "virtual-machine",
     name: values.name,
-    sourceDiskSize: fileSize,
+    source_disk_size: fileSize,
     architecture: values.architecture,
   };
 


### PR DESCRIPTION
## Done

- Updated payload field name (source_disk_size) for conversion API call. This is related to the upstream [PR](https://github.com/canonical/lxd/pull/13996) that was recently merged.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that vmdk import still works