### PR TITLE
Use all projects parameter to resolve image fingerprints in permission config

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -26,7 +26,8 @@ export const fetchImage = (
 
 export const fetchImageList = (project?: string): Promise<LxdImage[]> => {
   const url =
-    "/1.0/images?recursion=1" + (project ? `&project=${project}` : "");
+    "/1.0/images?recursion=1" +
+    (project ? `&project=${project}` : "&all-projects=1");
   return new Promise((resolve, reject) => {
     fetch(url)
       .then(handleResponse)

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -371,7 +371,7 @@ export const enablePermissionsFeature = (): boolean => {
 // each resource type has specific columns to display, which should uniquely identify the resource
 export const getResourceOptionColumns = (type: string) => {
   const resourceOptionColumns: Record<string, (keyof ResourceDetail)[]> = {
-    image: ["description", "aliases", "fingerprint", "imageType"],
+    image: ["description", "aliases", "fingerprint", "imageType", "project"],
     image_alias: ["name", "project"],
     instance: ["name", "project"],
     network: ["name", "project"],
@@ -379,7 +379,7 @@ export const getResourceOptionColumns = (type: string) => {
     network_zone: ["name", "project"],
     profile: ["name", "project"],
     storage_bucket: ["name", "project"],
-    storage_volume: ["name", "project", "pool"],
+    storage_volume: ["name", "pool", "project"],
     default: ["name"],
   };
 


### PR DESCRIPTION
## Done

- Use all projects parameter to resolve image fingerprints in permission config
- Show project for images in permission selector
- Since https://github.com/canonical/lxd/issues/14126 got merged, this is now unblocked. For older versions (non latest/edge) the parameter won't harm so we don't need to consume the api extension for this feature.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - configure image permissions for a lxd deployment that has images in different projects
    - the images from all projects should be resolved to names in the permission selection and editing when assigning permissions to groups.