### PR TITLE
feat: generalise bulk delete button across UI pages [WD-19546]

### DIFF
--- a/src/components/BulkDeleteButton.tsx
+++ b/src/components/BulkDeleteButton.tsx
@@ -1,0 +1,87 @@
+import { FC } from "react";
+import { pluralize } from "util/instanceBulkActions";
+import {
+  ConfirmationButton,
+  ConfirmationButtonProps,
+  Icon,
+} from "@canonical/react-components";
+import classnames from "classnames";
+
+interface Props {
+  entities: unknown[];
+  deletableEntities: unknown[];
+  entityType: string;
+  onDelete: () => void;
+  disabledReason?: string;
+  bulkDeleteBreakdown?: string[];
+  confirmationButtonProps?: Partial<ConfirmationButtonProps>;
+  buttonLabel?: React.ReactNode;
+  className?: string;
+}
+
+const BulkDeleteButton: FC<Props> = ({
+  entities,
+  deletableEntities,
+  disabledReason,
+  entityType,
+  bulkDeleteBreakdown,
+  confirmationButtonProps,
+  onDelete,
+  buttonLabel = "Delete",
+  className,
+}) => {
+  const totalCount = entities.length;
+  const deleteCount = deletableEntities.length;
+
+  const breakdown =
+    bulkDeleteBreakdown?.map((action) => {
+      return (
+        <li key={action} className="p-list__item">
+          - {action}
+        </li>
+      );
+    }) || [];
+
+  const modalContent = (
+    <>
+      {breakdown.length > 0 && (
+        <>
+          <p>
+            <b>{totalCount}</b> {pluralize(entityType, entities.length)}{" "}
+            selected:
+          </p>
+          <ul className="p-list">{breakdown}</ul>
+        </>
+      )}
+      <p className="u-no-padding--top">
+        This will permanently delete <b>{deleteCount}</b>{" "}
+        {pluralize(entityType, deleteCount)}.{"\n"}This action cannot be undone,
+        and can result in data loss.
+      </p>
+    </>
+  );
+
+  return (
+    <ConfirmationButton
+      className={classnames("has-icon", className)}
+      onHoverText={
+        disabledReason ?? `Delete ${pluralize(entityType, entities.length)}`
+      }
+      disabled={deleteCount === 0 || !!disabledReason}
+      shiftClickEnabled
+      showShiftClickHint
+      {...confirmationButtonProps}
+      confirmationModalProps={{
+        title: "Confirm delete",
+        children: modalContent,
+        confirmButtonLabel: "Delete",
+        onConfirm: onDelete,
+      }}
+    >
+      <Icon name="delete" />
+      <span>{buttonLabel}</span>
+    </ConfirmationButton>
+  );
+};
+
+export default BulkDeleteButton;

--- a/src/pages/images/ImageList.tsx
+++ b/src/pages/images/ImageList.tsx
@@ -99,6 +99,10 @@ const ImageList: FC = () => {
     .filter(canDeleteImage)
     .map((image) => image.fingerprint);
 
+  const selectedImages = images.filter((image) =>
+    selectedNames.includes(image.fingerprint),
+  );
+
   const rows = filteredImages.map((image) => {
     const actions = (
       <List
@@ -121,10 +125,7 @@ const ImageList: FC = () => {
 
     return {
       key: image.fingerprint,
-      // disable image selection if user does not have entitlement to delete
-      name: deletableImages.includes(image.fingerprint)
-        ? image.fingerprint
-        : "",
+      name: image.fingerprint,
       columns: [
         {
           content: description,
@@ -221,9 +222,9 @@ const ImageList: FC = () => {
                 />
               </PageHeader.Search>
             )}
-            {selectedNames.length > 0 && (
+            {selectedImages.length > 0 && (
               <BulkDeleteImageBtn
-                fingerprints={selectedNames}
+                images={selectedImages}
                 project={project}
                 onStart={() => setProcessingNames(selectedNames)}
                 onFinish={() => setProcessingNames([])}
@@ -290,7 +291,6 @@ const ImageList: FC = () => {
                 filteredNames={filteredImages.map((item) => item.fingerprint)}
                 disabledNames={processingNames}
                 rows={[]}
-                disableSelect={!deletableImages.length}
               />
             </TablePagination>
           </ScrollableTable>

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
@@ -4,11 +4,10 @@ import { deleteInstanceSnapshotBulk } from "api/instance-snapshots";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { pluralize } from "util/instanceBulkActions";
-import { ConfirmationButton, Icon } from "@canonical/react-components";
-import classnames from "classnames";
 import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/helpers";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import BulkDeleteButton from "components/BulkDeleteButton";
 
 interface Props {
   instance: LxdInstance;
@@ -80,34 +79,23 @@ const InstanceSnapshotBulkDelete: FC<Props> = ({
   };
 
   return (
-    <ConfirmationButton
-      loading={isLoading}
-      confirmationModalProps={{
-        title: "Confirm delete",
-        children: (
-          <p>
-            This will permanently delete <b>{count}</b>{" "}
-            {pluralize("snapshot", count)}
-            .<br />
-            This action cannot be undone, and can result in data loss.
-          </p>
-        ),
-        confirmButtonLabel: "Delete",
-        onConfirm: handleDelete,
+    <BulkDeleteButton
+      confirmationButtonProps={{
+        loading: isLoading,
+        disabled: isLoading || !canManageInstanceSnapshots(instance),
+        appearance: "",
       }}
-      disabled={isLoading || !canManageInstanceSnapshots(instance)}
-      className={classnames({ "has-icon": isLoading })}
-      onHoverText={
+      onDelete={handleDelete}
+      entityType="snapshot"
+      entities={snapshotNames}
+      deletableEntities={snapshotNames}
+      disabledReason={
         canManageInstanceSnapshots(instance)
-          ? "Delete snapshots"
+          ? undefined
           : "You do not have permission to manage snapshots for this instance"
       }
-      shiftClickEnabled
-      showShiftClickHint
-    >
-      {isLoading && <Icon name="spinner" />}
-      <span>Delete snapshots</span>
-    </ConfirmationButton>
+      buttonLabel={`Delete ${pluralize("snapshot", snapshotNames.length)}`}
+    />
   );
 };
 

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -277,10 +277,7 @@ const PermissionIdentities: FC = () => {
                 />
               )}
               {!!selectedIdentityIds.length && hasAccessManagementTLS && (
-                <BulkDeleteIdentitiesBtn
-                  identities={selectedIdentities}
-                  className="u-no-margin--bottom has-icon"
-                />
+                <BulkDeleteIdentitiesBtn identities={selectedIdentities} />
               )}
             </PageHeader.Left>
             <PageHeader.BaseActions>

--- a/src/pages/permissions/actions/BulkDeleteGroupsBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteGroupsBtn.tsx
@@ -29,7 +29,6 @@ const BulkDeleteGroupsBtn: FC<Props> = ({ groups, className, onDelete }) => {
     <>
       <Button
         onClick={handleConfirmDelete}
-        aria-label="Delete groups"
         title={
           deletableGroups.length
             ? "Delete groups"

--- a/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
@@ -1,79 +1,43 @@
 import { FC } from "react";
-import {
-  ConfirmationButton,
-  Icon,
-  Notification,
-} from "@canonical/react-components";
 import type { IdpGroup } from "types/permissions";
 import { pluralize } from "util/instanceBulkActions";
 import { useDeleteIdpGroups } from "util/permissionIdpGroups";
+import BulkDeleteButton from "components/BulkDeleteButton";
 
 interface Props {
   idpGroups: IdpGroup[];
 }
 
 const BulkDeleteIdpGroupsBtn: FC<Props> = ({ idpGroups }) => {
-  const {
-    isDeleting,
-    deletableIdpGroups,
-    restrictedIdpGroups,
-    deleteIdpGroups,
-  } = useDeleteIdpGroups(idpGroups);
+  const { deletableIdpGroups, restrictedIdpGroups, deleteIdpGroups } =
+    useDeleteIdpGroups(idpGroups);
 
-  const hasOneGroup = deletableIdpGroups.length === 1;
+  const getBulkDeleteBreakdown = () => {
+    if (!restrictedIdpGroups.length) {
+      return undefined;
+    }
+
+    return [
+      `${deletableIdpGroups.length} ${pluralize("IDP group", deletableIdpGroups.length)} will be deleted.`,
+      `${restrictedIdpGroups.length} ${pluralize("IDP group", restrictedIdpGroups.length)} that you do not have permission to delete will be ignored.`,
+    ];
+  };
 
   return (
-    <ConfirmationButton
-      onHoverText={
-        deletableIdpGroups.length
-          ? "Delete IDP groups"
-          : `You do not have permission to delete the selected ${pluralize("idp group", idpGroups.length)}`
+    <BulkDeleteButton
+      entities={idpGroups}
+      deletableEntities={deletableIdpGroups}
+      entityType="IDP group"
+      onDelete={deleteIdpGroups}
+      disabledReason={
+        !deletableIdpGroups.length
+          ? `You do not have permission to delete the selected ${pluralize("idp group", idpGroups.length)}`
+          : undefined
       }
-      className="has-icon u-no-margin--bottom"
-      aria-label="Delete IDP groups"
-      disabled={!deletableIdpGroups.length}
-      shiftClickEnabled
-      showShiftClickHint
-      confirmationModalProps={{
-        title: "Confirm IDP group deletion",
-        confirmButtonLabel: "Delete",
-        confirmButtonLoading: isDeleting,
-        onConfirm: deleteIdpGroups,
-        className: "permission-confirm-modal",
-        children: (
-          <>
-            <p>
-              Are you sure you want to delete{" "}
-              <strong>
-                {hasOneGroup
-                  ? `"${deletableIdpGroups[0].name}"`
-                  : `${deletableIdpGroups.length} IDP groups`}
-              </strong>
-              ? This action is permanent and can not be undone.
-            </p>
-            {restrictedIdpGroups.length ? (
-              <Notification
-                severity="caution"
-                title="Restricted permissions"
-                titleElement="h2"
-              >
-                <p className="u-no-margin--bottom">
-                  You do not have permission to delete the following IDP groups:
-                </p>
-                <ul className="u-no-margin--bottom">
-                  {restrictedIdpGroups.map((group) => (
-                    <li key={group.name}>{group.name}</li>
-                  ))}
-                </ul>
-              </Notification>
-            ) : null}
-          </>
-        ),
-      }}
-    >
-      <Icon name="delete" />
-      <span>{`Delete ${idpGroups.length} ${pluralize("IDP group", idpGroups.length)}`}</span>
-    </ConfirmationButton>
+      className="u-no-margin--bottom"
+      buttonLabel={`Delete ${idpGroups.length} ${pluralize("IDP group", idpGroups.length)}`}
+      bulkDeleteBreakdown={getBulkDeleteBreakdown()}
+    />
   );
 };
 

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
@@ -3,12 +3,11 @@ import { deleteVolumeSnapshotBulk } from "api/volume-snapshots";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { pluralize } from "util/instanceBulkActions";
-import { ConfirmationButton, Icon } from "@canonical/react-components";
-import classnames from "classnames";
 import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/helpers";
 import type { LxdStorageVolume } from "types/storage";
 import { useToastNotification } from "context/toastNotificationProvider";
+import BulkDeleteButton from "components/BulkDeleteButton";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -78,30 +77,18 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
   };
 
   return (
-    <ConfirmationButton
-      loading={isLoading}
-      confirmationModalProps={{
-        title: "Confirm delete",
-        children: (
-          <p>
-            This will permanently delete <b>{count}</b>{" "}
-            {pluralize("snapshot", count)}
-            .<br />
-            This action cannot be undone, and can result in data loss.
-          </p>
-        ),
-        confirmButtonLabel: "Delete",
-        onConfirm: handleDelete,
+    <BulkDeleteButton
+      confirmationButtonProps={{
+        loading: isLoading,
+        disabled: isLoading,
+        appearance: "",
       }}
-      disabled={isLoading}
-      className={classnames({ "has-icon": isLoading })}
-      onHoverText="Delete snapshots"
-      shiftClickEnabled
-      showShiftClickHint
-    >
-      {isLoading && <Icon name="spinner" />}
-      <span>Delete snapshots</span>
-    </ConfirmationButton>
+      onDelete={handleDelete}
+      entityType="snapshot"
+      entities={snapshotNames}
+      deletableEntities={snapshotNames}
+      buttonLabel={`Delete ${pluralize("snapshot", snapshotNames.length)}`}
+    />
   );
 };
 

--- a/tests/permission-groups.spec.ts
+++ b/tests/permission-groups.spec.ts
@@ -147,7 +147,7 @@ test("bulk delete groups", async ({ page, lxdVersion }) => {
   await createGroup(page, groupOne, groupOne);
   await createGroup(page, groupTwo, groupTwo);
   await selectGroupsToModify(page, [groupOne, groupTwo]);
-  await page.getByLabel("Delete groups").click();
+  await page.getByRole("button", { name: "Delete 2 groups" }).click();
   await page.getByPlaceholder("confirm-delete-group").click();
   await page
     .getByPlaceholder("confirm-delete-group")

--- a/tests/permission-idp-groups.spec.ts
+++ b/tests/permission-idp-groups.spec.ts
@@ -78,7 +78,7 @@ test("bulk delete idp groups", async ({ page, lxdVersion }) => {
     .getByRole("row", { name: `Select ${idpGroupTwo}` })
     .locator("span")
     .click();
-  await page.getByLabel("Delete IDP groups").click();
+  await page.getByRole("button", { name: "Delete 2 IDP groups" }).click();
   await page.getByRole("button", { name: "Delete", exact: true }).click();
   await page.waitForSelector(`text=2 IDP groups deleted.`);
   await deleteGroup(page, groupOne);


### PR DESCRIPTION
## Done

- Create a generalised bulk delete button component to standardise usage across UI pages

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Test Bulk delete instances, images, instance and volume snapshots