### PR TITLE
feat: add support for instance/profile host path devices [WD-17682]

### DIFF
--- a/src/components/DeviceDetails.tsx
+++ b/src/components/DeviceDetails.tsx
@@ -1,8 +1,9 @@
 import { FC } from "react";
-import { isRootDisk } from "util/instanceValidation";
+import { isHostPath, isRootDisk } from "util/instanceValidation";
 import { FormDevice } from "util/formDevices";
 import { LxdDeviceValue } from "types/device";
 import ResourceLink from "components/ResourceLink";
+import ResourceLabel from "./ResourceLabel";
 
 interface Props {
   device: LxdDeviceValue;
@@ -20,6 +21,15 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
             value={device.pool}
             to={`/ui/project/${project}/storage/pool/${device.pool}`}
           />
+        </>
+      );
+    }
+
+    if (isHostPath(device as FormDevice)) {
+      return (
+        <>
+          Host path{" "}
+          <ResourceLabel type={"volume"} value={device.source as string} />
         </>
       );
     }

--- a/src/components/DeviceDetails.tsx
+++ b/src/components/DeviceDetails.tsx
@@ -1,9 +1,9 @@
 import { FC } from "react";
-import { isHostPath, isRootDisk } from "util/instanceValidation";
+import { isRootDisk } from "util/instanceValidation";
 import { FormDevice } from "util/formDevices";
 import { LxdDeviceValue } from "types/device";
 import ResourceLink from "components/ResourceLink";
-import ResourceLabel from "./ResourceLabel";
+import { isHostDiskDevice } from "util/devices";
 
 interface Props {
   device: LxdDeviceValue;
@@ -18,20 +18,15 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
           Pool{" "}
           <ResourceLink
             type={"pool"}
-            value={device.pool}
+            value={device.pool || ""}
             to={`/ui/project/${project}/storage/pool/${device.pool}`}
           />
         </>
       );
     }
 
-    if (isHostPath(device as FormDevice)) {
-      return (
-        <>
-          Host path{" "}
-          <ResourceLabel type={"volume"} value={device.source as string} />
-        </>
-      );
+    if (isHostDiskDevice(device)) {
+      return device.source;
     }
 
     return (
@@ -45,7 +40,7 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
         on pool{" "}
         <ResourceLink
           type={"pool"}
-          value={device.pool}
+          value={device.pool || ""}
           to={`/ui/project/${project}/storage/pool/${device.pool}`}
         />
       </>

--- a/src/components/DeviceListTable.tsx
+++ b/src/components/DeviceListTable.tsx
@@ -3,7 +3,12 @@ import { MainTable } from "@canonical/react-components";
 import { isRootDisk } from "util/instanceValidation";
 import { FormDevice } from "util/formDevices";
 import ResourceLink from "components/ResourceLink";
-import { isOtherDevice } from "util/devices";
+import {
+  isDiskDevice,
+  isHostDiskDevice,
+  isOtherDevice,
+  isVolumeDevice,
+} from "util/devices";
 import DeviceDetails from "./DeviceDetails";
 import { useParams } from "react-router-dom";
 import { LxdDeviceValue, LxdDevices } from "types/device";
@@ -47,6 +52,21 @@ const DeviceListTable: FC<Props> = ({ configBaseURL, devices }) => {
   ];
 
   const deviceRows = overviewDevices.map(([devicename, device]) => {
+    let deviceType = device.type;
+    if (isDiskDevice(device)) {
+      if (isRootDisk(device as FormDevice)) {
+        deviceType += " (root)";
+      }
+
+      if (isVolumeDevice(device)) {
+        deviceType += " (volume)";
+      }
+
+      if (isHostDiskDevice(device)) {
+        deviceType += " (host)";
+      }
+    }
+
     return {
       columns: [
         {
@@ -61,8 +81,7 @@ const DeviceListTable: FC<Props> = ({ configBaseURL, devices }) => {
           "aria-label": "Name",
         },
         {
-          content: `${device.type} ${isRootDisk(device as FormDevice) ? "(root)" : ""}`,
-
+          content: deviceType,
           role: "cell",
           "aria-label": "Type",
         },

--- a/src/components/DeviceListTable.tsx
+++ b/src/components/DeviceListTable.tsx
@@ -63,7 +63,7 @@ const DeviceListTable: FC<Props> = ({ configBaseURL, devices }) => {
       }
 
       if (isHostDiskDevice(device)) {
-        deviceType += " (host)";
+        deviceType += " (host path)";
       }
     }
 

--- a/src/components/ResourceLabel.tsx
+++ b/src/components/ResourceLabel.tsx
@@ -14,7 +14,7 @@ const ResourceLabel: FC<Props> = ({ type, value, bold, truncate = true }) => {
   return (
     <span className={classNames("resource-label", { "u-truncate": truncate })}>
       <ResourceIcon type={type} />
-      <ValueWrapper>{value}</ValueWrapper>
+      <ValueWrapper title={value}>{value}</ValueWrapper>
     </span>
   );
 };

--- a/src/components/ResourceLabel.tsx
+++ b/src/components/ResourceLabel.tsx
@@ -12,9 +12,12 @@ interface Props {
 const ResourceLabel: FC<Props> = ({ type, value, bold, truncate = true }) => {
   const ValueWrapper = bold ? "strong" : "span";
   return (
-    <span className={classNames("resource-label", { "u-truncate": truncate })}>
+    <span
+      className={classNames("resource-label", { "u-truncate": truncate })}
+      title={value}
+    >
       <ResourceIcon type={type} />
-      <ValueWrapper title={value}>{value}</ValueWrapper>
+      <ValueWrapper>{value}</ValueWrapper>
     </span>
   );
 };

--- a/src/components/forms/DiskDeviceForm.tsx
+++ b/src/components/forms/DiskDeviceForm.tsx
@@ -6,7 +6,7 @@ import { fetchStoragePools } from "api/storage-pools";
 import { InstanceAndProfileFormikProps } from "./instanceAndProfileFormValues";
 import { fetchProfiles } from "api/profiles";
 import Loader from "components/Loader";
-import { getInheritedVolumes } from "util/configInheritance";
+import { getInheritedDiskDevices } from "util/configInheritance";
 import DiskDeviceFormRoot from "./DiskDeviceFormRoot";
 import DiskDeviceFormInherited from "./DiskDeviceFormInherited";
 import DiskDeviceFormCustom from "./DiskDeviceFormCustom";
@@ -51,7 +51,7 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
     return <Loader />;
   }
 
-  const inheritedVolumes = getInheritedVolumes(formik.values, profiles);
+  const inheritedDiskDevices = getInheritedDiskDevices(formik.values, profiles);
 
   return (
     <div
@@ -65,7 +65,7 @@ const DiskDeviceForm: FC<Props> = ({ formik, project }) => {
         <DiskDeviceFormRoot formik={formik} pools={pools} profiles={profiles} />
         <DiskDeviceFormInherited
           formik={formik}
-          inheritedVolumes={inheritedVolumes}
+          inheritedDiskDevices={inheritedDiskDevices}
         />
         <DiskDeviceFormCustom
           formik={formik}

--- a/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
+++ b/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
@@ -10,10 +10,10 @@ const DetachDiskDeviceBtn: FC<Props> = ({ onDetach }) => {
     <ConfirmationButton
       appearance="base"
       type="button"
-      title="Detach disk devicve"
+      title="Detach disk"
       className="has-icon u-no-margin--bottom is-dense"
       confirmationModalProps={{
-        title: "Confirm disk device detach",
+        title: "Confirm disk detachment",
         children: (
           <p>
             Are you sure you want to clear this disk attachment?

--- a/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
+++ b/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
@@ -10,15 +10,15 @@ const DetachDiskDeviceBtn: FC<Props> = ({ onDetach }) => {
     <ConfirmationButton
       appearance="base"
       type="button"
-      title="Detach volume"
+      title="Detach disk devicve"
       className="has-icon u-no-margin--bottom is-dense"
       confirmationModalProps={{
-        title: "Confirm volume detach",
+        title: "Confirm disk device detach",
         children: (
           <p>
-            Are you sure you want to clear this volume attachment?
+            Are you sure you want to clear this disk attachment?
             <br />
-            This action may result in data loss if the volume is still mounted.
+            This action may result in data loss if the disk is still mounted.
           </p>
         ),
         confirmButtonLabel: "Detach",

--- a/src/pages/profiles/ProfileStorageList.tsx
+++ b/src/pages/profiles/ProfileStorageList.tsx
@@ -20,7 +20,7 @@ const ProfileStorageList: FC<Props> = ({ profile, project }) => {
               <ResourceLink
                 key={device.path}
                 type="pool"
-                value={device.pool}
+                value={device.pool || ""}
                 to={`/ui/project/${project}/storage/pool/${device.pool}`}
               />
             ))}

--- a/src/pages/storage/AttachDiskDeviceBtn.tsx
+++ b/src/pages/storage/AttachDiskDeviceBtn.tsx
@@ -1,7 +1,6 @@
 import { FC, ReactNode } from "react";
 import { Button, ButtonProps } from "@canonical/react-components";
 import usePortal from "react-useportal";
-import { LxdStorageVolume } from "types/storage";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import AttachDiskDeviceModal from "./AttachDiskDeviceModal";
 import { LxdDiskDevice } from "types/device";
@@ -11,7 +10,7 @@ interface Props {
   children: ReactNode;
   buttonProps?: ButtonProps;
   project: string;
-  setValue: (device: LxdStorageVolume | LxdDiskDevice) => void;
+  setValue: (device: LxdDiskDevice) => void;
 }
 
 const AttachDiskDeviceBtn: FC<Props> = ({
@@ -22,7 +21,7 @@ const AttachDiskDeviceBtn: FC<Props> = ({
   setValue,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
-  const handleFinish = (device: LxdStorageVolume | LxdDiskDevice) => {
+  const handleFinish = (device: LxdDiskDevice) => {
     setValue(device);
     closePortal();
   };

--- a/src/pages/storage/AttachDiskDeviceBtn.tsx
+++ b/src/pages/storage/AttachDiskDeviceBtn.tsx
@@ -1,0 +1,49 @@
+import { FC, ReactNode } from "react";
+import { Button, ButtonProps } from "@canonical/react-components";
+import usePortal from "react-useportal";
+import { LxdStorageVolume } from "types/storage";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import AttachDiskDeviceModal from "./AttachDiskDeviceModal";
+import { LxdDiskDevice } from "types/device";
+
+interface Props {
+  formik: InstanceAndProfileFormikProps;
+  children: ReactNode;
+  buttonProps?: ButtonProps;
+  project: string;
+  setValue: (device: LxdStorageVolume | LxdDiskDevice) => void;
+}
+
+const AttachDiskDeviceBtn: FC<Props> = ({
+  formik,
+  children,
+  buttonProps,
+  project,
+  setValue,
+}) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const handleFinish = (device: LxdStorageVolume | LxdDiskDevice) => {
+    setValue(device);
+    closePortal();
+  };
+
+  return (
+    <>
+      <Button onClick={openPortal} type="button" hasIcon {...buttonProps}>
+        {children}
+      </Button>
+      {isOpen && (
+        <Portal>
+          <AttachDiskDeviceModal
+            formik={formik}
+            project={project}
+            onFinish={handleFinish}
+            close={closePortal}
+          />
+        </Portal>
+      )}
+    </>
+  );
+};
+
+export default AttachDiskDeviceBtn;

--- a/src/pages/storage/AttachDiskDeviceModal.tsx
+++ b/src/pages/storage/AttachDiskDeviceModal.tsx
@@ -1,0 +1,99 @@
+import { FC, KeyboardEvent, useState } from "react";
+import { Modal } from "@canonical/react-components";
+import FormLink from "components/FormLink";
+import BackLink from "components/BackLink";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import CustomVolumeModal from "./CustomVolumeModal";
+import { LxdStorageVolume } from "types/storage";
+import { LxdDiskDevice } from "types/device";
+import HostPathDeviceModal from "./HostPathDeviceModal";
+
+type DiskDeviceType = "custom volume" | "host path" | "";
+
+interface Props {
+  close: () => void;
+  onFinish: (device: LxdStorageVolume | LxdDiskDevice) => void;
+  formik: InstanceAndProfileFormikProps;
+  project: string;
+}
+
+const AttachDiskDeviceModal: FC<Props> = ({
+  close,
+  formik,
+  project,
+  onFinish,
+}) => {
+  const [type, setType] = useState<DiskDeviceType>("");
+
+  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === "Escape") {
+      close();
+    }
+  };
+
+  const handleGoBack = () => {
+    if (type) {
+      setType("");
+      return;
+    }
+  };
+
+  const modalTitle = !type ? (
+    "Choose disk device type"
+  ) : (
+    <BackLink
+      title={`Attach ${type} device`}
+      onClick={handleGoBack}
+      linkText={"Choose disk device type"}
+    />
+  );
+
+  return (
+    <>
+      {!type && (
+        <Modal
+          close={close}
+          className="migrate-instance-modal"
+          title={modalTitle}
+          onKeyDown={handleEscKey}
+        >
+          {!type && (
+            <div className="choose-migration-type">
+              <FormLink
+                icon="add-logical-volume"
+                title="Attach custom volume device"
+                onClick={() => setType("custom volume")}
+              />
+              <FormLink
+                icon="mount"
+                title="Attach host path device"
+                onClick={() => setType("host path")}
+              />
+            </div>
+          )}
+        </Modal>
+      )}
+
+      {type === "custom volume" && (
+        <CustomVolumeModal
+          formik={formik}
+          project={project}
+          onFinish={onFinish}
+          onCancel={handleGoBack}
+          title={modalTitle}
+        />
+      )}
+
+      {type === "host path" && (
+        <HostPathDeviceModal
+          formik={formik}
+          onFinish={onFinish}
+          onCancel={handleGoBack}
+          title={modalTitle}
+        />
+      )}
+    </>
+  );
+};
+
+export default AttachDiskDeviceModal;

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -117,7 +117,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
           className="u-no-margin--bottom"
           onClick={onCancel}
         >
-          Cancel
+          Back
         </Button>
         <ActionButton
           appearance="positive"

--- a/src/pages/storage/CustomVolumeModal.tsx
+++ b/src/pages/storage/CustomVolumeModal.tsx
@@ -12,6 +12,7 @@ interface Props {
   project: string;
   onFinish: (volume: LxdStorageVolume) => void;
   onCancel: () => void;
+  onClose: () => void;
   title?: ReactNode;
 }
 
@@ -23,6 +24,7 @@ const CustomVolumeModal: FC<Props> = ({
   project,
   onFinish,
   onCancel,
+  onClose,
   title,
 }) => {
   const [content, setContent] = useState(SELECT_VOLUME);
@@ -45,9 +47,9 @@ const CustomVolumeModal: FC<Props> = ({
   if (content === CREATE_VOLUME) {
     modalTitle = title ? (
       <BackLink
-        title={"Create volume"}
+        title="Create volume"
         onClick={handleGoBack}
-        linkText={"Attach custom volume device"}
+        linkText="Attach custom volume"
       />
     ) : (
       "Create volume"
@@ -55,7 +57,7 @@ const CustomVolumeModal: FC<Props> = ({
   }
 
   return (
-    <Modal className="custom-volume-modal" close={onCancel} title={modalTitle}>
+    <Modal className="custom-volume-modal" close={onClose} title={modalTitle}>
       {content === SELECT_VOLUME && (
         <CustomVolumeSelectModal
           project={project}
@@ -64,6 +66,7 @@ const CustomVolumeModal: FC<Props> = ({
           onFinish={onFinish}
           onCancel={onCancel}
           onCreate={() => setContent(CREATE_VOLUME)}
+          hasPrevStep={!!title}
         />
       )}
       {content === CREATE_VOLUME && (

--- a/src/pages/storage/CustomVolumeModal.tsx
+++ b/src/pages/storage/CustomVolumeModal.tsx
@@ -1,16 +1,18 @@
-import { FC, useState } from "react";
+import { FC, ReactNode, useState } from "react";
 import CustomVolumeSelectModal from "pages/storage/CustomVolumeSelectModal";
 import CustomVolumeCreateModal from "pages/storage/CustomVolumeCreateModal";
 import { Modal } from "@canonical/react-components";
 import { LxdStorageVolume } from "types/storage";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import { getInstanceLocation } from "util/instanceLocation";
+import BackLink from "components/BackLink";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
   project: string;
   onFinish: (volume: LxdStorageVolume) => void;
   onCancel: () => void;
+  title?: ReactNode;
 }
 
 const SELECT_VOLUME = "selectVolume";
@@ -21,6 +23,7 @@ const CustomVolumeModal: FC<Props> = ({
   project,
   onFinish,
   onCancel,
+  title,
 }) => {
   const [content, setContent] = useState(SELECT_VOLUME);
   const [primaryVolume, setPrimaryVolume] = useState<
@@ -34,14 +37,25 @@ const CustomVolumeModal: FC<Props> = ({
     setPrimaryVolume(volume);
   };
 
+  const handleGoBack = () => {
+    setContent(SELECT_VOLUME);
+  };
+
+  let modalTitle = title ?? "Choose custom volume";
+  if (content === CREATE_VOLUME) {
+    modalTitle = title ? (
+      <BackLink
+        title={"Create volume"}
+        onClick={handleGoBack}
+        linkText={"Attach custom volume device"}
+      />
+    ) : (
+      "Create volume"
+    );
+  }
+
   return (
-    <Modal
-      className="custom-volume-modal"
-      close={onCancel}
-      title={
-        content === SELECT_VOLUME ? "Choose custom volume" : "Create volume"
-      }
-    >
+    <Modal className="custom-volume-modal" close={onCancel} title={modalTitle}>
       {content === SELECT_VOLUME && (
         <CustomVolumeSelectModal
           project={project}
@@ -56,7 +70,7 @@ const CustomVolumeModal: FC<Props> = ({
         <CustomVolumeCreateModal
           project={project}
           instanceLocation={instanceLocation}
-          onCancel={() => setContent(SELECT_VOLUME)}
+          onCancel={handleGoBack}
           onFinish={handleCreateVolume}
         />
       )}

--- a/src/pages/storage/CustomVolumeSelectBtn.tsx
+++ b/src/pages/storage/CustomVolumeSelectBtn.tsx
@@ -2,15 +2,15 @@ import { FC, ReactNode } from "react";
 import { Button, ButtonProps } from "@canonical/react-components";
 import usePortal from "react-useportal";
 import CustomVolumeModal from "pages/storage/CustomVolumeModal";
-import { LxdStorageVolume } from "types/storage";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { LxdStorageVolume } from "types/storage";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
   children: ReactNode;
   buttonProps?: ButtonProps;
   project: string;
-  setValue: (volume: LxdStorageVolume) => void;
+  setValue: (device: LxdStorageVolume) => void;
 }
 
 const CustomVolumeSelectBtn: FC<Props> = ({
@@ -21,8 +21,6 @@ const CustomVolumeSelectBtn: FC<Props> = ({
   setValue,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
-
-  const handleCancel = () => closePortal();
 
   const handleFinish = (volume: LxdStorageVolume) => {
     setValue(volume);
@@ -40,7 +38,8 @@ const CustomVolumeSelectBtn: FC<Props> = ({
             formik={formik}
             project={project}
             onFinish={handleFinish}
-            onCancel={handleCancel}
+            onCancel={closePortal}
+            onClose={closePortal}
           />
         </Portal>
       )}

--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -18,6 +18,7 @@ interface Props {
   onFinish: (volume: LxdStorageVolume) => void;
   onCancel: () => void;
   onCreate: () => void;
+  hasPrevStep?: boolean;
 }
 
 const CustomVolumeSelectModal: FC<Props> = ({
@@ -27,6 +28,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
   onFinish,
   onCancel,
   onCreate,
+  hasPrevStep,
 }) => {
   const notify = useNotify();
   const { hasStorageVolumesAll } = useSupportedFeatures();
@@ -186,7 +188,7 @@ const CustomVolumeSelectModal: FC<Props> = ({
             onClick={onCancel}
             appearance="base"
           >
-            Cancel
+            {hasPrevStep ? "Back" : "Cancel"}
           </Button>
           <Button
             className="u-no-margin--bottom"

--- a/src/pages/storage/HostPathDeviceModal.tsx
+++ b/src/pages/storage/HostPathDeviceModal.tsx
@@ -1,0 +1,98 @@
+import { FC, ReactNode, useRef, useState } from "react";
+import { Button, Input, Modal } from "@canonical/react-components";
+import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { LxdDiskDevice } from "types/device";
+
+interface Props {
+  formik: InstanceAndProfileFormikProps;
+  onFinish: (device: LxdDiskDevice) => void;
+  onCancel: () => void;
+  title?: ReactNode;
+}
+
+const HostPathDeviceModal: FC<Props> = ({
+  formik,
+  onFinish,
+  onCancel,
+  title,
+}) => {
+  const [source, setSource] = useState("");
+  const [path, setPath] = useState<string>();
+  const touchedRef = useRef({
+    source: false,
+    path: false,
+  });
+
+  const handleFinish = () => {
+    const device: LxdDiskDevice = {
+      type: "disk",
+      source,
+      path,
+    };
+
+    onFinish(device);
+  };
+
+  return (
+    <Modal
+      className="host-path-device-modal"
+      close={onCancel}
+      title={title}
+      buttonRow={
+        <>
+          <Button
+            appearance="base"
+            className="u-no-margin--bottom"
+            type="button"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            appearance=""
+            className="u-no-margin--bottom"
+            type="button"
+            loading={formik.isSubmitting}
+            disabled={!source || !path}
+            onClick={handleFinish}
+          >
+            Attach
+          </Button>
+        </>
+      }
+    >
+      <Input
+        value={source}
+        onChange={(e) => {
+          touchedRef.current.source = true;
+          setSource(e.target.value);
+        }}
+        type="text"
+        label="Host path"
+        required
+        error={
+          !source && touchedRef.current.source
+            ? "Host path is required"
+            : undefined
+        }
+      />
+      <Input
+        value={path}
+        onChange={(e) => {
+          touchedRef.current.path = true;
+          setPath(e.target.value);
+        }}
+        type="text"
+        label="Mount point"
+        required
+        error={
+          !path && touchedRef.current.path
+            ? "Mount point is required"
+            : undefined
+        }
+      />
+    </Modal>
+  );
+};
+
+export default HostPathDeviceModal;

--- a/src/pages/storage/HostPathDeviceModal.tsx
+++ b/src/pages/storage/HostPathDeviceModal.tsx
@@ -1,12 +1,14 @@
-import { FC, ReactNode, useRef, useState } from "react";
+import { FC, ReactNode, useEffect, useRef, useState } from "react";
 import { Button, Input, Modal } from "@canonical/react-components";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import { LxdDiskDevice } from "types/device";
+import { focusField } from "util/formFields";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
   onFinish: (device: LxdDiskDevice) => void;
   onCancel: () => void;
+  onClose: () => void;
   title?: ReactNode;
 }
 
@@ -14,14 +16,19 @@ const HostPathDeviceModal: FC<Props> = ({
   formik,
   onFinish,
   onCancel,
+  onClose,
   title,
 }) => {
   const [source, setSource] = useState("");
-  const [path, setPath] = useState<string>();
+  const [path, setPath] = useState("");
   const touchedRef = useRef({
     source: false,
     path: false,
   });
+
+  useEffect(() => {
+    focusField("host-path");
+  }, []);
 
   const handleFinish = () => {
     const device: LxdDiskDevice = {
@@ -36,7 +43,7 @@ const HostPathDeviceModal: FC<Props> = ({
   return (
     <Modal
       className="host-path-device-modal"
-      close={onCancel}
+      close={onClose}
       title={title}
       buttonRow={
         <>
@@ -46,7 +53,7 @@ const HostPathDeviceModal: FC<Props> = ({
             type="button"
             onClick={onCancel}
           >
-            Cancel
+            Back
           </Button>
           <Button
             appearance=""
@@ -62,6 +69,7 @@ const HostPathDeviceModal: FC<Props> = ({
       }
     >
       <Input
+        id="host-path"
         value={source}
         onChange={(e) => {
           touchedRef.current.source = true;
@@ -75,6 +83,7 @@ const HostPathDeviceModal: FC<Props> = ({
             ? "Host path is required"
             : undefined
         }
+        placeholder="Enter full path (e.g. /home)"
       />
       <Input
         value={path}
@@ -90,6 +99,7 @@ const HostPathDeviceModal: FC<Props> = ({
             ? "Mount point is required"
             : undefined
         }
+        placeholder="Enter full path (e.g. /data)"
       />
     </Modal>
   );

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -6,6 +6,7 @@
 @import "pattern_icon";
 @include lxdui-p-icon;
 @include vf-p-icon-add-canvas;
+@include vf-p-icon-add-logical-volume;
 @include vf-p-icon-applications;
 @include vf-p-icon-begin-downloading;
 @include vf-p-icon-book;
@@ -350,4 +351,12 @@ body {
 
 .clickable-cell {
   cursor: pointer;
+}
+
+.host-path-device-modal {
+  .p-modal__dialog {
+    @include large {
+      width: 40rem;
+    }
+  }
 }

--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -1,7 +1,7 @@
 export interface LxdDiskDevice {
   name?: string;
   path?: string;
-  pool: string;
+  pool?: string;
   size?: string;
   "boot.priority"?: string;
   "size.state"?: string;

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -5,9 +5,11 @@ import { EditInstanceFormValues } from "pages/instances/EditInstance";
 import {
   isDiskDevice,
   isGPUDevice,
+  isHostDiskDevice,
   isNicDevice,
   isOtherDevice,
   isProxyDevice,
+  isVolumeDevice,
 } from "util/devices";
 import {
   LxdDeviceValue,
@@ -267,18 +269,23 @@ export const getInheritedRootStorage = (
   return [null, "LXD"];
 };
 
-export interface InheritedVolume {
+export interface InheritedDiskDevice {
   key: string;
   disk: LxdDiskDevice;
   source: string;
 }
 
-export const getInheritedVolumes = (
+export const getInheritedDiskDevices = (
   values: InstanceAndProfileFormValues,
   profiles: LxdProfile[],
-): InheritedVolume[] => {
+): InheritedDiskDevice[] => {
   return getInheritedDevices(values, profiles)
-    .filter((item) => isDiskDevice(item.device) && item.device.path !== "/")
+    .filter((item) => {
+      return (
+        isVolumeDevice(item.device as LxdDiskDevice) ||
+        isHostDiskDevice(item.device as LxdDiskDevice)
+      );
+    })
     .map((item) => ({
       ...item,
       disk: item.device as LxdDiskDevice,

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -8,7 +8,7 @@ import {
   LxdProxyDevice,
 } from "types/device";
 import { LxdProfile } from "types/profile";
-import { FormDevice } from "util/formDevices";
+import { FormDevice, FormDiskDevice } from "util/formDevices";
 import { getAppliedProfiles } from "./configInheritance";
 
 export const isNicDevice = (device: LxdDeviceValue): device is LxdNicDevice =>
@@ -16,6 +16,18 @@ export const isNicDevice = (device: LxdDeviceValue): device is LxdNicDevice =>
 
 export const isDiskDevice = (device: LxdDeviceValue): device is LxdDiskDevice =>
   device.type === "disk";
+
+export const isHostDiskDevice = (device: LxdDiskDevice): boolean => {
+  return (
+    device.type === "disk" && device.pool === undefined && device.path !== "/"
+  );
+};
+
+export const isVolumeDevice = (
+  device: FormDiskDevice | LxdDiskDevice,
+): boolean => {
+  return device.type === "disk" && !!device.pool && device.path !== "/";
+};
 
 export const isGPUDevice = (device: LxdDeviceValue): device is LxdGPUDevice =>
   device.type === "gpu";

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -39,7 +39,7 @@ export interface CustomNetworkDevice {
 }
 
 export type FormDiskDevice = Partial<LxdDiskDevice> &
-  Required<Pick<LxdDiskDevice, "name" | "pool">> & {
+  Required<Pick<LxdDiskDevice, "name">> & {
     limits?: {
       read?: string;
       write?: string;
@@ -65,6 +65,12 @@ export type FormDevice =
 export interface FormDeviceValues {
   devices: FormDevice[];
 }
+
+export const isFormDiskDevice = (
+  device: FormDevice,
+): device is FormDiskDevice => {
+  return device.type === "disk";
+};
 
 export const isEmptyDevice = (device: FormDevice): boolean =>
   device.type === "nic" &&

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -325,7 +325,7 @@ export const getRootPool = (instance: LxdInstance): string => {
     .find((device) => {
       return isRootDisk(device as FormDevice);
     });
-  return rootStorage ? rootStorage.pool : "";
+  return rootStorage ? rootStorage.pool || "" : "";
 };
 
 export const getDefaultStoragePool = (profile: LxdProfile) => {
@@ -334,7 +334,7 @@ export const getDefaultStoragePool = (profile: LxdProfile) => {
     .find((device) => {
       return isRootDisk(device as FormDevice);
     });
-  return rootStorage ? rootStorage.pool : "";
+  return rootStorage ? (rootStorage.pool ?? "") : "";
 };
 
 export const isUnrestricted = (identity: LxdIdentity) => {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -325,7 +325,7 @@ export const getRootPool = (instance: LxdInstance): string => {
     .find((device) => {
       return isRootDisk(device as FormDevice);
     });
-  return rootStorage ? rootStorage.pool || "" : "";
+  return rootStorage?.pool ?? "";
 };
 
 export const getDefaultStoragePool = (profile: LxdProfile) => {
@@ -334,7 +334,7 @@ export const getDefaultStoragePool = (profile: LxdProfile) => {
     .find((device) => {
       return isRootDisk(device as FormDevice);
     });
-  return rootStorage ? (rootStorage.pool ?? "") : "";
+  return rootStorage?.pool ?? "";
 };
 
 export const isUnrestricted = (identity: LxdIdentity) => {

--- a/src/util/instanceValidation.tsx
+++ b/src/util/instanceValidation.tsx
@@ -18,12 +18,8 @@ export const hasNoRootDisk = (
   return missingRoot(values.devices) && !inheritsRoot(values, profiles);
 };
 
-export const isRootDisk = (device: FormDevice): device is FormDiskDevice => {
+export const isRootDisk = (device: FormDevice): boolean => {
   return device.type === "disk" && device.path === "/" && !device.source;
-};
-
-export const isHostPath = (device: FormDevice): boolean => {
-  return device.type === "disk" && !!device.source && device.pool === undefined;
 };
 
 const missingRoot = (devices: FormDevice[]): boolean => {

--- a/src/util/instanceValidation.tsx
+++ b/src/util/instanceValidation.tsx
@@ -22,6 +22,10 @@ export const isRootDisk = (device: FormDevice): device is FormDiskDevice => {
   return device.type === "disk" && device.path === "/" && !device.source;
 };
 
+export const isHostPath = (device: FormDevice): boolean => {
+  return device.type === "disk" && !!device.source && device.pool === undefined;
+};
+
 const missingRoot = (devices: FormDevice[]): boolean => {
   return !devices.some(isRootDisk);
 };

--- a/tests/helpers/devices.ts
+++ b/tests/helpers/devices.ts
@@ -7,9 +7,7 @@ export const attachVolume = async (
   path: string,
 ) => {
   await page.getByRole("button", { name: "Attach disk device" }).click();
-  await page
-    .getByRole("button", { name: "Attach custom volume device" })
-    .click();
+  await page.getByRole("button", { name: "Attach custom volume" }).click();
   await page.getByRole("button", { name: "Create volume" }).click();
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByRole("button", { name: "Create volume" }).click();
@@ -23,10 +21,10 @@ export const attachHostPath = async (
   path: string,
 ) => {
   await page.getByRole("button", { name: "Attach disk device" }).click();
-  await page.getByRole("button", { name: "Attach host path device" }).click();
+  await page.getByRole("button", { name: "Mount host path" }).click();
   await page.getByLabel("Host path", { exact: true }).click();
   await page.getByLabel("Host path", { exact: true }).fill(source);
-  const hostPathModal = page.getByLabel("Choose disk device type /");
+  const hostPathModal = page.getByLabel("Choose disk type /");
   await hostPathModal.getByLabel("Mount point").click();
   await hostPathModal.getByLabel("Mount point").fill(path);
   await page.getByRole("button", { name: "Attach", exact: true }).click();
@@ -38,7 +36,7 @@ export const detachDiskDevice = async (page: Page, volumeDevice: string) => {
     .getByTitle("Detach")
     .click();
   await page
-    .getByLabel("Confirm disk device detach")
+    .getByLabel("Confirm disk detachment")
     .getByRole("button", { name: "Detach" })
     .click();
 };

--- a/tests/helpers/devices.ts
+++ b/tests/helpers/devices.ts
@@ -7,6 +7,9 @@ export const attachVolume = async (
   path: string,
 ) => {
   await page.getByRole("button", { name: "Attach disk device" }).click();
+  await page
+    .getByRole("button", { name: "Attach custom volume device" })
+    .click();
   await page.getByRole("button", { name: "Create volume" }).click();
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByRole("button", { name: "Create volume" }).click();
@@ -14,13 +17,28 @@ export const attachVolume = async (
   await page.getByPlaceholder("Enter full path (e.g. /data)").last().fill(path);
 };
 
-export const detachVolume = async (page: Page, volumeDevice: string) => {
+export const attachHostPath = async (
+  page: Page,
+  source: string,
+  path: string,
+) => {
+  await page.getByRole("button", { name: "Attach disk device" }).click();
+  await page.getByRole("button", { name: "Attach host path device" }).click();
+  await page.getByLabel("Host path", { exact: true }).click();
+  await page.getByLabel("Host path", { exact: true }).fill(source);
+  const hostPathModal = page.getByLabel("Choose disk device type /");
+  await hostPathModal.getByLabel("Mount point").click();
+  await hostPathModal.getByLabel("Mount point").fill(path);
+  await page.getByRole("button", { name: "Attach", exact: true }).click();
+};
+
+export const detachDiskDevice = async (page: Page, volumeDevice: string) => {
   await page
     .getByRole("row", { name: volumeDevice })
     .getByTitle("Detach")
     .click();
   await page
-    .getByLabel("Confirm volume detach")
+    .getByLabel("Confirm disk device detach")
     .getByRole("button", { name: "Detach" })
     .click();
 };


### PR DESCRIPTION
## Done

- Adjusted devices table in instance/profile overview page to show host path disk devices
- Added support for create/edit host path disk devices in instance/profile configuration pages
- Adjusted the workflow for adding disk devices, now it is a multi-step flow, starting with selecting the type of disk device (volume or host path).
- Adjusted/added e2e tests to reflect the above changes.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new profile, add both custom volume and host path disk devices to it.
    - Create an instance and apply the profile to that instance, make sure all disk devices are inherited.
    - Create custom volume and host path disk devices for the above instance, using different volume and mount point.
    - Start the instance, go to its terminal and make sure that path corresponding to every disk device exists. Make sure that the mounted host path has the correct content (should be the same to the path on your machine).
    - Go to the instance/profile overview page, check the device list table and make sure disk devices are displayed correctly.
    - Try modifying the volume and host path disk devices on the profile and instance.
