### PR TITLE
fix: update changed docs link

### DIFF
--- a/src/pages/cluster/ClusterList.tsx
+++ b/src/pages/cluster/ClusterList.tsx
@@ -64,8 +64,8 @@ const ClusterList: FC = () => {
       contentClassName="cluster-content"
       title={
         <HelpLink
-          href={`${docBaseLink}/explanation/clustering/`}
-          title="Learn more about clustering"
+          href={`${docBaseLink}/explanation/clusters/`}
+          title="Learn more about clusters"
         >
           {isClustered ? (
             <ClusterGroupSelector
@@ -122,11 +122,11 @@ const ClusterList: FC = () => {
               <p>Add cluster members to this group.</p>
               <p>
                 <a
-                  href={`${docBaseLink}/explanation/clustering/`}
+                  href={`${docBaseLink}/explanation/clusters/`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Learn more about clustering
+                  Learn more about clusters
                   <Icon className="external-link-icon" name="external-link" />
                 </a>
               </p>
@@ -145,11 +145,11 @@ const ClusterList: FC = () => {
             </p>
             <p>
               <a
-                href={`${docBaseLink}/explanation/clustering/`}
+                href={`${docBaseLink}/explanation/clusters/`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Learn more about clustering
+                Learn more about clusters
                 <Icon className="external-link-icon" name="external-link" />
               </a>
             </p>

--- a/tests/doc-links.spec.ts
+++ b/tests/doc-links.spec.ts
@@ -66,7 +66,7 @@ test("Ensure the documentation link text and link targets are present: Server Se
   await validateLink(
     page,
     "Instance placement scriptlet",
-    "/documentation/explanation/clustering/#clustering-instance-placement-scriptlet",
+    "/documentation/explanation/clusters/#clustering-instance-placement-scriptlet",
   );
 });
 


### PR DESCRIPTION
## Done

- Updates references to LXD's docs/explanation/clustering.md which has been renamed to clusters.md as part of https://github.com/canonical/lxd/pull/14692
- Note: a redirect was added as part of the above PR to redirect from explanation/clustering to explanation/clusters, but it doesn't prevent the lxd-ui test from failing (see below)

Fixes [list issues/bugs if needed]
Fixes this test failure: https://github.com/canonical/lxd/actions/runs/12413640553/job/34656601439

## QA

Ran UI with dotrun and confirmed that links have changed.