### PR TITLE
fix: fix broken doc link e2e test

### DIFF
--- a/tests/doc-links.spec.ts
+++ b/tests/doc-links.spec.ts
@@ -64,9 +64,9 @@ test("Ensure the documentation link text and link targets are present: Server Se
 
   await openServerSetting(page, "instances.placement.scriptlet");
   const scriptletLink =
-    lxdVersion === "latest-edge"
-      ? "/documentation/explanation/clusters/#clustering-instance-placement-scriptlet"
-      : "/documentation/explanation/clustering/#clustering-instance-placement-scriptlet";
+    lxdVersion === "5.0-edge"
+      ? "/documentation/explanation/clustering/#clustering-instance-placement-scriptlet"
+      : "/documentation/explanation/clusters/#clustering-instance-placement-scriptlet";
   await validateLink(page, "Instance placement scriptlet", scriptletLink);
 });
 


### PR DESCRIPTION
## Done

- Fixed e2e for doc link tests as update was merged into lxd stable-5.21 branch

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure e2e passes