### PR TITLE
Remove project parameter from storage pool api

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -17,25 +17,20 @@ import { LxdClusterMember } from "types/cluster";
 
 export const fetchStoragePool = (
   pool: string,
-  project: string,
   target?: string,
 ): Promise<LxdStoragePool> => {
   return new Promise((resolve, reject) => {
     const targetParam = target ? `&target=${target}` : "";
-    fetch(
-      `/1.0/storage-pools/${pool}?project=${project}&recursion=1${targetParam}`,
-    )
+    fetch(`/1.0/storage-pools/${pool}?recursion=1${targetParam}`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdStoragePool>) => resolve(data.metadata))
       .catch(reject);
   });
 };
 
-export const fetchStoragePools = (
-  project: string,
-): Promise<LxdStoragePool[]> => {
+export const fetchStoragePools = (): Promise<LxdStoragePool[]> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools?project=${project}&recursion=1`)
+    fetch(`/1.0/storage-pools?recursion=1`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdStoragePool[]>) => resolve(data.metadata))
       .catch(reject);
@@ -57,12 +52,11 @@ export const fetchStoragePoolResources = (
 
 export const createPool = (
   pool: Partial<LxdStoragePool>,
-  project: string,
   target?: string,
 ): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const targetParam = target ? `&target=${target}` : "";
-    fetch(`/1.0/storage-pools?project=${project}${targetParam}`, {
+    const targetParam = target ? `?target=${target}` : "";
+    fetch(`/1.0/storage-pools${targetParam}`, {
       method: "POST",
       body: JSON.stringify(pool),
     })
@@ -102,19 +96,16 @@ const getClusterAndMemberPools = (pool: Partial<LxdStoragePool>) => {
 
 export const createClusteredPool = (
   pool: LxdStoragePool,
-  project: string,
   clusterMembers: LxdClusterMember[],
 ): Promise<void> => {
   const { memberPool, clusterPool } = getClusterAndMemberPools(pool);
   return new Promise((resolve, reject) => {
     void Promise.allSettled(
-      clusterMembers.map((item) =>
-        createPool(memberPool, project, item.server_name),
-      ),
+      clusterMembers.map((item) => createPool(memberPool, item.server_name)),
     )
       .then(handleSettledResult)
       .then(() => {
-        return createPool(clusterPool, project);
+        return createPool(clusterPool);
       })
       .then(resolve)
       .catch(reject);
@@ -123,12 +114,11 @@ export const createClusteredPool = (
 
 export const updatePool = (
   pool: Partial<LxdStoragePool>,
-  project: string,
   target?: string,
 ): Promise<void> => {
   return new Promise((resolve, reject) => {
-    const targetParam = target ? `&target=${target}` : "";
-    fetch(`/1.0/storage-pools/${pool.name}?project=${project}${targetParam}`, {
+    const targetParam = target ? `?target=${target}` : "";
+    fetch(`/1.0/storage-pools/${pool.name}${targetParam}`, {
       method: "PATCH",
       body: JSON.stringify(pool),
     })
@@ -140,18 +130,17 @@ export const updatePool = (
 
 export const updateClusteredPool = (
   pool: Partial<LxdStoragePool>,
-  project: string,
   clusterMembers: LxdClusterMember[],
 ): Promise<void> => {
   const { memberPool, clusterPool } = getClusterAndMemberPools(pool);
   return new Promise((resolve, reject) => {
     void Promise.allSettled(
       clusterMembers.map(async (item) =>
-        updatePool(memberPool, project, item.server_name),
+        updatePool(memberPool, item.server_name),
       ),
     )
       .then(handleSettledResult)
-      .then(() => updatePool(clusterPool, project))
+      .then(() => updatePool(clusterPool))
       .then(resolve)
       .catch(reject);
   });
@@ -160,10 +149,9 @@ export const updateClusteredPool = (
 export const renameStoragePool = (
   oldName: string,
   newName: string,
-  project: string,
 ): Promise<void> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools/${oldName}?project=${project}`, {
+    fetch(`/1.0/storage-pools/${oldName}`, {
       method: "POST",
       body: JSON.stringify({
         name: newName,
@@ -175,12 +163,9 @@ export const renameStoragePool = (
   });
 };
 
-export const deleteStoragePool = (
-  pool: string,
-  project: string,
-): Promise<void> => {
+export const deleteStoragePool = (pool: string): Promise<void> => {
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools/${pool}?project=${project}`, {
+    fetch(`/1.0/storage-pools/${pool}`, {
       method: "DELETE",
     })
       .then(handleResponse)

--- a/src/components/forms/DiskDeviceForm.tsx
+++ b/src/components/forms/DiskDeviceForm.tsx
@@ -40,7 +40,7 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
     error: storageError,
   } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(project),
+    queryFn: () => fetchStoragePools(),
   });
 
   if (storageError) {
@@ -62,12 +62,7 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
       <ScrollableForm>
         {/* hidden submit to enable enter key in inputs */}
         <Input type="submit" hidden value="Hidden input" />
-        <DiskDeviceFormRoot
-          formik={formik}
-          project={project}
-          pools={pools}
-          profiles={profiles}
-        />
+        <DiskDeviceFormRoot formik={formik} pools={pools} profiles={profiles} />
         <DiskDeviceFormInherited
           formik={formik}
           inheritedVolumes={inheritedVolumes}

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -18,17 +18,11 @@ import { focusField } from "util/formFields";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
-  project: string;
   pools: LxdStoragePool[];
   profiles: LxdProfile[];
 }
 
-const DiskDeviceFormRoot: FC<Props> = ({
-  formik,
-  project,
-  pools,
-  profiles,
-}) => {
+const DiskDeviceFormRoot: FC<Props> = ({ formik, pools, profiles }) => {
   const readOnly = (formik.values as EditInstanceFormValues).readOnly;
   const rootIndex = formik.values.devices.findIndex(isRootDisk);
   const hasRootStorage = rootIndex !== -1;
@@ -126,7 +120,6 @@ const DiskDeviceFormRoot: FC<Props> = ({
             overrideForm: (
               <>
                 <StoragePoolSelector
-                  project={project}
                   value={formRootDevice?.pool ?? ""}
                   setValue={(value) =>
                     void formik.setFieldValue(

--- a/src/context/loadIsoVolumes.tsx
+++ b/src/context/loadIsoVolumes.tsx
@@ -36,7 +36,7 @@ export const collectAllStorageVolumes = async (
   project: string,
 ): Promise<LxdStorageVolume[]> => {
   const allVolumes: LxdStorageVolume[] = [];
-  const pools = await fetchStoragePools(project);
+  const pools = await fetchStoragePools();
 
   const poolVolumes = await Promise.allSettled(
     pools.map(async (pool) => fetchStorageVolumes(pool.name, project)),

--- a/src/pages/instances/InstanceStoragePoolMigration.tsx
+++ b/src/pages/instances/InstanceStoragePoolMigration.tsx
@@ -35,7 +35,6 @@ const InstanceStoragePoolMigration: FC<Props> = ({
       {targetPool && summary}
       {!targetPool && (
         <StoragePoolSelectTable
-          project={instance.project}
           onSelect={onSelect}
           disablePool={{
             name: getRootPool(instance),

--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -96,7 +96,7 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
 
   const { data: storagePools = [], isLoading: storagePoolsLoading } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(instance.project),
+    queryFn: () => fetchStoragePools(),
   });
 
   const { data: instances = [] } = useQuery({

--- a/src/pages/instances/forms/DuplicateInstanceForm.tsx
+++ b/src/pages/instances/forms/DuplicateInstanceForm.tsx
@@ -56,7 +56,7 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
 
   const { data: storagePools = [], isLoading: storagePoolsLoading } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(instance.project),
+    queryFn: () => fetchStoragePools(),
   });
 
   const { data: instances = [] } = useQuery({

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -269,7 +269,6 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           setMember={(member) => void formik.setFieldValue("member", member)}
         />
         <StoragePoolSelector
-          project={project?.name || ""}
           value={formik.values.pool}
           setValue={(value) => void formik.setFieldValue("pool", value)}
           selectProps={{

--- a/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
+++ b/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
@@ -208,7 +208,6 @@ const UploadInstanceBackupFileForm: FC<Props> = ({
           title={noFileSelectedMessage}
         />
         <StoragePoolSelector
-          project={project?.name || ""}
           value={formik.values.pool}
           setValue={(value) => void formik.setFieldValue("pool", value)}
           selectProps={{

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -65,8 +65,8 @@ const CreateStoragePool: FC = () => {
 
       const mutation =
         clusterMembers.length > 0
-          ? () => createClusteredPool(storagePool, project, clusterMembers)
-          : () => createPool(storagePool, project);
+          ? () => createClusteredPool(storagePool, clusterMembers)
+          : () => createPool(storagePool);
 
       mutation()
         .then(() => {

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -37,7 +37,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
 
   const { data: pools = [] } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(project),
+    queryFn: () => fetchStoragePools(),
   });
 
   const StorageVolumeSchema = Yup.object().shape({
@@ -106,11 +106,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
   return (
     <>
       <div className="volume-create-form">
-        <StorageVolumeFormMain
-          formik={formik}
-          project={project}
-          poolError={poolError}
-        />
+        <StorageVolumeFormMain formik={formik} poolError={poolError} />
       </div>
       <footer className="p-modal__footer">
         <Button

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -76,18 +76,14 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
 
       const mutation =
         clusterMembers.length > 0
-          ? () => updateClusteredPool(savedPool, project, clusterMembers)
-          : () => updatePool(savedPool, project);
+          ? () => updateClusteredPool(savedPool, clusterMembers)
+          : () => updatePool(savedPool);
 
       mutation()
         .then(async () => {
           toastNotify.success(`Storage pool ${savedPool.name} updated.`);
           const member = clusterMembers[0]?.server_name ?? undefined;
-          const updatedPool = await fetchStoragePool(
-            values.name,
-            project,
-            member,
-          );
+          const updatedPool = await fetchStoragePool(values.name, member);
           void formik.setValues(toStoragePoolFormValues(updatedPool));
         })
         .catch((e) => {

--- a/src/pages/storage/MigrateVolumeModal.tsx
+++ b/src/pages/storage/MigrateVolumeModal.tsx
@@ -72,7 +72,6 @@ const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
         summary
       ) : (
         <StoragePoolSelectTable
-          project={storageVolume.project}
           onSelect={setSelectedPool}
           disablePool={{
             name: storageVolume.pool,

--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -37,8 +37,8 @@ const StoragePoolDetail: FC = () => {
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.storage, project, name, member],
-    queryFn: () => fetchStoragePool(name, project, member),
+    queryKey: [queryKeys.storage, name, member],
+    queryFn: () => fetchStoragePool(name, member),
   });
 
   if (error) {

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -40,7 +40,7 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
         formik.setSubmitting(false);
         return;
       }
-      renameStoragePool(name, values.name, project)
+      renameStoragePool(name, values.name)
         .then(() => {
           navigate(`/ui/project/${project}/storage/pool/${values.name}`);
           toastNotify.success(

--- a/src/pages/storage/StoragePoolSelectTable.tsx
+++ b/src/pages/storage/StoragePoolSelectTable.tsx
@@ -8,7 +8,6 @@ import { fetchStoragePools } from "api/storage-pools";
 import classnames from "classnames";
 
 interface Props {
-  project: string;
   onSelect: (pool: string) => void;
   disablePool?: {
     name: string;
@@ -16,14 +15,10 @@ interface Props {
   };
 }
 
-const StoragePoolSelectTable: FC<Props> = ({
-  project,
-  onSelect,
-  disablePool,
-}) => {
+const StoragePoolSelectTable: FC<Props> = ({ onSelect, disablePool }) => {
   const { data: pools = [], isLoading } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(project),
+    queryFn: () => fetchStoragePools(),
   });
 
   const headers = [

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -9,7 +9,6 @@ import { useSettings } from "context/useSettings";
 import { getSupportedStorageDrivers } from "util/storageOptions";
 
 interface Props {
-  project: string;
   value: string;
   setValue: (value: string) => void;
   selectProps?: SelectProps;
@@ -18,7 +17,6 @@ interface Props {
 }
 
 const StoragePoolSelector: FC<Props> = ({
-  project,
   value,
   setValue,
   selectProps,
@@ -33,7 +31,7 @@ const StoragePoolSelector: FC<Props> = ({
     isLoading,
   } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(project),
+    queryFn: () => fetchStoragePools(),
   });
 
   const supportedStorageDrivers = getSupportedStorageDrivers(settings);

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -36,8 +36,8 @@ const StoragePools: FC = () => {
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.storage, project],
-    queryFn: () => fetchStoragePools(project),
+    queryKey: [queryKeys.storage],
+    queryFn: () => fetchStoragePools(),
   });
 
   if (error) {

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -124,7 +124,6 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
           stacked
         />
         <StoragePoolSelector
-          project={projectName}
           value={pool}
           setValue={setPool}
           selectProps={{

--- a/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
+++ b/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
@@ -34,7 +34,7 @@ const DeleteStoragePoolBtn: FC<Props> = ({
 
   const handleDelete = () => {
     setLoading(true);
-    deleteStoragePool(pool.name, project)
+    deleteStoragePool(pool.name)
       .then(() => {
         void queryClient.invalidateQueries({
           queryKey: [queryKeys.storage],

--- a/src/pages/storage/forms/DuplicateVolumeForm.tsx
+++ b/src/pages/storage/forms/DuplicateVolumeForm.tsx
@@ -204,7 +204,6 @@ const DuplicateVolumeForm: FC<Props> = ({ volume, close }) => {
           error={formik.touched.name ? formik.errors.name : null}
         />
         <StoragePoolSelector
-          project={volume.project}
           value={formik.values.pool}
           setValue={(value) => void formik.setFieldValue("pool", value)}
           selectProps={{

--- a/src/pages/storage/forms/StorageVolumeForm.tsx
+++ b/src/pages/storage/forms/StorageVolumeForm.tsx
@@ -140,7 +140,7 @@ const StorageVolumeForm: FC<Props> = ({ formik, section, setSection }) => {
 
   const { data: pools = [], error } = useQuery({
     queryKey: [queryKeys.storage],
-    queryFn: () => fetchStoragePools(project),
+    queryFn: () => fetchStoragePools(),
   });
 
   if (error) {
@@ -183,7 +183,7 @@ const StorageVolumeForm: FC<Props> = ({ formik, section, setSection }) => {
       <Row className="form-contents">
         <Col size={12}>
           {section === slugify(MAIN_CONFIGURATION) && (
-            <StorageVolumeFormMain formik={formik} project={project} />
+            <StorageVolumeFormMain formik={formik} />
           )}
           {section === slugify(SNAPSHOTS) && (
             <StorageVolumeFormSnapshots formik={formik} />

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -15,11 +15,10 @@ import { ensureEditMode } from "util/instanceEdit";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
-  project: string;
   poolError?: string;
 }
 
-const StorageVolumeFormMain: FC<Props> = ({ formik, project, poolError }) => {
+const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
   return (
     <ScrollableForm>
       <Row>
@@ -31,7 +30,6 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, project, poolError }) => {
             Storage pool
           </Label>
           <StoragePoolSelector
-            project={project}
             value={formik.values.pool}
             setValue={(val) => void formik.setFieldValue("pool", val)}
             hidePoolsWithUnsupportedDrivers

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -132,8 +132,8 @@ const getStorageVolumeRowMetadata = (
 ): ConfigRowMetadata => {
   // when creating the defaults will be taken from the storage pool, if set there
   const { data: pool } = useQuery({
-    queryKey: [queryKeys.storage, values.pool, values.project],
-    queryFn: () => fetchStoragePool(values.pool, values.project),
+    queryKey: [queryKeys.storage, values.pool],
+    queryFn: () => fetchStoragePool(values.pool),
     enabled: values.isCreating,
   });
   const poolField = `volume.${getVolumeKey(name)}`;


### PR DESCRIPTION
## Done

- Remove project parameter from storage pool fetch as pools are global over all projects

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check list and selectors of storage pool in various places in the app (storage pool list, custom volume creation, instance root device override, profile root disk selector, duplicate instance modal, etc)