### PR TITLE
volume snapshots can have an empty expiry

### DIFF
--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -13,7 +13,7 @@ import { FormDevice } from "./formDevices";
 export const UNDEFINED_DATE = "0001-01-01T00:00:00Z";
 
 export const isoTimeToString = (isoTime: string): string => {
-  if (isoTime === UNDEFINED_DATE) {
+  if (isoTime === UNDEFINED_DATE || !isoTime) {
     return "";
   }
 


### PR DESCRIPTION
## Done

- fix volume snapshots, they can have an empty expiry, and we should show that correctly

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a custom volume, create snapshots without a name or expiry on that volume, browse the snapshot list of that volume.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/acf34012-3698-4f79-a091-e1c10e678e51)


After:

![image](https://github.com/user-attachments/assets/535109f4-51c6-49c7-9864-5992056d2fb7)
