### PR TITLE
feat: [WD-15296] Disable other devices for LXD 5.0

### DIFF
--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -3,6 +3,7 @@ import MenuItem from "components/forms/FormMenuItem";
 import { Button, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -34,6 +35,7 @@ const InstanceFormMenu: FC<Props> = ({
 }) => {
   const notify = useNotify();
   const [isDeviceExpanded, setDeviceExpanded] = useState(true);
+  const { hasMetadataConfiguration } = useSupportedFeatures();
 
   const disableReason = isDisabled
     ? "Please select an image before adding custom configuration"
@@ -87,7 +89,9 @@ const InstanceFormMenu: FC<Props> = ({
               />
               <MenuItem label={GPU_DEVICES} {...menuItemProps} />
               <MenuItem label={PROXY_DEVICES} {...menuItemProps} />
-              <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+              {hasMetadataConfiguration && (
+                <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+              )}
             </ul>
           </li>
           <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />

--- a/src/pages/profiles/forms/ProfileFormMenu.tsx
+++ b/src/pages/profiles/forms/ProfileFormMenu.tsx
@@ -5,6 +5,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -34,6 +35,7 @@ const ProfileFormMenu: FC<Props> = ({
 }) => {
   const notify = useNotify();
   const [isDeviceExpanded, setDeviceExpanded] = useState(true);
+  const { hasMetadataConfiguration } = useSupportedFeatures();
 
   const disableReason = isDisabled
     ? "Please enter a name before adding custom configuration"
@@ -87,7 +89,9 @@ const ProfileFormMenu: FC<Props> = ({
               />
               <MenuItem label={GPU_DEVICES} {...menuItemProps} />
               <MenuItem label={PROXY_DEVICES} {...menuItemProps} />
-              <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+              {hasMetadataConfiguration && (
+                <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+              )}
             </ul>
           </li>
           <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -398,3 +398,15 @@ test("Migrate instance root storage volume to a different pool", async ({
   await migrateInstanceRootStorage(page, instance, "default", serverClustered);
   await deletePool(page, targetPool);
 });
+
+test("'Other' tab is removed when config/creating Instances, on LXD Version 5.0", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion != "5.0-edge",
+    "Newer LXD versions has the metadata_configuration API extension.",
+  );
+  await editInstance(page, instance);
+  await expect(page.getByText("Other", { exact: true })).not.toBeVisible();
+});

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./fixtures/lxd-test";
+import { expect, test } from "./fixtures/lxd-test";
 import {
   assertCode,
   assertReadMode,
@@ -170,4 +170,16 @@ name: ${profile}`);
 
   await page.locator("#form-footer").getByText("YAML Configuration").click();
   await assertTextVisible(page, "DescriptionA-new-description");
+});
+
+test("'Other' tab is removed when config/creating Profiles, on LXD Version 5.0", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion != "5.0-edge",
+    "Newer LXD versions has the metadata_configuration API extension.",
+  );
+  await editProfile(page, profile);
+  await expect(page.getByText("Other", { exact: true })).not.toBeVisible();
 });


### PR DESCRIPTION
## Done

- Disables the 'Other' tab in Profile and Instance configuration when using LXD 5.0
- Added a test to ensure this.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Attempt to access the 'Other' tab when in Instance or Profile config.

## Screenshots

N/A