### PR TITLE
Fix image filter on instance selection

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -237,7 +237,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       };
 
       return {
-        key: itemType + item.os + displayRelease + displayVariant,
+        key: itemType + item.os + displayRelease + displayVariant + item.server,
         className: "u-row",
         columns: [
           {


### PR DESCRIPTION
## Done

- Fix image filter on instance selection
- Ubuntu images would not be filtered when selecting other distributions because of invalid row keys

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start instance creation, select image modal
    - filter by distribution
    - ensure no errors in console and rows represent filter status