### PR TITLE
fix: un-select items when closing permission side panels

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -85,6 +85,7 @@ interface SidePanelProps {
   className?: string;
   width?: "narrow" | "wide";
   pinned?: boolean;
+  onClose?: () => void;
 }
 
 const SidePanelComponent: FC<SidePanelProps> = ({
@@ -96,12 +97,16 @@ const SidePanelComponent: FC<SidePanelProps> = ({
   className,
   pinned,
   width,
+  onClose,
 }) => {
   const panelParams = usePanelParams();
 
   useEventListener("keydown", (e: KeyboardEvent) => {
     // Close panel if Escape key is pressed
-    if (e.code === "Escape") panelParams.clear();
+    if (e.code === "Escape") {
+      onClose?.();
+      panelParams.clear();
+    }
   });
 
   return createPortal(

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -273,7 +273,10 @@ const PermissionIdentities: FC = () => {
         </Row>
       </CustomLayout>
       {panelParams.panel === panels.identityGroups && (
-        <EditIdentityGroupsPanel identities={selectedIdentities} />
+        <EditIdentityGroupsPanel
+          identities={selectedIdentities}
+          onClose={() => setSelectedIdentityIds([])}
+        />
       )}
     </>
   );

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from "@canonical/react-components";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import SidePanel from "components/SidePanel";
-import React, { FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import usePanelParams from "util/usePanelParams";
 import { useToastNotification } from "context/toastNotificationProvider";
 import * as Yup from "yup";
@@ -233,6 +233,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
         className={classnames({
           "edit-permissions-panel": subForm === "permission",
         })}
+        onClose={closePanel}
       >
         <SidePanel.Header>
           <SidePanel.HeaderTitle>

--- a/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
+++ b/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
@@ -20,9 +20,10 @@ type GroupEditHistory = {
 
 interface Props {
   identities: LxdIdentity[];
+  onClose: () => void;
 }
 
-const EditIdentityGroupsPanel: FC<Props> = ({ identities }) => {
+const EditIdentityGroupsPanel: FC<Props> = ({ identities, onClose }) => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const [confirming, setConfirming] = useState(false);
@@ -149,6 +150,7 @@ const EditIdentityGroupsPanel: FC<Props> = ({ identities }) => {
     panelParams.clear();
     notify.clear();
     setConfirming(false);
+    onClose();
   };
 
   const closeModal = () => {
@@ -165,7 +167,12 @@ const EditIdentityGroupsPanel: FC<Props> = ({ identities }) => {
 
   return (
     <>
-      <SidePanel isOverlay loading={isLoading} hasError={!groups}>
+      <SidePanel
+        isOverlay
+        loading={isLoading}
+        hasError={!groups}
+        onClose={closePanel}
+      >
         <SidePanel.Header>
           <SidePanel.HeaderTitle>{panelTitle}</SidePanel.HeaderTitle>
         </SidePanel.Header>

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -195,7 +195,12 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
 
   return (
     <>
-      <SidePanel isOverlay loading={isLoading} hasError={!groups}>
+      <SidePanel
+        isOverlay
+        loading={isLoading}
+        hasError={!groups}
+        onClose={onClose}
+      >
         <SidePanel.Header>
           <SidePanel.HeaderTitle>{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
         </SidePanel.Header>


### PR DESCRIPTION
## Done

- When closing permission side panels (i.e. edit identity groups panel, edit groups panel, edit idp groups panel), the selected item in the list table should be un-selected.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - try close all permission panels either using the "Cancel" button or using the "Esc" key. Check that the selected item in the list table is un-selected.