### PR TITLE
Hide non managed networks as uplink options for ovn

### DIFF
--- a/src/pages/networks/forms/UplinkSelector.tsx
+++ b/src/pages/networks/forms/UplinkSelector.tsx
@@ -27,7 +27,10 @@ const UplinkSelector: FC<Props> = ({ project: projectName, props }) => {
   const availableUplinks =
     project?.config?.["restricted.networks.uplinks"]?.split(",") ||
     networks
-      .filter((network) => UPLINK_NETWORK_TYPES.includes(network.type))
+      .filter(
+        (network) =>
+          UPLINK_NETWORK_TYPES.includes(network.type) && network.managed,
+      )
       .map((network) => network.name);
 
   const options = availableUplinks.map((name) => {

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -243,7 +243,7 @@ test.describe("OVN type", () => {
     await page.getByLabel("Type").selectOption("OVN");
     await page.getByLabel("Name").click();
     await page.getByLabel("Name").fill(network);
-    await page.getByLabel("Uplink").selectOption({ index: 2 });
+    await page.getByLabel("Uplink").selectOption({ index: 1 });
   });
 
   test("configure main OVN network settings", async ({ page }) => {


### PR DESCRIPTION
## Done

- Hide non managed networks as uplink options for ovn

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create or edit an ovn network
    - ensure only managed networks of type bridge or physical are available in the uplink selector in the network form.