### PR TITLE
fix(profile) ensure space in hint about modifications

### DIFF
--- a/src/pages/profiles/ProfileDetailOverview.tsx
+++ b/src/pages/profiles/ProfileDetailOverview.tsx
@@ -52,7 +52,7 @@ const ProfileDetailOverview: FC<Props> = ({ profile, featuresProfiles }) => {
     <div className="profile-overview-tab">
       {!featuresProfiles && (
         <Notification severity="caution" title="Inherited profile">
-          Modifications are only available in the
+          Modifications are only available in the{" "}
           <Link to={`/ui/project/default/profile/${profile.name}`}>
             default project
           </Link>


### PR DESCRIPTION
## Done

- ensure space in hint about modifications to be done in the default project when profiles are shared

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check project with shared profiles, the hint about the default project in the profile overview on that profile should contain a space.

Before:

![image](https://github.com/user-attachments/assets/865166ec-f648-4a09-9690-0df00a16a826)


After:

![image](https://github.com/user-attachments/assets/e9d2acca-176b-4c83-8fed-689d9ad634cd)
