### PR TITLE
Add hover text to instance metrics, surfacing details about cached memory and disk size

### DIFF
--- a/src/components/Meter.tsx
+++ b/src/components/Meter.tsx
@@ -5,16 +5,18 @@ interface Props {
   percentage: number;
   secondaryPercentage?: number;
   text: string;
+  hoverText?: string;
 }
 
 const Meter: FC<Props> = ({
   percentage,
   secondaryPercentage = 0,
   text,
+  hoverText,
 }: Props) => {
   return (
     <>
-      <div className="p-meter u-no-margin--bottom">
+      <div className="p-meter u-no-margin--bottom" title={hoverText}>
         <div
           style={{ width: `max(${percentage}%, 5px)` }}
           className={classnames({

--- a/src/pages/instances/InstanceDisk.tsx
+++ b/src/pages/instances/InstanceDisk.tsx
@@ -13,25 +13,26 @@ const InstanceUsageDisk: FC<Props> = ({ instance }) => {
   const { data: metrics = [] } = useMetrics(instance.location);
 
   const instanceMetrics = getInstanceMetrics(metrics, instance);
+  const disk = instanceMetrics.disk;
 
-  return instanceMetrics.disk ? (
+  if (!disk) {
+    return "";
+  }
+
+  const used = disk.total - disk.free;
+
+  return (
     <div>
       <Meter
-        percentage={
-          (100 / instanceMetrics.disk.total) *
-          (instanceMetrics.disk.total - instanceMetrics.disk.free)
-        }
+        percentage={(100 / disk.total) * used}
         text={
-          humanFileSize(
-            instanceMetrics.disk.total - instanceMetrics.disk.free,
-          ) +
+          humanFileSize(disk.total - disk.free) +
           " of " +
-          humanFileSize(instanceMetrics.disk.total)
+          humanFileSize(disk.total)
         }
+        hoverText={`free: ${humanFileSize(disk.free)}\nused: ${humanFileSize(used)}`}
       />
     </div>
-  ) : (
-    ""
   );
 };
 

--- a/src/pages/instances/InstanceUsageMemory.tsx
+++ b/src/pages/instances/InstanceUsageMemory.tsx
@@ -14,29 +14,30 @@ const InstanceUsageMemory: FC<Props> = ({ instance }) => {
 
   const instanceMetrics = getInstanceMetrics(metrics, instance);
 
-  return instanceMetrics.memory ? (
+  const memory = instanceMetrics.memory;
+  if (!memory) {
+    return "";
+  }
+
+  const used = memory.total - memory.free - memory.cached;
+
+  return (
     <div>
       <Meter
-        percentage={
-          (100 / instanceMetrics.memory.total) *
-          (instanceMetrics.memory.total -
-            instanceMetrics.memory.free -
-            instanceMetrics.memory.cached)
-        }
-        secondaryPercentage={
-          (100 / instanceMetrics.memory.total) * instanceMetrics.memory.cached
-        }
+        percentage={(100 / memory.total) * used}
+        secondaryPercentage={(100 / memory.total) * memory.cached}
         text={
-          humanFileSize(
-            instanceMetrics.memory.total - instanceMetrics.memory.free,
-          ) +
+          humanFileSize(memory.total - memory.free) +
           " of " +
-          humanFileSize(instanceMetrics.memory.total)
+          humanFileSize(memory.total)
+        }
+        hoverText={
+          `free: ${humanFileSize(memory.free)}\n` +
+          `used: ${humanFileSize(used)}\n` +
+          `cached: ${humanFileSize(memory.cached)}\n`
         }
       />
     </div>
-  ) : (
-    ""
   );
 };
 


### PR DESCRIPTION
## Done

- Add hover text to instance metrics, surfacing details about cached memory and disk size

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check hover text for instance memory and cpu meters