### PR TITLE
fix: setup lxd with group "lxd" in GH actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,6 +99,7 @@ jobs:
         uses: canonical/setup-lxd@v0.1.2
         with:
           channel: ${{ matrix.lxd_channel }}
+          group: lxd
 
       - name: Setup LXD
         shell: bash
@@ -127,7 +128,7 @@ jobs:
       - name: Setup for tests
         if: ${{ matrix.lxd_channel != '5.0/edge' }}
         shell: bash
-        run: ./tests/scripts/setup_test
+        run: sudo -E ./tests/scripts/setup_test
 
       - name: Run Playwright tests
         run: npx playwright test --project ${{ matrix.browser }}:lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -17,14 +17,14 @@ test("login", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("login"));
   // remove tls certificate from trust store so we can test oidc login
   const fingerprint = execSync(
-    "lxc config trust list | grep lxd-ui.crt | awk '{print $8}'",
+    "sudo lxc config trust list | grep lxd-ui.crt | awk '{print $8}'",
   ).toString();
-  execSync(`lxc config trust remove ${fingerprint}`);
+  execSync(`sudo lxc config trust remove ${fingerprint}`);
 
   await gotoURL(page, "/ui/");
   await loginUser(page);
   await page.getByText("Log out").click();
 
   // add tls certificate to trust store so rest of tests can run correctly
-  execSync("lxc config trust add keys/lxd-ui.crt");
+  execSync("sudo lxc config trust add keys/lxd-ui.crt");
 });


### PR DESCRIPTION
## Done

- Fix issue with lxd group membership in github actions. It was failing the install LXD step previously for the latest/edge version of the lxd snap (something must have changed there).

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes