### PR TITLE
fix(instance) ensure meters for memory and cpu are positioned in line with text in instance list rows

### DIFF
--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -103,6 +103,10 @@
     min-height: auto;
     overflow: hidden;
   }
+
+  .p-meter {
+    margin-top: 4px;
+  }
 }
 
 .table-column-select-list {


### PR DESCRIPTION
## Done

- ensure meters for memory and cpu are positioned in line with text in instance list rows

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @mas-who or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the memory and cpu columns in the instance list for running instances. ensure the meter is positioned well with the rest of the text in the instance rows with a meter.