### PR TITLE
Avoid memory leak on uploading external instance files

### DIFF
--- a/src/util/uploadExternalFormatFile.tsx
+++ b/src/util/uploadExternalFormatFile.tsx
@@ -117,7 +117,10 @@ export const sendFileByWebSocket = (
         onProgress(sentFileSize, file.size);
       }
 
-      readNextFileChunk();
+      // setTimeout is used to prevent the stack from increasing and
+      // causing a memory leak on larger files,
+      // because readNextFileChunk is called recursively
+      setTimeout(readNextFileChunk, 0);
     };
 
     reader.onerror = (e) => {


### PR DESCRIPTION
## Done

- Avoid memory leak on uploading external instance files

Fixes #1087

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - upload a large external file on instance creation, monitor chromes memory usage