### PR TITLE
fix(instance) layout adjustments for the instance overview tab

### DIFF
--- a/src/pages/instances/InstanceOverviewDeviceDetail.tsx
+++ b/src/pages/instances/InstanceOverviewDeviceDetail.tsx
@@ -14,7 +14,7 @@ const InstanceOverviewDeviceDetail: FC<Props> = ({ device, project }) => {
     if (isRootDisk(device as FormDevice)) {
       return (
         <>
-          <span>pool </span>
+          Pool{" "}
           <ResourceLink
             type={"pool"}
             value={device.pool}
@@ -26,15 +26,13 @@ const InstanceOverviewDeviceDetail: FC<Props> = ({ device, project }) => {
 
     return (
       <>
-        <span>
-          volume&nbsp;
-          <ResourceLink
-            type={"volume"}
-            value={device.source as string}
-            to={`/ui/project/${project}/storage/pool/${device.pool}/volumes/custom/${device.source}`}
-          />{" "}
-        </span>
-        <span> on pool </span>
+        Volume{" "}
+        <ResourceLink
+          type={"volume"}
+          value={device.source as string}
+          to={`/ui/project/${project}/storage/pool/${device.pool}/volumes/custom/${device.source}`}
+        />{" "}
+        on pool{" "}
         <ResourceLink
           type={"pool"}
           value={device.pool}
@@ -47,7 +45,7 @@ const InstanceOverviewDeviceDetail: FC<Props> = ({ device, project }) => {
   if (device.type === "gpu") {
     return (
       <span title={device.pci} className="u-truncate">
-        {device.pci ? `pci: ${device.pci}` : `id: ${device.id}`}
+        {device.pci ? `PCI  ${device.pci}` : `ID ${device.id}`}
       </span>
     );
   }
@@ -55,15 +53,12 @@ const InstanceOverviewDeviceDetail: FC<Props> = ({ device, project }) => {
   if (device.type === "proxy") {
     return (
       <>
-        <span
-          title={device.listen}
-          className="u-truncate"
-        >{`listen: ${device.listen}`}</span>{" "}
-        <br />
-        <span
-          title={device.connect}
-          className="u-truncate"
-        >{`connect: ${device.connect}`}</span>
+        <div title={device.listen} className="u-truncate">
+          Listen: {device.listen}
+        </div>
+        <div title={device.connect} className="u-truncate">
+          Connect: {device.connect}
+        </div>
       </>
     );
   }

--- a/src/pages/instances/InstanceOverviewDevices.tsx
+++ b/src/pages/instances/InstanceOverviewDevices.tsx
@@ -46,12 +46,12 @@ const InstanceOverviewDevices: FC<Props> = ({ instance }) => {
           content: (
             <ResourceLink type="device" value={devicename} to={configUrl} />
           ),
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Name",
         },
         {
-          content: `${device.type} ${isRootDisk(device as FormDevice) ? "(root)" : ""}`,
-          role: "rowheader",
+          content: `${device.type}${isRootDisk(device as FormDevice) ? " (root)" : ""}`,
+          role: "cell",
           "aria-label": "Type",
         },
         {
@@ -61,7 +61,7 @@ const InstanceOverviewDevices: FC<Props> = ({ instance }) => {
               project={instance.project}
             />
           ),
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Details",
         },
       ],
@@ -75,7 +75,12 @@ const InstanceOverviewDevices: FC<Props> = ({ instance }) => {
   return (
     <>
       {hasDevices && (
-        <MainTable headers={deviceHeaders} rows={deviceRows} sortable />
+        <MainTable
+          headers={deviceHeaders}
+          rows={deviceRows}
+          sortable
+          className="devices"
+        />
       )}
       {!hasDevices && <>-</>}
     </>

--- a/src/sass/_instance_detail_overview.scss
+++ b/src/sass/_instance_detail_overview.scss
@@ -54,6 +54,13 @@
     }
   }
 
+  .devices {
+    th:nth-child(2),
+    td:nth-child(2) {
+      width: 12rem;
+    }
+  }
+
   .profiles {
     th:nth-child(1) {
       width: 30%;

--- a/src/sass/_resources.scss
+++ b/src/sass/_resources.scss
@@ -16,10 +16,6 @@
 }
 
 .resource-label {
-  // align font size with chip component
-  font-size: #{map-get($font-sizes, small)}rem;
-  line-height: #{map-get($line-heights, small)}rem;
-
   i {
     margin-right: $sph--x-small;
   }


### PR DESCRIPTION
## Done

- layout adjustments for the instance overview tab
- consistent font size
- slightly improved spacing, captions and tag usage for the devices table.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance overview tab