### PR TITLE
Ensure volatile keys are preserved, when saving a network

### DIFF
--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -99,9 +99,7 @@ export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
   const excludeConfigKeys = getHandledNetworkConfigKeys();
   const missingConfigFields = Object.fromEntries(
     Object.entries(values.bareNetwork?.config ?? {}).filter(
-      (e) =>
-        !excludeConfigKeys.has(e[0] as keyof LxdNetworkConfig) &&
-        !e[0].startsWith("volatile"),
+      (e) => !excludeConfigKeys.has(e[0] as keyof LxdNetworkConfig),
     ),
   );
 

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -57,6 +57,7 @@ export interface LxdNetworkConfig {
   network?: string;
   parent?: string;
   [key: `user.${string}`]: string;
+  [key: `volatile.${string}`]: string;
 }
 
 export interface LxdNetwork {

--- a/src/util/networkForm.spec.ts
+++ b/src/util/networkForm.spec.ts
@@ -29,4 +29,19 @@ describe("conversion to form values and back with toNetworkFormValues and toNetw
 
     expect(payload.config?.["user.key"]).toBe("custom-config-value");
   });
+
+  it("preserves volatile keys in network config", () => {
+    const network = {
+      devices: {},
+      config: {
+        "user.key": "custom-config-value",
+        "volatile.network.ipv4.address": "1.2.3.4",
+      },
+    } as unknown as LxdNetwork;
+
+    const formValues = toNetworkFormValues(network);
+    const payload = toNetwork(formValues);
+
+    expect(payload.config?.["volatile.network.ipv4.address"]).toBe("1.2.3.4");
+  });
 });


### PR DESCRIPTION
## Done

- Ensure volatile keys are preserved, when saving a network

Fixes https://github.com/canonical/lxd/issues/14531

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit a network, that has settings under config.volatile.*
    - modify the network in the UI, ensure the save call contains all config.volatile keys in the payload