### PR TITLE
Avoid duplicate title setting from resource label and the table cell in identities list

### DIFF
--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -154,7 +154,6 @@ const PermissionIdentities: FC = () => {
           role: "cell",
           "aria-label": "Type",
           className: "u-truncate",
-          title: identity.type,
         },
         {
           content: (


### PR DESCRIPTION
## Done

- Avoid duplicate title setting from resource label and the table cell in identities list

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check title for identity list > type column. there used to be two titles.