### PR TITLE
Permissions ux improvements

### DIFF
--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -159,8 +159,8 @@ const GroupSelection: FC<Props> = ({
           title="No groups"
         >
           <p>No groups found.</p>
-          <Link to={`/ui/permissions/groups`}>
-            Create groups
+          <Link to={`/ui/permissions/groups?panel=create-groups`}>
+            Create group
             <Icon className="external-link-icon" name="external-link" />
           </Link>
         </EmptyState>

--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -156,9 +156,12 @@ const GroupSelection: FC<Props> = ({
         <EmptyState
           className="empty-state empty-state__full-width"
           image={<Icon name="user-group" className="empty-state-icon" />}
-          title="No groups"
+          title="No groups found"
         >
-          <p>No groups found.</p>
+          <p>
+            Groups are an easy way to manage the structured assignment of
+            permissions.
+          </p>
           <Link to={`/ui/permissions/groups?panel=create-groups`}>
             Create group
             <Icon className="external-link-icon" name="external-link" />

--- a/src/types/permissions.d.ts
+++ b/src/types/permissions.d.ts
@@ -4,6 +4,7 @@ export interface LxdIdentity {
     | "Client certificate"
     | "Client certificate (pending)"
     | "Client certificate (unrestricted)"
+    | "Metrics certificate (unrestricted)"
     | "OIDC client";
   name: string;
   authentication_method: "tls" | "oidc";

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -338,7 +338,8 @@ export const getDefaultStoragePool = (profile: LxdProfile) => {
 };
 
 export const isUnrestricted = (identity: LxdIdentity) => {
-  return identity.type === "Client certificate (unrestricted)";
+  // matches both "Client certificate (unrestricted)" and "Metrics certificate (unrestricted)"
+  return identity.type.endsWith("(unrestricted)");
 };
 
 export const isFineGrainedTls = (identity: LxdIdentity) => {


### PR DESCRIPTION
## Done

- handle unrestricted metrics certificate as such
- link identity empty group state directly to group creation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test group selection for identity with empty groups
    - test having a metrics certificate ignored as unrestricted in selecting identities for groups or having them disabled on the identities list