### PR TITLE
chore: retry lazy load components when server is down [WD-13909]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { FC, lazy, Suspense } from "react";
+import { FC, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import Loader from "components/Loader";
 import ProjectRedirect from "pages/projects/ProjectRedirect";
@@ -10,6 +10,7 @@ import CustomLayout from "components/CustomLayout";
 import NoMatch from "components/NoMatch";
 import { logout } from "util/helpers";
 import NoProject from "components/NoProject";
+import lazy from "util/lazyWithRetry";
 
 const CertificateAdd = lazy(() => import("pages/login/CertificateAdd"));
 const CertificateGenerate = lazy(

--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -40,6 +40,35 @@ ${error?.stack ?? "No stack trace"}
   useEffect(updateHeight, []);
   useEventListener("resize", updateHeight);
 
+  const errorBlocks = [];
+  if (error?.message) {
+    errorBlocks.push({
+      title: "Error",
+      appearance: CodeSnippetBlockAppearance.NUMBERED,
+      wrapLines: true,
+      code: error.message,
+    });
+  }
+
+  if (error?.message.toLowerCase().includes("dynamically imported module")) {
+    errorBlocks.push({
+      title: "Possible causes",
+      appearance: CodeSnippetBlockAppearance.NUMBERED,
+      wrapLines: true,
+      code: `This might be due to a temporary network issue. Please try refreshing the page.
+If the problem continues, ensure your connection to the LXD server is active or try again later.`,
+    });
+  }
+
+  if (error?.stack) {
+    errorBlocks.push({
+      title: "Stack trace",
+      appearance: CodeSnippetBlockAppearance.NUMBERED,
+      wrapLines: true,
+      code: error.stack,
+    });
+  }
+
   return (
     <Strip className="u-no-padding--bottom">
       <Notification severity="negative" title="Error">
@@ -50,28 +79,7 @@ ${error?.stack ?? "No stack trace"}
       </Notification>
       <CodeSnippet
         className="error-info u-no-margin--bottom"
-        blocks={[
-          ...(error?.message
-            ? [
-                {
-                  title: "Error",
-                  appearance: CodeSnippetBlockAppearance.NUMBERED,
-                  wrapLines: true,
-                  code: error.message,
-                },
-              ]
-            : []),
-          ...(error?.stack
-            ? [
-                {
-                  title: "Stack trace",
-                  appearance: CodeSnippetBlockAppearance.NUMBERED,
-                  wrapLines: true,
-                  code: error.stack,
-                },
-              ]
-            : []),
-        ]}
+        blocks={errorBlocks}
       />
     </Strip>
   );

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,12 +1,13 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "context/auth";
 import Loader from "./Loader";
+import { FC } from "react";
 
 interface Props {
   outlet: JSX.Element;
 }
 
-const ProtectedRoute = ({ outlet }: Props) => {
+const ProtectedRoute: FC<Props> = ({ outlet }) => {
   const { isAuthenticated, isAuthLoading } = useAuth();
 
   if (isAuthLoading) {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -298,3 +298,6 @@ export const getFileExtension = (filename: string): string => {
 
   return `.${filename.split(".").pop()}` || "";
 };
+
+export const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/util/lazyWithRetry.tsx
+++ b/src/util/lazyWithRetry.tsx
@@ -1,0 +1,63 @@
+import { lazy } from "react";
+import { delay } from "./helpers";
+
+const RETRIES = 3;
+const DELAY_TIME = 250;
+
+// This function is a wrapper around React.lazy that will retry the import
+// keeping the function type signature the same as React.lazy
+// using "any" type here allows for components with any type interface to be imported
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const lazyWithRetry = <T extends React.ComponentType<any>>(
+  importFunction: () => Promise<{ default: T }>,
+) => {
+  const retryImport = async () => {
+    try {
+      const module = await importFunction();
+      return module;
+    } catch (error) {
+      let lastError = error as Error;
+      for (let attempt = 0; attempt < RETRIES; attempt++) {
+        await delay(DELAY_TIME * attempt);
+
+        // dynamic import i.e. import() unfortunately caches network response for fetching modules
+        // this is true even if a module fails to load
+        // if we simply just retry the import, the cached error response will be returned
+        // to work around this, we can invalidate the cache by adding a dynamic query parameter to the module URL
+        // the original module url can be potentially found in the error message
+        // HOWEVER, this is not a guaranteed solution since the error message may not contain the module URL depending on the browser used
+        // therefore, this is a best effort attempt, worst case scenario, the error will be thrown again causing the error boundary to render
+        const origin = window.location.origin;
+        const errorSegments = (error as Error).message.split(" ");
+        let moduleUrl = "";
+        for (const segment of errorSegments) {
+          if (segment.startsWith(origin)) {
+            moduleUrl = segment;
+            break;
+          }
+        }
+
+        const url = new URL(moduleUrl.trim());
+        // add a timestamp query parameter to invalidate the cache
+        url.searchParams.set("cacheBuster", `${+Date.now()}`);
+
+        try {
+          // vite does not support static checks with dynamic imports that takes in a non-relative path
+          // ref: https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations
+          const module = (await import(/* @vite-ignore */ url.href)) as {
+            default: T;
+          };
+          return module;
+        } catch (e) {
+          lastError = e as Error;
+        }
+      }
+
+      throw lastError;
+    }
+  };
+
+  return lazy(retryImport);
+};
+
+export default lazyWithRetry;


### PR DESCRIPTION
## Done

- support retry lazy loading modules with increasing delay
- add more info for dynamic module loading error in the Error page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Load LXD-UI initially, don't navigate anywhere so that the pages are not cached
    - Open dev tool, go to the Network tab and select Offline as network condition
    - Go to a different page in the UI, it may not be very noticeable but it will now take a little longer for the error page to show because we will now retry fetch the module a few times before throwing an error (this will be more noticeable if you increase the delayTime input for the `lazyWithRetry` function.
    - See that the error message includes details about lxd server being down if it's a dynamic module loading error

## Screenshots
![Screenshot from 2024-09-26 10-27-29](https://github.com/user-attachments/assets/840d8dd3-4f7a-47a1-bec1-aec25f647b2c)
