### PR TITLE
fix: update permission selector to use entity type metadata if api extension exists [WD-15109]

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -29,5 +29,8 @@ export const useSupportedFeatures = () => {
     hasInstanceImportConversion: apiExtensions.has(
       "instance_import_conversion",
     ),
+    hasEntityTypeMetadata: apiExtensions.has(
+      "metadata_configuration_entity_types",
+    ),
   };
 };

--- a/src/pages/permissions/panels/PermissionSelector.tsx
+++ b/src/pages/permissions/panels/PermissionSelector.tsx
@@ -28,7 +28,8 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
   const [resourceType, setResourceType] = useState("");
   const [resource, setResource] = useState("");
   const [entitlement, setEntitlement] = useState("");
-  const { hasMetadataConfiguration } = useSupportedFeatures();
+  const { hasMetadataConfiguration, hasEntityTypeMetadata } =
+    useSupportedFeatures();
 
   const {
     data: permissions,
@@ -140,10 +141,12 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
     identityNamesLookup,
   );
 
+  // if we have metadata api extension, but no entity type metadata, we can't show entitlement descriptions
+  const validMetadata = hasEntityTypeMetadata ? metadata : null;
   const entitlementOptions = generateEntitlementOptions(
     resourceType,
     permissions,
-    metadata,
+    validMetadata,
   );
 
   const isServerResourceType = resourceType === "server";

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -29,7 +29,10 @@ export interface LxdEntitlement {
 }
 
 export interface LxdEntityEntitlements {
-  [entity: string]: LxdEntitlement[];
+  [entity: string]: {
+    entitlements: LxdEntitlement[];
+    project_specific: boolean;
+  };
 }
 
 export interface LxdMetadata {

--- a/src/util/permissions.spec.ts
+++ b/src/util/permissions.spec.ts
@@ -112,7 +112,7 @@ describe("General util functions for permissions feature", () => {
       },
     ];
 
-    it("should have description titles in entitlement options if metadata is provided", () => {
+    it("should have description titles in entitlement options if entity type metadata is provided", () => {
       const metadata: LxdMetadata = {
         configs: {
           cluster: {},
@@ -134,12 +134,15 @@ describe("General util functions for permissions feature", () => {
           "storage-zfs": {},
         },
         entities: {
-          server: [
-            {
-              name: "admin",
-              description: "admin entitlement description",
-            },
-          ],
+          server: {
+            entitlements: [
+              {
+                name: "admin",
+                description: "admin entitlement description",
+              },
+            ],
+            project_specific: false,
+          },
         },
       };
 
@@ -186,7 +189,7 @@ describe("General util functions for permissions feature", () => {
       ]);
     });
 
-    it("should generate entitlement options without metadata", () => {
+    it("should generate entitlement options without entity type metadata", () => {
       const entitlementOptions = generateEntitlementOptions(
         resourceType,
         permissions,

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -176,7 +176,7 @@ export const getEntitlementDescriptions = (
   resourceType: string,
 ) => {
   const entitlementDescriptions: Record<string, string> = {};
-  const entitlements = metadata.entities[resourceType];
+  const entitlements = metadata.entities[resourceType].entitlements;
   for (const entitlement of entitlements) {
     entitlementDescriptions[entitlement.name] = entitlement.description;
   }


### PR DESCRIPTION
## Done

- Update permission selector to use entity type meta data if api extension exists
- This is related to upstream [PR](https://github.com/canonical/lxd/pull/14132) that was recently merged in lxd

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that permission selector works and UI does not break