### PR TITLE
feat: [WD-17724] CMS Storage Pool size field

### DIFF
--- a/src/components/forms/ClusteredDiskSizeSelector.tsx
+++ b/src/components/forms/ClusteredDiskSizeSelector.tsx
@@ -1,0 +1,116 @@
+import { FC, Fragment, useEffect, useState } from "react";
+import { CheckboxInput, Label } from "@canonical/react-components";
+import ResourceLink from "components/ResourceLink";
+import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
+import { useClusterMembers } from "context/useClusterMembers";
+import DiskSizeSelector from "./DiskSizeSelector";
+
+interface Props {
+  id: string;
+  setValue: (value: ClusterSpecificValues) => void;
+  values?: ClusterSpecificValues;
+  helpText?: string;
+}
+
+const ClusteredDiskSizeSelector: FC<Props> = ({
+  id,
+  setValue,
+  values,
+  helpText,
+}) => {
+  const { data: clusterMembers = [] } = useClusterMembers();
+  const memberNames = clusterMembers.map((member) => member.server_name);
+  const [isSpecific, setIsSpecific] = useState<boolean | null>(null);
+  const firstValue = Object.values(values ?? {})[0];
+
+  useEffect(() => {
+    const rawValues = Object.values(values ?? {});
+    if (isSpecific === null && rawValues.length > 0) {
+      const newDefaultSpecific = rawValues.some(
+        (item) => item !== rawValues[0],
+      );
+      setIsSpecific(newDefaultSpecific);
+    }
+  }, [isSpecific, values]);
+
+  const setValueForAllMembers = (value: string) => {
+    const update: ClusterSpecificValues = {};
+    memberNames.forEach((member) => (update[member] = value));
+    setValue(update);
+  };
+
+  const setValueForMember = (value: string, member: string) => {
+    const update = {
+      ...values,
+      [member]: value,
+    };
+    setValue(update);
+  };
+
+  return (
+    <div className="u-sv3">
+      <Label forId="sizePerClusterMember">Size</Label>
+      {
+        <CheckboxInput
+          id={`${id}-same-for-all-toggle`}
+          label="Same for all cluster members"
+          checked={!isSpecific}
+          onChange={() => {
+            setValueForAllMembers(firstValue);
+            setIsSpecific((val) => !val);
+          }}
+        />
+      }
+      {isSpecific && (
+        <div className="cluster-specific-input">
+          {memberNames.map((item) => {
+            const activeValue = values?.[item] ?? "";
+
+            return (
+              <Fragment key={item}>
+                <div className="cluster-specific-member">
+                  <ResourceLink
+                    type="cluster-member"
+                    value={item}
+                    to={"/ui/cluster"}
+                  />
+                </div>
+
+                <div className="cluster-specific-value">
+                  <DiskSizeSelector
+                    id={memberNames.indexOf(item) === 0 ? id : `${id}-${item}`}
+                    value={activeValue}
+                    setMemoryLimit={(value) => setValueForMember(value, item)}
+                    disabled={false}
+                    classname="u-no-margin--bottom"
+                  />
+                </div>
+              </Fragment>
+            );
+          })}
+          {helpText && (
+            <div className="p-form-help-text cluster-specific-helptext">
+              {helpText}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isSpecific && (
+        <div>
+          {
+            <DiskSizeSelector
+              id={id}
+              value={firstValue}
+              setMemoryLimit={(value) => setValueForAllMembers(value)}
+              disabled={false}
+              help={helpText}
+            />
+          }
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ClusteredDiskSizeSelector;

--- a/src/components/forms/DiskSizeSelector.tsx
+++ b/src/components/forms/DiskSizeSelector.tsx
@@ -4,21 +4,25 @@ import { BYTES_UNITS } from "types/limits";
 import { parseMemoryLimit } from "util/limits";
 
 interface Props {
+  id?: string;
   label?: string;
   value?: string;
   help?: string;
   helpTotal?: ReactNode;
-  setMemoryLimit: (val?: string) => void;
+  setMemoryLimit: (val: string) => void;
   disabled?: boolean;
+  classname?: string;
 }
 
 const DiskSizeSelector: FC<Props> = ({
+  id = "limits_disk",
   label,
   value,
   help,
   helpTotal,
   setMemoryLimit,
   disabled,
+  classname,
 }) => {
   const limit = parseMemoryLimit(value) ?? {
     value: 1,
@@ -41,7 +45,7 @@ const DiskSizeSelector: FC<Props> = ({
       )}
       <div className="memory-limit-with-unit">
         <Input
-          id="limits_disk"
+          id={id}
           name="limits_disk"
           type="number"
           min="0"
@@ -50,9 +54,10 @@ const DiskSizeSelector: FC<Props> = ({
           onChange={(e) => setMemoryLimit(e.target.value + limit.unit)}
           value={value?.match(/^\d/) ? limit.value : ""}
           disabled={disabled}
+          className={classname}
         />
         <Select
-          id="memUnitSelect"
+          id={`memUnitSelect-${id}`}
           name="memUnitSelect"
           label="Select disk size unit"
           labelClassName="u-off-screen"
@@ -62,6 +67,7 @@ const DiskSizeSelector: FC<Props> = ({
           }
           value={limit.unit}
           disabled={disabled}
+          className={classname}
         />
       </div>
       {(help || helpTotal) && (

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -73,6 +73,7 @@ const CreateStoragePool: FC = () => {
                 clusterMembers,
                 values.sourcePerClusterMember,
                 values.zfsPoolNamePerClusterMember,
+                values.sizePerClusterMember,
               )
           : () => createPool(storagePool);
 

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -91,7 +91,12 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
 
       const mutation =
         clusterMembers.length > 0
-          ? () => updateClusteredPool(savedPool, clusterMembers)
+          ? () =>
+              updateClusteredPool(
+                savedPool,
+                clusterMembers,
+                values.sizePerClusterMember,
+              )
           : () => updatePool(savedPool);
 
       mutation()
@@ -109,8 +114,12 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
           );
           const member = clusterMembers[0]?.server_name ?? undefined;
           const updatedPool = await fetchStoragePool(values.name, member);
+          const updatedPoolOnMembers = await fetchPoolFromClusterMembers(
+            pool.name,
+            clusterMembers,
+          );
           void formik.setValues(
-            toStoragePoolFormValues(updatedPool, poolOnMembers),
+            toStoragePoolFormValues(updatedPool, updatedPoolOnMembers),
           );
         })
         .catch((e) => {

--- a/src/pages/storage/forms/ClusteredSourceSelector.tsx
+++ b/src/pages/storage/forms/ClusteredSourceSelector.tsx
@@ -10,10 +10,7 @@ interface Props {
   helpText?: string;
 }
 
-const StoragePoolClusteredSourceSelector: FC<Props> = ({
-  formik,
-  helpText,
-}) => {
+const ClusteredSourceSelector: FC<Props> = ({ formik, helpText }) => {
   const { data: clusterMembers = [] } = useClusterMembers();
   const memberNames = clusterMembers.map((member) => member.server_name);
 
@@ -37,4 +34,4 @@ const StoragePoolClusteredSourceSelector: FC<Props> = ({
   );
 };
 
-export default StoragePoolClusteredSourceSelector;
+export default ClusteredSourceSelector;

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -72,6 +72,7 @@ export interface StoragePoolFormValues {
   powerflex_sdt?: string;
   powerflex_user_name?: string;
   powerflex_user_password?: string;
+  sizePerClusterMember?: ClusterSpecificValues;
   pure_api_token?: string;
   pure_gateway?: string;
   pure_gateway_verify?: string;

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -45,6 +45,7 @@ test("storage pool create, edit and remove", async ({ page }) => {
   await createPool(page, pool);
 
   await editPool(page, pool);
+  await page.getByPlaceholder("Enter description").click();
   await page.getByPlaceholder("Enter description").fill("A-new-description");
   await savePool(page, pool);
 


### PR DESCRIPTION
## Done

- Added ClusteredDiskSizeSelector

Fixes 
- Inability to host Cluster member specific storage pool sizes.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
![image](https://github.com/user-attachments/assets/f9ac8826-765d-42a4-b0d1-4d0393d62021)

![image](https://github.com/user-attachments/assets/079de03a-c6b4-47a1-ba18-58e7fa0c4bf0)