### PR TITLE
Close side panel if panel instance was deleted

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -210,6 +210,16 @@ const InstanceList: FC = () => {
     }
   }, [filteredInstances]);
 
+  useEffect(() => {
+    if (panelParams.instance) {
+      if (
+        !instances.some((instance) => instance.name === panelParams.instance)
+      ) {
+        panelParams.clear();
+      }
+    }
+  }, [instances]);
+
   const getHeaders = (hiddenCols: string[]) =>
     [
       {


### PR DESCRIPTION
## Done

- Close side panel if panel instance was deleted

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open the side panel on the instance list
    - select the instance that is opened in the side panel
    - bulk delete that instance
    - ensure the side panel closes
    - repeat by opening a different instance and deleting yet another instance, ensure the panel stays open