### PR TITLE
Add cluster.evacuate as instance and profile configuration

### DIFF
--- a/src/components/forms/MigrationForm.tsx
+++ b/src/components/forms/MigrationForm.tsx
@@ -8,16 +8,21 @@ import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { getInstanceKey } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
-import { optionAllowDeny } from "util/instanceOptions";
+import {
+  clusterEvacuationOptions,
+  optionAllowDeny,
+} from "util/instanceOptions";
 import { CreateInstanceFormValues } from "pages/instances/CreateInstance";
 
 export interface MigrationFormValues {
   migration_stateful?: string;
+  cluster_evacuate?: string;
 }
 
 export const migrationPayload = (values: InstanceAndProfileFormValues) => {
   return {
     [getInstanceKey("migration_stateful")]: values.migration_stateful,
+    [getInstanceKey("cluster_evacuate")]: values.cluster_evacuate,
   };
 };
 
@@ -48,6 +53,15 @@ const MigrationForm: FC<Props> = ({ formik }) => {
           children: (
             <Select options={optionAllowDeny} disabled={isVmOnlyDisabled} />
           ),
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Cluster evacuation",
+          name: "cluster_evacuate",
+          defaultValue: "auto",
+          readOnlyRenderer: (val) =>
+            optionRenderer(val, clusterEvacuationOptions),
+          children: <Select options={clusterEvacuationOptions} />,
         }),
       ]}
     />

--- a/src/util/instanceConfigFields.tsx
+++ b/src/util/instanceConfigFields.tsx
@@ -20,6 +20,7 @@ const instanceConfigFormFieldsToPayload: Record<string, string> = {
   snapshots_schedule: "snapshots.schedule",
   snapshots_schedule_stopped: "snapshots.schedule.stopped",
   migration_stateful: "migration.stateful",
+  cluster_evacuate: "cluster.evacuate",
   boot_autostart: "boot.autostart",
   boot_autostart_delay: "boot.autostart.delay",
   boot_autostart_priority: "boot.autostart.priority",

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -54,6 +54,7 @@ const getEditValues = (
     snapshots_schedule_stopped: item.config["snapshots.schedule.stopped"],
 
     migration_stateful: item.config["migration.stateful"],
+    cluster_evacuate: item.config["cluster.evacuate"],
 
     boot_autostart: item.config["boot.autostart"],
     boot_autostart_delay: item.config["boot.autostart.delay"],

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -96,3 +96,27 @@ export const proxyAddressTypeOptions = [
     value: "unix",
   },
 ];
+
+export const clusterEvacuationOptions = [
+  {
+    label: "Select option",
+    value: "",
+    disabled: true,
+  },
+  {
+    label: "auto",
+    value: "auto",
+  },
+  {
+    label: "live-migrate",
+    value: "live-migrate",
+  },
+  {
+    label: "migrate",
+    value: "migrate",
+  },
+  {
+    label: "stop",
+    value: "stop",
+  },
+];

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -79,7 +79,7 @@ test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
   await page
     .getByRole("combobox", { name: "Stateful migration" })
     .selectOption("Deny");
-  await page.getByRole("button", { name: "Create" }).click();
+  await page.getByRole("button", { name: "Create", exact: true }).click();
 
   await page.waitForSelector(`text=Created instance ${instance}.`);
 


### PR DESCRIPTION
## Done

- Add cluster.evacuate as instance and profile configuration

Fixes #1078

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance and profile configuration for create and edit.
    - ensure under migration the new option cluster evacuation is loading and saving fine.