### PR TITLE
Fix various UI bugs

### DIFF
--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -124,7 +124,7 @@ const DiskDeviceFormRoot: FC<Props> = ({
               inheritValue?.size ?? (inheritValue ? "unlimited" : ""),
             inheritSource,
             readOnly: readOnly,
-            overrideValue: (
+            overrideValue: hasRootStorage && (
               <>
                 {formRootDevice?.size ?? (hasRootStorage ? "unlimited" : "")}
                 {hasRootStorage && (

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -101,7 +101,26 @@ const DiskDeviceFormRoot: FC<Props> = ({
             inheritValue: inheritValue?.pool ?? "",
             inheritSource,
             readOnly: readOnly,
-            overrideValue: formRootDevice?.pool,
+            overrideValue: hasRootStorage && (
+              <>
+                {formRootDevice?.pool}
+                {formik.values.entityType === "profile" && (
+                  <Button
+                    onClick={() => {
+                      ensureEditMode(formik);
+                      focusField("storage-pool-selector");
+                    }}
+                    type="button"
+                    appearance="base"
+                    title="Edit"
+                    className="u-no-margin--bottom"
+                    hasIcon
+                  >
+                    <Icon name="edit" />
+                  </Button>
+                )}
+              </>
+            ),
             overrideForm: (
               <StoragePoolSelector
                 project={project}

--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -250,7 +250,7 @@ const ProxyDeviceForm: FC<Props> = ({ formik, project }) => {
         device.bind,
         "Whether to bind the listen address to the instance or host",
         (value) => {
-          if (value === "instance" && device.nat !== undefined) {
+          if (value === "instance") {
             void formik.setFieldValue(`devices.${index}.nat`, undefined);
           }
         },

--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -250,8 +250,8 @@ const ProxyDeviceForm: FC<Props> = ({ formik, project }) => {
         device.bind,
         "Whether to bind the listen address to the instance or host",
         (value) => {
-          if (value === "instance" && device.nat === "true") {
-            void formik.setFieldValue(`devices.${index}.nat`, "false");
+          if (value === "instance" && device.nat !== undefined) {
+            void formik.setFieldValue(`devices.${index}.nat`, undefined);
           }
         },
       ),

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -108,19 +108,15 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const archSupported = getArchitectureAliases(
     settings?.environment?.architectures ?? [],
   );
-  let images = isLoading
+  const images = isLoading
     ? []
     : localImages
         .map(localLxdToRemoteImage)
-        .sort((a, b) => Number(b.cached) - Number(a.cached));
-
-  if (!hideRemote) {
-    images = images
-      .concat([...canonicalImages].reverse().sort(byLtsFirst))
-      .concat([...minimalImages].reverse().sort(byLtsFirst))
-      .concat([...imagesLxdImages])
-      .filter((image) => archSupported.includes(image.arch));
-  }
+        .sort((a, b) => Number(b.cached) - Number(a.cached))
+        .concat([...canonicalImages].reverse().sort(byLtsFirst))
+        .concat([...minimalImages].reverse().sort(byLtsFirst))
+        .concat([...imagesLxdImages])
+        .filter((image) => archSupported.includes(image.arch));
 
   const archAll = [...new Set(images.map((item) => item.arch))]
     .filter((arch) => arch !== "")
@@ -183,6 +179,12 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
         item.os.toLowerCase().includes(query) ||
         item.release.toLowerCase().includes(query)
       );
+    })
+    .filter((item) => {
+      if (!hideRemote) {
+        return true;
+      }
+      return item.server === LOCAL_IMAGE;
     })
     .map((item) => {
       const figureType = () => {

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -184,7 +184,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       if (!hideRemote) {
         return true;
       }
-      return item.server === LOCAL_IMAGE;
+      return item.server === LOCAL_IMAGE || item.cached;
     })
     .map((item) => {
       const figureType = () => {

--- a/src/pages/images/actions/forms/UploadImageForm.tsx
+++ b/src/pages/images/actions/forms/UploadImageForm.tsx
@@ -15,7 +15,6 @@ import { Link } from "react-router-dom";
 import { humanFileSize } from "util/helpers";
 import ProgressBar from "components/ProgressBar";
 import { UploadState } from "types/storage";
-import Loader from "components/Loader";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { LxdSyncResponse } from "types/apiResponse";
@@ -140,9 +139,6 @@ const UploadImageForm: FC<Props> = ({ close, project }) => {
                 {humanFileSize(uploadState.loaded)} loaded of{" "}
                 {humanFileSize(uploadState.total ?? 0)}
               </p>
-              {uploadState.loaded === uploadState.total && (
-                <Loader text="Uploading file" />
-              )}
             </>
           )}
           <Button

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -14,7 +14,6 @@ interface Props {
   setValue: (value: string) => void;
   selectProps?: SelectProps;
   hidePoolsWithUnsupportedDrivers?: boolean;
-  disabled?: boolean;
   help?: string;
 }
 
@@ -24,7 +23,6 @@ const StoragePoolSelector: FC<Props> = ({
   setValue,
   selectProps,
   hidePoolsWithUnsupportedDrivers = false,
-  disabled,
   help,
 }) => {
   const notify = useNotify();
@@ -86,7 +84,6 @@ const StoragePoolSelector: FC<Props> = ({
       onChange={(e) => setValue(e.target.value)}
       value={value}
       {...selectProps}
-      disabled={disabled}
       help={help}
     />
   );

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -34,7 +34,9 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
             value={formik.values.pool}
             setValue={(val) => void formik.setFieldValue("pool", val)}
             hidePoolsWithUnsupportedDrivers
-            disabled={!formik.values.isCreating}
+            selectProps={{
+              disabled: !formik.values.isCreating,
+            }}
             help={
               formik.values.isCreating
                 ? undefined


### PR DESCRIPTION
## Done

-  fix(image) avoid duplicate loading indicator
- fix(profile) show edit icon next to root storage pool on profile edit configuration
- fix(instance) reset nat for proxy device configuration, in case bind is set to instance
- fix(instance) avoid displaying root storage size as overridden, without an override present
- fix(operations) ensure operations cache is cleared to show correct amount of running operations in footer
- fix(storage) remove redundant disabled field on storage pool selector, that overrides the already used, nested disabled flag
- fix(instance) avoid crash on filtering only cached images with no cached images

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - upload image and ensure 1 loading indicator
    - ensure edit icon next to root storage in configuration edit for profile, but not for instances
    - add a proxy device to instance configuration, set nat to enabled or disabled and set bind to instance, ensure the nat value is unset
    - check instance config that has no root storage override, ensure the size is not shown as overridden in configuration > disk
    - ensure the number of running operations in the footer is updating correctly for any action that triggers an operation -- also on operation finish the number of running operations should decrease
    - ensure storage pool is disabled on opening the upload custom iso flow
    - ensure storage pool is disabled on opening the upload instance flow with internal or external format
    - ensure checking the "only show cached images" filter is not crashing the interface, when no cached images are present