### PR TITLE
fix: show meter bar in storage list and other places

### DIFF
--- a/src/pages/storage/StoragePoolOptionLabel.tsx
+++ b/src/pages/storage/StoragePoolOptionLabel.tsx
@@ -4,10 +4,9 @@ import StoragePoolSize from "./StoragePoolSize";
 
 interface Props {
   pool: LxdStoragePool;
-  hasMeterBar?: boolean;
 }
 
-const StoragePoolOptionLabel: FC<Props> = ({ pool, hasMeterBar }) => {
+const StoragePoolOptionLabel: FC<Props> = ({ pool }) => {
   return (
     <div className="label">
       <span key="name" title={pool.name || "-"} className="resource u-truncate">
@@ -21,11 +20,7 @@ const StoragePoolOptionLabel: FC<Props> = ({ pool, hasMeterBar }) => {
         {pool.driver || "-"}
       </span>
       <span key="usage" title="Usage" className="resource-usage u-truncate">
-        <StoragePoolSize
-          key={pool.name}
-          pool={pool}
-          hasMeterBar={hasMeterBar}
-        />
+        <StoragePoolSize key={pool.name} pool={pool} />
       </span>
     </div>
   );

--- a/src/pages/storage/StoragePoolOverview.tsx
+++ b/src/pages/storage/StoragePoolOverview.tsx
@@ -38,7 +38,7 @@ const StoragePoolOverview: FC<Props> = ({ pool, project }) => {
               <tr>
                 <th className="u-text--muted">Size</th>
                 <td>
-                  <StoragePoolSize pool={pool} />
+                  <StoragePoolSize pool={pool} hasMeterBar />
                 </td>
               </tr>
               <tr>

--- a/src/pages/storage/StoragePoolSelectTable.tsx
+++ b/src/pages/storage/StoragePoolSelectTable.tsx
@@ -68,7 +68,7 @@ const StoragePoolSelectTable: FC<Props> = ({ onSelect, disablePool }) => {
           onClick: selectPool,
         },
         {
-          content: <StoragePoolSize pool={pool} />,
+          content: <StoragePoolSize pool={pool} hasMeterBar />,
           role: "cell",
           "aria-label": "Size",
           onClick: selectPool,

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -64,7 +64,7 @@ const StoragePoolSelector: FC<Props> = ({
     if (poolsToUse) {
       poolsToUse.forEach((pool) => {
         options.push({
-          label: <StoragePoolOptionLabel pool={pool} hasMeterBar={false} />,
+          label: <StoragePoolOptionLabel pool={pool} />,
           value: pool.name,
           disabled: false,
           text: `${pool.name} (${pool.driver})`,
@@ -95,7 +95,7 @@ const StoragePoolSelector: FC<Props> = ({
       options={getStoragePoolOptions()}
       onChange={handleStoragePoolChange}
       value={value}
-      dropdownClassName={"storage-pool-select-dropdown"}
+      dropdownClassName="storage-pool-select-dropdown"
       header={<StoragePoolOptionHeader />}
     />
   );

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -103,7 +103,7 @@ const StoragePools: FC = () => {
           "aria-label": "Driver",
         },
         {
-          content: <StoragePoolSize pool={pool} />,
+          content: <StoragePoolSize pool={pool} hasMeterBar />,
           role: "rowheader",
           "aria-label": "Size",
           className: "size",


### PR DESCRIPTION
## Done

- show meter bar in storage list and other places, only hide it in the storage selector
- simplify code a bit


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure the storage meter appears in the pool list, migrate modals for instances and volumes and the storage selector works as expected.