### PR TITLE
Allow auto assignment of listen address when creating a network forward

### DIFF
--- a/src/pages/networks/forms/NetworkFormIpv4.tsx
+++ b/src/pages/networks/forms/NetworkFormIpv4.tsx
@@ -77,19 +77,24 @@ const NetworkFormIpv4: FC<Props> = ({ formik }) => {
             ]
           : []),
 
+        ...(["bridge", "physical"].includes(formik.values.networkType)
+          ? [
+              getConfigurationRow({
+                formik,
+                name: "ipv4_routes",
+                label: "IPv4 routes",
+                defaultValue: "",
+                children: <Textarea />,
+              }),
+            ]
+          : []),
+
         ...(formik.values.networkType === "physical"
           ? [
               getConfigurationRow({
                 formik,
                 name: "ipv4_gateway",
                 label: "IPv4 gateway",
-                defaultValue: "",
-                children: <Textarea />,
-              }),
-              getConfigurationRow({
-                formik,
-                name: "ipv4_routes",
-                label: "IPv4 routes",
                 defaultValue: "",
                 children: <Textarea />,
               }),

--- a/src/pages/networks/forms/NetworkFormIpv6.tsx
+++ b/src/pages/networks/forms/NetworkFormIpv6.tsx
@@ -91,19 +91,24 @@ const NetworkFormIpv6: FC<Props> = ({ formik }) => {
             ]
           : []),
 
+        ...(["bridge", "physical"].includes(formik.values.networkType)
+          ? [
+              getConfigurationRow({
+                formik,
+                name: "ipv6_routes",
+                label: "IPv6 routes",
+                defaultValue: "",
+                children: <Textarea />,
+              }),
+            ]
+          : []),
+
         ...(formik.values.networkType === "physical"
           ? [
               getConfigurationRow({
                 formik,
                 name: "ipv6_gateway",
                 label: "IPv6 gateway",
-                defaultValue: "",
-                children: <Textarea />,
-              }),
-              getConfigurationRow({
-                formik,
-                name: "ipv6_routes",
-                label: "IPv6 routes",
                 defaultValue: "",
                 children: <Textarea />,
               }),


### PR DESCRIPTION
## Done

- Show ipv4.routes and ipv6.routes option for bridge networks
- Allow auto assignment of listen address when creating a network forward on an ovn network

Fixes WD-16475

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a microcluster to have running ovn
    - create an uplink with ipv4.routes set i.e. to `192.168.42.0/24` and ipv6.routes to `fe80:b416:5119:8b44::0/64`
    - create a new ovn network with the uplink created in the previous step
    - create network forwards on the new ovn network. There should be an option to "auto assign ipv4" and "auto assign ipv6" listen address. test both
    - ensure when creating a network forward on a bridge network, that the auto options for listen address are not available.

## Screenshots

![image](https://github.com/user-attachments/assets/ee3143ec-9628-43ca-a9c9-e695443abf56)
