### PR TITLE
fix: create instance from snapshot in a different project when instance project is restricted

### DIFF
--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -150,10 +150,17 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
     return errors;
   };
 
+  const validTargetProjects = projects.filter(canCreateInstances);
+  const hasInstanceProjectPermission = validTargetProjects.some(
+    (project) => project.name === instance.project,
+  );
+
   const formik = useFormik<CreateInstanceFromSnapshotValues>({
     initialValues: {
       instanceName: getNewInstanceName(instance),
-      targetProject: instance.project,
+      targetProject: hasInstanceProjectPermission
+        ? instance.project
+        : validTargetProjects[0]?.name,
       stateful: false,
       targetClusterMember: isClustered ? instance.location : "",
       targetStoragePool:
@@ -274,7 +281,7 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
           {...formik.getFieldProps("targetProject")}
           id="project"
           label="Target project"
-          options={projects.filter(canCreateInstances).map((project) => {
+          options={validTargetProjects.map((project) => {
             return {
               label: project.name,
               value: project.name,


### PR DESCRIPTION
## Done

- Fixed issue for creating an instance from snapshot in a different project when the user does not have permission to create the instance in the instance's project.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Test the scenario detailed in the [comment](https://github.com/canonical/lxd-ui/pull/1114#pullrequestreview-2627431602)