### PR TITLE
Link idp group count to edit panel

### DIFF
--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -98,7 +98,15 @@ const PermissionIdpGroups: FC = () => {
           title: idpGroup.name,
         },
         {
-          content: idpGroup.groups.length,
+          content: (
+            <Button
+              appearance="link"
+              dense
+              onClick={() => panelParams.openEditIdpGroup(idpGroup.name)}
+            >
+              {idpGroup.groups.length}
+            </Button>
+          ),
           role: "cell",
           className: "u-align--right",
           "aria-label": "Number of mapped groups",


### PR DESCRIPTION
## Done

- Link idp group count to edit panel

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check idp group list, the count of linked groups should be a link, opening the side panel to reveal the selections and allow editing them.