### PR TITLE
fix(permissions) link identity groups count to edit panel

### DIFF
--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -114,6 +114,10 @@ const PermissionIdentities: FC = () => {
 
   const rows = filteredIdentities.map((identity) => {
     const isLoggedInIdentity = settings?.auth_user_name === identity.id;
+    const openGroupPanelForIdentity = () => {
+      panelParams.openIdentityGroups(identity.id);
+      setSelectedIdentityIds([identity.id]);
+    };
 
     return {
       name: isUnrestricted(identity) ? "" : identity.id,
@@ -151,7 +155,11 @@ const PermissionIdentities: FC = () => {
           title: identity.type,
         },
         {
-          content: identity.groups?.length || 0,
+          content: (
+            <Button appearance="link" dense onClick={openGroupPanelForIdentity}>
+              {identity.groups?.length || 0}
+            </Button>
+          ),
           role: "cell",
           className: "u-align--right",
           "aria-label": "Groups for this identity",
@@ -164,10 +172,7 @@ const PermissionIdentities: FC = () => {
                 className="u-no-margin--bottom"
                 hasIcon
                 dense
-                onClick={() => {
-                  panelParams.openIdentityGroups(identity.id);
-                  setSelectedIdentityIds([identity.id]);
-                }}
+                onClick={openGroupPanelForIdentity}
                 type="button"
                 aria-label="Manage groups"
                 title="Manage groups"


### PR DESCRIPTION
## Done

- fix(permissions) link identity groups count to edit panel

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check permissions > identities list. The group count should be a shortcut to show and edit the linked groups for an identity.