### PR TITLE
fix(instance) show help text for instance root disk device on edit

### DIFF
--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -13,7 +13,6 @@ interface Props {
   setValue: (value: string) => void;
   selectProps?: SelectProps;
   hidePoolsWithUnsupportedDrivers?: boolean;
-  help?: string;
 }
 
 const StoragePoolSelector: FC<Props> = ({
@@ -21,7 +20,6 @@ const StoragePoolSelector: FC<Props> = ({
   setValue,
   selectProps,
   hidePoolsWithUnsupportedDrivers = false,
-  help,
 }) => {
   const notify = useNotify();
   const { data: settings } = useSettings();
@@ -82,7 +80,6 @@ const StoragePoolSelector: FC<Props> = ({
       onChange={(e) => setValue(e.target.value)}
       value={value}
       {...selectProps}
-      help={help}
     />
   );
 };

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -36,12 +36,10 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
             selectProps={{
               disabled: !formik.values.isCreating,
               error: poolError,
-            }}
-            help={
-              formik.values.isCreating
+              help: formik.values.isCreating
                 ? undefined
-                : "Use the migrate button in the header to move the volume to a different storage pool."
-            }
+                : "Use the migrate button in the header to move the volume to a different storage pool.",
+            }}
           />
           <Input
             {...getFormProps(formik, "name")}


### PR DESCRIPTION
## Done

- show help text for instance root disk device on edit

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open the configuration of an existing instance or storage volume
    - the root storage pool input should be disabled and have a help text below indicating to use the "migrate" button in the header to change the storage pool