### PR TITLE
test: add e2e test for external instance file [WD-14777]

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -70,10 +70,11 @@ jobs:
           sudo lxc cluster enable local
           sudo lxc config set user.show_permissions=true
 
-      - name: Create a custom image
+      - name: Create and download custom images
         shell: bash
         run: |
           set -x
+          curl -L -o ubuntu-minimal.qcow2 https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img &
           sudo lxc launch ubuntu-minimal:22.04 my-instance
           sudo lxc publish my-instance --alias my-custom-image --force
           sudo lxc delete my-instance --force

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,10 +131,11 @@ jobs:
           sudo lxc cluster enable local
           sudo lxc config set user.show_permissions=true
 
-      - name: Create a custom image
+      - name: Create and download custom images
         shell: bash
         run: |
           set -x
+          curl -L -o ubuntu-minimal.qcow2 https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img &
           sudo lxc launch ubuntu-minimal:22.04 my-instance
           sudo lxc publish my-instance --alias my-custom-image --force
           sudo lxc delete my-instance --force

--- a/src/pages/cluster/ClusterMemberSelector.tsx
+++ b/src/pages/cluster/ClusterMemberSelector.tsx
@@ -2,13 +2,18 @@ import { Select, SelectProps } from "@canonical/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { fetchClusterMembers } from "api/cluster";
 import { useSettings } from "context/useSettings";
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import { queryKeys } from "util/queryKeys";
 import { isClusteredServer } from "util/settings";
 
-const ClusterMemberSelector: FC<SelectProps> = ({
+interface Props {
+  setMember?: (member: string) => void;
+}
+
+const ClusterMemberSelector: FC<SelectProps & Props> = ({
   label,
   disabled,
+  setMember,
   ...props
 }) => {
   const { data: settings } = useSettings();
@@ -19,6 +24,12 @@ const ClusterMemberSelector: FC<SelectProps> = ({
       queryFn: fetchClusterMembers,
       enabled: isClustered,
     });
+
+  useEffect(() => {
+    if (clusterMembers.length > 0 && setMember) {
+      setMember(clusterMembers[0].server_name);
+    }
+  }, [clusterMembers]);
 
   return isClustered ? (
     <Select

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -34,6 +34,7 @@ import classnames from "classnames";
 import InstanceFileTypeSelector, {
   InstanceFileType,
 } from "./InstanceFileTypeSelector";
+import ClusterMemberSelector from "pages/cluster/ClusterMemberSelector";
 
 interface Props {
   close: () => void;
@@ -136,7 +137,11 @@ const UploadExternalFormatFileForm: FC<Props> = ({
 
   const handleSubmit = (values: UploadExternalFormatFileFormValues) => {
     // start create instance operation
-    createInstance(uploadExternalFormatFilePayload(values), project?.name || "")
+    createInstance(
+      uploadExternalFormatFilePayload(values),
+      project?.name || "",
+      values.member,
+    )
       .then((operation) => {
         const operationId = operation.metadata.id;
         const operationSecret = operation.metadata?.metadata?.fs;
@@ -178,6 +183,7 @@ const UploadExternalFormatFileForm: FC<Props> = ({
     initialValues: {
       name: defaultInstanceName || "",
       pool: "",
+      member: "",
       file: null,
       formatConversion: true,
       virtioConversion: false,
@@ -255,6 +261,12 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           error={formik.touched.name ? formik.errors.name : null}
           disabled={!!noFileSelectedMessage}
           title={noFileSelectedMessage}
+        />
+        <ClusterMemberSelector
+          {...formik.getFieldProps("member")}
+          id="member"
+          label="Target cluster member"
+          setMember={(member) => void formik.setFieldValue("member", member)}
         />
         <StoragePoolSelector
           project={project?.name || ""}

--- a/src/util/uploadExternalFormatFile.tsx
+++ b/src/util/uploadExternalFormatFile.tsx
@@ -2,6 +2,7 @@ export interface UploadExternalFormatFileFormValues {
   file: File | null;
   name: string;
   pool: string;
+  member: string;
   formatConversion: boolean;
   virtioConversion: boolean;
   architecture: string;

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -351,3 +351,35 @@ test("Export and Upload an instance backup", async ({ page }) => {
   await page.waitForSelector(`text=Created instance ${instance}-1`);
   await deleteInstance(page, `${instance}-1`);
 });
+
+test("Create instance from external instance file", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion === "5.0-edge",
+    "External instance file conversion is only supported in newer versions of LXD",
+  );
+
+  test.skip(
+    Boolean(!process.env.CI),
+    "Skipping test locally for external instance file creation",
+  );
+
+  const INSTANCE_FILE = "ubuntu-minimal.qcow2";
+  await page.goto("/ui/");
+  await page.getByRole("button", { name: "Create instance" }).click();
+  await page.getByRole("button", { name: "Upload instance file" }).click();
+  await page.getByText("External format (.qcow2, .").click();
+  await page
+    .getByRole("textbox", { name: "External format (.qcow2, ." })
+    .setInputFiles(INSTANCE_FILE);
+  const instanceName = randomInstanceName();
+  await page.getByRole("textbox", { name: "Enter name" }).fill(instanceName);
+  await page
+    .getByLabel("Upload instance file")
+    .getByRole("button", { name: "Upload and create" })
+    .click();
+  await page.waitForSelector(`text=Created instance ${instanceName}.`);
+  await deleteInstance(page, instanceName);
+});


### PR DESCRIPTION
## Done

- add e2e for uploading external format instance file
- fixed a bug where uploading external instance file to a lxd cluster fails

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes