### PR TITLE
fix: prevent the instance file upload modal from closing when clicking on the backdrop

### DIFF
--- a/src/pages/instances/forms/UploadInstanceFileModal.tsx
+++ b/src/pages/instances/forms/UploadInstanceFileModal.tsx
@@ -21,6 +21,7 @@ const UploadInstanceFileModal: FC<Props> = ({ close, name }) => {
       close={close}
       className="upload-instance-modal"
       title="Upload instance file"
+      closeOnOutsideClick={false}
     >
       <NotificationRow className="u-no-padding u-no-margin" />
       {uploadState && (


### PR DESCRIPTION
## Done

- prevent the instance file upload modal from closing when clicking on the backdrop

Fixes #1086 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Upload a instance file (backup or external format) and try clicking outside the modal, it should not close the modal.