### PR TITLE
Prevent local volume attach to instances on another cluster member

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -310,12 +310,18 @@ export const createStorageVolume = (
   pool: string,
   project: string,
   volume: Partial<LxdStorageVolume>,
+  target?: string,
 ): Promise<void> => {
+  const targetParam = target ? `&target=${target}` : "";
+
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools/${pool}/volumes?project=${project}`, {
-      method: "POST",
-      body: JSON.stringify(volume),
-    })
+    fetch(
+      `/1.0/storage-pools/${pool}/volumes?project=${project}${targetParam}`,
+      {
+        method: "POST",
+        body: JSON.stringify(volume),
+      },
+    )
       .then(handleResponse)
       .then(resolve)
       .catch(reject);

--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -130,6 +130,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
               </b>
             </div>
             <CustomVolumeSelectBtn
+              formik={formik}
               project={project}
               setValue={(volume) => {
                 ensureEditMode(formik);
@@ -285,6 +286,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
         </>
       )}
       <CustomVolumeSelectBtn
+        formik={formik}
         project={project}
         setValue={(volume) => {
           ensureEditMode(formik);

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -5,30 +5,40 @@ import {
   volumeFormToPayload,
 } from "pages/storage/forms/StorageVolumeForm";
 import { useFormik } from "formik";
-import { createStorageVolume } from "api/storage-pools";
+import { createStorageVolume, fetchStoragePools } from "api/storage-pools";
 import { queryKeys } from "util/queryKeys";
 import * as Yup from "yup";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import StorageVolumeFormMain from "pages/storage/forms/StorageVolumeFormMain";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "@use-it/event-listener";
 import { testDuplicateStorageVolumeName } from "util/storageVolume";
 import { LxdStorageVolume } from "types/storage";
+import { useSettings } from "context/useSettings";
 
 interface Props {
   project: string;
+  instanceLocation?: string;
   onCancel: () => void;
   onFinish: (volume: LxdStorageVolume) => void;
 }
 
 const CustomVolumeCreateModal: FC<Props> = ({
   project,
+  instanceLocation,
   onCancel,
   onFinish,
 }) => {
   const notify = useNotify();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+
+  const { data: settings } = useSettings();
+
+  const { data: pools = [] } = useQuery({
+    queryKey: [queryKeys.storage],
+    queryFn: () => fetchStoragePools(project),
+  });
 
   const StorageVolumeSchema = Yup.object().shape({
     name: Yup.string()
@@ -37,6 +47,14 @@ const CustomVolumeCreateModal: FC<Props> = ({
       )
       .required("This field is required"),
   });
+
+  const isLocalPool = (poolName: string) => {
+    const pool = pools.find((pool) => pool.name === poolName);
+    const driverDetails = settings?.environment?.storage_supported_drivers.find(
+      (driver) => driver.Name === pool?.driver,
+    );
+    return !driverDetails?.Remote ?? false;
+  };
 
   const formik = useFormik<StorageVolumeFormValues>({
     initialValues: {
@@ -53,7 +71,9 @@ const CustomVolumeCreateModal: FC<Props> = ({
     validationSchema: StorageVolumeSchema,
     onSubmit: (values) => {
       const volume = volumeFormToPayload(values, project);
-      createStorageVolume(values.pool, project, volume)
+      const target = isLocalPool(values.pool) ? instanceLocation : undefined;
+
+      createStorageVolume(values.pool, project, volume, target)
         .then(() => {
           void queryClient.invalidateQueries({
             queryKey: [queryKeys.storage],
@@ -71,6 +91,12 @@ const CustomVolumeCreateModal: FC<Props> = ({
     },
   });
 
+  const validPool =
+    !isLocalPool(formik.values.pool) || instanceLocation !== "any";
+  const poolError = validPool
+    ? undefined
+    : "Please select a remote storage pool, or set a cluster member for the instance";
+
   const updateFormHeight = () => {
     updateMaxHeight("volume-create-form", "p-modal__footer", 32, undefined, []);
   };
@@ -80,7 +106,11 @@ const CustomVolumeCreateModal: FC<Props> = ({
   return (
     <>
       <div className="volume-create-form">
-        <StorageVolumeFormMain formik={formik} project={project} />
+        <StorageVolumeFormMain
+          formik={formik}
+          project={project}
+          poolError={poolError}
+        />
       </div>
       <footer className="p-modal__footer">
         <Button
@@ -94,7 +124,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
           appearance="positive"
           className="u-no-margin--bottom"
           onClick={() => void formik.submitForm()}
-          disabled={!formik.isValid}
+          disabled={!formik.isValid || !validPool}
           loading={formik.isSubmitting}
         >
           Create volume

--- a/src/pages/storage/CustomVolumeModal.tsx
+++ b/src/pages/storage/CustomVolumeModal.tsx
@@ -3,8 +3,11 @@ import CustomVolumeSelectModal from "pages/storage/CustomVolumeSelectModal";
 import CustomVolumeCreateModal from "pages/storage/CustomVolumeCreateModal";
 import { Modal } from "@canonical/react-components";
 import { LxdStorageVolume } from "types/storage";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { getInstanceLocation } from "util/instanceLocation";
 
 interface Props {
+  formik: InstanceAndProfileFormikProps;
   project: string;
   onFinish: (volume: LxdStorageVolume) => void;
   onCancel: () => void;
@@ -13,11 +16,18 @@ interface Props {
 const SELECT_VOLUME = "selectVolume";
 const CREATE_VOLUME = "createVolume";
 
-const CustomVolumeModal: FC<Props> = ({ project, onFinish, onCancel }) => {
+const CustomVolumeModal: FC<Props> = ({
+  formik,
+  project,
+  onFinish,
+  onCancel,
+}) => {
   const [content, setContent] = useState(SELECT_VOLUME);
   const [primaryVolume, setPrimaryVolume] = useState<
     LxdStorageVolume | undefined
   >(undefined);
+
+  const instanceLocation = getInstanceLocation(formik);
 
   const handleCreateVolume = (volume: LxdStorageVolume) => {
     setContent(SELECT_VOLUME);
@@ -36,6 +46,7 @@ const CustomVolumeModal: FC<Props> = ({ project, onFinish, onCancel }) => {
         <CustomVolumeSelectModal
           project={project}
           primaryVolume={primaryVolume}
+          instanceLocation={instanceLocation}
           onFinish={onFinish}
           onCancel={onCancel}
           onCreate={() => setContent(CREATE_VOLUME)}
@@ -44,6 +55,7 @@ const CustomVolumeModal: FC<Props> = ({ project, onFinish, onCancel }) => {
       {content === CREATE_VOLUME && (
         <CustomVolumeCreateModal
           project={project}
+          instanceLocation={instanceLocation}
           onCancel={() => setContent(SELECT_VOLUME)}
           onFinish={handleCreateVolume}
         />

--- a/src/pages/storage/CustomVolumeSelectBtn.tsx
+++ b/src/pages/storage/CustomVolumeSelectBtn.tsx
@@ -3,8 +3,10 @@ import { Button, ButtonProps } from "@canonical/react-components";
 import usePortal from "react-useportal";
 import CustomVolumeModal from "pages/storage/CustomVolumeModal";
 import { LxdStorageVolume } from "types/storage";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 
 interface Props {
+  formik: InstanceAndProfileFormikProps;
   children: ReactNode;
   buttonProps?: ButtonProps;
   project: string;
@@ -12,6 +14,7 @@ interface Props {
 }
 
 const CustomVolumeSelectBtn: FC<Props> = ({
+  formik,
   children,
   buttonProps,
   project,
@@ -34,6 +37,7 @@ const CustomVolumeSelectBtn: FC<Props> = ({
       {isOpen && (
         <Portal>
           <CustomVolumeModal
+            formik={formik}
             project={project}
             onFinish={handleFinish}
             onCancel={handleCancel}

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -16,16 +16,17 @@ import { ensureEditMode } from "util/instanceEdit";
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
   project: string;
+  poolError?: string;
 }
 
-const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
+const StorageVolumeFormMain: FC<Props> = ({ formik, project, poolError }) => {
   return (
     <ScrollableForm>
       <Row>
         <Col size={12}>
           <Label
             forId="storage-pool-selector"
-            required={formik.values.isCreating ? true : false}
+            required={formik.values.isCreating}
           >
             Storage pool
           </Label>
@@ -36,6 +37,7 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project }) => {
             hidePoolsWithUnsupportedDrivers
             selectProps={{
               disabled: !formik.values.isCreating,
+              error: poolError,
             }}
             help={
               formik.values.isCreating

--- a/src/util/instanceLocation.tsx
+++ b/src/util/instanceLocation.tsx
@@ -1,0 +1,27 @@
+import { FormikProps } from "formik/dist/types";
+import { CreateInstanceFormValues } from "pages/instances/CreateInstance";
+import { EditInstanceFormValues } from "pages/instances/EditInstance";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { useSettings } from "context/useSettings";
+import { isClusteredServer } from "util/settings";
+
+export const getInstanceLocation = (formik: InstanceAndProfileFormikProps) => {
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
+
+  if (!isClustered) {
+    return undefined;
+  }
+
+  if (formik.values.entityType !== "instance") {
+    return undefined;
+  }
+
+  if (formik.values.isCreating) {
+    const createFormik = formik as FormikProps<CreateInstanceFormValues>;
+    return createFormik.values.target ?? "any";
+  }
+
+  const editFormik = formik as FormikProps<EditInstanceFormValues>;
+  return editFormik.values.location;
+};

--- a/tests/helpers/devices.ts
+++ b/tests/helpers/devices.ts
@@ -10,7 +10,7 @@ export const attachVolume = async (
   await page.getByRole("button", { name: "Create volume" }).click();
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByRole("button", { name: "Create volume" }).click();
-  await page.getByLabel(`Select ${volume}`, { exact: true }).click();
+  await page.getByTitle(`Select ${volume}`, { exact: true }).click();
   await page.getByPlaceholder("Enter full path (e.g. /data)").last().fill(path);
 };
 


### PR DESCRIPTION
## Done

- Prevent local volume attach to instances on another cluster member
- disable volume selection on instance creation unless the target member is specified and the volume location match
- always allow selection of remote volumes
- handle target of local storage pools, when creating them on instance creation / instance edit.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run clustered lxd with local volumes and remote volumes
    - attach disk volume on instance creation. any local volumes should be disabled
    - attach disk volume on instance creation. any local volumes should be enabled that match location after selecting a target member for the instance
    - attach disk volume on instance creation. table should display location
    - attach disk volume on instance creation in non-clustered environment: the location column should be hidden
    - create a disk volume on instance creation on a local storage pool, with a target for the instance selected. The volume should be created on the same target as chosen for the instance
    - create a disk volume on instance creation on a local storage pool, with a target for the instance *not* selected. The volume creation should be blocked for any local pool. It should succeed for remote pools.