### PR TITLE
fix custom select

### DIFF
--- a/src/components/select/CustomSelect.tsx
+++ b/src/components/select/CustomSelect.tsx
@@ -132,6 +132,7 @@ const CustomSelect: FC<Props> = ({
   );
 
   const handleSelect = (value: string) => {
+    document.getElementById(selectId)?.focus();
     setIsOpen(false);
     onChange(value);
   };
@@ -197,6 +198,7 @@ const CustomSelect: FC<Props> = ({
               document.getElementById(selectId)?.focus();
             }}
             header={header}
+            toggleId={selectId}
           />
         )}
       </ContextualMenu>

--- a/src/components/select/CustomSelectDropdown.tsx
+++ b/src/components/select/CustomSelectDropdown.tsx
@@ -29,6 +29,7 @@ interface Props {
   onSelect: (value: string) => void;
   onClose: () => void;
   header?: ReactNode;
+  toggleId: string;
 }
 
 export const getOptionText = (option: CustomSelectOption): string => {
@@ -62,6 +63,7 @@ const CustomSelectDropdown: FC<Props> = ({
   onSelect,
   onClose,
   header,
+  toggleId,
 }) => {
   const [search, setSearch] = useState("");
   // track selected option index for keyboard actions
@@ -77,6 +79,38 @@ const CustomSelectDropdown: FC<Props> = ({
     (searchable === "always" || (searchable === "auto" && options.length >= 5));
 
   useEffect(() => {
+    if (dropdownRef.current) {
+      const toggle = document.getElementById(toggleId);
+
+      // align width with wrapper toggle width
+      const toggleWidth = toggle?.getBoundingClientRect()?.width ?? 0;
+      dropdownRef.current.style.setProperty("min-width", `${toggleWidth}px`);
+
+      // align z-index: if in a modal context, take the next z-index we find above + 1
+      const getRecursiveZIndex = (element: HTMLElement | null): string => {
+        if (!document.defaultView || !element) {
+          return "0";
+        }
+        const zIndex = document.defaultView
+          .getComputedStyle(element, null)
+          .getPropertyValue("z-index");
+        if (!element.parentElement) {
+          return zIndex;
+        }
+        if (zIndex === "auto" || zIndex === "0" || zIndex === "") {
+          return getRecursiveZIndex(element.parentElement);
+        }
+        return zIndex;
+      };
+      const zIndex = getRecursiveZIndex(toggle);
+      if (parseInt(zIndex) > 0) {
+        dropdownRef.current.parentElement?.style.setProperty(
+          "z-index",
+          zIndex + 1,
+        );
+      }
+    }
+
     setTimeout(() => {
       if (isSearchable) {
         searchRef.current?.focus();

--- a/src/sass/_custom_select.scss
+++ b/src/sass/_custom_select.scss
@@ -74,7 +74,3 @@
     width: 20rem;
   }
 }
-
-.p-custom-select__wrapper {
-  z-index: 400;
-}

--- a/src/sass/_custom_select.scss
+++ b/src/sass/_custom_select.scss
@@ -13,6 +13,7 @@
       center;
     background-repeat: no-repeat;
     background-size: map-get($icon-sizes, default);
+    border-top: none;
     box-shadow: none;
     min-height: map-get($line-heights, default-text);
     padding-right: calc($default-icon-size + 2 * $sph--small);

--- a/src/util/zIndex.tsx
+++ b/src/util/zIndex.tsx
@@ -1,1 +1,20 @@
 export const TOOLTIP_OVER_MODAL_ZINDEX = 150;
+
+// nearest parents z-index that is not 0 or auto
+export const getNearestParentsZIndex = (
+  element: HTMLElement | null,
+): string => {
+  if (!document.defaultView || !element) {
+    return "0";
+  }
+  const zIndex = document.defaultView
+    .getComputedStyle(element, null)
+    .getPropertyValue("z-index");
+  if (!element.parentElement) {
+    return zIndex;
+  }
+  if (zIndex === "auto" || zIndex === "0" || zIndex === "") {
+    return getNearestParentsZIndex(element.parentElement);
+  }
+  return zIndex;
+};


### PR DESCRIPTION
## Done

- align dropdown width to custom select wrapper width
- focus wrapper after selection of an option in the dropdown
- align z-index of dropdown to custom select parents, so when the custom select is in a modal, its dropdown is rendered above the modal.
- avoid bubbling up mouse down events on the dropdown, so a modal stays open

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check custom selects in permission context