### PR TITLE
feat: [WD-16398] Set default storage pool for new project...

### DIFF
--- a/src/pages/projects/EditProject.tsx
+++ b/src/pages/projects/EditProject.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect } from "react";
 import { Button, useNotify } from "@canonical/react-components";
 import { updateProject } from "api/projects";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { PROJECT_DETAILS } from "pages/projects/forms/ProjectFormMenu";
 import { useFormik } from "formik";
@@ -23,6 +23,7 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import ResourceLink from "components/ResourceLink";
+import { fetchProfile } from "api/profiles";
 
 interface Props {
   project: LxdProject;
@@ -38,6 +39,10 @@ const EditProject: FC<Props> = ({ project }) => {
   const { hasProjectsNetworksZones, hasStorageBuckets } =
     useSupportedFeatures();
 
+  const { data: profile } = useQuery({
+    queryKey: [queryKeys.profiles, "default", project.name],
+    queryFn: () => fetchProfile("default", project.name),
+  });
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
   };
@@ -48,7 +53,7 @@ const EditProject: FC<Props> = ({ project }) => {
     name: Yup.string().required(),
   });
 
-  const initialValues = getProjectEditValues(project);
+  const initialValues = getProjectEditValues(project, profile);
 
   const formik: FormikProps<ProjectFormValues> = useFormik({
     initialValues: initialValues,

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -17,10 +17,13 @@ import ScrollableForm from "components/ScrollableForm";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { LxdConfigPair } from "types/config";
 import { ensureEditMode } from "util/instanceEdit";
+import StoragePoolSelector from "pages/storage/StoragePoolSelector";
+import ResourceLink from "components/ResourceLink";
 
 export interface ProjectDetailsFormValues {
   name: string;
   description?: string;
+  default_instance_storage_pool: string;
   restricted: boolean;
   features_images?: boolean;
   features_profiles?: boolean;
@@ -146,144 +149,181 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             }}
             value={formik.values.description}
           />
-          <Select
-            id="features"
-            name="features"
-            label="Features"
-            onChange={(e) => {
-              ensureEditMode(formik);
-              setFeatures(e.target.value);
-              void formik.setFieldValue("features_images", true);
-              void formik.setFieldValue("features_profiles", true);
-              void formik.setFieldValue("features_networks", false);
-              void formik.setFieldValue("features_networks_zones", false);
-              void formik.setFieldValue("features_storage_buckets", true);
-              void formik.setFieldValue("features_storage_volumes", true);
-            }}
-            value={features}
-            options={[
-              {
-                label: "Default LXD",
-                value: "default",
-              },
-              {
-                label: "Customised",
-                value: "customised",
-              },
-            ]}
-            disabled={
-              isDefaultProject ||
-              (isNonEmpty && hadFeaturesNetwork) ||
-              (isNonEmpty && hadFeaturesNetworkZones)
+          <div
+            title={
+              isDefaultProject
+                ? "Custom features are immutable on the default project"
+                : ""
             }
-          />
-          {features === "customised" && (
-            <>
-              Isolate the following features:
-              <CheckboxInput
-                id="features_images"
-                name="features_images"
-                label="Images"
-                onChange={() => {
-                  ensureEditMode(formik);
-                  void formik.setFieldValue(
-                    "features_images",
-                    !formik.values.features_images,
-                  );
-                }}
-                checked={formik.values.features_images}
-                disabled={isDefaultProject || isNonEmpty}
-              />
-              <CheckboxInput
-                id="features_profiles"
-                name="features_profiles"
-                label={
-                  <>
-                    Profiles
-                    <Tooltip
-                      className="checkbox-label-tooltip"
-                      message={`Allow profiles to enable custom${"\n"}restrictions on a project level`}
-                    >
-                      <Icon name="information" />
-                    </Tooltip>
-                  </>
-                }
-                onChange={() => {
-                  ensureEditMode(formik);
-                  const newValue = !formik.values.features_profiles;
-                  void formik.setFieldValue("features_profiles", newValue);
-                  if (!newValue) {
-                    void formik.setFieldValue("restricted", false);
-                  }
-                }}
-                checked={formik.values.features_profiles}
-                disabled={isDefaultProject || isNonEmpty}
-              />
-              <CheckboxInput
-                id="features_networks"
-                name="features_networks"
-                label="Networks"
-                onChange={() => {
-                  ensureEditMode(formik);
-                  void formik.setFieldValue(
-                    "features_networks",
-                    !formik.values.features_networks,
-                  );
-                }}
-                checked={formik.values.features_networks}
-                disabled={isDefaultProject || isNonEmpty}
-              />
-              {hasProjectsNetworksZones && (
+          >
+            <Select
+              id="features"
+              name="features"
+              label="Features"
+              onChange={(e) => {
+                ensureEditMode(formik);
+                setFeatures(e.target.value);
+                void formik.setFieldValue("features_images", true);
+                void formik.setFieldValue("features_profiles", true);
+                void formik.setFieldValue("features_networks", false);
+                void formik.setFieldValue("features_networks_zones", false);
+                void formik.setFieldValue("features_storage_buckets", true);
+                void formik.setFieldValue("features_storage_volumes", true);
+              }}
+              value={features}
+              options={[
+                {
+                  label: "Default LXD",
+                  value: "default",
+                },
+                {
+                  label: "Customised",
+                  value: "customised",
+                },
+              ]}
+              disabled={
+                isDefaultProject ||
+                (isNonEmpty && hadFeaturesNetwork) ||
+                (isNonEmpty && hadFeaturesNetworkZones)
+              }
+            />
+
+            {features === "customised" && (
+              <>
+                Isolate the following features:
                 <CheckboxInput
-                  id="features_networks_zones"
-                  name="features_networks_zones"
-                  label="Network zones"
+                  id="features_images"
+                  name="features_images"
+                  label="Images"
                   onChange={() => {
                     ensureEditMode(formik);
                     void formik.setFieldValue(
-                      "features_networks_zones",
-                      !formik.values.features_networks_zones,
+                      "features_images",
+                      !formik.values.features_images,
                     );
                   }}
-                  checked={formik.values.features_networks_zones}
-                  disabled={
-                    isDefaultProject || (isNonEmpty && hadFeaturesNetworkZones)
-                  }
-                />
-              )}
-              {hasStorageBuckets && (
-                <CheckboxInput
-                  id="features_storage_buckets"
-                  name="features_storage_buckets"
-                  label="Storage buckets"
-                  onChange={() => {
-                    ensureEditMode(formik);
-                    void formik.setFieldValue(
-                      "features_storage_buckets",
-                      !formik.values.features_storage_buckets,
-                    );
-                  }}
-                  checked={formik.values.features_storage_buckets}
+                  checked={formik.values.features_images}
                   disabled={isDefaultProject || isNonEmpty}
                 />
-              )}
-              <CheckboxInput
-                id="features_storage_volumes"
-                name="features_storage_volumes"
-                label="Storage volumes"
-                onChange={() => {
-                  ensureEditMode(formik);
-                  void formik.setFieldValue(
-                    "features_storage_volumes",
-                    !formik.values.features_storage_volumes,
-                  );
-                }}
-                checked={formik.values.features_storage_volumes}
-                disabled={isDefaultProject || isNonEmpty}
-              />
-            </>
-          )}
+                <CheckboxInput
+                  id="features_profiles"
+                  name="features_profiles"
+                  label={
+                    <>
+                      Profiles
+                      <Tooltip
+                        className="checkbox-label-tooltip"
+                        message={`Allow profiles to enable custom${"\n"}restrictions on a project level`}
+                      >
+                        <Icon name="information" />
+                      </Tooltip>
+                    </>
+                  }
+                  onChange={() => {
+                    ensureEditMode(formik);
+                    const newValue = !formik.values.features_profiles;
+                    void formik.setFieldValue("features_profiles", newValue);
+                    if (!newValue) {
+                      void formik.setFieldValue("restricted", false);
+                    }
+                  }}
+                  checked={formik.values.features_profiles}
+                  disabled={isDefaultProject || isNonEmpty}
+                />
+                <CheckboxInput
+                  id="features_networks"
+                  name="features_networks"
+                  label="Networks"
+                  onChange={() => {
+                    ensureEditMode(formik);
+                    void formik.setFieldValue(
+                      "features_networks",
+                      !formik.values.features_networks,
+                    );
+                  }}
+                  checked={formik.values.features_networks}
+                  disabled={isDefaultProject || isNonEmpty}
+                />
+                {hasProjectsNetworksZones && (
+                  <CheckboxInput
+                    id="features_networks_zones"
+                    name="features_networks_zones"
+                    label="Network zones"
+                    onChange={() => {
+                      ensureEditMode(formik);
+                      void formik.setFieldValue(
+                        "features_networks_zones",
+                        !formik.values.features_networks_zones,
+                      );
+                    }}
+                    checked={formik.values.features_networks_zones}
+                    disabled={
+                      isDefaultProject ||
+                      (isNonEmpty && hadFeaturesNetworkZones)
+                    }
+                  />
+                )}
+                {hasStorageBuckets && (
+                  <CheckboxInput
+                    id="features_storage_buckets"
+                    name="features_storage_buckets"
+                    label="Storage buckets"
+                    onChange={() => {
+                      ensureEditMode(formik);
+                      void formik.setFieldValue(
+                        "features_storage_buckets",
+                        !formik.values.features_storage_buckets,
+                      );
+                    }}
+                    checked={formik.values.features_storage_buckets}
+                    disabled={isDefaultProject || isNonEmpty}
+                  />
+                )}
+                <CheckboxInput
+                  id="features_storage_volumes"
+                  name="features_storage_volumes"
+                  label="Storage volumes"
+                  onChange={() => {
+                    ensureEditMode(formik);
+                    void formik.setFieldValue(
+                      "features_storage_volumes",
+                      !formik.values.features_storage_volumes,
+                    );
+                  }}
+                  checked={formik.values.features_storage_volumes}
+                  disabled={isDefaultProject || isNonEmpty}
+                />
+              </>
+            )}
+          </div>
+
           <hr />
+          <StoragePoolSelector
+            value={formik.values.default_instance_storage_pool}
+            setValue={(value) =>
+              void formik.setFieldValue("default_instance_storage_pool", value)
+            }
+            selectProps={{
+              label: "Default instance storage pool",
+              disabled:
+                (formik.values.features_profiles === false &&
+                  features === "customised") ||
+                isEdit,
+              help: isEdit ? (
+                <>
+                  Edit the storage pool in the{" "}
+                  <ResourceLink
+                    type="profile"
+                    value="default"
+                    to={`/ui/project/${project?.name}/profile/default`}
+                  />{" "}
+                  {" profile"}
+                </>
+              ) : (
+                ""
+              ),
+            }}
+          />
           <CheckboxInput
             id="custom_restrictions"
             name="custom_restrictions"

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -336,3 +336,12 @@ export const getRootPool = (instance: LxdInstance): string => {
     });
   return rootStorage ? rootStorage.pool : "";
 };
+
+export const getDefaultStoragePool = (profile: LxdProfile) => {
+  const rootStorage = Object.values(profile.devices ?? {})
+    .filter(isDiskDevice)
+    .find((device) => {
+      return isRootDisk(device as FormDevice);
+    });
+  return rootStorage ? rootStorage.pool : "";
+};

--- a/src/util/projectEdit.tsx
+++ b/src/util/projectEdit.tsx
@@ -12,14 +12,20 @@ import { instanceRestrictionPayload } from "pages/projects/forms/InstanceRestric
 import { deviceUsageRestrictionPayload } from "pages/projects/forms/DeviceUsageRestrictionForm";
 import { networkRestrictionPayload } from "pages/projects/forms/NetworkRestrictionForm";
 import { getUnhandledKeyValues } from "util/formFields";
+import { getDefaultStoragePool } from "./helpers";
+import { LxdProfile } from "types/profile";
 
 export const getProjectEditValues = (
   project: LxdProject,
+  defaultProfile?: LxdProfile,
 ): ProjectFormValues => {
   return {
     name: project.name,
     readOnly: true,
     description: project.description,
+    default_instance_storage_pool: defaultProfile
+      ? getDefaultStoragePool(defaultProfile)
+      : "",
     restricted: project.config.restricted === "true",
     features_images: project.config["features.images"] === "true",
     features_profiles: isProjectWithProfiles(project),


### PR DESCRIPTION
...on creation

## Done
- Create new project case
    - Used StoragePool Selector component
    - Disabled storage pool selector (sps) when profiles are shared.
    - Selected storage pool becomes project's default profile's storage pool when saved.
    - Error handling.
- Edit project case
    - Storage pool is disabled
    - Help text shown to direct the user on where to edit the storage pool
    - Initial value of storage pool is set to be the default profile's storage pool.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

![image](https://github.com/user-attachments/assets/b8dcfcfe-6f16-419e-8f16-1a5d63c76406)