### PR TITLE
update: remove `user.show_permissions`

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -51,7 +51,6 @@ jobs:
           sudo lxc config trust add keys/lxd-ui.crt
           sudo lxc config set cluster.https_address "127.0.0.1"
           sudo lxc cluster enable local
-          sudo lxc config set user.show_permissions=true
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,7 +109,6 @@ jobs:
           sudo lxc config trust add keys/lxd-ui.crt
           sudo lxc config set cluster.https_address "127.0.0.1"
           sudo lxc cluster enable local
-          sudo lxc config set user.show_permissions=true
 
       - uses: actions/setup-node@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,7 @@
       <br/>
       <pre><code>snap install lxd
     lxd init # can accept all defaults
-    lxc config set core.https_address "[::]:8443"
-    lxc config set user.show_permissions=true</code></pre>
+    lxc config set core.https_address "[::]:8443"</code></pre>
     </details>
 
     <details>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,7 +12,6 @@ import NavLink from "components/NavLink";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import NavAccordion, { AccordionNavMenu } from "./NavAccordion";
 import useEventListener from "util/useEventListener";
-import { enablePermissionsFeature } from "util/permissions";
 import { Location, useLocation } from "react-router-dom";
 import { useLoggedInUser } from "context/useLoggedInUser";
 
@@ -41,9 +40,8 @@ const Navigation: FC = () => {
   const [projectName, setProjectName] = useState(
     project && !isLoading ? project.name : "default",
   );
-  const { hasCustomVolumeIso } = useSupportedFeatures();
+  const { hasCustomVolumeIso, hasAccessManagement } = useSupportedFeatures();
   const { loggedInUserName, loggedInUserID, authMethod } = useLoggedInUser();
-  const enablePermissions = enablePermissionsFeature();
   const [scroll, setScroll] = useState(false);
   const location = useLocation();
   const [openNavMenus, setOpenNavMenus] = useState<AccordionNavMenu[]>(() =>
@@ -352,7 +350,7 @@ const Navigation: FC = () => {
                           </NavLink>
                         </SideNavigationItem>
                       )}
-                      {enablePermissions && (
+                      {hasAccessManagement && (
                         <SideNavigationItem>
                           <NavAccordion
                             baseUrl="/ui/permissions"

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -32,7 +32,6 @@ const Settings: FC = () => {
     settings,
     isSettingsLoading,
     settingsError,
-    hasAccessManagement,
   } = useSupportedFeatures();
   const { canEditServerConfiguration } = useServerEntitlements();
 
@@ -79,17 +78,6 @@ const Settings: FC = () => {
     shortdesc: "Title for the LXD-UI web page. Shows the hostname when unset.",
     type: "string",
   });
-
-  if (hasAccessManagement) {
-    configFields.push({
-      key: "user.show_permissions",
-      category: "user",
-      default: "false",
-      shortdesc:
-        "Show the permissions feature. If oidc configs are set, the permissions feature is available in the UI independent of this setting.",
-      type: "bool",
-    });
-  }
 
   configFields.push({
     key: "user.grafana_base_url",

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -1,6 +1,5 @@
 import type { LxdIdentity, LxdPermission } from "types/permissions";
 import type { LxdImage } from "types/image";
-import { useSupportedFeatures } from "context/useSupportedFeatures";
 import {
   extractResourceDetailsFromUrl,
   ResourceDetail,
@@ -361,19 +360,6 @@ export const permissionSort = (
   return (
     resourceTypeComparison || resourceNameComparison || entitlementComparison
   );
-};
-
-export const enablePermissionsFeature = (): boolean => {
-  const { hasAccessManagement, settings } = useSupportedFeatures();
-
-  const userShowPermissions =
-    (settings?.config?.["user.show_permissions"] ?? "false") === "true";
-
-  const hasOIDCSettings =
-    !!settings?.config?.["oidc.client.id"] &&
-    !!settings?.config?.["oidc.issuer"];
-
-  return hasAccessManagement && (hasOIDCSettings || userShowPermissions);
 };
 
 // each resource type has specific columns to display, which should uniquely identify the resource


### PR DESCRIPTION
## Done

- The introduction of fine-grained TLS identities in LXD means we should no longer hide the permissions feature based on presence of oidc configs. Due to this, the `user.show_permissions` config previously introduced is no longer needed.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check that permissions feature is not hidden as long as lxd version supports it.