### PR TITLE
feat: [WD-18263] CMS Storage pool usage

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -62,12 +62,45 @@ export const fetchStoragePools = async (
 
 export const fetchStoragePoolResources = async (
   pool: string,
+  target?: string,
 ): Promise<LxdStoragePoolResources> => {
+  const targetParam = target ? `?target=${target}` : "";
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/storage-pools/${pool}/resources`)
+    fetch(`/1.0/storage-pools/${pool}/resources${targetParam}`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdStoragePoolResources>) => {
         resolve(data.metadata);
+      })
+      .catch(reject);
+  });
+};
+
+export const fetchClusteredStoragePoolResources = async (
+  pool: string,
+  clusterMembers: LxdClusterMember[],
+): Promise<LxdStoragePoolResources[]> => {
+  return new Promise((resolve, reject) => {
+    Promise.allSettled(
+      clusterMembers.map(async (member) => {
+        return fetchStoragePoolResources(pool, member.server_name);
+      }),
+    )
+      .then((results) => {
+        const poolsOnMembers: LxdStoragePoolResources[] = [];
+        for (let i = 0; i < clusterMembers.length; i++) {
+          const memberName = clusterMembers[i].server_name;
+          const result = results[i];
+          if (result.status === "rejected") {
+            reject(constructMemberError(result, memberName));
+          }
+          if (result.status === "fulfilled") {
+            const promise = results[
+              i
+            ] as PromiseFulfilledResult<LxdStoragePoolResources>;
+            poolsOnMembers.push({ ...promise.value, memberName: memberName });
+          }
+        }
+        resolve(poolsOnMembers);
       })
       .catch(reject);
   });

--- a/src/context/useStoragePools.tsx
+++ b/src/context/useStoragePools.tsx
@@ -5,8 +5,10 @@ import { useAuth } from "./auth";
 import type {
   LxdStoragePool,
   LXDStoragePoolOnClusterMember,
+  LxdStoragePoolResources,
 } from "types/storage";
 import {
+  fetchClusteredStoragePoolResources,
   fetchPoolFromClusterMembers,
   fetchStoragePool,
   fetchStoragePools,
@@ -47,5 +49,17 @@ export const usePoolFromClusterMembers = (
     queryFn: async () =>
       fetchPoolFromClusterMembers(pool, clusterMembers, isFineGrained),
     enabled: isFineGrained !== null && clusterMembers.length > 0,
+  });
+};
+
+export const useClusteredStoragePoolResources = (
+  pool: string,
+): UseQueryResult<LxdStoragePoolResources[]> => {
+  const { data: clusterMembers = [] } = useClusterMembers();
+  return useQuery({
+    queryKey: [queryKeys.storage, pool, queryKeys.cluster, queryKeys.resources],
+    queryFn: async () =>
+      fetchClusteredStoragePoolResources(pool, clusterMembers),
+    enabled: clusterMembers.length > 0,
   });
 };

--- a/src/pages/storage/StoragePoolClusterMember.tsx
+++ b/src/pages/storage/StoragePoolClusterMember.tsx
@@ -1,0 +1,38 @@
+import ResourceLink from "components/ResourceLink";
+import { useClusterMembers } from "context/useClusterMembers";
+import type { FC } from "react";
+import type { LxdStoragePool } from "types/storage";
+import { hasPoolMemberSpecificSize } from "util/storagePool";
+
+interface Props {
+  pool: LxdStoragePool;
+}
+
+export const StoragePoolClusterMember: FC<Props> = ({ pool }) => {
+  const hasMemberSpecificSize = hasPoolMemberSpecificSize(pool.driver);
+  const { data: clusterMembers = [] } = useClusterMembers();
+
+  return (
+    <div>
+      {hasMemberSpecificSize ? (
+        clusterMembers.map((member) => {
+          return (
+            <div className="clustered-resource-link" key={member.server_name}>
+              <ResourceLink
+                to="/ui/cluster"
+                type="cluster-member"
+                value={member.server_name}
+              />
+            </div>
+          );
+        })
+      ) : (
+        <ResourceLink
+          to="/ui/cluster"
+          type="cluster-group"
+          value="Cluster wide"
+        />
+      )}
+    </div>
+  );
+};

--- a/src/pages/storage/StoragePoolOverview.tsx
+++ b/src/pages/storage/StoragePoolOverview.tsx
@@ -6,6 +6,10 @@ import StorageUsedBy from "pages/storage/StorageUsedBy";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "util/useEventListener";
 import type { LxdStoragePool } from "types/storage";
+import { StoragePoolClusterMember } from "./StoragePoolClusterMember";
+import { isClusteredServer } from "util/settings";
+import { useSettings } from "context/useSettings";
+import { hasPoolMemberSpecificSize } from "util/storagePool";
 
 interface Props {
   pool: LxdStoragePool;
@@ -18,6 +22,9 @@ const StoragePoolOverview: FC<Props> = ({ pool, project }) => {
   };
   useEffect(updateContentHeight, [project, pool]);
   useEventListener("resize", updateContentHeight);
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
+  const hasMemberSpecificSize = hasPoolMemberSpecificSize(pool.driver);
 
   return (
     <div className="storage-overview-tab">
@@ -38,7 +45,10 @@ const StoragePoolOverview: FC<Props> = ({ pool, project }) => {
               </tr>
               <tr>
                 <th className="u-text--muted">Size</th>
-                <td>
+                <td className="cluster-member-with-meters">
+                  {hasMemberSpecificSize && isClustered && (
+                    <StoragePoolClusterMember pool={pool} />
+                  )}
                   <StoragePoolSize pool={pool} hasMeterBar />
                 </td>
               </tr>

--- a/src/pages/storage/StoragePoolSelectTable.tsx
+++ b/src/pages/storage/StoragePoolSelectTable.tsx
@@ -4,6 +4,9 @@ import ScrollableTable from "components/ScrollableTable";
 import StoragePoolSize from "pages/storage/StoragePoolSize";
 import classnames from "classnames";
 import { useStoragePools } from "context/useStoragePools";
+import { StoragePoolClusterMember } from "./StoragePoolClusterMember";
+import { isClusteredServer } from "util/settings";
+import { useSettings } from "context/useSettings";
 
 interface Props {
   onSelect: (pool: string) => void;
@@ -15,11 +18,14 @@ interface Props {
 
 const StoragePoolSelectTable: FC<Props> = ({ onSelect, disablePool }) => {
   const { data: pools = [], isLoading } = useStoragePools();
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
 
   const headers = [
     { content: "Name", sortKey: "name" },
     { content: "Driver", sortKey: "driver" },
     { content: "Status", sortKey: "status" },
+    ...(isClustered ? [{ content: "Cluster member" }] : []),
     { content: "Size", className: "size" },
     { "aria-label": "Actions", className: "actions" },
   ];
@@ -63,6 +69,15 @@ const StoragePoolSelectTable: FC<Props> = ({ onSelect, disablePool }) => {
           "aria-label": "Status",
           onClick: selectPool,
         },
+        ...(isClustered
+          ? [
+              {
+                content: <StoragePoolClusterMember pool={pool} />,
+                role: "cell",
+                "aria-label": "Cluster member",
+              },
+            ]
+          : []),
         {
           content: <StoragePoolSize pool={pool} hasMeterBar />,
           role: "cell",

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -19,11 +19,17 @@ import NotificationRow from "components/NotificationRow";
 import CustomLayout from "components/CustomLayout";
 import PageHeader from "components/PageHeader";
 import { useStoragePools } from "context/useStoragePools";
+import classNames from "classnames";
+import { useSettings } from "context/useSettings";
+import { isClusteredServer } from "util/settings";
+import { StoragePoolClusterMember } from "./StoragePoolClusterMember";
 
 const StoragePools: FC = () => {
   const docBaseLink = useDocs();
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
+  const { data: settings } = useSettings();
+  const isClustered = isClusteredServer(settings);
 
   if (!project) {
     return <>Missing project</>;
@@ -40,7 +46,13 @@ const StoragePools: FC = () => {
   const headers = [
     { content: "Name", sortKey: "name" },
     { content: "Driver", sortKey: "driver" },
-    { content: "Size", className: "size" },
+    ...(isClustered
+      ? [{ content: "Cluster member", className: "cluster-member" }]
+      : []),
+    {
+      content: "Size",
+      className: classNames("size", { clustered: isClustered }),
+    },
     {
       content: (
         <>
@@ -86,19 +98,29 @@ const StoragePools: FC = () => {
               {pool.name}
             </Link>
           ),
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Name",
         },
         {
           content: pool.driver,
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Driver",
         },
+        ...(isClustered
+          ? [
+              {
+                content: <StoragePoolClusterMember pool={pool} />,
+                role: "cell",
+                "aria-label": "Cluster member",
+                className: "cluster-member",
+              },
+            ]
+          : []),
         {
           content: <StoragePoolSize pool={pool} hasMeterBar />,
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Size",
-          className: "size",
+          className: classNames("size", { clustered: isClustered }),
         },
         {
           content: (
@@ -111,19 +133,19 @@ const StoragePools: FC = () => {
               {currentProjectVolumeCount}
             </StorageVolumesInPoolBtn>
           ),
-          role: "rowheader",
+          role: "cell",
           className: "u-align--right",
           "aria-label": "Volumes in this projects",
         },
         {
           content: totalVolumeCount,
-          role: "rowheader",
+          role: "cell",
           className: "u-align--right",
           "aria-label": "Volumes in all projects",
         },
         {
           content: pool.status,
-          role: "rowheader",
+          role: "cell",
           "aria-label": "Status",
         },
         {
@@ -134,7 +156,7 @@ const StoragePools: FC = () => {
               project={project}
             />
           ),
-          role: "rowheader",
+          role: "cell",
           className: "u-align--right actions",
           "aria-label": "Actions",
         },

--- a/src/sass/_meter.scss
+++ b/src/sass/_meter.scss
@@ -4,7 +4,6 @@
   display: flex;
   height: 0.75rem;
   margin-bottom: 0.375rem;
-  width: 100%;
 
   div {
     background-color: #06c;

--- a/src/sass/_migrate_instance.scss
+++ b/src/sass/_migrate_instance.scss
@@ -22,6 +22,10 @@
       .p-meter {
         margin-top: $spv--x-small;
       }
+
+      .clustered-resource-link {
+        height: 2.25rem;
+      }
     }
 
     @include large {

--- a/src/sass/_scrollable_table.scss
+++ b/src/sass/_scrollable_table.scss
@@ -11,7 +11,6 @@
 
   th::before {
     content: "";
-    display: inline-block;
     height: 1rem;
   }
 

--- a/src/sass/_storage.scss
+++ b/src/sass/_storage.scss
@@ -11,6 +11,10 @@
     width: 14rem;
   }
 
+  .size.clustered {
+    width: 20rem;
+  }
+
   .actions {
     width: 5rem;
   }
@@ -21,6 +25,20 @@
 
   .p-meter {
     margin-top: 4px;
+  }
+
+  @media screen and (width < 1200px) {
+    .size.clustered {
+      display: none;
+    }
+
+    .cluster-member {
+      display: none;
+    }
+  }
+
+  .clustered-resource-link {
+    height: 2.25rem;
   }
 }
 

--- a/src/sass/_storage_detail_overview.scss
+++ b/src/sass/_storage_detail_overview.scss
@@ -44,4 +44,17 @@
       padding-top: $spv--small;
     }
   }
+
+  .cluster-member-with-meters {
+    display: flex;
+
+    .p-meter {
+      margin-top: 0.4rem;
+    }
+  }
+
+  .clustered-resource-link {
+    height: 2.4rem;
+    margin-right: 1rem;
+  }
 }

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -80,6 +80,7 @@ export interface LxdStoragePoolResources {
     used?: number;
     total: number;
   };
+  memberName?: string;
 }
 
 export interface UploadState {

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -4,7 +4,14 @@ import type { AnyObject, TestFunction } from "yup";
 import type { LxdConfigOptionsKeys } from "types/config";
 import type { FormikProps } from "formik";
 import type { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
-import { powerFlex, pureStorage } from "util/storageOptions";
+import {
+  btrfsDriver,
+  dirDriver,
+  lvmDriver,
+  powerFlex,
+  pureStorage,
+  zfsDriver,
+} from "util/storageOptions";
 
 export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   ceph_cluster_name: "ceph.cluster_name",
@@ -35,6 +42,11 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   zfs_clone_copy: "zfs.clone_copy",
   zfs_export: "zfs.export",
   zfs_pool_name: "zfs.pool_name",
+};
+
+export const hasPoolMemberSpecificSize = (poolDriver: string) => {
+  const sizeSpecificDrivers = [btrfsDriver, dirDriver, lvmDriver, zfsDriver];
+  return sizeSpecificDrivers.includes(poolDriver);
 };
 
 export const getPoolKey = (formField: string): string => {


### PR DESCRIPTION
## Done
- Displaying multiple pools depending on Cluster

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Review the Storage Pool list page on a clustered and non-clustered environment.

## Screenshots

![image](https://github.com/user-attachments/assets/295e3ee6-9d5b-41c0-a51e-8d2a82b389c2)