### PR TITLE
fix(edit) instance and profile configuration: clear cpu or memory limit

### DIFF
--- a/src/util/formChangeCount.tsx
+++ b/src/util/formChangeCount.tsx
@@ -72,13 +72,14 @@ const getLimitChanges = (formik: ConfigurationRowFormikProps): number => {
   let changeCount = 0;
 
   ["limits_cpu", "limits_memory"].forEach((key) => {
+    const keyType = key as "limits_memory" | "limits_cpu";
+    const init = (formik.initialValues as ResourceLimitsFormValues)[keyType];
+
     if (!Object.hasOwn(formik.values, key)) {
+      changeCount += init ? 1 : 0;
       return;
     }
 
-    const keyType = key as "limits_memory" | "limits_cpu";
-
-    const init = (formik.initialValues as ResourceLimitsFormValues)[keyType];
     const value = (formik.values as ResourceLimitsFormValues)[keyType];
 
     if (stringifyWithOrder(init) !== stringifyWithOrder(value)) {

--- a/tests/helpers/configuration.ts
+++ b/tests/helpers/configuration.ts
@@ -65,6 +65,13 @@ export const setCpuLimit = async (
   await page.getByPlaceholder(placeholder).fill(limit);
 };
 
+export const clearCpuLimit = async (page: Page) => {
+  await page.getByTestId("tab-link-Configuration").click();
+  await page.getByText("Resource limits").click();
+  await activateOverride(page, "Exposed CPU limit");
+  await clearOverride(page, "Exposed CPU limit");
+};
+
 export const setMemLimit = async (
   page: Page,
   type: "absolute" | "percentage",
@@ -124,6 +131,34 @@ export const activateOverride = async (page: Page, field: string) => {
     await page
       .getByRole("row", { name: field })
       .getByRole("button", { name: "Create override" })
+      .click();
+  }
+};
+
+export const clearOverride = async (page: Page, field: string) => {
+  if (
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Edit" })
+      .isVisible()
+  ) {
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Edit" })
+      .click();
+
+    return;
+  }
+
+  if (
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Clear override" })
+      .isVisible()
+  ) {
+    await page
+      .getByRole("row", { name: field })
+      .getByRole("button", { name: "Clear override" })
       .click();
   }
 };

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "./fixtures/lxd-test";
 import {
   assertCode,
   assertReadMode,
+  clearCpuLimit,
   setCodeInput,
   setCpuLimit,
   setInput,
@@ -65,6 +66,9 @@ test("profile cpu and memory", async ({ page }) => {
   await setCpuLimit(page, "fixed", "1-23");
   await saveProfile(page, profile, 1);
   await assertReadMode(page, "Exposed CPU limit", "1-23");
+
+  await clearCpuLimit(page);
+  await saveProfile(page, profile, 1);
 
   await setMemLimit(page, "percentage", "2");
   await saveProfile(page, profile, 1);


### PR DESCRIPTION
## Done

- instance and profile configuration: clear cpu or memory limitits should count as 1 change and allow saving.
- before clearing a cpu or memory change would count as no change and the save button stay disabled

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit instance or profile
    - change cpu or memory limit to a value
    - save changes
    - clear cpu and/or memory limit
    - save changes should be possible right away (previously the save button would not activate)