### PR TITLE
Show line and ... for an ovn network that has an uplink with parent next to it to indicate further level of detail

### DIFF
--- a/src/pages/networks/NetworkTopology.tsx
+++ b/src/pages/networks/NetworkTopology.tsx
@@ -96,7 +96,7 @@ const NetworkTopology: FC<Props> = ({ formik, project, isServerClustered }) => {
             {hasClusteredUplinks
               ? clusterUplinks
               : uplink && (
-                  <div className="uplink-item">
+                  <div className="uplink-item has-parent">
                     <ResourceLink
                       type="network"
                       value={uplink}

--- a/src/sass/_network_topology.scss
+++ b/src/sass/_network_topology.scss
@@ -52,6 +52,12 @@
     );
   }
 
+  .uplink-item.has-parent::before {
+    color: #6e7681;
+    content: "... ——";
+    display: contents;
+  }
+
   .downstream-item.has-descendents::after {
     color: #6e7681;
     content: "—— ...";


### PR DESCRIPTION
## Done

- Show line and ... for an ovn network that has an uplink with parent next to it to indicate further level of detail

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the connection diagram for an ovn network with an uplink that has a parent. There should be a "..." indicator of the uplinks parent.

## Screenshots

New connection:

![image](https://github.com/user-attachments/assets/ff26e409-4a31-4638-ae8a-2c4c8c2eb1ff)

Old connection:

![image](https://github.com/user-attachments/assets/b1598635-4a10-41e1-a910-a70993b4d263)
