### PR TITLE
Ensure storage pool detail is fetched from the cluster

### DIFF
--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -10,13 +10,11 @@ import NotificationRow from "components/NotificationRow";
 import StoragePoolOverview from "pages/storage/StoragePoolOverview";
 import CustomLayout from "components/CustomLayout";
 import EditStoragePool from "pages/storage/EditStoragePool";
-import { useClusterMembers } from "context/useClusterMembers";
 import TabLinks from "components/TabLinks";
 import { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
 
 const StoragePoolDetail: FC = () => {
   const notify = useNotify();
-  const { data: clusterMembers = [] } = useClusterMembers();
   const { name, project, activeTab } = useParams<{
     name: string;
     project: string;
@@ -30,15 +28,13 @@ const StoragePoolDetail: FC = () => {
     return <>Missing project</>;
   }
 
-  const member = clusterMembers[0]?.server_name ?? undefined;
-
   const {
     data: pool,
     error,
     isLoading,
   } = useQuery({
-    queryKey: [queryKeys.storage, name, member],
-    queryFn: () => fetchStoragePool(name, member),
+    queryKey: [queryKeys.storage, name],
+    queryFn: () => fetchStoragePool(name),
   });
 
   if (error) {


### PR DESCRIPTION
## Done

- Ensure storage pool detail is fetched from the cluster, and not a specific member, so the used by list is complete

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check a storage pool with driver directory on a cluster backend
    - create volumes on different cluster members in that pool
    - ensure all volumes show up on the storage pool detail page