### PR TITLE
feat: [WD-19336] Storage volumes permission checks

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -21,6 +21,7 @@ export const instanceEntitlements = [
   "can_delete",
   "can_edit",
   "can_exec",
+  "can_view",
   "can_manage_backups",
   "can_manage_snapshots",
   "can_update_state",

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -21,7 +21,6 @@ export const instanceEntitlements = [
   "can_delete",
   "can_edit",
   "can_exec",
-  "can_view",
   "can_manage_backups",
   "can_manage_snapshots",
   "can_update_state",

--- a/src/api/storage-volumes.tsx
+++ b/src/api/storage-volumes.tsx
@@ -10,7 +10,11 @@ import axios from "axios";
 import type { LxdApiResponse } from "types/apiResponse";
 import { withEntitlementsQuery } from "util/entitlements/api";
 
-export const storageVolumeEntitlements = ["can_delete", "can_edit"];
+export const storageVolumeEntitlements = [
+  "can_delete",
+  "can_edit",
+  "can_manage_snapshots",
+];
 
 export const fetchStorageVolumes = async (
   pool: string,

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router-dom";
 import ResourceLabel from "components/ResourceLabel";
 import ResourceLink from "components/ResourceLink";
 import { migrateStorageVolume } from "api/storage-volumes";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   storageVolume: LxdStorageVolume;
@@ -32,6 +33,7 @@ const MigrateVolumeBtn: FC<Props> = ({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [isVolumeLoading, setVolumeLoading] = useState(false);
+  const { canEditVolume } = useStorageVolumeEntitlements();
 
   const handleSuccess = (
     newTarget: string,
@@ -157,7 +159,7 @@ const MigrateVolumeBtn: FC<Props> = ({
         type="button"
         className={classname}
         loading={isVolumeLoading}
-        disabled={isVolumeLoading}
+        disabled={!canEditVolume(storageVolume) || isVolumeLoading}
         title="Migrate volume"
       >
         <Icon name="machines" />

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -161,9 +161,9 @@ const MigrateVolumeBtn: FC<Props> = ({
         loading={isVolumeLoading}
         disabled={!canEditVolume(storageVolume) || isVolumeLoading}
         title={
-          !canEditVolume(storageVolume)
-            ? "You do not have permission to migrate this volume"
-            : "Migrate volume"
+          canEditVolume(storageVolume)
+            ? "Migrate volume"
+            : "You do not have permission to migrate this volume"
         }
       >
         <Icon name="machines" />

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -160,7 +160,11 @@ const MigrateVolumeBtn: FC<Props> = ({
         className={classname}
         loading={isVolumeLoading}
         disabled={!canEditVolume(storageVolume) || isVolumeLoading}
-        title="Migrate volume"
+        title={
+          !canEditVolume(storageVolume)
+            ? "You do not have permission to migrate this volume"
+            : "Migrate volume"
+        }
       >
         <Icon name="machines" />
         <span>Migrate</span>

--- a/src/pages/storage/StorageVolumeHeader.tsx
+++ b/src/pages/storage/StorageVolumeHeader.tsx
@@ -31,6 +31,16 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
   const { hasClusterInternalCustomVolumeCopy } = useSupportedFeatures();
   const { canEditVolume } = useStorageVolumeEntitlements();
 
+  const getDisabledReason = (volume: LxdStorageVolume) => {
+    if ((volume.used_by?.length ?? 0) > 0) {
+      return "Can not rename, volume is currently in use.";
+    }
+    if (!canEditVolume(volume)) {
+      return "You do not have permission to rename this volume";
+    }
+    return undefined;
+  };
+
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
       .test(
@@ -122,13 +132,7 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
       }
       isLoaded={true}
       formik={formik}
-      renameDisabledReason={
-        (volume.used_by?.length ?? 0) > 0
-          ? "Can not rename, volume is currently in use."
-          : !canEditVolume(volume)
-            ? "You do not have permission to rename this volume"
-            : undefined
-      }
+      renameDisabledReason={getDisabledReason(volume)}
     />
   );
 };

--- a/src/pages/storage/StorageVolumeHeader.tsx
+++ b/src/pages/storage/StorageVolumeHeader.tsx
@@ -16,6 +16,7 @@ import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
 import { renameStorageVolume } from "api/storage-volumes";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -28,6 +29,7 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
   const { hasClusterInternalCustomVolumeCopy } = useSupportedFeatures();
+  const { canEditVolume } = useStorageVolumeEntitlements();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
@@ -123,7 +125,9 @@ const StorageVolumeHeader: FC<Props> = ({ volume, project }) => {
       renameDisabledReason={
         (volume.used_by?.length ?? 0) > 0
           ? "Can not rename, volume is currently in use."
-          : undefined
+          : !canEditVolume(volume)
+            ? "You do not have permission to rename this volume"
+            : undefined
       }
     />
   );

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -37,8 +37,8 @@ const StorageVolumeNameLink: FC<Props> = ({
   const image =
     isImage && images.find((image) => image.fingerprint === volume.name);
 
-  const isCustomISO = volume.content_type === "iso";
-  const displayLink = instance || image || isCustomISO;
+  const isCustom = volume.type === "custom";
+  const displayLink = instance || image || isCustom;
 
   const caption = overrideName
     ? displayLink
@@ -50,7 +50,7 @@ const StorageVolumeNameLink: FC<Props> = ({
     <div className={classnames("u-flex", className)}>
       <div
         className={classnames("u-truncate", "volume-name-link")}
-        title={caption}
+        title={volume.name}
       >
         {displayLink ? (
           <Link

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -8,6 +8,7 @@ import {
   hasVolumeDetailPage,
 } from "util/storageVolume";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useInstances } from "context/useInstances";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -24,6 +25,12 @@ const StorageVolumeNameLink: FC<Props> = ({
   const { project } = useCurrentProject();
   const isExternalLink = !hasVolumeDetailPage(volume);
   const caption = overrideName ? overrideName : volume.name;
+  const isInstance =
+    volume.type === "container" || volume.type === "virtual-machine";
+  const { data: instances = [] } = useInstances(volume.project);
+  const instance = isInstance
+    ? instances.find((instance) => instance.name === volume.name)
+    : true;
 
   return (
     <div className={classnames("u-flex", className)}>
@@ -31,13 +38,17 @@ const StorageVolumeNameLink: FC<Props> = ({
         className={classnames("u-truncate", "volume-name-link")}
         title={caption}
       >
-        <Link
-          to={generateLinkForVolumeDetail(volume, project?.name ?? "")}
-          className={isExternalLink ? "has-icon" : undefined}
-        >
-          {caption}
-          {isExternalLink && <Icon name={ICONS.externalLink} />}
-        </Link>
+        {instance ? (
+          <Link
+            to={generateLinkForVolumeDetail(volume, project?.name ?? "")}
+            className={isExternalLink ? "has-icon" : undefined}
+          >
+            {caption}
+            {isExternalLink && <Icon name={ICONS.externalLink} />}
+          </Link>
+        ) : (
+          caption
+        )}
       </div>
     </div>
   );

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -39,18 +39,17 @@ const StorageVolumeNameLink: FC<Props> = ({
 
   const isCustom = volume.type === "custom";
   const displayLink = instance || image || isCustom;
+  const caption = overrideName ? overrideName : volume.name;
 
-  const caption = overrideName
-    ? displayLink
-      ? overrideName
-      : ""
-    : volume.name;
+  if (overrideName && !displayLink) {
+    return null;
+  }
 
   return (
     <div className={classnames("u-flex", className)}>
       <div
         className={classnames("u-truncate", "volume-name-link")}
-        title={volume.name}
+        title={caption}
       >
         {displayLink ? (
           <Link

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -373,7 +373,7 @@ const StorageVolumes: FC = () => {
           <Icon className="external-link-icon" name="external-link" />
         </a>
       </p>
-      <CreateVolumeBtn project={project} className="empty-state-button" />
+      <CreateVolumeBtn projectName={project} className="empty-state-button" />
     </EmptyState>
   ) : (
     <div className="storage-volumes">
@@ -425,7 +425,7 @@ const StorageVolumes: FC = () => {
           {hasVolumes && (
             <PageHeader.BaseActions>
               <CreateVolumeBtn
-                project={project}
+                projectName={project}
                 defaultPool={defaultPoolForVolumeCreate}
                 className="u-float-right u-no-margin--bottom"
               />

--- a/src/pages/storage/actions/CreateVolumeBtn.tsx
+++ b/src/pages/storage/actions/CreateVolumeBtn.tsx
@@ -2,20 +2,28 @@ import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import { useNavigate } from "react-router-dom";
 import { useSmallScreen } from "context/useSmallScreen";
+import { useProjectEntitlements } from "util/entitlements/projects";
+import { useProject } from "context/useProjects";
 
 interface Props {
-  project: string;
+  projectName: string;
   defaultPool?: string;
   className?: string;
 }
 
-const CreateVolumeBtn: FC<Props> = ({ project, className, defaultPool }) => {
+const CreateVolumeBtn: FC<Props> = ({
+  projectName,
+  className,
+  defaultPool,
+}) => {
   const navigate = useNavigate();
   const isSmallScreen = useSmallScreen();
+  const { canCreateStorageVolumes } = useProjectEntitlements();
+  const { data: project } = useProject(projectName);
 
   const handleAdd = () => {
     navigate(
-      `/ui/project/${project}/storage/volumes/create${
+      `/ui/project/${projectName}/storage/volumes/create${
         defaultPool ? `?pool=${defaultPool}` : ""
       }`,
     );
@@ -27,6 +35,7 @@ const CreateVolumeBtn: FC<Props> = ({ project, className, defaultPool }) => {
       hasIcon={!isSmallScreen}
       onClick={handleAdd}
       className={className}
+      disabled={!canCreateStorageVolumes(project)}
     >
       {!isSmallScreen && <Icon name="plus" light />}
       <span>Create volume</span>

--- a/src/pages/storage/actions/CreateVolumeBtn.tsx
+++ b/src/pages/storage/actions/CreateVolumeBtn.tsx
@@ -36,6 +36,11 @@ const CreateVolumeBtn: FC<Props> = ({
       onClick={handleAdd}
       className={className}
       disabled={!canCreateStorageVolumes(project)}
+      title={
+        !canCreateStorageVolumes(project)
+          ? "You do not have permission to duplicate this volume"
+          : "Create volume"
+      }
     >
       {!isSmallScreen && <Icon name="plus" light />}
       <span>Create volume</span>

--- a/src/pages/storage/actions/CreateVolumeBtn.tsx
+++ b/src/pages/storage/actions/CreateVolumeBtn.tsx
@@ -37,9 +37,9 @@ const CreateVolumeBtn: FC<Props> = ({
       className={className}
       disabled={!canCreateStorageVolumes(project)}
       title={
-        !canCreateStorageVolumes(project)
-          ? "You do not have permission to duplicate this volume"
-          : "Create volume"
+        canCreateStorageVolumes(project)
+          ? "Create volume"
+          : "You do not have permission to create volumes in this project"
       }
     >
       {!isSmallScreen && <Icon name="plus" light />}

--- a/src/pages/storage/actions/DuplicateVolumeBtn.tsx
+++ b/src/pages/storage/actions/DuplicateVolumeBtn.tsx
@@ -4,6 +4,7 @@ import DuplicateVolumeForm from "../forms/DuplicateVolumeForm";
 import type { LxdStorageVolume } from "types/storage";
 import { usePortal } from "@canonical/react-components";
 import { useProjectEntitlements } from "util/entitlements/projects";
+import { useProject } from "context/useProjects";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -14,6 +15,7 @@ interface Props {
 const DuplicateVolumeBtn: FC<Props> = ({ volume, className, onClose }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const { canCreateStorageVolumes } = useProjectEntitlements();
+  const { data: project } = useProject(volume.project);
 
   const handleClose = () => {
     closePortal();
@@ -33,11 +35,11 @@ const DuplicateVolumeBtn: FC<Props> = ({ volume, className, onClose }) => {
         className={className}
         onClick={openPortal}
         title={
-          !canCreateStorageVolumes(volume)
-            ? "You do not have permission to duplicate this volume"
-            : "Duplicate volume"
+          canCreateStorageVolumes(project)
+            ? "Duplicate volume"
+            : "You do not have permission to duplicate this volume"
         }
-        disabled={!canCreateStorageVolumes(volume)}
+        disabled={!canCreateStorageVolumes(project)}
       >
         <Icon name="canvas" />
         <span>Duplicate</span>

--- a/src/pages/storage/actions/DuplicateVolumeBtn.tsx
+++ b/src/pages/storage/actions/DuplicateVolumeBtn.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from "@canonical/react-components";
 import DuplicateVolumeForm from "../forms/DuplicateVolumeForm";
 import type { LxdStorageVolume } from "types/storage";
 import { usePortal } from "@canonical/react-components";
+import { useProjectEntitlements } from "util/entitlements/projects";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -12,6 +13,7 @@ interface Props {
 
 const DuplicateVolumeBtn: FC<Props> = ({ volume, className, onClose }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { canCreateStorageVolumes } = useProjectEntitlements();
 
   const handleClose = () => {
     closePortal();
@@ -31,6 +33,7 @@ const DuplicateVolumeBtn: FC<Props> = ({ volume, className, onClose }) => {
         className={className}
         onClick={openPortal}
         title="Duplicate volume"
+        disabled={!canCreateStorageVolumes(volume)}
       >
         <Icon name="canvas" />
         <span>Duplicate</span>

--- a/src/pages/storage/actions/DuplicateVolumeBtn.tsx
+++ b/src/pages/storage/actions/DuplicateVolumeBtn.tsx
@@ -32,7 +32,11 @@ const DuplicateVolumeBtn: FC<Props> = ({ volume, className, onClose }) => {
         aria-label="Duplicate volume"
         className={className}
         onClick={openPortal}
-        title="Duplicate volume"
+        title={
+          !canCreateStorageVolumes(volume)
+            ? "You do not have permission to duplicate this volume"
+            : "Duplicate volume"
+        }
         disabled={!canCreateStorageVolumes(volume)}
       >
         <Icon name="canvas" />

--- a/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
@@ -3,6 +3,7 @@ import type { LxdStorageVolume } from "types/storage";
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { usePortal } from "@canonical/react-components";
 import CreateVolumeSnapshotForm from "pages/storage/forms/CreateVolumeSnapshotForm";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -18,6 +19,7 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
   className,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
 
   return (
     <>
@@ -37,9 +39,11 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
           title={
             isDisabled
               ? `Snapshot creation is blocked for project ${volume.project}`
-              : "Add Snapshot"
+              : !canManageStorageVolumeSnapshots(volume)
+                ? "You do not have permission to create or delete snapshots of this volume."
+                : "Add Snapshot"
           }
-          disabled={isDisabled}
+          disabled={isDisabled || !canManageStorageVolumeSnapshots(volume)}
           className={className}
         >
           <Icon name="add-canvas" />

--- a/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
@@ -21,6 +21,16 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
 
+  const getDisabledReason = () => {
+    if (isDisabled) {
+      return `Snapshot creation is blocked for project ${volume.project}`;
+    }
+    if (!canManageStorageVolumeSnapshots(volume)) {
+      return "You do not have permission to create or delete snapshots of this volume.";
+    }
+    return "Add Snapshot";
+  };
+
   return (
     <>
       {isOpen ? (
@@ -36,13 +46,7 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
           onClick={openPortal}
           type="button"
           aria-label="Add Snapshot"
-          title={
-            isDisabled
-              ? `Snapshot creation is blocked for project ${volume.project}`
-              : !canManageStorageVolumeSnapshots(volume)
-                ? "You do not have permission to create or delete snapshots of this volume."
-                : "Add Snapshot"
-          }
+          title={getDisabledReason()}
           disabled={isDisabled || !canManageStorageVolumeSnapshots(volume)}
           className={className}
         >

--- a/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeAddSnapshotBtn.tsx
@@ -26,7 +26,7 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
       return `Snapshot creation is blocked for project ${volume.project}`;
     }
     if (!canManageStorageVolumeSnapshots(volume)) {
-      return "You do not have permission to create or delete snapshots of this volume.";
+      return "You do not have permission to create snapshots of this volume.";
     }
     return "Add Snapshot";
   };
@@ -57,7 +57,8 @@ const VolumeAddSnapshotBtn: FC<Props> = ({
           appearance="positive"
           className={className}
           onClick={openPortal}
-          disabled={isDisabled}
+          disabled={isDisabled || !canManageStorageVolumeSnapshots(volume)}
+          title={getDisabledReason()}
         >
           {isDisabled ? (
             <Tooltip

--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
@@ -3,6 +3,7 @@ import { usePortal } from "@canonical/react-components";
 import { Button } from "@canonical/react-components";
 import VolumeConfigureSnapshotModal from "./VolumeConfigureSnapshotModal";
 import type { LxdStorageVolume } from "types/storage";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -16,6 +17,7 @@ const VolumeConfigureSnapshotBtn: FC<Props> = ({
   className,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { canEditVolume } = useStorageVolumeEntitlements();
 
   return (
     <>
@@ -26,7 +28,16 @@ const VolumeConfigureSnapshotBtn: FC<Props> = ({
           </div>
         </Portal>
       )}
-      <Button onClick={openPortal} className={className} disabled={isDisabled}>
+      <Button
+        onClick={openPortal}
+        className={className}
+        disabled={!canEditVolume(volume) || isDisabled}
+        title={
+          !canEditVolume(volume)
+            ? "You do not have permission to configure this volume"
+            : "Configure snapshot"
+        }
+      >
         See configuration
       </Button>
     </>

--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotBtn.tsx
@@ -33,9 +33,9 @@ const VolumeConfigureSnapshotBtn: FC<Props> = ({
         className={className}
         disabled={!canEditVolume(volume) || isDisabled}
         title={
-          !canEditVolume(volume)
-            ? "You do not have permission to configure this volume"
-            : "Configure snapshot"
+          canEditVolume(volume)
+            ? "Configure snapshot"
+            : "You do not have permission to configure this volume"
         }
       >
         See configuration

--- a/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
@@ -43,7 +43,7 @@ const VolumeEditSnapshotBtn: FC<Props> = ({
         type="button"
         aria-label="Edit snapshot"
         title={
-          !canManageStorageVolumeSnapshots
+          !canManageStorageVolumeSnapshots(volume)
             ? "You do not have permission to edit this snapshot"
             : "Edit"
         }

--- a/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
@@ -43,9 +43,9 @@ const VolumeEditSnapshotBtn: FC<Props> = ({
         type="button"
         aria-label="Edit snapshot"
         title={
-          !canManageStorageVolumeSnapshots(volume)
-            ? "You do not have permission to edit this snapshot"
-            : "Edit"
+          canManageStorageVolumeSnapshots(volume)
+            ? "Edit"
+            : "You do not have permission to edit this snapshot"
         }
       >
         <Icon name="edit" />

--- a/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeEditSnapshotBtn.tsx
@@ -3,6 +3,7 @@ import { usePortal } from "@canonical/react-components";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdStorageVolume, LxdVolumeSnapshot } from "types/storage";
 import EditVolumeSnapshotForm from "pages/storage/forms/EditVolumeSnapshotForm";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -18,6 +19,7 @@ const VolumeEditSnapshotBtn: FC<Props> = ({
   isRestoring,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
 
   return (
     <>
@@ -34,11 +36,17 @@ const VolumeEditSnapshotBtn: FC<Props> = ({
         appearance="base"
         hasIcon
         dense={true}
-        disabled={isDeleting || isRestoring}
+        disabled={
+          !canManageStorageVolumeSnapshots(volume) || isDeleting || isRestoring
+        }
         onClick={openPortal}
         type="button"
         aria-label="Edit snapshot"
-        title="Edit"
+        title={
+          !canManageStorageVolumeSnapshots
+            ? "You do not have permission to edit this snapshot"
+            : "Edit"
+        }
       >
         <Icon name="edit" />
       </Button>

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
@@ -21,6 +21,7 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import ResourceLabel from "components/ResourceLabel";
 import VolumeSnapshotLinkChip from "pages/storage/VolumeSnapshotLinkChip";
 import ResourceLink from "components/ResourceLink";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -34,6 +35,7 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
   const [isDeleting, setDeleting] = useState(false);
   const [isRestoring, setRestoring] = useState(false);
   const queryClient = useQueryClient();
+  const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
 
   const volumeLink = (
     <ResourceLink
@@ -42,6 +44,12 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
       to={`/ui/project/${volume.project}/storage/pool/${volume.pool}/volumes/custom/${volume.name}`}
     />
   );
+
+  const getTitle = (action: string) => {
+    return !canManageStorageVolumeSnapshots(volume)
+      ? `You do not have permission to ${action} this snapshot`
+      : `Confirm ${action}`;
+  };
 
   const handleDelete = () => {
     setDeleting(true);
@@ -129,7 +137,7 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
             className="has-icon is-dense"
             title="Confirm restore"
             confirmationModalProps={{
-              title: "Confirm restore",
+              title: getTitle("restore"),
               children: (
                 <p>
                   This will restore snapshot <ItemName item={snapshot} bold />.
@@ -141,7 +149,11 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
               confirmButtonAppearance: "positive",
               onConfirm: handleRestore,
             }}
-            disabled={isDeleting || isRestoring}
+            disabled={
+              !canManageStorageVolumeSnapshots(volume) ||
+              isDeleting ||
+              isRestoring
+            }
             shiftClickEnabled
             showShiftClickHint
           >

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
@@ -47,8 +47,8 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
 
   const getTitle = (action: string) => {
     return !canManageStorageVolumeSnapshots(volume)
-      ? `You do not have permission to ${action} this snapshot`
-      : `Confirm ${action}`;
+      ? `You do not have permission to ${action.toLowerCase()} this snapshot`
+      : `${action} snapshot`;
   };
 
   const handleDelete = () => {
@@ -137,7 +137,7 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
             className="has-icon is-dense"
             title="Confirm restore"
             confirmationModalProps={{
-              title: getTitle("restore"),
+              title: "Confirm restore",
               children: (
                 <p>
                   This will restore snapshot <ItemName item={snapshot} bold />.
@@ -145,7 +145,7 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
                   This action cannot be undone, and can result in data loss.
                 </p>
               ),
-              confirmButtonLabel: "Restore",
+              confirmButtonLabel: getTitle("Restore"),
               confirmButtonAppearance: "positive",
               onConfirm: handleRestore,
             }}
@@ -173,10 +173,14 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
                   This action cannot be undone, and can result in data loss.
                 </p>
               ),
-              confirmButtonLabel: "Delete snapshot",
+              confirmButtonLabel: getTitle("Delete"),
               onConfirm: handleDelete,
             }}
-            disabled={isDeleting || isRestoring}
+            disabled={
+              !canManageStorageVolumeSnapshots(volume) ||
+              isDeleting ||
+              isRestoring
+            }
             shiftClickEnabled
             showShiftClickHint
           >

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
@@ -46,9 +46,9 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
   );
 
   const getTitle = (action: string) => {
-    return !canManageStorageVolumeSnapshots(volume)
-      ? `You do not have permission to ${action.toLowerCase()} this snapshot`
-      : `${action} snapshot`;
+    return canManageStorageVolumeSnapshots(volume)
+      ? `${action} snapshot`
+      : `You do not have permission to ${action.toLowerCase()} this snapshot`;
   };
 
   const handleDelete = () => {

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
@@ -95,9 +95,9 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
       deletableEntities={snapshotNames}
       buttonLabel={`Delete ${pluralize("snapshot", snapshotNames.length)}`}
       disabledReason={
-        !canManageStorageVolumeSnapshots(volume)
-          ? "You do not have permission to delete these volumes"
-          : undefined
+        canManageStorageVolumeSnapshots(volume)
+          ? undefined
+          : "You do not have permission to manage snapshots for this volume"
       }
     />
   );

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
@@ -9,6 +9,7 @@ import { getPromiseSettledCounts } from "util/helpers";
 import type { LxdStorageVolume } from "types/storage";
 import { useToastNotification } from "context/toastNotificationProvider";
 import BulkDeleteButton from "components/BulkDeleteButton";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -27,6 +28,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
 
   const count = snapshotNames.length;
 
@@ -84,7 +86,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
     <BulkDeleteButton
       confirmationButtonProps={{
         loading: isLoading,
-        disabled: isLoading,
+        disabled: !canManageStorageVolumeSnapshots(volume) || isLoading,
         appearance: "",
       }}
       onDelete={handleDelete}
@@ -92,6 +94,11 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
       entities={snapshotNames}
       deletableEntities={snapshotNames}
       buttonLabel={`Delete ${pluralize("snapshot", snapshotNames.length)}`}
+      disabledReason={
+        !canManageStorageVolumeSnapshots(volume)
+          ? "You do not have permission to delete these volumes"
+          : undefined
+      }
     />
   );
 };

--- a/src/pages/storage/forms/EditStorageVolume.tsx
+++ b/src/pages/storage/forms/EditStorageVolume.tsx
@@ -18,6 +18,7 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import ResourceLink from "components/ResourceLink";
 import { updateStorageVolume } from "api/storage-volumes";
+import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -30,6 +31,7 @@ const EditStorageVolume: FC<Props> = ({ volume }) => {
   const queryClient = useQueryClient();
   const { section } = useParams<{ section: string }>();
   const { project } = useParams<{ project: string }>();
+  const { canEditVolume } = useStorageVolumeEntitlements();
 
   if (!project) {
     return <>Missing project</>;
@@ -39,8 +41,12 @@ const EditStorageVolume: FC<Props> = ({ volume }) => {
     name: Yup.string().required("This field is required"),
   });
 
+  const editRestriction = canEditVolume(volume)
+    ? undefined
+    : "You do not have permission to edit this volume";
+
   const formik = useFormik<StorageVolumeFormValues>({
-    initialValues: getStorageVolumeEditValues(volume),
+    initialValues: getStorageVolumeEditValues(volume, editRestriction),
     validationSchema: StorageVolumeSchema,
     enableReinitialize: true,
     onSubmit: (values) => {

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -64,7 +64,10 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
               ensureEditMode(formik);
               formik.setFieldValue("size", val);
             }}
-            disabled={formik.values.volumeType !== "custom"}
+            disabled={
+              !!formik.values.editRestriction ||
+              formik.values.volumeType !== "custom"
+            }
           />
           <Select
             {...getFormProps(formik, "content_type")}

--- a/src/util/entitlements/storage-volumes.tsx
+++ b/src/util/entitlements/storage-volumes.tsx
@@ -11,8 +11,16 @@ export const useStorageVolumeEntitlements = () => {
   const canEditVolume = (volume?: LxdStorageVolume) =>
     hasEntitlement(isFineGrained, "can_edit", volume?.access_entitlements);
 
+  const canManageStorageVolumeSnapshots = (volume?: LxdStorageVolume) =>
+    hasEntitlement(
+      isFineGrained,
+      "can_manage_snapshots",
+      volume?.access_entitlements,
+    );
+
   return {
     canDeleteVolume,
     canEditVolume,
+    canManageStorageVolumeSnapshots,
   };
 };

--- a/src/util/storageVolumeEdit.tsx
+++ b/src/util/storageVolumeEdit.tsx
@@ -3,6 +3,7 @@ import type { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeF
 
 export const getStorageVolumeEditValues = (
   volume: LxdStorageVolume,
+  editRestriction?: string,
 ): StorageVolumeFormValues => {
   return {
     name: volume.name,
@@ -28,5 +29,6 @@ export const getStorageVolumeEditValues = (
     readOnly: true,
     isCreating: false,
     entityType: "storageVolume",
+    editRestriction,
   };
 };


### PR DESCRIPTION
## Done

**Storage Volumes page**
- if instance view permission is missing we should disable linking to the instance
- if image view permission is missing we should disable linking to the image list
- disable create volume button if user does not have permission
- disable add snapshot button if user does not have permission
- disable button if user does not have permission to delete a SV (DeleteStorageVolumeComponent x2)
- disable rename header if permission is missing
- disable SV migrate button if user does not have permission
- disable SV duplicate button if user does not have permission for any projects
- disable Add SV Snapshot button if user does not have permission
- disable button if user does not have permission
- disable configure volume snapshot configs button if user does not have permission
- disable bulk delete volume snapshots button if user does not have permission
- disable edit volume snapshot button if user does not have permission
- disable restore volume from snapshot button if user does not have permission
- disable delete volume snapshot button if user does not have permission
- disable all configs if permission is missing
- bugfix: [Permission Checks] Disk Size select component not mirroring edi…

See [Storage Volume Permission Actions](https://docs.google.com/spreadsheets/d/1fXBNG9B8CL2iXP6kPEe4a3YM0q2QcOnj-I3essIUuh8/edit?gid=954494754#gid=954494754) for full list of implemented / pending actions to permission check.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
![image](https://github.com/user-attachments/assets/338faf83-f38e-48c3-9c63-baec8957a306)
