### PR TITLE
Iterate on pool config forms for pure and powerflex drivers

### DIFF
--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -11,6 +11,7 @@ import { queryKeys } from "util/queryKeys";
 import { zfsDriver } from "util/storageOptions";
 import {
   isPowerflexIncomplete,
+  isPureStorageIncomplete,
   testDuplicateStoragePoolName,
 } from "util/storagePool";
 import StoragePoolForm, {
@@ -139,7 +140,8 @@ const CreateStoragePool: FC = () => {
           disabled={
             !formik.isValid ||
             !formik.values.name ||
-            isPowerflexIncomplete(formik)
+            isPowerflexIncomplete(formik) ||
+            isPureStorageIncomplete(formik)
           }
           onClick={() => void formik.submitForm()}
         >

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -14,6 +14,7 @@ import StoragePoolFormMenu, {
   CEPHFS_CONFIGURATION,
   MAIN_CONFIGURATION,
   POWERFLEX,
+  PURE_STORAGE,
   YAML_CONFIGURATION,
   ZFS_CONFIGURATION,
 } from "./StoragePoolFormMenu";
@@ -42,6 +43,7 @@ import { useSettings } from "context/useSettings";
 import { ensureEditMode } from "util/instanceEdit";
 import StoragePoolFormCephFS from "pages/storage/forms/StoragePoolFormCephFS";
 import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
+import StoragePoolFormPure from "pages/storage/forms/StoragePoolFormPure";
 
 export interface StoragePoolFormValues {
   barePool?: LxdStoragePool;
@@ -74,6 +76,7 @@ export interface StoragePoolFormValues {
   pure_gateway?: string;
   pure_gateway_verify?: string;
   pure_mode?: string;
+  pure_target?: string;
   readOnly: boolean;
   size?: string;
   source: string;
@@ -143,6 +146,7 @@ export const toStoragePool = (
         [getPoolKey("pure_gateway")]: values.pure_gateway,
         [getPoolKey("pure_gateway_verify")]: values.pure_gateway_verify,
         [getPoolKey("pure_mode")]: values.pure_mode,
+        [getPoolKey("pure_target")]: values.pure_target,
       };
     }
     if (isZFSDriver) {
@@ -243,6 +247,9 @@ const StoragePoolForm: FC<Props> = ({
           )}
           {section === slugify(POWERFLEX) && (
             <StoragePoolFormPowerflex formik={formik} />
+          )}
+          {section === slugify(PURE_STORAGE) && (
+            <StoragePoolFormPure formik={formik} />
           )}
           {section === slugify(ZFS_CONFIGURATION) && (
             <StoragePoolFormZFS formik={formik} />

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -15,11 +15,14 @@ import {
 import { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
-import { getCephPoolFormFields } from "util/storagePool";
+import {
+  getCephPoolFormFields,
+  getPowerflexPoolFormFields,
+  getPureStoragePoolFormFields,
+} from "util/storagePool";
 import { useSettings } from "context/useSettings";
 import ScrollableForm from "components/ScrollableForm";
 import { ensureEditMode } from "util/instanceEdit";
-import { optionTrueFalse } from "util/instanceOptions";
 import StoragePoolClusteredSourceSelector from "./StoragePoolClusteredSourceSelector";
 import { isClusteredServer } from "util/settings";
 
@@ -102,6 +105,18 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
               if (val !== cephDriver) {
                 const cephFields = getCephPoolFormFields();
                 for (const field of cephFields) {
+                  void formik.setFieldValue(field, undefined);
+                }
+              }
+              if (val !== powerFlex) {
+                const powerflexFields = getPowerflexPoolFormFields();
+                for (const field of powerflexFields) {
+                  void formik.setFieldValue(field, undefined);
+                }
+              }
+              if (val !== pureStorage) {
+                const pureFields = getPureStoragePoolFormFields();
+                for (const field of pureFields) {
                   void formik.setFieldValue(field, undefined);
                 }
               }
@@ -239,40 +254,6 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                   formik.handleChange(e);
                 }}
                 required
-              />
-              <Select
-                {...formik.getFieldProps("pure_gateway_verify")}
-                label="Verify gateway"
-                help="Whether to verify the PureStorage certificate. Set this option to false for self-signed certs, or add the cert to the OS trust store."
-                options={optionTrueFalse}
-                onChange={(e) => {
-                  ensureEditMode(formik);
-                  formik.handleChange(e);
-                }}
-              />
-              <Select
-                {...formik.getFieldProps("pure_mode")}
-                label="Mode"
-                help="Whether to use nvme or iscsi to connect to Pure Storage array."
-                options={[
-                  {
-                    label: "Select option",
-                    value: "",
-                    disabled: true,
-                  },
-                  {
-                    label: "NVME",
-                    value: "nvme",
-                  },
-                  {
-                    label: "ISCSI",
-                    value: "iscsi",
-                  },
-                ]}
-                onChange={(e) => {
-                  ensureEditMode(formik);
-                  formik.handleChange(e);
-                }}
               />
             </>
           )}

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -9,9 +9,13 @@ import {
   cephDriver,
   cephFSDriver,
   powerFlex,
+  pureStorage,
   zfsDriver,
 } from "util/storageOptions";
-import { isPowerflexIncomplete } from "util/storagePool";
+import {
+  isPowerflexIncomplete,
+  isPureStorageIncomplete,
+} from "util/storagePool";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const CEPH_CONFIGURATION = "Ceph";
@@ -43,13 +47,22 @@ const StoragePoolFormMenu: FC<Props> = ({
   const isCephDriver = formik.values.driver === cephDriver;
   const isCephFSDriver = formik.values.driver === cephFSDriver;
   const isPowerFlexDriver = formik.values.driver === powerFlex;
+  const isPureDriver = formik.values.driver === pureStorage;
   const isZfsDriver = formik.values.driver === zfsDriver;
   const hasName = formik.values.name.length > 0;
-  const disableReason = hasName
-    ? isPowerflexIncomplete(formik)
-      ? "Please enter a domain, gateway, pool, and user name to enable this section"
-      : undefined
-    : "Please enter a storage pool name to enable this section";
+  const getDisableReason = () => {
+    if (!hasName) {
+      return "Please enter a storage pool name to enable this section";
+    }
+    if (isPowerflexIncomplete(formik)) {
+      return "Please enter a domain, gateway, pool, and user name to enable this section";
+    }
+    if (isPureStorageIncomplete(formik)) {
+      return "Please enter an API token and gateway to enable this section";
+    }
+    return undefined;
+  };
+  const disableReason = getDisableReason();
 
   const resize = () => {
     updateMaxHeight("form-navigation", "p-bottom-controls");
@@ -81,6 +94,13 @@ const StoragePoolFormMenu: FC<Props> = ({
           {isPowerFlexDriver && (
             <MenuItem
               label={POWERFLEX}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
+          {isPureDriver && (
+            <MenuItem
+              label={PURE_STORAGE}
               {...menuItemProps}
               disableReason={disableReason}
             />

--- a/src/pages/storage/forms/StoragePoolFormPure.tsx
+++ b/src/pages/storage/forms/StoragePoolFormPure.tsx
@@ -3,48 +3,42 @@ import { FC } from "react";
 import { StoragePoolFormValues } from "./StoragePoolForm";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import { Input, Select } from "@canonical/react-components";
-import { optionNvmeSdc, optionTrueFalse } from "util/instanceOptions";
+import { optionIscsiNvme, optionTrueFalse } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
-const StoragePoolFormPowerflex: FC<Props> = ({ formik }) => {
+const StoragePoolFormPure: FC<Props> = ({ formik }) => {
   return (
     <ScrollableConfigurationTable
       rows={[
         getConfigurationRow({
           formik,
-          label: "Clone copy",
-          name: "powerflex_clone_copy",
-          defaultValue: "",
-          children: <Select options={optionTrueFalse} />,
-        }),
-        getConfigurationRow({
-          formik,
-          label: "SDT",
-          name: "powerflex_sdt",
-          defaultValue: "",
-          children: <Input type="text" />,
-        }),
-        getConfigurationRow({
-          formik,
           label: "Gateway verify",
-          name: "powerflex_gateway_verify",
+          name: "pure_gateway_verify",
           defaultValue: "",
           children: <Select options={optionTrueFalse} />,
         }),
         getConfigurationRow({
           formik,
           label: "Mode",
-          name: "powerflex_mode",
+          name: "pure_mode",
           defaultValue: "",
-          children: <Select options={optionNvmeSdc} />,
+          disabled: !formik.values.isCreating,
+          children: <Select options={optionIscsiNvme} />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Target",
+          name: "pure_target",
+          defaultValue: "",
+          children: <Input type="text" />,
         }),
       ]}
     />
   );
 };
 
-export default StoragePoolFormPowerflex;
+export default StoragePoolFormPure;

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -120,3 +120,35 @@ export const clusterEvacuationOptions = [
     value: "stop",
   },
 ];
+
+export const optionIscsiNvme = [
+  {
+    label: "Select option",
+    value: "",
+    disabled: true,
+  },
+  {
+    label: "iSCSI",
+    value: "iscsi",
+  },
+  {
+    label: "NVMe over TCP",
+    value: "nvme",
+  },
+];
+
+export const optionNvmeSdc = [
+  {
+    label: "Select option",
+    value: "",
+    disabled: true,
+  },
+  {
+    label: "NVMe over TCP",
+    value: "nvme",
+  },
+  {
+    label: "Dell Storage Data Client",
+    value: "sdc",
+  },
+];

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -3,7 +3,7 @@ import { AnyObject, TestFunction } from "yup";
 import type { LxdConfigOptionsKeys } from "types/config";
 import { FormikProps } from "formik";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
-import { powerFlex } from "util/storageOptions";
+import { powerFlex, pureStorage } from "util/storageOptions";
 
 export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   ceph_cluster_name: "ceph.cluster_name",
@@ -30,6 +30,7 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   pure_gateway: "pure.gateway",
   pure_gateway_verify: "pure.gateway.verify",
   pure_mode: "pure.mode",
+  pure_target: "pure.target",
   zfs_clone_copy: "zfs.clone_copy",
   zfs_export: "zfs.export",
   zfs_pool_name: "zfs.pool_name",
@@ -47,6 +48,18 @@ export const getPoolKey = (formField: string): string => {
 export const getCephPoolFormFields = () => {
   return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
     item.startsWith("ceph_"),
+  );
+};
+
+export const getPowerflexPoolFormFields = () => {
+  return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
+    item.startsWith("powerflex_"),
+  );
+};
+
+export const getPureStoragePoolFormFields = () => {
+  return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
+    item.startsWith("pure_"),
   );
 };
 
@@ -96,5 +109,14 @@ export const isPowerflexIncomplete = (
     (!formik.values.powerflex_pool ||
       !formik.values.powerflex_gateway ||
       !formik.values.powerflex_user_password)
+  );
+};
+
+export const isPureStorageIncomplete = (
+  formik: FormikProps<StoragePoolFormValues>,
+): boolean => {
+  return (
+    formik.values.driver === pureStorage &&
+    (!formik.values.pure_gateway || !formik.values.pure_api_token)
   );
 };

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -48,6 +48,7 @@ export const toStoragePoolFormValues = (
     pure_gateway: pool.config?.["pure.gateway"],
     pure_gateway_verify: pool.config?.["pure.gateway.verify"],
     pure_mode: pool.config?.["pure.mode"],
+    pure_target: pool.config?.["pure.target"],
     zfs_clone_copy: pool.config?.["zfs.clone_copy"],
     zfs_export: pool.config?.["zfs.export"],
     zfs_pool_name: pool.config?.["zfs.pool_name"],


### PR DESCRIPTION
## Done

1. Introduce a separate section for optional config keys of the pure storage pool driver configuration.
2. Add "target" option for pure storage pool driver.
3. Add "mode" field for powerflex storage pool driver.
4. Ensure state fields for a driver get wiped when changing to another driver in the storage pool form.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test pure and powerflex storage pool driver configuration.

## Screenshots

### Powerflex

![image](https://github.com/user-attachments/assets/6c17de64-c3f1-492f-83d5-c2a710f1fda1)
![image](https://github.com/user-attachments/assets/f79a8a5d-4521-4e17-a684-3ff288291c6c)
![image](https://github.com/user-attachments/assets/8a2e65cc-ebc3-4ebb-a72f-a6dc5fb8a48c)


### Pure
![image](https://github.com/user-attachments/assets/7535096e-ea5b-456d-b6f6-bb2b4095f3fe)
![image](https://github.com/user-attachments/assets/8db570db-a059-4dea-8dff-f73d6356a62d)
