### PR TITLE
feat: initial approach for restricted users permission checks [WD-18836]

### DIFF
--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -11,6 +11,15 @@ export const fetchIdentities = (): Promise<LxdIdentity[]> => {
   });
 };
 
+export const fetchCurrentIdentity = (): Promise<LxdIdentity> => {
+  return new Promise((resolve, reject) => {
+    fetch(`/1.0/auth/identities/current?recursion=1`)
+      .then(handleResponse)
+      .then((data: LxdApiResponse<LxdIdentity>) => resolve(data.metadata))
+      .catch(reject);
+  });
+};
+
 export const fetchIdentity = (
   id: string,
   authMethod: string,

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -13,23 +13,33 @@ import type { LxdOperationResponse } from "types/operation";
 import { EventQueue } from "context/eventQueue";
 import axios, { AxiosResponse } from "axios";
 import type { UploadState } from "types/storage";
+import { withEntitlementsQuery } from "util/entitlements/api";
+
+export const instanceEntitlements = ["can_update_state"];
 
 export const fetchInstance = (
   name: string,
   project: string,
-  recursion = 2,
+  isFineGrained: boolean | null,
 ): Promise<LxdInstance> => {
+  const entitlements = `&${withEntitlementsQuery(isFineGrained, instanceEntitlements)}`;
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/instances/${name}?project=${project}&recursion=${recursion}`)
+    fetch(
+      `/1.0/instances/${name}?project=${project}&recursion=2${entitlements}`,
+    )
       .then(handleEtagResponse)
       .then((data) => resolve(data as LxdInstance))
       .catch(reject);
   });
 };
 
-export const fetchInstances = (project: string): Promise<LxdInstance[]> => {
+export const fetchInstances = (
+  project: string,
+  isFineGrained: boolean | null,
+): Promise<LxdInstance[]> => {
+  const entitlements = `&${withEntitlementsQuery(isFineGrained, instanceEntitlements)}`;
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/instances?project=${project}&recursion=2`)
+    fetch(`/1.0/instances?project=${project}&recursion=2${entitlements}`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdInstance[]>) => resolve(data.metadata))
       .catch(reject);

--- a/src/context/useInstances.tsx
+++ b/src/context/useInstances.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { UseQueryResult } from "@tanstack/react-query";
+import { fetchInstance, fetchInstances } from "api/instances";
+import { useAuth } from "./auth";
+import type { LxdInstance } from "types/instance";
+
+export const useInstances = (
+  project: string,
+): UseQueryResult<LxdInstance[]> => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [queryKeys.instances, project],
+    queryFn: () => fetchInstances(project, isFineGrained),
+    enabled: !!project && isFineGrained !== null,
+  });
+};
+
+export const useInstance = (
+  name: string,
+  project: string,
+  enabled?: boolean,
+): UseQueryResult<LxdInstance> => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [queryKeys.instances, name, project],
+    queryFn: () => fetchInstance(name, project, isFineGrained),
+    enabled: enabled && isFineGrained !== null,
+  });
+};

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -36,5 +36,8 @@ export const useSupportedFeatures = () => {
     hasClusterInternalCustomVolumeCopy: apiExtensions.has(
       "cluster_internal_custom_volume_copy",
     ),
+    hasEntitiesWithEntitlements: apiExtensions.has(
+      "entities_with_entitlements",
+    ),
   };
 };

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -4,9 +4,6 @@ import InstanceOverview from "./InstanceOverview";
 import InstanceTerminal from "./InstanceTerminal";
 import { useParams } from "react-router-dom";
 import InstanceSnapshots from "./InstanceSnapshots";
-import { useQuery } from "@tanstack/react-query";
-import { fetchInstance } from "api/instances";
-import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import InstanceConsole from "pages/instances/InstanceConsole";
 import InstanceLogs from "pages/instances/InstanceLogs";
@@ -16,6 +13,7 @@ import CustomLayout from "components/CustomLayout";
 import TabLinks from "components/TabLinks";
 import { useSettings } from "context/useSettings";
 import { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
+import { useInstance } from "context/useInstances";
 
 const tabs: string[] = [
   "Overview",
@@ -47,10 +45,7 @@ const InstanceDetail: FC = () => {
     error,
     refetch: refreshInstance,
     isLoading,
-  } = useQuery({
-    queryKey: [queryKeys.instances, name, project],
-    queryFn: () => fetchInstance(name, project),
-  });
+  } = useInstance(name, project);
 
   const renderTabs: (string | TabLink)[] = [...tabs];
 

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -2,28 +2,22 @@ import { FC } from "react";
 import OpenTerminalBtn from "./actions/OpenTerminalBtn";
 import OpenConsoleBtn from "./actions/OpenConsoleBtn";
 import { Button, Icon, List, useNotify } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { fetchInstance } from "api/instances";
-import { queryKeys } from "util/queryKeys";
 import usePanelParams from "util/usePanelParams";
 import InstanceStateActions from "pages/instances/actions/InstanceStateActions";
 import SidePanel from "components/SidePanel";
 import InstanceDetailPanelContent from "./InstanceDetailPanelContent";
+import { useInstance } from "context/useInstances";
 
 const InstanceDetailPanel: FC = () => {
   const notify = useNotify();
   const panelParams = usePanelParams();
 
+  const enable = panelParams.instance !== null;
   const {
     data: instance,
     error,
     isLoading,
-  } = useQuery({
-    queryKey: [queryKeys.instances, panelParams.instance, panelParams.project],
-    queryFn: () =>
-      fetchInstance(panelParams.instance ?? "", panelParams.project),
-    enabled: panelParams.instance !== null,
-  });
+  } = useInstance(panelParams.instance ?? "", panelParams.project, enable);
 
   if (error) {
     notify.failure("Loading instance failed", error);

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -9,7 +9,6 @@ import {
   TablePagination,
   useNotify,
 } from "@canonical/react-components";
-import { fetchInstances } from "api/instances";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import usePanelParams, { panels } from "util/usePanelParams";
@@ -65,6 +64,7 @@ import { useSettings } from "context/useSettings";
 import { isClusteredServer } from "util/settings";
 import InstanceUsageMemory from "pages/instances/InstanceUsageMemory";
 import InstanceUsageDisk from "pages/instances/InstanceDisk";
+import { useInstances } from "context/useInstances";
 
 const loadHidden = () => {
   const saved = localStorage.getItem("instanceListHiddenColumns");
@@ -111,14 +111,7 @@ const InstanceList: FC = () => {
     return <>Missing project</>;
   }
 
-  const {
-    data: instances = [],
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: [queryKeys.instances, project],
-    queryFn: () => fetchInstances(project),
-  });
+  const { data: instances = [], error, isLoading } = useInstances(project);
 
   if (error) {
     notify.failure("Loading instances failed", error);

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -9,6 +9,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
+import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -19,6 +20,7 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
   const instanceLoading = useInstanceLoading();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
+  const { canUpdateInstanceState } = useInstanceEntitlements(instance);
 
   const clearCache = () => {
     void queryClient.invalidateQueries({
@@ -81,10 +83,12 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
           </p>
         ),
         onConfirm: handleFreeze,
-        confirmButtonLabel: "Freeze",
+        confirmButtonLabel: canUpdateInstanceState()
+          ? "Freeze"
+          : "You do not have permission to freeze this instance",
       }}
       className="has-icon is-dense"
-      disabled={isDisabled}
+      disabled={isDisabled || !canUpdateInstanceState()}
       shiftClickEnabled
       showShiftClickHint
     >

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -10,6 +10,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
+import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -24,6 +25,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
   const isLoading =
     instanceLoading.getType(instance) === "Restarting" ||
     instance.status === "Restarting";
+  const { canUpdateInstanceState } = useInstanceEntitlements(instance);
 
   const instanceLink = <InstanceLinkChip instance={instance} />;
 
@@ -74,7 +76,9 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
         ),
         onConfirm: handleRestart,
         close: () => setForce(false),
-        confirmButtonLabel: "Restart",
+        confirmButtonLabel: canUpdateInstanceState()
+          ? "Restart"
+          : "You do not have permission to restart this instance",
         confirmExtra: (
           <ConfirmationForce
             label="Force restart"
@@ -82,7 +86,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
           />
         ),
       }}
-      disabled={isDisabled}
+      disabled={isDisabled || !canUpdateInstanceState()}
       shiftClickEnabled
       showShiftClickHint
     >

--- a/src/pages/instances/actions/StartInstanceBtn.tsx
+++ b/src/pages/instances/actions/StartInstanceBtn.tsx
@@ -3,6 +3,7 @@ import type { LxdInstance } from "types/instance";
 import { Button, Icon } from "@canonical/react-components";
 import classnames from "classnames";
 import { useInstanceStart } from "util/instanceStart";
+import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -10,17 +11,22 @@ interface Props {
 
 const StartInstanceBtn: FC<Props> = ({ instance }) => {
   const { handleStart, isLoading, isDisabled } = useInstanceStart(instance);
+  const { canUpdateInstanceState } = useInstanceEntitlements(instance);
 
   return (
     <Button
       appearance="base"
       hasIcon
       dense={true}
-      disabled={isDisabled}
+      disabled={isDisabled || !canUpdateInstanceState()}
       onClick={handleStart}
       type="button"
       aria-label={isLoading ? "Starting" : "Start"}
-      title="Start"
+      title={
+        canUpdateInstanceState()
+          ? "Start"
+          : "You do not have permission to start this instance"
+      }
     >
       <Icon
         className={classnames({ "u-animation--spin": isLoading })}

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -10,6 +10,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
+import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -21,6 +22,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
   const toastNotify = useToastNotification();
   const [isForce, setForce] = useState(false);
   const queryClient = useQueryClient();
+  const { canUpdateInstanceState } = useInstanceEntitlements(instance);
 
   const clearCache = () => {
     void queryClient.invalidateQueries({
@@ -76,7 +78,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
     <ConfirmationButton
       appearance="base"
       loading={isLoading}
-      disabled={isDisabled}
+      disabled={isDisabled || !canUpdateInstanceState()}
       confirmationModalProps={{
         title: "Confirm stop",
         children: (
@@ -89,7 +91,9 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
         ),
         onConfirm: handleStop,
         close: () => setForce(false),
-        confirmButtonLabel: "Stop",
+        confirmButtonLabel: canUpdateInstanceState()
+          ? "Stop"
+          : "You do not have permission to stop this instance",
       }}
       className="has-icon is-dense"
       shiftClickEnabled

--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -11,7 +11,7 @@ import {
   Select,
 } from "@canonical/react-components";
 import * as Yup from "yup";
-import { createInstance, fetchInstances } from "api/instances";
+import { createInstance } from "api/instances";
 import { isClusteredServer } from "util/settings";
 import { useSettings } from "context/useSettings";
 import { useQuery } from "@tanstack/react-query";
@@ -25,6 +25,7 @@ import ClusterMemberSelector from "pages/cluster/ClusterMemberSelector";
 import ResourceLabel from "components/ResourceLabel";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { InstanceIconType } from "components/ResourceIcon";
+import { useInstances } from "context/useInstances";
 
 interface Props {
   instance: LxdInstance;
@@ -100,10 +101,7 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
     queryFn: () => fetchStoragePools(),
   });
 
-  const { data: instances = [] } = useQuery({
-    queryKey: [queryKeys.instances],
-    queryFn: () => fetchInstances(instance.project),
-  });
+  const { data: instances = [] } = useInstances(instance.project);
 
   const notifySuccess = (
     name: string,

--- a/src/pages/instances/forms/DuplicateInstanceForm.tsx
+++ b/src/pages/instances/forms/DuplicateInstanceForm.tsx
@@ -11,7 +11,7 @@ import {
   Select,
 } from "@canonical/react-components";
 import * as Yup from "yup";
-import { createInstance, fetchInstances } from "api/instances";
+import { createInstance } from "api/instances";
 import { isClusteredServer } from "util/settings";
 import { useSettings } from "context/useSettings";
 import { useQuery } from "@tanstack/react-query";
@@ -28,6 +28,7 @@ import ResourceLink from "components/ResourceLink";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { InstanceIconType } from "components/ResourceIcon";
 import StoragePoolSelector from "pages/storage/StoragePoolSelector";
+import { useInstances } from "context/useInstances";
 
 interface Props {
   instance: LxdInstance;
@@ -62,10 +63,7 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
     queryFn: () => fetchStoragePools(),
   });
 
-  const { data: instances = [] } = useQuery({
-    queryKey: [queryKeys.instances],
-    queryFn: () => fetchInstances(instance.project),
-  });
+  const { data: instances = [] } = useInstances(instance.project);
 
   const notifySuccess = (
     name: string,

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -104,4 +104,5 @@ export interface LxdInstance {
   status: LxdInstanceStatus;
   type: "container" | "virtual-machine";
   etag?: string;
+  access_entitlements?: string[];
 }

--- a/src/types/permissions.d.ts
+++ b/src/types/permissions.d.ts
@@ -11,6 +11,7 @@ export interface LxdIdentity {
   groups?: string[] | null;
   effective_groups?: string[];
   effective_permissions?: LxdPermission[];
+  fine_grained: boolean;
 }
 
 export interface LxdGroup {

--- a/src/util/entitlements/api.tsx
+++ b/src/util/entitlements/api.tsx
@@ -1,0 +1,14 @@
+export const withEntitlementsQuery = (
+  isFineGrained: boolean | null,
+  entitlements: string[],
+): string => {
+  if (isFineGrained === null) {
+    throw new Error("Resource API fetch disabled if isFineGrained is null");
+  }
+
+  if (!entitlements.length || !isFineGrained) {
+    return "";
+  }
+
+  return `with-access-entitlements=${entitlements.join(",")}`;
+};

--- a/src/util/entitlements/helpers.tsx
+++ b/src/util/entitlements/helpers.tsx
@@ -1,0 +1,13 @@
+export const hasEntitlement = (
+  isFineGrained: boolean | null,
+  entitlement: string,
+  grantedEntitlements?: string[],
+): boolean => {
+  // if isFineGrained is null, we are still awaiting the api response to determine if the user has fine grained entitlements
+  // in this case, we should grant access to the user assuming they have sufficient permission
+  if (isFineGrained === null) {
+    return true;
+  }
+
+  return !isFineGrained || (grantedEntitlements || []).includes(entitlement);
+};

--- a/src/util/entitlements/instances.tsx
+++ b/src/util/entitlements/instances.tsx
@@ -1,0 +1,18 @@
+import { useAuth } from "context/auth";
+import { LxdInstance } from "types/instance";
+import { hasEntitlement } from "./helpers";
+
+export const useInstanceEntitlements = (instance: LxdInstance) => {
+  const { isFineGrained } = useAuth();
+
+  const canUpdateInstanceState = () =>
+    hasEntitlement(
+      isFineGrained,
+      "can_update_state",
+      instance?.access_entitlements,
+    );
+
+  return {
+    canUpdateInstanceState,
+  };
+};

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -26,4 +26,5 @@ export const queryKeys = {
   authGroups: "authGroups",
   idpGroups: "idpGroups",
   permissions: "permissions",
+  currentIdentity: "currentIdentity",
 };


### PR DESCRIPTION
## Done

- Check if user is restricted by using `/1.0/identities/current` endpoint
- Wrap `fetchInstances` and `fetchInstance` inside custom hooks to apply entitlement query params if the user is restricted
- Setup custom hook for checking instance entitlements
- Applied entitlement checks for instance state action buttons on the instance list page.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that for a non-restricted user, the instance state action buttons are enabled
    - Check that for a restricted user, with limited permissions, the instance state action buttons are disabled.

## Screenshots
[Screencast from 30-01-2025 17:48:13.webm](https://github.com/user-attachments/assets/5abe9878-7da6-4ffb-b5be-e864a1c87344)
