### PR TITLE
fix: migrate custom volume in non-default project

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -367,15 +367,19 @@ export const deleteStorageVolume = (
 export const migrateStorageVolume = (
   volume: Partial<LxdStorageVolume>,
   targetPool: string,
+  targetProject: string,
 ): Promise<LxdOperationResponse> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools/${volume.pool}/volumes/custom/${volume.name}`, {
-      method: "POST",
-      body: JSON.stringify({
-        name: volume.name,
-        pool: targetPool,
-      }),
-    })
+    fetch(
+      `/1.0/storage-pools/${volume.pool}/volumes/custom/${volume.name}?project=${targetProject}`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: volume.name,
+          pool: targetPool,
+        }),
+      },
+    )
       .then(handleResponse)
       .then(resolve)
       .catch(reject);

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -79,7 +79,7 @@ const MigrateVolumeBtn: FC<Props> = ({
 
   const handleMigrate = (targetPool: string) => {
     setVolumeLoading(true);
-    migrateStorageVolume(storageVolume, targetPool)
+    migrateStorageVolume(storageVolume, targetPool, storageVolume.project)
       .then((operation) => {
         eventQueue.set(
           operation.metadata.id,


### PR DESCRIPTION
## Done

- Migrating custom volume in a non-defautl project was broken due to project query param not being passed in api call. This is fixed now.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new project
    - Create a new custom volume in that project
    - Migrate the volume to a different pool and make sure it does not break.