### PR TITLE
Ensure the creating instances are displayed with the correct column width and span in a clustered backend

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -286,7 +286,11 @@ const InstanceList: FC = () => {
   const getRows = (hiddenCols: string[]): MainTableRow[] => {
     const spannedWidth = CREATION_SPAN_COLUMNS.filter(
       (col) => !hiddenCols.includes(col),
-    ).reduce((partialSum, col) => partialSum + COLUMN_WIDTHS[col], 0);
+    )
+      .concat(...(isClustered ? [CLUSTER_MEMBER] : []))
+      .reduce((partialSum, col) => partialSum + COLUMN_WIDTHS[col], 0);
+
+    const totalColumnCount = getHeaders(userHidden.concat(sizeHidden)).length;
 
     const creationRows: MainTableRow[] = creationOperations.map((operation) => {
       return {
@@ -301,7 +305,7 @@ const InstanceList: FC = () => {
             "aria-label": NAME,
             style: { width: `${COLUMN_WIDTHS[NAME]}px` },
           },
-          ...(hiddenCols.length < 5
+          ...(totalColumnCount > 3
             ? [
                 {
                   content: (
@@ -316,7 +320,7 @@ const InstanceList: FC = () => {
                     </i>
                   ),
                   role: "cell",
-                  colSpan: 5 - hiddenCols.length,
+                  colSpan: totalColumnCount - 3,
                   style: { width: `${spannedWidth}px` },
                 },
               ]


### PR DESCRIPTION
## Done

- Ensure the creating instances are displayed with the correct column width and span in a clustered backend

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create an instance in a clustered and non-clustered backend. Manually hide and unhide some columns in the instance table. Ensure the "creating instance" row in the instance table is aligned with the headers and other instance rows in all cases.