### PR TITLE
feat: increase number of retrys and duration of delay for loading the UI

### DIFF
--- a/src/util/lazyWithRetry.tsx
+++ b/src/util/lazyWithRetry.tsx
@@ -1,8 +1,8 @@
 import { lazy } from "react";
 import { delay } from "./helpers";
 
-const RETRIES = 3;
-const DELAY_TIME = 250;
+const RETRIES = 5;
+const DELAY_TIME = 300;
 
 // This function is a wrapper around React.lazy that will retry the import
 // keeping the function type signature the same as React.lazy


### PR DESCRIPTION
## Done

- Increase number of retries to 5 for lazy loading UI assets
- Increase retry delay to 800ms
- effectively, on the 5th retry, the delay will be 4s

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Load the UI first
    - Throttle network (turn it off) in the browser and go to a different page
    - Turn the network back on before the retry attempts run out
    - Make sure that the UI loads with out manual refresh