### PR TITLE
feat(instance) add cluster member column and filter to instance list

### DIFF
--- a/src/pages/instances/InstanceSearchFilter.tsx
+++ b/src/pages/instances/InstanceSearchFilter.tsx
@@ -11,13 +11,16 @@ import {
   paramsFromSearchData,
   searchParamsToChips,
 } from "util/searchAndFilter";
+import { useSettings } from "context/useSettings";
+import { isClusteredServer } from "util/settings";
 
 export const QUERY = "query";
 export const STATUS = "status";
 export const TYPE = "type";
 export const PROFILE = "profile";
+export const CLUSTER_MEMBER = "member";
 
-const QUERY_PARAMS = [QUERY, STATUS, TYPE, PROFILE];
+const QUERY_PARAMS = [QUERY, STATUS, TYPE, PROFILE, CLUSTER_MEMBER];
 
 interface Props {
   instances: LxdInstance[];
@@ -25,9 +28,15 @@ interface Props {
 
 const InstanceSearchFilter: FC<Props> = ({ instances }) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
 
   const profileSet = [
     ...new Set(instances.flatMap((instance) => instance.profiles)),
+  ];
+
+  const locationSet = [
+    ...new Set(instances.flatMap((instance) => instance.location)),
   ];
 
   const searchAndFilterData: SearchAndFilterData[] = [
@@ -52,6 +61,17 @@ const InstanceSearchFilter: FC<Props> = ({ instances }) => {
         return { lead: PROFILE, value: profile };
       }),
     },
+    ...(isClustered
+      ? [
+          {
+            id: 4,
+            heading: "Cluster member",
+            chips: locationSet.map((location) => {
+              return { lead: CLUSTER_MEMBER, value: location };
+            }),
+          },
+        ]
+      : []),
   ];
 
   const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {

--- a/src/util/instanceFilter.tsx
+++ b/src/util/instanceFilter.tsx
@@ -4,7 +4,8 @@ export interface InstanceFilters {
   queries: string[];
   statuses: LxdInstanceStatus[];
   types: string[];
-  profileQueries: string[];
+  profiles: string[];
+  clusterMembers: string[];
 }
 
 export const instanceStatuses: LxdInstanceStatus[] = [

--- a/src/util/instanceTable.tsx
+++ b/src/util/instanceTable.tsx
@@ -1,6 +1,7 @@
 export const STATUS = "Status";
 export const NAME = "Name";
 export const TYPE = "Type";
+export const CLUSTER_MEMBER = "Cluster member";
 export const DESCRIPTION = "Description";
 export const IPV4 = "IPv4";
 export const IPV6 = "IPv6";
@@ -10,6 +11,7 @@ export const ACTIONS = "Actions";
 export const COLUMN_WIDTHS: Record<string, number> = {
   [NAME]: 170,
   [TYPE]: 130,
+  [CLUSTER_MEMBER]: 150,
   [DESCRIPTION]: 150,
   [IPV4]: 150,
   [IPV6]: 330,

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -277,7 +277,9 @@ test("Bulk start, pause, unpause and stop instances", async ({ page }) => {
 
   //Bulk start instances
   await page
-    .getByRole("row", { name: "select Name Type Description Status Actions" })
+    .getByRole("row", {
+      name: "select Name Type Cluster member Status Actions",
+    })
     .getByLabel("multiselect rows")
     .click();
   await page


### PR DESCRIPTION
## Done

- feat(instance) add cluster member column and filter to instance list

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance list in a clustered and non-clustered environment
    - in one the new cluster member column should show up and a filter on the instance list for it be available
    - in a non-clustered environment, the cluster member column and filter input should be invisible.