### PR TITLE
fix(project) sum of memory limits is a size with unit

### DIFF
--- a/src/pages/projects/forms/ProjectResourceLimitsForm.tsx
+++ b/src/pages/projects/forms/ProjectResourceLimitsForm.tsx
@@ -15,7 +15,7 @@ export interface ProjectResourceLimitsFormValues {
   limits_disk?: string;
   limits_networks?: number;
   limits_cpu?: number;
-  limits_memory?: number;
+  limits_memory?: string;
   limits_processes?: number;
 }
 
@@ -102,7 +102,13 @@ const ProjectResourceLimitsForm: FC<Props> = ({ formik }) => {
           name: "limits_memory",
           label: "Max sum of memory limits",
           defaultValue: "",
-          children: <Input placeholder="Enter number" min={0} type="number" />,
+          children: (
+            <DiskSizeSelector
+              setMemoryLimit={(val?: string) =>
+                void formik.setFieldValue("limits_memory", val)
+              }
+            />
+          ),
         }),
 
         getConfigurationRow({

--- a/src/util/projectEdit.tsx
+++ b/src/util/projectEdit.tsx
@@ -55,7 +55,7 @@ export const getProjectEditValues = (
       ? parseInt(project.config["limits.cpu"])
       : undefined,
     limits_memory: project.config["limits.memory"]
-      ? parseInt(project.config["limits.memory"])
+      ? project.config["limits.memory"]
       : undefined,
     limits_processes: project.config["limits.processes"]
       ? parseInt(project.config["limits.processes"])

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -55,7 +55,7 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setInput(page, "Max disk space", "Enter value", "4");
   await setInput(page, "Max number of networks", "Enter number", "5");
   await setInput(page, "Max sum of CPU", "Enter number", "6");
-  await setInput(page, "Max sum of memory", "Enter number", "7");
+  await setInput(page, "Max sum of memory", "Enter value", "7");
   await setInput(page, "Max sum of processes", "Enter number", "8");
 
   await page.getByText("Clusters").click();
@@ -117,7 +117,7 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await assertReadMode(page, "Max disk space (used by all instances)", "4GiB");
   await assertReadMode(page, "Max number of networks", "5");
   await assertReadMode(page, "Max sum of CPU", "6");
-  await assertReadMode(page, "Max sum of memory limits", "7");
+  await assertReadMode(page, "Max sum of memory limits", "7GiB");
   await assertReadMode(page, "Max sum of processes", "8");
 
   await page.getByText("Clusters").click();


### PR DESCRIPTION
## Done

- sum of memory limits is a size with unit, not a plain number

Fixes #1005

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit "Max sum of memory limits" in a project configuration. You should be able to set and read back the value with a unit