### PR TITLE
fix: don't wait for slow page load network events in e2e

### DIFF
--- a/tests/cluster.spec.ts
+++ b/tests/cluster.spec.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { test } from "./fixtures/lxd-test";
 import { randomNameSuffix } from "./helpers/name";
+import { gotoURL } from "./helpers/navigate";
 
 test("cluster group create and delete", async ({ page }) => {
   const group = randomGroupName();
@@ -14,7 +15,7 @@ test("cluster group add and remove members", async ({ page }) => {
   await createClusterGroup(page, group);
   await toggleClusterGroupMember(page, group, member);
 
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   await page.getByRole("button", { name: "All cluster groups" }).click();
   await page.getByRole("link", { name: group }).click();
@@ -29,7 +30,7 @@ export const randomGroupName = (): string => {
 };
 
 export const createClusterGroup = async (page: Page, group: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   await page.getByRole("button", { name: "All cluster groups" }).click();
   await page.getByRole("button", { name: "Create group" }).click();
@@ -41,7 +42,7 @@ export const createClusterGroup = async (page: Page, group: string) => {
 };
 
 export const deleteClusterGroup = async (page: Page, group: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   await page.getByRole("button", { name: "All cluster groups" }).click();
   await page.getByRole("link", { name: group }).click();
@@ -56,7 +57,7 @@ export const toggleClusterGroupMember = async (
   group: string,
   member: string,
 ) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   await page.getByRole("button", { name: "All cluster groups" }).click();
   await page.getByRole("link", { name: group }).click();
@@ -71,7 +72,7 @@ export const toggleClusterGroupMember = async (
 };
 
 export const getFirstClusterMember = async (page: Page): Promise<string> => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   const firstCellContent = await page.getByRole("cell").first().textContent();
   return firstCellContent?.split("http")[0] ?? "";

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -1,7 +1,8 @@
 import { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export const isServerClustered = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Cluster" }).click();
   const count = await page.getByText("This server is not clustered").count();
   return count === 0;

--- a/tests/helpers/images.ts
+++ b/tests/helpers/images.ts
@@ -1,11 +1,12 @@
 import { expect } from "../fixtures/lxd-test";
 import { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export const deleteAllImages = async (
   page: Page,
   project: string = "default",
 ) => {
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page.getByRole("link", { name: "Images", exact: true }).first().click();
   await page
     .getByRole("columnheader", { name: "select" })
@@ -22,7 +23,7 @@ export const deleteAllImages = async (
 };
 
 export const deleteImage = async (page: Page, imageName: string) => {
-  await page.goto(`/ui`);
+  await gotoURL(page, `/ui`);
   await page.getByRole("link", { name: "Images", exact: true }).first().click();
 
   await page.getByPlaceholder("Search").click();
@@ -37,7 +38,7 @@ export const deleteImage = async (page: Page, imageName: string) => {
 };
 
 export const getImageNameFromAlias = async (page: Page, imageAlias: string) => {
-  await page.goto(`/ui`);
+  await gotoURL(page, `/ui`);
   await page.getByRole("link", { name: "Images", exact: true }).first().click();
 
   await page.getByPlaceholder("Search").click();

--- a/tests/helpers/instancePanel.ts
+++ b/tests/helpers/instancePanel.ts
@@ -1,7 +1,8 @@
 import { Page, expect } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export const openInstancePanel = async (page: Page, instance: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const instanceRow = page.getByRole("row", { name: instance }).first();
   await instanceRow.waitFor({ state: "visible" });
   const cells = instanceRow.locator(":has-text('Container')");

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -1,5 +1,6 @@
 import { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
+import { gotoURL } from "./navigate";
 
 export const randomInstanceName = (): string => {
   return `playwright-instance-${randomNameSuffix()}`;
@@ -16,7 +17,7 @@ export const createInstance = async (
   project: string = "default",
   image: string = "alpine/3.19/cloud",
 ) => {
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page
     .getByRole("link", { name: "Instances", exact: true })
     .first()
@@ -52,7 +53,7 @@ export const visitInstance = async (
   instance: string,
   project: string = "default",
 ) => {
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(instance);
   await page.getByRole("link", { name: instance }).first().click();
@@ -97,7 +98,7 @@ export const deleteInstance = async (
 };
 
 export const hasInstance = async (page: Page, instance: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(instance);
   return await page.getByRole("link", { name: instance }).first().isVisible();
@@ -121,7 +122,7 @@ export const createAndStartInstance = async (
   instance: string,
   type = "container",
 ) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page
     .getByRole("link", { name: "Instances", exact: true })
     .first()

--- a/tests/helpers/navigate.ts
+++ b/tests/helpers/navigate.ts
@@ -1,0 +1,5 @@
+import { Page } from "@playwright/test";
+
+export const gotoURL = async (page: Page, url: string) => {
+  await page.goto(url, { waitUntil: "commit" });
+};

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -2,6 +2,7 @@ import { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
 import { LxdNetworkType } from "types/network";
 import { activateAllTableOverrides } from "./configuration";
+import { gotoURL } from "./navigate";
 
 export const randomNetworkName = (): string => {
   return `test-${randomNameSuffix()}`;
@@ -12,7 +13,7 @@ export const createNetwork = async (
   network: string,
   type: LxdNetworkType = "bridge",
 ) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Networks", exact: true }).click();
   await page.getByRole("button", { name: "Create network" }).click();
   await page.getByRole("heading", { name: "Create a network" }).click();
@@ -38,7 +39,7 @@ export const deleteNetwork = async (page: Page, network: string) => {
 };
 
 export const visitNetwork = async (page: Page, network: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByTitle("Networks (default)").click();
   await page.getByRole("link", { name: network }).first().click();
   await page.getByTestId("tab-link-Configuration").click();

--- a/tests/helpers/permission-groups.ts
+++ b/tests/helpers/permission-groups.ts
@@ -1,13 +1,14 @@
 import { Page } from "@playwright/test";
 import { expect } from "../fixtures/lxd-test";
 import { randomNameSuffix } from "./name";
+import { gotoURL } from "./navigate";
 
 export const randomGroupName = (): string => {
   return `playwright-group-${randomNameSuffix()}`;
 };
 
 export const visitGroups = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Permissions" }).click();
   await page.getByRole("link", { name: "Groups", exact: true }).click();
   await expect(

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -1,12 +1,13 @@
 import { Page } from "@playwright/test";
 import { expect } from "../fixtures/lxd-test";
+import { gotoURL } from "./navigate";
 
 // These identities are created by the setup_test script in tests/scripts
 export const identityBar = "bar@bar.com";
 export const identityFoo = "foo@foo.com";
 
 export const visitIdentities = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Permissions" }).click();
   await page.getByRole("link", { name: "Identities" }).click();
   await expect(

--- a/tests/helpers/permission-idp-groups.ts
+++ b/tests/helpers/permission-idp-groups.ts
@@ -2,13 +2,14 @@ import { Page } from "@playwright/test";
 import { expect } from "../fixtures/lxd-test";
 import { pluralize } from "util/instanceBulkActions";
 import { randomNameSuffix } from "./name";
+import { gotoURL } from "./navigate";
 
 export const randomIdpGroupName = (): string => {
   return `playwright-idp-group-${randomNameSuffix()}`;
 };
 
 export const visitIdpGroups = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Permissions" }).click();
   await page.getByRole("link", { name: "IDP groups" }).click();
   await expect(

--- a/tests/helpers/profile.ts
+++ b/tests/helpers/profile.ts
@@ -1,5 +1,6 @@
 import { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
+import { gotoURL } from "./navigate";
 
 export const randomProfileName = (): string => {
   return `playwright-profile-${randomNameSuffix()}`;
@@ -19,7 +20,7 @@ export const startProfileCreation = async (
   profile: string,
   project: string = "default",
 ) => {
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page.getByRole("link", { name: "Profiles" }).click();
   await page.getByRole("button", { name: "Create profile" }).click();
   await page.getByLabel("Profile name").fill(profile);
@@ -49,7 +50,7 @@ export const visitProfile = async (
   profile: string,
   project: string = "default",
 ) => {
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page.getByRole("link", { name: "Profiles" }).click();
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(profile);

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -1,12 +1,13 @@
 import { randomNameSuffix } from "./name";
 import { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export const randomProjectName = (): string => {
   return `playwright-project-${randomNameSuffix()}`;
 };
 
 const openProjectCreationForm = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("button", { name: "Create project" }).click();
 };
@@ -43,7 +44,7 @@ export const renameProject = async (
 };
 
 export const deleteProject = async (page: Page, project: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("link", { name: project }).click();
   await page.getByRole("link", { name: "Configuration" }).click();

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,9 +1,10 @@
 import { Locator, Page, expect } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export type ServerSettingType = "checkbox" | "text" | "number" | "password";
 
 export const visitServerSettings = async (page: Page) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Settings", exact: true }).click();
 };
 

--- a/tests/helpers/snapshots.ts
+++ b/tests/helpers/snapshots.ts
@@ -1,5 +1,6 @@
 import { randomNameSuffix } from "./name";
 import { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
 
 export const randomSnapshotName = (): string => {
   return `playwright-snapshot-${randomNameSuffix()}`;
@@ -12,7 +13,7 @@ export const createInstanceSnapshot = async (
   project?: string,
 ) => {
   const route = project ? `/ui/project/${project}/instances` : "/ui";
-  await page.goto(route);
+  await gotoURL(page, route);
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(instance);
   await page.getByRole("link", { name: instance }).first().click();

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -1,12 +1,13 @@
 import { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
+import { gotoURL } from "./navigate";
 
 export const randomPoolName = (): string => {
   return `playwright-pool-${randomNameSuffix()}`;
 };
 
 export const createPool = async (page: Page, pool: string, driver = "dir") => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Pools" }).click();
   await page.getByRole("button", { name: "Create pool" }).click();
@@ -27,7 +28,7 @@ export const deletePool = async (page: Page, pool: string) => {
 };
 
 export const visitPool = async (page: Page, pool: string) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Pools" }).click();
   await page.getByRole("link", { name: pool }).first().click();

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
 import { expect } from "../fixtures/lxd-test";
+import { gotoURL } from "./navigate";
 
 export const randomVolumeName = (): string => {
   return `playwright-volume-${randomNameSuffix()}`;
@@ -11,7 +12,7 @@ export const createVolume = async (
   volume: string,
   volumeType = "filesystem",
 ) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Volumes" }).click();
   await page.getByRole("button", { name: "Create volume" }).click();
@@ -45,7 +46,7 @@ export const visitVolume = async (
   project?: string,
 ) => {
   const url = project ? `/ui/project/${project}` : "/ui/";
-  await page.goto(url);
+  await gotoURL(page, url);
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Volumes" }).click();
   await page.getByPlaceholder("Search and filter").fill(volume);

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -6,6 +6,7 @@ import {
   deleteInstance,
   randomInstanceName,
 } from "./helpers/instances";
+import { gotoURL } from "./helpers/navigate";
 
 test("search for custom image and create an instance from it", async ({
   page,
@@ -17,7 +18,7 @@ test("search for custom image and create an instance from it", async ({
   const customInstance = randomInstanceName();
   const image = "my-custom-image"; // this is created in pr.yaml and coverage.yaml
 
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Images", exact: true }).click();
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(image);
@@ -54,7 +55,7 @@ test("Export and Upload an image", async ({ page }) => {
   await deleteImage(page, imageName);
 
   //Upload an image
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Images", exact: true }).click();
 
   await page.getByRole("button", { name: "Upload image" }).click();

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -31,6 +31,7 @@ import { assertTextVisible } from "./helpers/permissions";
 import { deleteImage, getImageNameFromAlias } from "./helpers/images";
 import { createPool, deletePool, randomPoolName } from "./helpers/storagePool";
 import { isServerClustered } from "./helpers/cluster";
+import { gotoURL } from "./helpers/navigate";
 
 let instance = randomInstanceName();
 let vmInstance = randomInstanceName();
@@ -83,7 +84,7 @@ test("instance terminal operations", async ({ page }) => {
 test("instance rename", async ({ page }) => {
   const newName = instance + "-rename";
   await renameInstance(page, instance, newName);
-  instance = newName;
+  await renameInstance(page, newName, instance);
 });
 
 test("instance edit basic details", async ({ page }) => {
@@ -261,14 +262,14 @@ test("Duplicate an instance", async ({ page }) => {
 });
 
 test("Create an image from an instance", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const imageAlias = await createImageFromInstance(page, instance);
   const imageName = await getImageNameFromAlias(page, imageAlias);
   await deleteImage(page, imageName);
 });
 
 test("Bulk start, pause, unpause and stop instances", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search and filter").fill(instance);
   await page.getByPlaceholder("Search and filter").press("Enter");
@@ -340,7 +341,7 @@ test("Export and Upload an instance backup", async ({ page }) => {
   await download.saveAs(INSTANCE_FILE);
 
   //Upload an instance
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByRole("button", { name: "Upload instance file" }).click();
   await page
@@ -370,7 +371,7 @@ test("Create instance from external instance file", async ({
   );
 
   const INSTANCE_FILE = "ubuntu-minimal.qcow2";
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByRole("button", { name: "Upload instance file" }).click();
   await page.getByText("External format (.qcow2, .").click();

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -3,6 +3,7 @@ import { randomNameSuffix } from "./helpers/name";
 import { deleteInstance, randomInstanceName } from "./helpers/instances";
 import { assertTextVisible } from "./helpers/permissions";
 import { activateOverride } from "./helpers/configuration";
+import { gotoURL } from "./helpers/navigate";
 
 const ISO_FILE = "./tests/fixtures/foo.iso";
 
@@ -17,7 +18,7 @@ test("upload and delete custom iso", async ({ page, lxdVersion }) => {
   );
   const isoName = randomIso();
 
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage", exact: true }).click();
   await page.getByRole("link", { name: "Custom ISOs" }).click();
   await page.getByRole("button", { name: "Upload custom ISO" }).click();
@@ -58,7 +59,7 @@ test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
   const instance = randomInstanceName();
   const isoName = randomIso();
 
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Instances", exact: true }).click();
   await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByLabel("Instance name").fill(instance);
@@ -83,7 +84,7 @@ test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
   await page.waitForSelector(`text=Created instance ${instance}.`);
 
   await deleteInstance(page, instance);
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage", exact: true }).click();
   await page.getByRole("link", { name: "Custom ISOs" }).click();
   await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
@@ -100,7 +101,7 @@ test("not allowed to upload custom iso for lxd v5.0/edge", async ({
     lxdVersion !== "5.0-edge",
     `this test is specific to lxd v5.0/edge, current lxd snap channel is ${lxdVersion}`,
   );
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage", exact: true }).click();
   await expect(page.getByRole("link", { name: "Custom ISOs" })).toBeHidden();
 });
@@ -120,7 +121,7 @@ test("not allowed to launch instance with custom iso for lxd v5.0/edge", async (
   );
 
   const instance = randomInstanceName();
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Instances", exact: true }).click();
   await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByLabel("Instance name").fill(instance);

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { test, expect } from "./fixtures/lxd-test";
 import { execSync } from "child_process";
+import { gotoURL } from "./helpers/navigate";
 
 const loginUser = async (page: Page) => {
   await page.getByRole("link", { name: "Login with SSO" }).click();
@@ -20,7 +21,7 @@ test("login", async ({ page }, testInfo) => {
   ).toString();
   execSync(`lxc config trust remove ${fingerprint}`);
 
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await loginUser(page);
   await page.getByText("Log out").click();
 

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -4,6 +4,7 @@ import {
   checkAllOptions,
   setTextarea,
 } from "./helpers/configuration";
+import { gotoURL } from "./helpers/navigate";
 import {
   createNetwork,
   createNetworkForward,
@@ -235,7 +236,7 @@ test.describe("OVN type", () => {
       "OVN can not be configured in lxd v5.0/edge",
     );
 
-    await page.goto("/ui/");
+    await gotoURL(page, "/ui/");
     await page.getByRole("link", { name: "Networks", exact: true }).click();
     await page.getByRole("button", { name: "Create network" }).click();
     await page.getByRole("heading", { name: "Create a network" }).click();

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -12,6 +12,7 @@ import {
   dismissNotification,
 } from "./helpers/notification";
 import { validateOperation } from "./helpers/operations";
+import { gotoURL } from "./helpers/navigate";
 
 test("instance operations are recognised on the Operations page", async ({
   page,
@@ -20,7 +21,7 @@ test("instance operations are recognised on the Operations page", async ({
   await createInstance(page, instance);
 
   // validate create operation is in operation list
-  await page.goto("/ui/operations");
+  await gotoURL(page, "/ui/operations");
   await validateOperation(page, "Creating Instance", instance);
 
   // start instance and wait for the notification instance was started
@@ -32,16 +33,16 @@ test("instance operations are recognised on the Operations page", async ({
   await dismissNotification(page);
 
   // validate the operation to start the instance is in the operation list
-  await page.goto("/ui/operations");
+  await gotoURL(page, "/ui/operations");
   await validateOperation(page, "Starting Instance", instance);
 
   // stop instance and validate stop operation is in operation list
   await visitAndStopInstance(page, instance);
-  await page.goto("/ui/operations");
+  await gotoURL(page, "/ui/operations");
   await validateOperation(page, "Stopping Instance", instance);
 
   // delete instance and validate delete operation is in operation list
   await deleteInstance(page, instance);
-  await page.goto("/ui/operations");
+  await gotoURL(page, "/ui/operations");
   await validateOperation(page, "Deleting Instance", instance);
 });

--- a/tests/permissions.spec.ts
+++ b/tests/permissions.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "./fixtures/lxd-test";
+import { gotoURL } from "./helpers/navigate";
 
 test("LXD 5.0 does not support permissions", async ({ page, lxdVersion }) => {
   test.skip(
     lxdVersion !== "5.0-edge",
     "Fine grained authorisation is supported in lxd 5.21 LTS and latest/edge",
   );
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await expect(page.getByRole("button", { name: "Permissions" })).toBeHidden();
 });

--- a/tests/readme-screenshots.spec.ts
+++ b/tests/readme-screenshots.spec.ts
@@ -6,6 +6,7 @@ import {
 } from "./helpers/instances";
 import { createProject, deleteProject } from "./helpers/projects";
 import { createProfile, deleteProfile, visitProfile } from "./helpers/profile";
+import { gotoURL } from "./helpers/navigate";
 
 test.beforeEach(() => {
   test.skip(
@@ -15,7 +16,7 @@ test.beforeEach(() => {
 });
 
 test("instance creation screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByText("Instances", { exact: true }).click();
   await page.getByText("Create instance").click();
   await page.getByPlaceholder("Enter name").fill("comic-glider");
@@ -31,7 +32,7 @@ test("instance creation screen", async ({ page }) => {
 });
 
 test("instance list screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const project = "my-cluster";
   await createProject(page, project);
   await visitProfile(page, "default", project);
@@ -50,7 +51,7 @@ test("instance list screen", async ({ page }) => {
   for (const instance of instances) {
     await createInstance(page, instance, "container", project, "24.04");
   }
-  await page.goto(`/ui/project/${project}`);
+  await gotoURL(page, `/ui/project/${project}`);
   await page
     .getByRole("row", {
       name: "Select comic-glider Name Type Description Status Actions",
@@ -70,7 +71,7 @@ test("instance list screen", async ({ page }) => {
 });
 
 test("instance terminal screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const instance = "comic-glider";
   await createInstance(page, instance, "container", "default", "24.04");
   await visitAndStartInstance(page, instance);
@@ -91,7 +92,7 @@ test("instance terminal screen", async ({ page }) => {
 });
 
 test("instance graphical console screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const instance = "upright-pangolin";
   await page.getByText("Instances", { exact: true }).click();
   await page.getByText("Create instance").click();
@@ -117,13 +118,13 @@ test("instance graphical console screen", async ({ page }) => {
 });
 
 test("profile list screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   const project = "my-cluster";
   await createProject(page, project);
   await createProfile(page, "small", project);
   await createProfile(page, "medium", project);
   await createProfile(page, "large", project);
-  await page.goto(`/ui/project/${project}/profiles`);
+  await gotoURL(page, `/ui/project/${project}/profiles`);
 
   await page.screenshot({ path: "tests/screenshots/profile-list.png" });
 
@@ -134,7 +135,7 @@ test("profile list screen", async ({ page }) => {
 });
 
 test("storage pool screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByText("Storage").click();
   await page.getByText("Pools").click();
   await page.getByText("Created").first().click();
@@ -143,7 +144,7 @@ test("storage pool screen", async ({ page }) => {
 });
 
 test("operations screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await createInstance(page, "comic-glider");
   await page.getByRole("button", { name: "Close notification" }).click();
   await page.getByText("Operations").click();
@@ -155,7 +156,7 @@ test("operations screen", async ({ page }) => {
 });
 
 test("warnings screen", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByText("Warnings").click();
 
   await page.screenshot({ path: "tests/screenshots/warnings-list.png" });

--- a/tests/warnings.spec.ts
+++ b/tests/warnings.spec.ts
@@ -1,8 +1,9 @@
 import { test } from "./fixtures/lxd-test";
+import { gotoURL } from "./helpers/navigate";
 import { assertTextVisible } from "./helpers/permissions";
 
 test("view warnings page", async ({ page }) => {
-  await page.goto("/ui/");
+  await gotoURL(page, "/ui/");
   await page.getByTitle("Warnings").click();
   await assertTextVisible(page, "Last message");
 });


### PR DESCRIPTION
## Done

- Make `page.goto` not wait on full page load event.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes