### PR TITLE
filter out networks of type unknown or loopback

### DIFF
--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -8,7 +8,14 @@ export const fetchNetworks = (project: string): Promise<LxdNetwork[]> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/networks?project=${project}&recursion=1`)
       .then(handleResponse)
-      .then((data: LxdApiResponse<LxdNetwork[]>) => resolve(data.metadata))
+      .then((data: LxdApiResponse<LxdNetwork[]>) => {
+        const filteredNetworks = data.metadata.filter(
+          // Filter out loopback and unknown networks, both are not useful for the user.
+          // this is in line with the filtering done in the LXD CLI
+          (network) => !["loopback", "unknown"].includes(network.type),
+        );
+        resolve(filteredNetworks);
+      })
       .catch(reject);
   });
 };

--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -62,6 +62,8 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
     return <Loader />;
   }
 
+  const managedNetworks = networks.filter((network) => network.managed);
+
   const focusNetwork = (id: number) => {
     focusField(`devices.${id}.name`);
   };
@@ -79,7 +81,7 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
     copy.push({
       type: "nic",
       name: deduplicateName("eth", 1, existingDeviceNames),
-      network: networks[0]?.name ?? "",
+      network: managedNetworks[0]?.name ?? "",
     });
     void formik.setFieldValue("devices", copy);
 
@@ -87,17 +89,15 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
   };
 
   const getNetworkOptions = () => {
-    const options = networks
-      .filter((network) => network.managed)
-      .map((network) => {
-        return {
-          label: network.name,
-          value: network.name,
-          disabled: false,
-        };
-      });
+    const options = managedNetworks.map((network) => {
+      return {
+        label: network.name,
+        value: network.name,
+        disabled: false,
+      };
+    });
     options.unshift({
-      label: networks.length === 0 ? "No networks available" : "Select option",
+      label: options.length === 0 ? "No networks available" : "Select option",
       value: "",
       disabled: true,
     });

--- a/src/pages/networks/forms/NetworkParentSelector.tsx
+++ b/src/pages/networks/forms/NetworkParentSelector.tsx
@@ -31,7 +31,7 @@ const NetworkParentSelector: FC<Props> = ({ props }) => {
       };
     });
   options.unshift({
-    label: networks.length === 0 ? "No networks available" : "Select option",
+    label: options.length === 0 ? "No networks available" : "Select option",
     value: "",
   });
 

--- a/src/pages/networks/forms/UplinkSelector.tsx
+++ b/src/pages/networks/forms/UplinkSelector.tsx
@@ -40,7 +40,7 @@ const UplinkSelector: FC<Props> = ({ project: projectName, props }) => {
     };
   });
   options.unshift({
-    label: networks.length === 0 ? "No networks available" : "Select option",
+    label: options.length === 0 ? "No networks available" : "Select option",
     value: "",
   });
 


### PR DESCRIPTION
## Done

- filter out networks of type unknown or loopback
- fix empty network selector conditions

Fixes #1003 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check network list and network selectors in network creation or profile/instance created and edit