### PR TITLE
fix: remove spaces from custom iso name

### DIFF
--- a/src/components/forms/SnapshotForm.tsx
+++ b/src/components/forms/SnapshotForm.tsx
@@ -54,7 +54,7 @@ const SnapshotForm: FC<Props> = (props) => {
       }
       onKeyDown={handleEscKey}
     >
-      <Form onSubmit={formik.handleSubmit}>
+      <Form onSubmit={formik.handleSubmit} className="snapshot-creation-form">
         <Input
           id="name"
           name="name"
@@ -63,7 +63,11 @@ const SnapshotForm: FC<Props> = (props) => {
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}
           value={formik.values.name}
-          error={formik.touched.name || isEdit ? formik.errors.name : null}
+          error={
+            formik.touched.name || isEdit ? (
+              <div className="name-error">{formik.errors.name}</div>
+            ) : null
+          }
           takeFocus
         />
         <Row className="expiration-wrapper">

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -20,6 +20,8 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import StoragePoolSelector from "./StoragePoolSelector";
 import { AxiosError } from "axios";
 import type { LxdSyncResponse } from "types/apiResponse";
+import { isValidISOAlias, sanitizeISOAlias } from "util/customISO";
+import classnames from "classnames";
 
 interface Props {
   onFinish: (name: string, pool: string) => void;
@@ -98,14 +100,18 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
     if (e.target.files) {
       const file = e.target.files[0];
       setFile(file);
-      setName(file.name);
+      setName(sanitizeISOAlias(file.name));
     }
   };
 
   return (
     <>
       {notify.notification ? <NotificationRow /> : <UploadCustomImageHint />}
-      <div className={uploadState === null ? "" : "u-hide"}>
+      <div
+        className={classnames("custom-iso-form", {
+          "u-hide": !!uploadState,
+        })}
+      >
         <Input
           name="iso"
           type="file"
@@ -122,6 +128,14 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
           value={name}
           onChange={(e) => setName(e.target.value)}
           disabled={file === null}
+          error={
+            name && !isValidISOAlias(name) ? (
+              <div className="alias-error">
+                Only alphanumeric characters, periods or hyphens are allowed in
+                this field
+              </div>
+            ) : undefined
+          }
           stacked
         />
         <StoragePoolSelector
@@ -158,7 +172,7 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
         <ActionButton
           appearance="positive"
           loading={isLoading}
-          disabled={!file}
+          disabled={!file || !isValidISOAlias(name)}
           className="u-no-margin--bottom"
           onClick={importFile}
         >

--- a/src/sass/_custom_isos.scss
+++ b/src/sass/_custom_isos.scss
@@ -14,3 +14,11 @@
     max-width: 20rem;
   }
 }
+
+.custom-iso-form {
+  @include large {
+    .alias-error {
+      max-width: 20rem;
+    }
+  }
+}

--- a/src/sass/_snapshots.scss
+++ b/src/sass/_snapshots.scss
@@ -80,3 +80,11 @@
     padding-right: 0;
   }
 }
+
+.snapshot-creation-form {
+  @include large {
+    .name-error {
+      max-width: 25rem;
+    }
+  }
+}

--- a/src/util/customISO.tsx
+++ b/src/util/customISO.tsx
@@ -1,0 +1,7 @@
+export const sanitizeISOAlias = (alias: string): string => {
+  return alias.replace(/[^A-Za-z0-9.-]/g, "-");
+};
+
+export const isValidISOAlias = (alias: string): boolean => {
+  return /^[A-Za-z0-9.-]+$/.test(alias) || !alias;
+};

--- a/src/util/instanceSnapshots.tsx
+++ b/src/util/instanceSnapshots.tsx
@@ -46,7 +46,7 @@ export const getInstanceSnapshotSchema = (
       )
       .matches(/^[A-Za-z0-9-_.:]+$/, {
         message:
-          "Please enter only alphanumeric characters, underscores (_), periods (.), hyphens (-), and colons (:) in this field",
+          "Only alphanumeric characters, underscores, periods, hyphens, and colons are allowed in this field",
       }),
     expirationDate: Yup.string()
       .nullable()

--- a/src/util/storageVolumeSnapshots.tsx
+++ b/src/util/storageVolumeSnapshots.tsx
@@ -43,7 +43,7 @@ export const getVolumeSnapshotSchema = (
       )
       .matches(/^[A-Za-z0-9-_.:]+$/, {
         message:
-          "Please enter only alphanumeric characters, underscores (_), periods (.), hyphens (-), and colons (:) in this field",
+          "Only alphanumeric characters, underscores, periods, hyphens, and colons are allowed in this field",
       }),
     expirationDate: Yup.string()
       .nullable()


### PR DESCRIPTION
## Done

- Remove spaces from uploaded custom iso file name
- Prevent custom iso alias with spaces

Fixes #1057 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Upload a custom iso with spaces in its file name, make sure the auto populated alias does not contain spaces.
    - Try change the alias so that it contains spaces
