### PR TITLE
Ensure to fetch instance metrics from the right cluster member

### DIFF
--- a/src/api/metrics.tsx
+++ b/src/api/metrics.tsx
@@ -2,6 +2,8 @@ import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import type { LxdMetricGroup } from "types/metrics";
 
 export const fetchMetrics = (target: string): Promise<LxdMetricGroup[]> => {
+  // in a simple and non-clustered environment, the LXD api responds
+  // with instance.location as "none". Handle it, to avoid sending an invalid target
   const params = target === "none" ? "" : `?target=${target}`;
 
   return new Promise((resolve, reject) => {

--- a/src/api/metrics.tsx
+++ b/src/api/metrics.tsx
@@ -1,9 +1,11 @@
 import parsePrometheusTextFormat from "parse-prometheus-text-format";
 import type { LxdMetricGroup } from "types/metrics";
 
-export const fetchMetrics = (): Promise<LxdMetricGroup[]> => {
+export const fetchMetrics = (target: string): Promise<LxdMetricGroup[]> => {
+  const params = target === "none" ? "" : `?target=${target}`;
+
   return new Promise((resolve, reject) => {
-    fetch("/1.0/metrics")
+    fetch(`/1.0/metrics${params}`)
       .then((response) => {
         return response.text();
       })

--- a/src/context/useMetrics.tsx
+++ b/src/context/useMetrics.tsx
@@ -1,0 +1,18 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useAuth } from "./auth";
+import { queryKeys } from "util/queryKeys";
+import { fetchMetrics } from "api/metrics";
+import { LxdMetricGroup } from "types/metrics";
+
+export const useMetrics = (
+  location: string,
+): UseQueryResult<LxdMetricGroup[]> => {
+  const { isRestricted } = useAuth();
+
+  return useQuery({
+    queryKey: [queryKeys.metrics, location],
+    queryFn: () => fetchMetrics(location),
+    refetchInterval: 15 * 1000, // 15 seconds
+    enabled: !isRestricted,
+  });
+};

--- a/src/context/useMetrics.tsx
+++ b/src/context/useMetrics.tsx
@@ -3,16 +3,18 @@ import { useAuth } from "./auth";
 import { queryKeys } from "util/queryKeys";
 import { fetchMetrics } from "api/metrics";
 import { LxdMetricGroup } from "types/metrics";
+import { useServerEntitlements } from "util/entitlements/server";
 
 export const useMetrics = (
   location: string,
 ): UseQueryResult<LxdMetricGroup[]> => {
-  const { isRestricted } = useAuth();
+  const { isRestricted, isFineGrained } = useAuth();
+  const { canViewMetrics } = useServerEntitlements();
 
   return useQuery({
     queryKey: [queryKeys.metrics, location],
     queryFn: () => fetchMetrics(location),
     refetchInterval: 15 * 1000, // 15 seconds
-    enabled: !isRestricted,
+    enabled: !isRestricted && isFineGrained !== null && canViewMetrics(),
   });
 };

--- a/src/pages/instances/InstanceDisk.tsx
+++ b/src/pages/instances/InstanceDisk.tsx
@@ -1,26 +1,16 @@
 import { FC } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { fetchMetrics } from "api/metrics";
 import { humanFileSize } from "util/helpers";
 import { getInstanceMetrics } from "util/metricSelectors";
 import Meter from "components/Meter";
 import type { LxdInstance } from "types/instance";
-import { useAuth } from "context/auth";
+import { useMetrics } from "context/useMetrics";
 
 interface Props {
   instance: LxdInstance;
 }
 
 const InstanceUsageDisk: FC<Props> = ({ instance }) => {
-  const { isRestricted } = useAuth();
-
-  const { data: metrics = [] } = useQuery({
-    queryKey: [queryKeys.metrics],
-    queryFn: fetchMetrics,
-    refetchInterval: 15 * 1000, // 15 seconds
-    enabled: !isRestricted,
-  });
+  const { data: metrics = [] } = useMetrics(instance.location);
 
   const instanceMetrics = getInstanceMetrics(metrics, instance);
 

--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -1,13 +1,11 @@
 import { FC } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { fetchMetrics } from "api/metrics";
 import { getInstanceMetrics } from "util/metricSelectors";
 import Loader from "components/Loader";
 import type { LxdInstance } from "types/instance";
 import { useAuth } from "context/auth";
 import InstanceUsageMemory from "pages/instances/InstanceUsageMemory";
 import InstanceUsageDisk from "pages/instances/InstanceDisk";
+import { useMetrics } from "context/useMetrics";
 
 interface Props {
   instance: LxdInstance;
@@ -21,12 +19,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
     data: metrics = [],
     error,
     isLoading,
-  } = useQuery({
-    queryKey: [queryKeys.metrics],
-    queryFn: fetchMetrics,
-    refetchInterval: 15 * 1000, // 15 seconds
-    enabled: !isRestricted,
-  });
+  } = useMetrics(instance.location);
 
   if (error) {
     onFailure("Loading metrics failed", error);

--- a/src/pages/instances/InstanceUsageMemory.tsx
+++ b/src/pages/instances/InstanceUsageMemory.tsx
@@ -1,26 +1,16 @@
 import { FC } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { fetchMetrics } from "api/metrics";
 import { humanFileSize } from "util/helpers";
 import { getInstanceMetrics } from "util/metricSelectors";
 import Meter from "components/Meter";
 import type { LxdInstance } from "types/instance";
-import { useAuth } from "context/auth";
+import { useMetrics } from "context/useMetrics";
 
 interface Props {
   instance: LxdInstance;
 }
 
 const InstanceUsageMemory: FC<Props> = ({ instance }) => {
-  const { isRestricted } = useAuth();
-
-  const { data: metrics = [] } = useQuery({
-    queryKey: [queryKeys.metrics],
-    queryFn: fetchMetrics,
-    refetchInterval: 15 * 1000, // 15 seconds
-    enabled: !isRestricted,
-  });
+  const { data: metrics = [] } = useMetrics(instance.location);
 
   const instanceMetrics = getInstanceMetrics(metrics, instance);
 

--- a/src/util/entitlements/server.tsx
+++ b/src/util/entitlements/server.tsx
@@ -8,7 +8,13 @@ export const useServerEntitlements = () => {
     hasEntitlement(isFineGrained, "can_edit", serverEntitlements) ||
     hasEntitlement(isFineGrained, "admin", serverEntitlements);
 
+  const canViewMetrics = () =>
+    hasEntitlement(isFineGrained, "can_view_metrics", serverEntitlements) ||
+    hasEntitlement(isFineGrained, "admin", serverEntitlements) ||
+    hasEntitlement(isFineGrained, "viewer", serverEntitlements);
+
   return {
     canEditServerConfiguration,
+    canViewMetrics,
   };
 };


### PR DESCRIPTION
## Done

- Ensure to fetch instance metrics from the right cluster member
- Add permission handling of the metrics query

Fixes #1102 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run a clustered backend with instances running on different members
    - ensure the cpu and disk metrics in the instance list and instance detail page show properly
    - test the same on a non-clustered backend