### PR TITLE
Allow member specific server setting for core.syslog_server WD-18265

### DIFF
--- a/src/components/ClusterSpecificSelect.tsx
+++ b/src/components/ClusterSpecificSelect.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import {
   Fragment,
   type OptionHTMLAttributes,
@@ -20,6 +20,7 @@ export interface ClusterSpecificSelectOption {
 
 interface Props {
   id: string;
+  classname?: string;
   isReadOnly: boolean;
   onChange: (value: ClusterSpecificValues) => void;
   toggleReadOnly: () => void;
@@ -29,10 +30,12 @@ interface Props {
   isDefaultSpecific?: boolean;
   clusterMemberLinkTarget?: (member: string) => string;
   disableReason?: string;
+  helpText?: string | ReactNode;
 }
 
 const ClusterSpecificSelect: FC<Props> = ({
   id,
+  classname = "u-sv3",
   isReadOnly,
   options,
   values,
@@ -42,6 +45,7 @@ const ClusterSpecificSelect: FC<Props> = ({
   isDefaultSpecific = false,
   clusterMemberLinkTarget = () => "/ui/cluster",
   disableReason,
+  helpText,
 }) => {
   const [isSpecific, setIsSpecific] = useState(isDefaultSpecific);
 
@@ -95,7 +99,7 @@ const ClusterSpecificSelect: FC<Props> = ({
   }, [isSpecific, values, firstOptionOnAllMembers]);
 
   return (
-    <div className="u-sv3">
+    <div className={classname}>
       {canToggleSpecific && !isReadOnly && (
         <CheckboxInput
           id={`${id}-same-for-all-toggle`}
@@ -157,13 +161,20 @@ const ClusterSpecificSelect: FC<Props> = ({
               </Fragment>
             );
           })}
+          {helpText && (
+            <div className="p-form-help-text cluster-specific-helptext">
+              {helpText}
+            </div>
+          )}
         </div>
       )}
       {!isSpecific && (
-        <div>
+        <div className="cluster-specific-value-wrapper">
           {isReadOnly ? (
             <>
-              {firstValue}
+              <span className="cluster-specific-value">
+                {firstValue === "" ? "-" : firstValue}
+              </span>
               <FormEditButton
                 toggleReadOnly={toggleReadOnly}
                 disableReason={disableReason}
@@ -178,6 +189,7 @@ const ClusterSpecificSelect: FC<Props> = ({
                 setValueForAllMembers(e.target.value);
               }}
               value={firstValue}
+              help={helpText}
             />
           )}
         </div>

--- a/src/components/forms/ClusterSpecificInput.tsx
+++ b/src/components/forms/ClusterSpecificInput.tsx
@@ -134,7 +134,7 @@ const ClusterSpecificInput: FC<Props> = ({
               </Fragment>
             );
           })}
-          {helpText && (
+          {helpText && !isReadOnly && (
             <div className="p-form-help-text cluster-specific-helptext">
               {helpText}
             </div>
@@ -145,7 +145,9 @@ const ClusterSpecificInput: FC<Props> = ({
         <div className="cluster-specific-value-wrapper">
           {isReadOnly ? (
             <>
-              <span className="cluster-specific-value">{firstValue}</span>
+              <span className="cluster-specific-value">
+                {firstValue === "" ? "-" : firstValue}
+              </span>
               {!disabled && (
                 <FormEditButton
                   disableReason={disableReason}

--- a/src/pages/networks/forms/NetworkParentSelector.tsx
+++ b/src/pages/networks/forms/NetworkParentSelector.tsx
@@ -105,6 +105,7 @@ const NetworkParentSelector: FC<Props> = ({ props, formik, isClustered }) => {
         </div>
         <div className="general-field-content">
           <ClusterSpecificSelect
+            key={JSON.stringify(formik.values.parentPerClusterMember)}
             id="parent"
             options={options}
             values={formik.values.parentPerClusterMember}

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -52,8 +52,9 @@ const SettingForm: FC<Props> = ({
   const isSecret = isTrustPassword || isLokiAuthPassword;
   const isAddress = configField.key.endsWith("_address");
   const isVolume = configField.key.endsWith("_volume");
+  const isSyslogSocket = configField.key === "core.syslog_socket";
   const isClusteredInput =
-    isClustered && (isMaasMachine || isAddress || isVolume);
+    isClustered && (isMaasMachine || isAddress || isVolume || isSyslogSocket);
 
   const settingLabel = (
     <ResourceLabel bold type="setting" value={configField.key} />
@@ -110,7 +111,7 @@ const SettingForm: FC<Props> = ({
   if (isClusteredInput) {
     return (
       <ClusteredSettingFormInput
-        key={JSON.stringify(clusteredValue)}
+        key={`${JSON.stringify(clusteredValue)}-${isEditMode}`}
         initialValue={clusteredValue ?? {}}
         disableReason={
           canEditServerConfiguration()

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -71,12 +71,13 @@ const Settings: FC = () => {
 
   const getClusteredValue = (
     clusteredSettings: LXDSettingOnClusterMember[],
-    configKey: string,
+    configField: ConfigField,
   ): ClusterSpecificValues => {
     const settingPerClusterMember: ClusterSpecificValues = {};
 
     clusteredSettings?.forEach((item) => {
-      settingPerClusterMember[item.memberName] = item.config?.[configKey] ?? "";
+      settingPerClusterMember[item.memberName] =
+        item.config?.[configField.key] ?? configField.default ?? "";
     });
 
     return settingPerClusterMember;
@@ -133,10 +134,7 @@ const Settings: FC = () => {
       );
       const value = getValue(configField);
 
-      const clusteredValue = getClusteredValue(
-        clusteredSettings,
-        configField.key,
-      );
+      const clusteredValue = getClusteredValue(clusteredSettings, configField);
 
       const isNewCategory = lastCategory !== configField.category;
       lastCategory = configField.category;

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -43,12 +43,30 @@
     padding-right: 0.5rem;
   }
 
+  .cluster-specific-input {
+    padding-bottom: 0;
+  }
+
   .cluster-specific-value-wrapper {
     align-items: center;
-    display: flex;
 
     .cluster-specific-value {
       flex-grow: 1;
+    }
+  }
+
+  .read-only {
+    .cluster-specific-value-wrapper {
+      display: flex;
+    }
+
+    .cluster-specific-value {
+      flex-grow: 0;
+    }
+
+    .p-button--base {
+      flex-grow: 1;
+      text-align: right;
     }
   }
 }


### PR DESCRIPTION
## Done

- Allow member specific server setting for core.syslog_server in clustered environment
- Adjust edit button for clustered server settings to be visually more like the non-clustered settings
- Adjust spacing for clustered server settings
- Fix race on loading network edit for cluster specific edit of physical managed networks parent field.

Fixes WD-18265

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - explore server settings in clustered and non-clustered backends.
    - ensure the core.syslog_server setting is handled correctly for member specific, and generic values in cluster backends