### PR TITLE
chore: update react to v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test-report-coverage": "cp coverage/unit/coverage-final.json coverage/playwright/ ; nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir coverage/playwright --report-dir coverage/playwright-report --exclude 'src/lib/**' --exclude 'src/types/**'"
   },
   "dependencies": {
-    "@canonical/react-components": "2.0.0",
+    "@canonical/react-components": "2.1.0",
     "@monaco-editor/react": "4.6.0",
     "@tanstack/react-query": "5.63.0",
     "axios": "1.7.9",
@@ -42,7 +42,6 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router-dom": "7.1.1",
-    "react-useportal": "1.0.19",
     "serve": "14.2.4",
     "vanilla-framework": "4.20.3",
     "xterm": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test-report-coverage": "cp coverage/unit/coverage-final.json coverage/playwright/ ; nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir coverage/playwright --report-dir coverage/playwright-report --exclude 'src/lib/**' --exclude 'src/types/**'"
   },
   "dependencies": {
-    "@canonical/react-components": "1.10.0",
+    "@canonical/react-components": "2.0.0",
     "@monaco-editor/react": "4.6.0",
     "@tanstack/react-query": "5.63.0",
     "axios": "1.7.9",
@@ -39,8 +39,8 @@
     "lodash.isequal": "4.5.0",
     "node-forge": "1.3.1",
     "parse-prometheus-text-format": "1.1.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
     "react-router-dom": "7.1.1",
     "react-useportal": "1.0.19",
     "serve": "14.2.4",
@@ -59,8 +59,8 @@
     "@types/dotenv": "8.2.3",
     "@types/lodash.isequal": "4.5.8",
     "@types/node-forge": "1.3.11",
-    "@types/react": "18.3.18",
-    "@types/react-dom": "18.3.5",
+    "@types/react": "19.0.8",
+    "@types/react-dom": "19.0.3",
     "@types/react-router-dom": "5.3.3",
     "@types/websocket": "1.0.10",
     "@typescript-eslint/eslint-plugin": "8.19.1",
@@ -108,6 +108,7 @@
     "src/**/*.scss": "stylelint"
   },
   "resolutions": {
-    "path-to-regexp": "8.2.0"
+    "path-to-regexp": "8.2.0",
+    "wrap-ansi": "7.0.0"
   }
 }

--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, ReactElement, ReactNode } from "react";
+import { cloneElement, ReactNode } from "react";
 import { Button, Icon, Label, Tooltip } from "@canonical/react-components";
 import type { CpuLimit, MemoryLimit } from "types/limits";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
@@ -35,7 +35,7 @@ interface Props {
   formik: ConfigurationRowFormikProps;
   name: string;
   label: string | ReactNode;
-  children: ReactElement;
+  children: React.JSX.Element;
   defaultValue?: string | CpuLimit | MemoryLimit | boolean;
   disabled?: boolean;
   disabledReason?: string;

--- a/src/components/forms/SelectGPUBtn.tsx
+++ b/src/components/forms/SelectGPUBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import SelectGPUModal from "components/forms/SelectGPUModal";
 import type { GpuCard } from "types/resources";
 

--- a/src/components/forms/YamlSwitch.tsx
+++ b/src/components/forms/YamlSwitch.tsx
@@ -6,7 +6,7 @@ import {
   MAIN_CONFIGURATION,
   YAML_CONFIGURATION,
 } from "pages/instances/forms/InstanceFormMenu";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { FormikProps } from "formik/dist/types";
 import classnames from "classnames";
 
@@ -28,7 +28,7 @@ const YamlSwitch: FC<Props> = ({
 
   const isChecked = slugify(section ?? "") === slugify(YAML_CONFIGURATION);
 
-  const handleSwitch = (e: FormEvent) => {
+  const handleSwitch = (e: FormEvent<HTMLInputElement>) => {
     if (yamlFormik.values.yaml) {
       return openPortal(e);
     }

--- a/src/pages/images/actions/SelectImageBtn.tsx
+++ b/src/pages/images/actions/SelectImageBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import type { LxdImageType, RemoteImage } from "types/image";
 import ImageSelector from "pages/images/ImageSelector";
 

--- a/src/pages/images/actions/UploadCustomIsoBtn.tsx
+++ b/src/pages/images/actions/UploadCustomIsoBtn.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Button, Icon, Modal } from "@canonical/react-components";
 import UploadCustomIso from "pages/storage/UploadCustomIso";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useToastNotification } from "context/toastNotificationProvider";

--- a/src/pages/images/actions/UploadImageBtn.tsx
+++ b/src/pages/images/actions/UploadImageBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import UploadImageForm from "./forms/UploadImageForm";
 import { useSmallScreen } from "context/useSmallScreen";
 

--- a/src/pages/images/actions/UseCustomIsoBtn.tsx
+++ b/src/pages/images/actions/UseCustomIsoBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import type { LxdImageType, RemoteImage } from "types/image";
 import CustomIsoModal from "pages/images/CustomIsoModal";
 

--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -7,7 +7,7 @@ import { getInstanceEditValues, getInstancePayload } from "util/instanceEdit";
 import type { LxdIsoDevice } from "types/device";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import type { RemoteImage } from "types/image";
 import CustomIsoModal from "pages/images/CustomIsoModal";
 import { remoteImageToIsoDevice } from "util/formDevices";

--- a/src/pages/instances/actions/CreateImageFromInstanceBtn.tsx
+++ b/src/pages/instances/actions/CreateImageFromInstanceBtn.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import type { LxdInstance } from "types/instance";
 import { ActionButton, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import CreateImageFromInstanceForm from "../forms/CreateImageFromInstanceForm";
 import { useInstanceLoading } from "context/instanceLoading";
 import classNames from "classnames";

--- a/src/pages/instances/actions/DuplicateInstanceBtn.tsx
+++ b/src/pages/instances/actions/DuplicateInstanceBtn.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import type { LxdInstance } from "types/instance";
 import { Button, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import DuplicateInstanceForm from "../forms/DuplicateInstanceForm";
 import classNames from "classnames";
 

--- a/src/pages/instances/actions/MigrateInstanceBtn.tsx
+++ b/src/pages/instances/actions/MigrateInstanceBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { ActionButton, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
 import { useInstanceLoading } from "context/instanceLoading";
 import MigrateInstanceModal from "../MigrateInstanceModal";

--- a/src/pages/instances/actions/UploadInstanceFileBtn.tsx
+++ b/src/pages/instances/actions/UploadInstanceFileBtn.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import { Button } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import UploadInstanceFileModal from "../forms/UploadInstanceFileModal";
 
 interface Props {

--- a/src/pages/instances/actions/snapshots/CreateImageFromInstanceSnapshotBtn.tsx
+++ b/src/pages/instances/actions/snapshots/CreateImageFromInstanceSnapshotBtn.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdInstance, LxdInstanceSnapshot } from "types/instance";
 import CreateImageFromInstanceSnapshotForm from "pages/instances/forms/CreateImageFromInstanceSnapshotForm";

--- a/src/pages/instances/actions/snapshots/CreateInstanceFromSnapshotBtn.tsx
+++ b/src/pages/instances/actions/snapshots/CreateInstanceFromSnapshotBtn.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import type { LxdInstance, LxdInstanceSnapshot } from "types/instance";
 import { Button, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import CreateInstanceFromSnapshotForm from "../../forms/CreateInstanceFromSnapshotForm";
 
 interface Props {

--- a/src/pages/instances/actions/snapshots/InstanceAddSnapshotBtn.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceAddSnapshotBtn.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { Button, Tooltip } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
 import CreateInstanceSnapshotForm from "pages/instances/forms/CreateInstanceSnapshotForm";

--- a/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotsBtn.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotsBtn.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import InstanceConfigureSnapshotModal from "./InstanceConfigureSnapshotModal";
 import { Button } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";

--- a/src/pages/instances/actions/snapshots/InstanceEditSnapshotBtn.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceEditSnapshotBtn.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdInstance, LxdInstanceSnapshot } from "types/instance";
 import EditInstanceSnapshotForm from "pages/instances/forms/EditInstanceSnapshotForm";

--- a/src/pages/permissions/CreateTlsIdentityBtn.tsx
+++ b/src/pages/permissions/CreateTlsIdentityBtn.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon } from "@canonical/react-components";
 import { useSmallScreen } from "context/useSmallScreen";
 import { FC } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import CreateIdentityModal from "./CreateIdentityModal";
 
 const CreateTlsIdentityBtn: FC = () => {

--- a/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
+++ b/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import type { IdpGroup } from "types/permissions";
 import DeleteIdpGroupsModal from "./DeleteIdpGroupsModal";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 
 interface Props {
   idpGroup: IdpGroup;

--- a/src/pages/permissions/actions/GroupActions.tsx
+++ b/src/pages/permissions/actions/GroupActions.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, List } from "@canonical/react-components";
 import type { LxdGroup } from "types/permissions";
 import usePanelParams from "util/usePanelParams";
 import DeleteGroupModal from "./DeleteGroupModal";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 
 interface Props {
   group: LxdGroup;

--- a/src/pages/permissions/panels/PermissionSelector.tsx
+++ b/src/pages/permissions/panels/PermissionSelector.tsx
@@ -36,9 +36,9 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
   const permissionSelectorRef = useRef<HTMLDivElement>(null);
 
   // Refs for select components, these contain methods to open/close the dropdown programmatically
-  const resourceTypeRef = useRef<SelectRef["current"]>();
-  const resourceRef = useRef<SelectRef["current"]>();
-  const entitlementRef = useRef<SelectRef["current"]>();
+  const resourceTypeRef = useRef<SelectRef["current"]>(null);
+  const resourceRef = useRef<SelectRef["current"]>(null);
+  const entitlementRef = useRef<SelectRef["current"]>(null);
 
   const {
     data: permissions,
@@ -196,7 +196,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
         aria-label="Resource type"
         onChange={handleResourceTypeChange}
         value={resourceType}
-        selectRef={resourceTypeRef}
+        selectRef={resourceTypeRef as SelectRef}
         searchable="always"
       />
       <CustomSelect
@@ -216,7 +216,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
         }
         dropdownClassName="permissions-select-dropdown"
         header={<ResourceOptionHeader resourceType={resourceType} />}
-        selectRef={resourceRef}
+        selectRef={resourceRef as SelectRef}
         searchable="always"
       />
       <CustomSelect
@@ -230,7 +230,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission }) => {
         value={entitlement}
         disabled={isLoading || (!resource && !isServerResourceType)}
         dropdownClassName="permissions-select-dropdown"
-        selectRef={entitlementRef}
+        selectRef={entitlementRef as SelectRef}
         searchable="always"
         initialPosition="right"
       />

--- a/src/pages/storage/AttachDiskDeviceBtn.tsx
+++ b/src/pages/storage/AttachDiskDeviceBtn.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from "react";
 import { Button, ButtonProps } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import AttachDiskDeviceModal from "./AttachDiskDeviceModal";
 import type { LxdDiskDevice } from "types/device";

--- a/src/pages/storage/CustomVolumeSelectBtn.tsx
+++ b/src/pages/storage/CustomVolumeSelectBtn.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from "react";
 import { Button, ButtonProps } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import CustomVolumeModal from "pages/storage/CustomVolumeModal";
 import { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import type { LxdStorageVolume } from "types/storage";

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from "react";
 import { ActionButton, Icon } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useEventQueue } from "context/eventQueue";

--- a/src/pages/storage/actions/DuplicateVolumeBtn.tsx
+++ b/src/pages/storage/actions/DuplicateVolumeBtn.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import DuplicateVolumeForm from "../forms/DuplicateVolumeForm";
 import type { LxdStorageVolume } from "types/storage";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 
 interface Props {
   volume: LxdStorageVolume;

--- a/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import type { LxdStorageVolume } from "types/storage";
 import { Button, Icon, Tooltip } from "@canonical/react-components";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import CreateVolumeSnapshotForm from "pages/storage/forms/CreateVolumeSnapshotForm";
 
 interface Props {

--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { Button } from "@canonical/react-components";
 import VolumeConfigureSnapshotModal from "./VolumeConfigureSnapshotModal";
 import type { LxdStorageVolume } from "types/storage";

--- a/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import usePortal from "react-useportal";
+import { usePortal } from "@canonical/react-components";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdStorageVolume, LxdVolumeSnapshot } from "types/storage";
 import EditVolumeSnapshotForm from "pages/storage/forms/EditVolumeSnapshotForm";

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,15 +313,15 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@canonical/react-components@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-1.10.0.tgz#ee9ec026932b592b4ea6f11a4820a05dadcfd97f"
-  integrity sha512-BQHnVJ1qLB/bGC1ZcyVCLYsJ1QzweEZMlMVZWTTq9lCJ+J+SJe9x5Zg+chheH6LfZlVaLHR2hkOUPYQRU20FIg==
+"@canonical/react-components@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.0.0.tgz#33f6f5e425e5966525ea4ac2120567cf329f6f6b"
+  integrity sha512-scmMyOcJ3Le2EPLu/rQE1j7WHLxXUH7X84zrmkTjaWu0qAKbdgOdGQfvr0ASswjaLKNpUVoinrn/LA2nPF/t+A==
   dependencies:
     "@types/jest" "29.5.14"
     "@types/node" "20.17.13"
-    "@types/react" "18.3.18"
-    "@types/react-dom" "18.3.5"
+    "@types/react" "19.0.8"
+    "@types/react-dom" "19.0.3"
     "@types/react-table" "7.7.20"
     classnames "2.5.1"
     jest-environment-jsdom "29.7.0"
@@ -1234,10 +1234,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
   integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
 
-"@types/react-dom@18.3.5":
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
-  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
+"@types/react-dom@19.0.3":
+  version "19.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.3.tgz#0804dfd279a165d5a0ad8b53a5b9e65f338050a4"
+  integrity sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==
 
 "@types/react-router-dom@5.3.3":
   version "5.3.3"
@@ -1271,12 +1271,11 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@18.3.18":
-  version "18.3.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
-  integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
+"@types/react@19.0.8":
+  version "19.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.8.tgz#7098e6159f2a61e4f4cef2c1223c044a9bec590e"
+  integrity sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==
   dependencies:
-    "@types/prop-types" "*"
     csstype "^3.0.2"
 
 "@types/stack-utils@^2.0.0":
@@ -1599,7 +1598,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -4368,7 +4367,7 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5146,13 +5145,12 @@ rc@^1.0.1, rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@18.3.1:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
-  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
+react-dom@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.0.0.tgz#43446f1f01c65a4cd7f7588083e686a6726cfb57"
+  integrity sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==
   dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.2"
+    scheduler "^0.25.0"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"
@@ -5203,12 +5201,10 @@ react-useportal@1.0.19:
   dependencies:
     use-ssr "^1.0.25"
 
-react@18.3.1:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
-  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
-  dependencies:
-    loose-envify "^1.1.0"
+react@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.0.0.tgz#6e1969251b9f108870aa4bff37a0ce9ddfaaabdd"
+  integrity sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -5474,12 +5470,10 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.23.2:
-  version "0.23.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
-  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
-  dependencies:
-    loose-envify "^1.1.0"
+scheduler@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0.tgz#336cd9768e8cceebf52d3c80e3dcf5de23e7e015"
+  integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
 
 semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
@@ -5743,16 +5737,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5857,14 +5842,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6645,7 +6623,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.0.1, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6653,42 +6631,6 @@ word-wrap@^1.2.5:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
-
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
-  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
-  dependencies:
-    ansi-styles "^6.1.0"
-    string-width "^5.0.1"
-    strip-ansi "^7.0.1"
-
-wrap-ansi@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
-  integrity sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==
-  dependencies:
-    ansi-styles "^6.2.1"
-    string-width "^7.0.0"
-    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,10 +313,10 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@canonical/react-components@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.0.0.tgz#33f6f5e425e5966525ea4ac2120567cf329f6f6b"
-  integrity sha512-scmMyOcJ3Le2EPLu/rQE1j7WHLxXUH7X84zrmkTjaWu0qAKbdgOdGQfvr0ASswjaLKNpUVoinrn/LA2nPF/t+A==
+"@canonical/react-components@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.1.0.tgz#439d5ca03b009b0c0ad72c8bb5170857bbecce86"
+  integrity sha512-OaZcQmwoXj25kCvOxYhaJQhUc4CX8t5pVbuqb+t2ELfREVRvlTnKAxMHeuAyihK81FQ712M8ziiKfybp2mNZYg==
   dependencies:
     "@types/jest" "29.5.14"
     "@types/node" "20.17.13"
@@ -328,7 +328,6 @@
     lodash.isequal "4.5.0"
     prop-types "15.8.1"
     react-table "7.8.0"
-    react-useportal "1.0.19"
 
 "@canonical/typescript-config-base@^0.4.0-experimental.0":
   version "0.4.0-experimental.0"
@@ -5194,13 +5193,6 @@ react-table@7.8.0:
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
   integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
 
-react-useportal@1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.19.tgz#473168f1a1c4009833d49a46b05d974a5850a166"
-  integrity sha512-gXXxBu/j+gQrghUh5l0/GJxy3MoRxQRX0P3jpNI8c+4v/ey1ZGW3Tqh/wTYgBs8NdumvaYe+IiKGMYntEv07CA==
-  dependencies:
-    use-ssr "^1.0.25"
-
 react@19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.0.0.tgz#6e1969251b9f108870aa4bff37a0ce9ddfaaabdd"
@@ -6345,11 +6337,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-ssr@^1.0.25:
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.25.tgz#c7f54b59d6e52db26749b1d4115a650101a190bd"
-  integrity sha512-VYF8kJKI+X7+U4XgGoUER2BUl0vIr+8OhlIhyldgSGE0KHMoDRXPvWeHUUeUktq7ACEOVLzXGq1+QRxcvtwvyQ==
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Done

- Upgraded react to v19 with latest react-components 2.0.0 release

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes
    - Spot check demo server app