### PR TITLE
simplify keys setup

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,12 +22,6 @@ jobs:
         run: |
           sudo pip3 install dotrun
 
-      - name: Restore cached keys
-        uses: actions/cache/restore@v3
-        with:
-          path: keys
-          key: keys-folder
-
       - name: Install LXD-UI dependencies
         run: |
           set -x
@@ -42,18 +36,6 @@ jobs:
         run: |
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
-
-      - name: Set keys permissions
-        run: |
-          set -x
-          sudo chmod -R 0666 keys
-          sudo chmod 0777 keys
-          
-      - name: Save keys
-        uses: actions/cache/save@v3
-        with:
-          path: keys
-          key: keys-folder
 
       - name: Install LXD
         uses: canonical/setup-lxd@v0.1.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,12 +87,6 @@ jobs:
         run: |
           sudo pip3 install dotrun
 
-      - name: Restore cached keys
-        uses: actions/cache/restore@v3
-        with:
-          path: keys
-          key: keys-folder
-
       - name: Install LXD-UI dependencies
         run: |
           set -x
@@ -107,18 +101,6 @@ jobs:
         run: |
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
-
-      - name: Set keys permissions
-        run: |
-          set -x
-          sudo chmod -R 0666 keys
-          sudo chmod 0777 keys
-          
-      - name: Save keys
-        uses: actions/cache/save@v3
-        with:
-          path: keys
-          key: keys-folder
 
       - name: Install LXD
         uses: canonical/setup-lxd@v0.1.1

--- a/entrypoint
+++ b/entrypoint
@@ -24,8 +24,7 @@ else
   # generate certificates for dev environment
   if [ ! -d "keys" ]; then
     mkdir -p keys
-    openssl req -nodes -x509 -newkey rsa:2048 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -subj "/C=GB/ST=London/L=London/O=LXD UI/OU=dev/CN=localhost" -days 3000
-    openssl dhparam -out keys/dhparams.pem 2048
+    openssl req -nodes -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -sha384 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -subj "/C=GB/ST=London/L=London/O=LXD UI/OU=dev/CN=localhost" -days 3000
     cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
     cp keys/lxd-ui.key keys/lxd-ui.crt.key
     echo 'finished generating certificates'

--- a/haproxy-dev.cfg
+++ b/haproxy-dev.cfg
@@ -1,6 +1,5 @@
 global
   daemon
-  ssl-dh-param-file keys/dhparams.pem
 
 defaults
   mode  http


### PR DESCRIPTION
## Done

- simplify keys setup, use ecc key which speeds up key generation, so we don't need to cache the key and can remove dhparams generation
