### PR TITLE
feat: [WD-18264] CMS fields for storage pool source

### DIFF
--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -1,4 +1,8 @@
-import { handleEtagResponse, handleResponse } from "util/helpers";
+import {
+  constructMemberError,
+  handleEtagResponse,
+  handleResponse,
+} from "util/helpers";
 import type {
   LxdNetwork,
   LXDNetworkOnClusterMember,
@@ -27,15 +31,6 @@ export const fetchNetworks = (
       })
       .catch(reject);
   });
-};
-
-const constructMemberError = (
-  result: PromiseRejectedResult,
-  member: string,
-) => {
-  const reason = result.reason as Error;
-  const message = `Error from cluster member ${member}: ${reason.message}`;
-  return new Error(message);
 };
 
 export const fetchNetworksFromClusterMembers = (

--- a/src/components/forms/ClusterSpecificInput.tsx
+++ b/src/components/forms/ClusterSpecificInput.tsx
@@ -1,0 +1,141 @@
+import { FC, Fragment, useEffect, useState } from "react";
+import { CheckboxInput, Input } from "@canonical/react-components";
+import ResourceLink from "components/ResourceLink";
+import FormEditButton from "components/FormEditButton";
+import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
+
+interface Props {
+  id: string;
+  isReadOnly: boolean;
+  onChange: (value: ClusterSpecificValues) => void;
+  toggleReadOnly: () => void;
+  memberNames: string[];
+  values?: ClusterSpecificValues;
+  canToggleSpecific?: boolean;
+  isDefaultSpecific?: boolean;
+  clusterMemberLinkTarget?: (member: string) => string;
+  disabled?: boolean;
+  helpText?: string;
+}
+
+const ClusterSpecificInput: FC<Props> = ({
+  values,
+  id,
+  isReadOnly,
+  memberNames,
+  onChange,
+  toggleReadOnly,
+  canToggleSpecific = true,
+  isDefaultSpecific = null,
+  clusterMemberLinkTarget = () => "/ui/cluster",
+  disabled = false,
+  helpText,
+}) => {
+  const [isSpecific, setIsSpecific] = useState<boolean | null>(
+    isDefaultSpecific,
+  );
+  const firstValue = Object.values(values ?? {})[0];
+
+  useEffect(() => {
+    const rawValues = Object.values(values ?? {});
+    if (isSpecific === null && rawValues.length > 0) {
+      const newDefaultSpecific = rawValues.some(
+        (item) => item !== rawValues[0],
+      );
+      setIsSpecific(newDefaultSpecific);
+    }
+  }, [isSpecific, values]);
+
+  const setValueForAllMembers = (value: string) => {
+    const update: ClusterSpecificValues = {};
+    memberNames.forEach((member) => (update[member] = value));
+    onChange(update);
+  };
+
+  const setValueForMember = (value: string, member: string) => {
+    const update = {
+      ...values,
+      [member]: value,
+    };
+    onChange(update);
+  };
+
+  return (
+    <div className="u-sv3">
+      {canToggleSpecific && !isReadOnly && (
+        <CheckboxInput
+          id={`${id}-same-for-all-toggle`}
+          label="Same for all cluster members"
+          checked={!isSpecific}
+          onChange={() => {
+            setIsSpecific((val) => !val);
+          }}
+        />
+      )}
+      {isSpecific && (
+        <div className="cluster-specific-input">
+          {memberNames.map((item) => {
+            const activeValue = values?.[item];
+
+            return (
+              <Fragment key={item}>
+                <div className="cluster-specific-member">
+                  <ResourceLink
+                    type="cluster-member"
+                    value={item}
+                    to={clusterMemberLinkTarget(item)}
+                  />
+                </div>
+                <div className="cluster-specific-value">
+                  {isReadOnly ? (
+                    <>
+                      {activeValue}
+                      <FormEditButton toggleReadOnly={toggleReadOnly} />
+                    </>
+                  ) : (
+                    <Input
+                      id={
+                        memberNames.indexOf(item) === 0 ? id : `${id}-${item}`
+                      }
+                      type="text"
+                      className="u-no-margin--bottom"
+                      value={activeValue}
+                      onChange={(e) => setValueForMember(e.target.value, item)}
+                      disabled={disabled}
+                    />
+                  )}
+                </div>
+              </Fragment>
+            );
+          })}
+          {helpText && (
+            <div className="p-form-help-text cluster-specific-helptext">
+              {helpText}
+            </div>
+          )}
+        </div>
+      )}
+      {!isSpecific && (
+        <div>
+          {isReadOnly ? (
+            <>
+              {firstValue}
+              <FormEditButton toggleReadOnly={toggleReadOnly} />
+            </>
+          ) : (
+            <Input
+              id={id}
+              type="text"
+              value={firstValue}
+              onChange={(e) => setValueForAllMembers(e.target.value)}
+              disabled={disabled}
+              help={helpText}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClusterSpecificInput;

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -66,7 +66,12 @@ const CreateStoragePool: FC = () => {
 
       const mutation =
         clusterMembers.length > 0
-          ? () => createClusteredPool(storagePool, clusterMembers)
+          ? () =>
+              createClusteredPool(
+                storagePool,
+                clusterMembers,
+                values.sourcePerClusterMember,
+              )
           : () => createPool(storagePool);
 
       mutation()

--- a/src/pages/storage/forms/StoragePoolClusteredSourceSelector.tsx
+++ b/src/pages/storage/forms/StoragePoolClusteredSourceSelector.tsx
@@ -1,0 +1,40 @@
+import { Label } from "@canonical/react-components";
+import ClusterSpecificInput from "components/forms/ClusterSpecificInput";
+import { FormikProps } from "formik";
+import { FC } from "react";
+import { StoragePoolFormValues } from "./StoragePoolForm";
+import { useClusterMembers } from "context/useClusterMembers";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+  helpText?: string;
+}
+
+const StoragePoolClusteredSourceSelector: FC<Props> = ({
+  formik,
+  helpText,
+}) => {
+  const { data: clusterMembers = [] } = useClusterMembers();
+  const memberNames = clusterMembers.map((member) => member.server_name);
+
+  return (
+    <>
+      <Label forId="sourcePerClusterMember">Source</Label>
+      <ClusterSpecificInput
+        values={formik.values.sourcePerClusterMember}
+        id="sourcePerClusterMember"
+        isReadOnly={false}
+        onChange={(value) => {
+          void formik.setFieldValue("sourcePerClusterMember", value);
+        }}
+        canToggleSpecific={formik.values.isCreating}
+        toggleReadOnly={() => {}}
+        memberNames={memberNames}
+        disabled={!formik.values.isCreating}
+        helpText={helpText}
+      />
+    </>
+  );
+};
+
+export default StoragePoolClusteredSourceSelector;

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -41,16 +41,10 @@ import StoragePoolFormZFS from "./StoragePoolFormZFS";
 import { useSettings } from "context/useSettings";
 import { ensureEditMode } from "util/instanceEdit";
 import StoragePoolFormCephFS from "pages/storage/forms/StoragePoolFormCephFS";
+import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 
 export interface StoragePoolFormValues {
-  isCreating: boolean;
-  readOnly: boolean;
-  name: string;
-  description: string;
-  driver: string;
-  source: string;
-  entityType: "storagePool";
-  size?: string;
+  barePool?: LxdStoragePool;
   ceph_cluster_name?: string;
   ceph_osd_pg_num?: string;
   ceph_rbd_clone_copy?: string;
@@ -62,6 +56,11 @@ export interface StoragePoolFormValues {
   cephfs_osd_pg_num?: string;
   cephfs_path?: string;
   cephfs_user_name?: string;
+  description: string;
+  driver: string;
+  entityType: "storagePool";
+  isCreating: boolean;
+  name: string;
   powerflex_clone_copy?: string;
   powerflex_domain?: string;
   powerflex_gateway?: string;
@@ -75,11 +74,14 @@ export interface StoragePoolFormValues {
   pure_gateway?: string;
   pure_gateway_verify?: string;
   pure_mode?: string;
+  readOnly: boolean;
+  size?: string;
+  source: string;
+  sourcePerClusterMember?: ClusterSpecificValues;
+  yaml?: string;
   zfs_clone_copy?: string;
   zfs_export?: string;
   zfs_pool_name?: string;
-  yaml?: string;
-  barePool?: LxdStoragePool;
 }
 
 interface Props {

--- a/src/sass/_cluster_specific_input.scss
+++ b/src/sass/_cluster_specific_input.scss
@@ -8,4 +8,8 @@
   .cluster-specific-member {
     overflow: hidden;
   }
+
+  .cluster-specific-helptext {
+    grid-column-start: 2;
+  }
 }

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -93,3 +93,7 @@ export interface LxdVolumeSnapshot {
   expires_at?: string;
   description?: string;
 }
+
+export type LXDStoragePoolOnClusterMember = LxdStoragePool & {
+  memberName: string;
+};

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -351,3 +351,12 @@ export const base64EncodeObject = (data: object) => {
   const jsonString = JSON.stringify(data);
   return btoa(jsonString);
 };
+
+export const constructMemberError = (
+  result: PromiseRejectedResult,
+  member: string,
+) => {
+  const reason = result.reason as Error;
+  const message = `Error from cluster member ${member}: ${reason.message}`;
+  return new Error(message);
+};

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -48,6 +48,8 @@ export const getSupportedStorageDrivers = (
 };
 
 const storageDriverToSourceHelp: Record<string, string> = {
+  btrfs:
+    "Optional, path to an existing block device, loop file or Btrfs subvolume",
   dir: "Optional, path to an existing directory",
   lvm: "Optional, path to an existing block device, loop file or LVM volume group",
   zfs: "Optional, path to an existing block device, loop file or ZFS dataset/pool",

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -1,9 +1,20 @@
-import type { LxdStoragePool } from "types/storage";
+import type {
+  LxdStoragePool,
+  LXDStoragePoolOnClusterMember,
+} from "types/storage";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
+import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 
 export const toStoragePoolFormValues = (
   pool: LxdStoragePool,
+  poolOnMembers?: LXDStoragePoolOnClusterMember[],
 ): StoragePoolFormValues => {
+  const sourcePerClusterMember: ClusterSpecificValues = {};
+  poolOnMembers?.forEach(
+    (item) =>
+      (sourcePerClusterMember[item.memberName] = item.config?.source ?? ""),
+  );
+
   return {
     readOnly: true,
     isCreating: false,
@@ -40,6 +51,7 @@ export const toStoragePoolFormValues = (
     zfs_clone_copy: pool.config?.["zfs.clone_copy"],
     zfs_export: pool.config?.["zfs.export"],
     zfs_pool_name: pool.config?.["zfs.pool_name"],
+    sourcePerClusterMember,
     barePool: pool,
   };
 };


### PR DESCRIPTION
## Done
- Added intermediary StoragePoolClusteredSourceSelector file + a ClusterSpecificInput component.
- Added functionality to create storage pool source fields for specific cluster members.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Within a clustered environment, navigate to the Create a storage pool page, and attempt to create a storage pool with a ZFS, LVM or Directory driver. (Directory is less prone to error and empty directories can be made for testing purposes by creating them in the terminal of the cluster node).
    - With a storage pool successfully created, navigate to it's configuration page and verify that
      - The page defaults to the correct setting (global source or single clusters sources)
      - The previously input sources persist.

## Screenshots
![image](https://github.com/user-attachments/assets/9fab2590-4e0d-4cb4-80af-7cc05a8b5958)
![image](https://github.com/user-attachments/assets/f2758ed2-ee38-4d29-8a13-3c0036b8baec)
