### PR TITLE
Ensure the size is unset, when selecting a storage pool driver without it, fix network form validation

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -114,11 +114,8 @@ export const createClusteredPool = (
           config: {
             ...memberPoolPayload.config,
             source: sourcePerClusterMember?.[item.server_name],
-
             size: sizePerClusterMember?.[item.server_name],
-            ...(zfsPoolNamePerClusterMember?.[item.server_name] && {
-              "zfs.pool_name": zfsPoolNamePerClusterMember[item.server_name],
-            }),
+            "zfs.pool_name": zfsPoolNamePerClusterMember?.[item.server_name],
           },
         };
         return createPool(clusteredMemberPool, item.server_name);

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -63,13 +63,6 @@ const CreateNetwork: FC = () => {
         checkDuplicateName(value, project, controllerState, "networks"),
       )
       .required("Network name is required"),
-    network: Yup.string().test(
-      "required",
-      "Uplink network is required",
-      (value, context) =>
-        (context.parent as NetworkFormValues).networkType !== "ovn" ||
-        Boolean(value),
-    ),
   });
 
   const formik = useFormik<NetworkFormValues>({

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -72,7 +72,6 @@ export interface StoragePoolFormValues {
   powerflex_sdt?: string;
   powerflex_user_name?: string;
   powerflex_user_password?: string;
-  sizePerClusterMember?: ClusterSpecificValues;
   pure_api_token?: string;
   pure_gateway?: string;
   pure_gateway_verify?: string;
@@ -80,6 +79,7 @@ export interface StoragePoolFormValues {
   pure_target?: string;
   readOnly: boolean;
   size?: string;
+  sizePerClusterMember?: ClusterSpecificValues;
   source: string;
   sourcePerClusterMember?: ClusterSpecificValues;
   yaml?: string;

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -4,7 +4,6 @@ import { FormikProps } from "formik";
 import {
   zfsDriver,
   dirDriver,
-  btrfsDriver,
   getSourceHelpForDriver,
   cephDriver,
   getStorageDriverOptions,
@@ -19,6 +18,7 @@ import {
   getCephPoolFormFields,
   getPowerflexPoolFormFields,
   getPureStoragePoolFormFields,
+  getZfsStoragePoolFormFields,
 } from "util/storagePool";
 import { useSettings } from "context/useSettings";
 import ScrollableForm from "components/ScrollableForm";
@@ -26,7 +26,10 @@ import { ensureEditMode } from "util/instanceEdit";
 import ClusteredSourceSelector from "./ClusteredSourceSelector";
 import { isClusteredServer } from "util/settings";
 import ClusteredDiskSizeSelector from "components/forms/ClusteredDiskSizeSelector";
-import { isStoragePoolWithSize } from "util/storagePoolForm";
+import {
+  isStoragePoolWithSize,
+  isStoragePoolWithSource,
+} from "util/storagePoolForm";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -96,12 +99,6 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
             options={storageDriverOptions}
             onChange={(target) => {
               const val = target.target.value;
-              if (val === dirDriver) {
-                void formik.setFieldValue("size", "");
-              }
-              if (val === btrfsDriver) {
-                void formik.setFieldValue("source", "");
-              }
               if (val !== cephDriver) {
                 const cephFields = getCephPoolFormFields();
                 for (const field of cephFields) {
@@ -120,7 +117,21 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                   void formik.setFieldValue(field, undefined);
                 }
               }
-
+              if (val !== zfsDriver) {
+                const zfsFields = getZfsStoragePoolFormFields();
+                for (const field of zfsFields) {
+                  void formik.setFieldValue(field, undefined);
+                }
+                void formik.setFieldValue("zfsPoolNamePerClusterMember", "");
+              }
+              if (!isStoragePoolWithSize(val)) {
+                void formik.setFieldValue("size", undefined);
+                void formik.setFieldValue("sizePerClusterMember", undefined);
+              }
+              if (!isStoragePoolWithSource(val)) {
+                void formik.setFieldValue("source", undefined);
+                void formik.setFieldValue("sourcePerClusterMember", undefined);
+              }
               void formik.setFieldValue("driver", val);
             }}
             value={formik.values.driver}

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -63,6 +63,12 @@ export const getPureStoragePoolFormFields = () => {
   );
 };
 
+export const getZfsStoragePoolFormFields = () => {
+  return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
+    item.startsWith("zfs_"),
+  );
+};
+
 const storagePoolDriverToOptionKey: Record<string, LxdConfigOptionsKeys> = {
   dir: "storage-dir",
   btrfs: "storage-btrfs",

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -4,11 +4,30 @@ import type {
 } from "types/storage";
 import { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 import { ClusterSpecificValues } from "components/ClusterSpecificSelect";
-import { zfsDriver, btrfsDriver, lvmDriver } from "util/storageOptions";
+import {
+  zfsDriver,
+  btrfsDriver,
+  lvmDriver,
+  dirDriver,
+  cephDriver,
+  cephFSDriver,
+} from "util/storageOptions";
 
 export const isStoragePoolWithSize = (driver: string) => {
   const driversWithSize = [zfsDriver, lvmDriver, btrfsDriver];
   return driversWithSize.includes(driver);
+};
+
+export const isStoragePoolWithSource = (driver: string) => {
+  const driversWithSource = [
+    dirDriver,
+    btrfsDriver,
+    lvmDriver,
+    zfsDriver,
+    cephDriver,
+    cephFSDriver,
+  ];
+  return driversWithSource.includes(driver);
 };
 
 export const toStoragePoolFormValues = (


### PR DESCRIPTION
## Done

- Ensure the size is unset, when selecting a storage pool driver without it
- Simplify and unify the storage pool field reset on driver changes, decouple this from the api layer.
- Do not rely on formik for validating an uplink is selected for ovn networks. there is a custom validation in place.

Fixes #1101

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a storage pool, configure some fields like size, then switch to another driver that has no size and ensure it gets created fine. Especially test in cluster and non-cluster backends.
    - create a network of type bridge, enter name, select type ovn, then select type bridge. Ensure the create button is active.