### PR TITLE
feat: [WD-18674] CMS Fields - ZFS.Poolname

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -101,6 +101,7 @@ export const createClusteredPool = (
   pool: LxdStoragePool,
   clusterMembers: LxdClusterMember[],
   sourcePerClusterMember?: ClusterSpecificValues,
+  zfsPoolNamePerClusterMember?: ClusterSpecificValues,
 ): Promise<void> => {
   const { memberPoolPayload, clusterPoolPayload } =
     getClusterAndMemberPoolPayload(pool);
@@ -112,6 +113,10 @@ export const createClusteredPool = (
           config: {
             ...memberPoolPayload.config,
             source: sourcePerClusterMember?.[item.server_name],
+
+            ...(zfsPoolNamePerClusterMember?.[item.server_name] && {
+              "zfs.pool_name": zfsPoolNamePerClusterMember[item.server_name],
+            }),
           },
         };
         return createPool(clusteredMemberPool, item.server_name);

--- a/src/components/forms/ClusterSpecificInput.tsx
+++ b/src/components/forms/ClusterSpecificInput.tsx
@@ -8,7 +8,7 @@ interface Props {
   id: string;
   isReadOnly: boolean;
   onChange: (value: ClusterSpecificValues) => void;
-  toggleReadOnly: () => void;
+  toggleReadOnly?: () => void;
   memberNames: string[];
   values?: ClusterSpecificValues;
   canToggleSpecific?: boolean;
@@ -16,6 +16,8 @@ interface Props {
   clusterMemberLinkTarget?: (member: string) => string;
   disabled?: boolean;
   helpText?: string;
+  placeholder?: string;
+  classname?: string;
 }
 
 const ClusterSpecificInput: FC<Props> = ({
@@ -24,12 +26,14 @@ const ClusterSpecificInput: FC<Props> = ({
   isReadOnly,
   memberNames,
   onChange,
-  toggleReadOnly,
+  toggleReadOnly = () => {},
   canToggleSpecific = true,
   isDefaultSpecific = null,
   clusterMemberLinkTarget = () => "/ui/cluster",
   disabled = false,
   helpText,
+  placeholder,
+  classname = "u-sv3",
 }) => {
   const [isSpecific, setIsSpecific] = useState<boolean | null>(
     isDefaultSpecific,
@@ -61,13 +65,17 @@ const ClusterSpecificInput: FC<Props> = ({
   };
 
   return (
-    <div className="u-sv3">
+    <div className={classname}>
       {canToggleSpecific && !isReadOnly && (
         <CheckboxInput
           id={`${id}-same-for-all-toggle`}
           label="Same for all cluster members"
           checked={!isSpecific}
+          labelClassName="cluster-specific-toggle-label"
           onChange={() => {
+            if (isSpecific) {
+              setValueForAllMembers(firstValue ?? "");
+            }
             setIsSpecific((val) => !val);
           }}
         />
@@ -90,7 +98,9 @@ const ClusterSpecificInput: FC<Props> = ({
                   {isReadOnly ? (
                     <>
                       {activeValue}
-                      <FormEditButton toggleReadOnly={toggleReadOnly} />
+                      {!disabled && (
+                        <FormEditButton toggleReadOnly={toggleReadOnly} />
+                      )}
                     </>
                   ) : (
                     <Input
@@ -102,6 +112,7 @@ const ClusterSpecificInput: FC<Props> = ({
                       value={activeValue}
                       onChange={(e) => setValueForMember(e.target.value, item)}
                       disabled={disabled}
+                      placeholder={placeholder}
                     />
                   )}
                 </div>
@@ -120,7 +131,7 @@ const ClusterSpecificInput: FC<Props> = ({
           {isReadOnly ? (
             <>
               {firstValue}
-              <FormEditButton toggleReadOnly={toggleReadOnly} />
+              {!disabled && <FormEditButton toggleReadOnly={toggleReadOnly} />}
             </>
           ) : (
             <Input
@@ -130,6 +141,7 @@ const ClusterSpecificInput: FC<Props> = ({
               onChange={(e) => setValueForAllMembers(e.target.value)}
               disabled={disabled}
               help={helpText}
+              placeholder={placeholder}
             />
           )}
         </div>

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -71,6 +71,7 @@ const CreateStoragePool: FC = () => {
                 storagePool,
                 clusterMembers,
                 values.sourcePerClusterMember,
+                values.zfsPoolNamePerClusterMember,
               )
           : () => createPool(storagePool);
 

--- a/src/pages/storage/forms/ClusteredZfsNameSelector.tsx
+++ b/src/pages/storage/forms/ClusteredZfsNameSelector.tsx
@@ -1,0 +1,41 @@
+import ClusterSpecificInput from "components/forms/ClusterSpecificInput";
+import { FormikProps } from "formik";
+import { FC } from "react";
+import { StoragePoolFormValues } from "./StoragePoolForm";
+import { useClusterMembers } from "context/useClusterMembers";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+  helpText?: string;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const ClusteredZfsNameSelector: FC<Props> = ({
+  formik,
+  helpText,
+  disabled = !formik.values.isCreating,
+  placeholder,
+}) => {
+  const { data: clusterMembers = [] } = useClusterMembers();
+  const memberNames = clusterMembers.map((member) => member.server_name);
+
+  return (
+    <ClusterSpecificInput
+      values={formik.values.zfsPoolNamePerClusterMember}
+      id="zfsPoolNamePerClusterMember"
+      isReadOnly={!formik.values.isCreating}
+      onChange={(value) => {
+        void formik.setFieldValue("zfsPoolNamePerClusterMember", value);
+      }}
+      canToggleSpecific={formik.values.isCreating}
+      memberNames={memberNames}
+      disabled={disabled}
+      helpText={helpText}
+      placeholder={placeholder}
+      classname=""
+    />
+  );
+};
+
+export default ClusteredZfsNameSelector;

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -82,6 +82,7 @@ export interface StoragePoolFormValues {
   zfs_clone_copy?: string;
   zfs_export?: string;
   zfs_pool_name?: string;
+  zfsPoolNamePerClusterMember?: ClusterSpecificValues;
 }
 
 interface Props {

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -54,6 +54,9 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const sourceHelpText = formik.values.isCreating
     ? getSourceHelpForDriver(formik.values.driver)
     : "Source can't be changed";
+  const nameHelpText = !formik.values.isCreating
+    ? "Cannot rename storage pools"
+    : undefined;
 
   return (
     <ScrollableForm>
@@ -65,11 +68,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
             label="Name"
             required
             disabled={!formik.values.isCreating}
-            help={
-              !formik.values.isCreating
-                ? "Cannot rename storage pools"
-                : undefined
-            }
+            help={nameHelpText}
           />
           <AutoExpandingTextArea
             {...getFormProps("description")}

--- a/src/pages/storage/forms/StoragePoolFormZFS.tsx
+++ b/src/pages/storage/forms/StoragePoolFormZFS.tsx
@@ -5,12 +5,17 @@ import { getConfigurationRow } from "components/ConfigurationRow";
 import { Input, Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import ClusteredZfsNameSelector from "./ClusteredZfsNameSelector";
+import { isClusteredServer } from "util/settings";
+import { useSettings } from "context/useSettings";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormZFS: FC<Props> = ({ formik }) => {
+  const { data: settings } = useSettings();
+
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -19,7 +24,23 @@ const StoragePoolFormZFS: FC<Props> = ({ formik }) => {
           label: "ZFS pool name",
           name: "zfs_pool_name",
           defaultValue: "",
-          children: <Input type="text" placeholder="Enter ZFS pool name" />,
+          children: isClusteredServer(settings) ? (
+            <ClusteredZfsNameSelector
+              formik={formik}
+              placeholder="Enter ZFS pool name"
+            />
+          ) : (
+            <Input type="text" placeholder="Enter ZFS pool name" />
+          ),
+          readOnlyRenderer: (value) =>
+            isClusteredServer(settings) && value !== "-" ? (
+              <ClusteredZfsNameSelector
+                formik={formik}
+                placeholder="Enter ZFS pool name"
+              />
+            ) : (
+              <>{value}</>
+            ),
           disabled: !formik.values.isCreating || formik.values.readOnly,
           disabledReason: "ZFS pool name cannot be modified",
         }),

--- a/src/sass/_cluster_specific_input.scss
+++ b/src/sass/_cluster_specific_input.scss
@@ -2,7 +2,7 @@
   align-items: center;
   display: grid;
   gap: $sp-medium;
-  grid-template-columns: fit-content(20%) 1fr;
+  grid-template-columns: fit-content(50%) 1fr;
   padding-bottom: $spv--large;
 
   .cluster-specific-member {
@@ -11,5 +11,11 @@
 
   .cluster-specific-helptext {
     grid-column-start: 2;
+  }
+}
+
+.configuration-table {
+  .cluster-specific-toggle-label {
+    margin-bottom: $spv--small !important;
   }
 }

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -10,10 +10,13 @@ export const toStoragePoolFormValues = (
   poolOnMembers?: LXDStoragePoolOnClusterMember[],
 ): StoragePoolFormValues => {
   const sourcePerClusterMember: ClusterSpecificValues = {};
-  poolOnMembers?.forEach(
-    (item) =>
-      (sourcePerClusterMember[item.memberName] = item.config?.source ?? ""),
-  );
+  const zfsPoolNamePerClusterMember: ClusterSpecificValues = {};
+
+  poolOnMembers?.forEach((item) => {
+    sourcePerClusterMember[item.memberName] = item.config?.source ?? "";
+    zfsPoolNamePerClusterMember[item.memberName] =
+      item.config?.["zfs.pool_name"] ?? "";
+  });
 
   return {
     readOnly: true,
@@ -53,6 +56,7 @@ export const toStoragePoolFormValues = (
     zfs_pool_name: pool.config?.["zfs.pool_name"],
     sourcePerClusterMember,
     barePool: pool,
+    zfsPoolNamePerClusterMember,
   };
 };
 


### PR DESCRIPTION
## Done

- Implemented ClusteredZfsNameSelector

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

![image](https://github.com/user-attachments/assets/b531f4fd-3456-49a3-8b02-d437ead705cd)
![image](https://github.com/user-attachments/assets/8dc68b6d-47b1-46de-92a1-5cb55a5cb15d)
![image](https://github.com/user-attachments/assets/5d7aa7a7-36da-486b-87a0-89a3fb6cd221)
