### PR TITLE
avoid invalid label on custom select options

### DIFF
--- a/src/components/select/CustomSelectDropdown.tsx
+++ b/src/components/select/CustomSelectDropdown.tsx
@@ -191,7 +191,6 @@ const CustomSelectDropdown: FC<Props> = ({
   const optionItems = filteredOptions.map((option, idx) => {
     return (
       <li
-        {...option}
         key={`${option.value}-${idx}`}
         onClick={() => handleSelect(option)}
         className={classnames(


### PR DESCRIPTION
## Done

- avoid invalid label on custom select options
- previously, the options would be rendered with an invalid label value, and also other properties on the list items that are not needed, see screen below

### before:

![image](https://github.com/user-attachments/assets/16d16389-9133-419c-bf7f-a5723886153a)

### after:

![image](https://github.com/user-attachments/assets/86fc3083-0fc4-44e3-98fc-86dace7c8d34)


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure custom select options are rendered correctly.