### PR TITLE
Improve design of project form

### DIFF
--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -105,6 +105,7 @@ const CreateProject: FC = () => {
         ? getDefaultStoragePool(profile)
         : "",
     },
+    enableReinitialize: true,
     validationSchema: ProjectSchema,
     onSubmit: (values) => {
       const restrictions = values.restricted

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -149,6 +149,32 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             }}
             value={formik.values.description}
           />
+          <StoragePoolSelector
+            value={formik.values.default_instance_storage_pool}
+            setValue={(value) =>
+              void formik.setFieldValue("default_instance_storage_pool", value)
+            }
+            selectProps={{
+              label: "Default instance storage pool",
+              disabled:
+                (formik.values.features_profiles === false &&
+                  features === "customised") ||
+                isEdit,
+              help: isEdit ? (
+                <>
+                  Edit the storage pool in the{" "}
+                  <ResourceLink
+                    type="profile"
+                    value="default"
+                    to={`/ui/project/${project?.name}/profile/default`}
+                  />{" "}
+                  {" profile"}
+                </>
+              ) : (
+                ""
+              ),
+            }}
+          />
           <div
             title={
               isDefaultProject
@@ -298,32 +324,6 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
           </div>
 
           <hr />
-          <StoragePoolSelector
-            value={formik.values.default_instance_storage_pool}
-            setValue={(value) =>
-              void formik.setFieldValue("default_instance_storage_pool", value)
-            }
-            selectProps={{
-              label: "Default instance storage pool",
-              disabled:
-                (formik.values.features_profiles === false &&
-                  features === "customised") ||
-                isEdit,
-              help: isEdit ? (
-                <>
-                  Edit the storage pool in the{" "}
-                  <ResourceLink
-                    type="profile"
-                    value="default"
-                    to={`/ui/project/${project?.name}/profile/default`}
-                  />{" "}
-                  {" profile"}
-                </>
-              ) : (
-                ""
-              ),
-            }}
-          />
           <CheckboxInput
             id="custom_restrictions"
             name="custom_restrictions"


### PR DESCRIPTION
## Done

- Improve design of project form
- move storage selector above the feature selection to have feature and restrictions closer together
- ensure the default projects storage pool is the default on the project create form

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check project creation and the default storage selector in it.