### PR TITLE
fix: avoid duplicate tooltip for disabled rename header

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -101,7 +101,7 @@ const RenameHeader: FC<Props> = ({
               <li
                 className="p-heading--4 u-no-margin--bottom name continuous-breadcrumb u-truncate"
                 onClick={toggleRename}
-                title={`Rename ${name}`}
+                title={canRename ? `Rename ${name}` : ""}
               >
                 <Tooltip
                   message={!canRename && renameDisabledReason}


### PR DESCRIPTION
## Done

- avoid duplicate tooltip for disabled rename header

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Attach a custom volume as disk device to an instance
    - Go to the detail page for that custom volume
    - Check that the rename header is disabled and upon hover that it only shows disabled tooltip message