### PR TITLE
Do not limit length when using resource link is use in the main section

### DIFF
--- a/src/sass/_resources.scss
+++ b/src/sass/_resources.scss
@@ -15,6 +15,10 @@
   }
 }
 
+.l-main .resource-link .p-chip__value {
+  max-width: inherit;
+}
+
 .resource-label {
   i {
     margin-right: $sph--x-small;


### PR DESCRIPTION
## Done

- Do not limit length when using resource link is use in the main section

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance detail > overview, i.e. the image name should not be truncated, or the used by lists under storage pools. In the notifications, the resource link will be capped as there is not much space.