### PR TITLE
fix: [WD-15307] Truncate instance name in instance list (when creatin…

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -258,6 +258,8 @@ const InstanceList: FC = () => {
         columns: [
           {
             content: getInstanceName(operation),
+            className: "u-truncate",
+            title: getInstanceName(operation),
             role: "rowheader",
             "aria-label": NAME,
             style: { width: `${COLUMN_WIDTHS[NAME]}px` },
@@ -331,11 +333,9 @@ const InstanceList: FC = () => {
         name: instance.name,
         columns: [
           {
-            content: (
-              <div className="u-truncate" title={`Instance ${instance.name}`}>
-                <InstanceLink instance={instance} />
-              </div>
-            ),
+            content: <InstanceLink instance={instance} />,
+            className: "u-truncate",
+            title: `Instance ${instance.name}`,
             role: "rowheader",
             style: { width: `${COLUMN_WIDTHS[NAME]}px` },
             "aria-label": NAME,


### PR DESCRIPTION
…g instances)

## Done

- When creating images, their names are now truncated within the instance list.

Fixes: As above

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Attempt to create an instance and observe the name being truncated on the instance list page.

## Screenshots

![image](https://github.com/user-attachments/assets/996a49e9-dcd4-41aa-8cf1-cf153d630fe3)