### PR TITLE
Show identity id instead of name, when the name is empty

### DIFF
--- a/src/context/useLoggedInUser.tsx
+++ b/src/context/useLoggedInUser.tsx
@@ -1,5 +1,6 @@
 import { useSettings } from "./useSettings";
 import { useIdentity } from "./useIdentities";
+import { getIdentityName } from "util/permissionIdentities";
 
 export const useLoggedInUser = () => {
   const { data: settings } = useSettings();
@@ -11,7 +12,7 @@ export const useLoggedInUser = () => {
   const { data: identity } = useIdentity(id, authMethod, identityQueryEnabled);
 
   return {
-    loggedInUserName: identity?.name,
+    loggedInUserName: getIdentityName(identity),
     loggedInUserID: id,
     authMethod,
   };

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -37,6 +37,7 @@ import CreateTlsIdentityBtn from "./CreateTlsIdentityBtn";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import { pluralize } from "util/instanceBulkActions";
+import { getIdentityName } from "util/permissionIdentities";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -87,7 +88,7 @@ const PermissionIdentities: FC = () => {
     if (
       !filters.queries.every(
         (q) =>
-          identity.name.toLowerCase().includes(q) ||
+          getIdentityName(identity).toLowerCase().includes(q) ||
           identity.id.toLowerCase().includes(q),
       )
     ) {
@@ -133,6 +134,7 @@ const PermissionIdentities: FC = () => {
         </div>
       );
     };
+    const name = getIdentityName(identity);
 
     return {
       key: identity.id,
@@ -142,13 +144,13 @@ const PermissionIdentities: FC = () => {
         {
           content: (
             <>
-              {identity.name} <Tag isVisible={isLoggedInIdentity}>You</Tag>
+              {name} <Tag isVisible={isLoggedInIdentity}>You</Tag>
             </>
           ),
           role: "cell",
           "aria-label": "Name",
           className: "u-truncate",
-          title: identity.name,
+          title: name,
         },
         {
           content: identity.id,
@@ -207,7 +209,7 @@ const PermissionIdentities: FC = () => {
       ],
       sortData: {
         id: identity.id,
-        name: identity.name.toLowerCase(),
+        name: name.toLowerCase(),
         authentication_method: identity.authentication_method,
         type: identity.type,
         groups: identity.groups?.length || 0,

--- a/src/pages/permissions/actions/EditIdentityGroupsBtn.tsx
+++ b/src/pages/permissions/actions/EditIdentityGroupsBtn.tsx
@@ -5,6 +5,7 @@ import type { LxdIdentity } from "types/permissions";
 import usePanelParams from "util/usePanelParams";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import { pluralize } from "util/instanceBulkActions";
+import { getIdentityName } from "util/permissionIdentities";
 
 interface Props {
   identities: LxdIdentity[];
@@ -29,7 +30,7 @@ const EditIdentityGroupsBtn: FC<Props & ButtonProps> = ({
 
   const getRestrictedWarning = () => {
     const restrictedList = restrictedIdentities
-      .map((identity) => `\n- ${identity.name}`)
+      .map((identity) => `\n- ${getIdentityName(identity)}`)
       .join("");
     return `You do not have permission to modify ${restrictedIdentities.length > 1 ? "some of the selected" : "the selected"} ${pluralize("identity", restrictedIdentities.length)}:${restrictedList}`;
   };

--- a/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
@@ -28,6 +28,7 @@ import useSortTableData from "util/useSortTableData";
 import { isUnrestricted } from "util/helpers";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
+import { getIdentityName } from "util/permissionIdentities";
 
 interface IdentityEditHistory {
   identitiesAdded: Set<string>;
@@ -193,7 +194,7 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
     if (
       !filters.queries.every(
         (q) =>
-          identity.name.toLowerCase().includes(q) ||
+          getIdentityName(identity).toLowerCase().includes(q) ||
           identity.id.toLowerCase().includes(q),
       )
     ) {
@@ -218,6 +219,7 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
       : desiredState.identitiesRemoved.has(identity.id)
         ? `Identity will be removed from ${selectedGroupText}`
         : "";
+    const name = getIdentityName(identity);
 
     return {
       key: identity.id,
@@ -225,11 +227,11 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
       className: "u-row",
       columns: [
         {
-          content: identity.name,
+          content: name,
           role: "cell",
           "aria-label": "Identity",
           title: canEditIdentity(identity)
-            ? identity.name
+            ? name
             : "You do not have permission to manage this identity",
         },
         {
@@ -243,7 +245,7 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
         },
       ],
       sortData: {
-        name: identity.name.toLowerCase(),
+        name: name.toLowerCase(),
       },
     };
   });

--- a/src/pages/permissions/panels/EditIdentitiesForm.tsx
+++ b/src/pages/permissions/panels/EditIdentitiesForm.tsx
@@ -8,6 +8,7 @@ import type { LxdIdentity } from "types/permissions";
 import { isUnrestricted } from "util/helpers";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
+import { getIdentityName } from "util/permissionIdentities";
 
 export type FormIdentity = LxdIdentity & {
   isRemoved?: boolean;
@@ -112,7 +113,8 @@ const EditIdentitiesForm: FC<Props> = ({
 
   const filteredIdentities = fineGrainedIdentities.filter((identity) => {
     if (filter) {
-      return identity.name.toLowerCase().includes(filter.toLowerCase());
+      const name = getIdentityName(identity);
+      return name.toLowerCase().includes(filter.toLowerCase());
     }
 
     return true;
@@ -124,6 +126,7 @@ const EditIdentitiesForm: FC<Props> = ({
     };
     const formIdentity = selected.find((id) => id.id === identity.id);
     const isModified = formIdentity?.isAdded || formIdentity?.isRemoved;
+    const name = getIdentityName(identity);
 
     return {
       key: identity.id,
@@ -131,11 +134,11 @@ const EditIdentitiesForm: FC<Props> = ({
       className: "u-row",
       columns: [
         {
-          content: identity.name,
+          content: name,
           role: "cell",
           "aria-label": "Identity",
           title: canEditIdentity(identity)
-            ? identity.name
+            ? name
             : "You do not have permission to allocate this identity to the group",
           onClick: clickRow,
           className: "clickable-cell",
@@ -148,7 +151,7 @@ const EditIdentitiesForm: FC<Props> = ({
         },
       ],
       sortData: {
-        name: identity.name.toLowerCase(),
+        name: name.toLowerCase(),
       },
     };
   });

--- a/src/pages/permissions/panels/GroupOrIdentityChangesTable.tsx
+++ b/src/pages/permissions/panels/GroupOrIdentityChangesTable.tsx
@@ -2,6 +2,7 @@ import { Button, Icon } from "@canonical/react-components";
 import type { FC } from "react";
 import { useEffect, useRef, useState } from "react";
 import type { ChangeSummary } from "util/permissionIdentities";
+import { getIdentityName } from "util/permissionIdentities";
 import Tag from "components/Tag";
 import type { LxdIdentity } from "types/permissions";
 import LoggedInUserNotification from "./LoggedInUserNotification";
@@ -73,7 +74,7 @@ const generateRowsFromGroupIdentityChanges = (
   const groups = Object.keys(groupIdentitiesChangeSummary);
   const identityNameLookup: Record<string, string> = {};
   identities.forEach(
-    (identity) => (identityNameLookup[identity.id] = identity.name),
+    (identity) => (identityNameLookup[identity.id] = getIdentityName(identity)),
   );
 
   const rows: React.JSX.Element[] = [];

--- a/src/util/permissionGroups.tsx
+++ b/src/util/permissionGroups.tsx
@@ -3,6 +3,7 @@ import type { AbortControllerState } from "./helpers";
 import { checkDuplicateName } from "./helpers";
 import type { LxdGroup, LxdIdentity } from "types/permissions";
 import type { ChangeSummary } from "./permissionIdentities";
+import { getIdentityName } from "./permissionIdentities";
 
 export const testDuplicateGroupName = (
   controllerState: AbortControllerState,
@@ -171,7 +172,7 @@ export const getChangesInGroupsForIdentities = (
       identityGroupsChangeSummary[identity.id] = {
         added: groupsAddedForIdentity,
         removed: groupsRemovedForIdentity,
-        name: identity.name,
+        name: getIdentityName(identity),
       };
     }
   }

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -129,7 +129,7 @@ export const getChangesInGroupsForIdentities = (
       identityGroupsChangeSummary[identity.id] = {
         added: groupsAddedForIdentity,
         removed: groupsRemovedForIdentity,
-        name: identity.name,
+        name: getIdentityName(identity),
       };
     }
   }
@@ -173,4 +173,11 @@ export const pivotIdentityGroupsChangeSummary = (
   }
 
   return groupIdentitiesChangeSummary;
+};
+
+export const getIdentityName = (identity?: LxdIdentity): string => {
+  if (!identity) {
+    return "";
+  }
+  return identity.name.length > 0 ? identity.name : identity.id;
 };

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -10,6 +10,7 @@ import ResourceOptionLabel from "pages/permissions/panels/ResourceOptionLabel";
 import EntitlementOptionLabel from "pages/permissions/panels/EntitlementOptionLabel";
 import type { CustomSelectOption } from "@canonical/react-components";
 import { getOptionText } from "@canonical/react-components/dist/components/CustomSelect/CustomSelectDropdown";
+import { getIdentityName } from "util/permissionIdentities";
 
 export const noneAvailableOption = {
   disabled: true,
@@ -324,7 +325,7 @@ export const getIdentityNameLookup = (
 ): Record<string, string> => {
   const nameLookup: Record<string, string> = {};
   for (const identity of identities) {
-    nameLookup[identity.id] = identity.name;
+    nameLookup[identity.id] = getIdentityName(identity);
   }
 
   return nameLookup;


### PR DESCRIPTION
## Done

- Show identity id instead of name, when the name is empty

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - use ory hydra as oidc provider as [described in the howto](https://github.com/canonical/lxd/pull/15126)
    - create an account to login, then browse the identity list and edit identity panel for groups. 

## Before
![image](https://github.com/user-attachments/assets/b99492b0-761b-4bb2-b158-d7f5d9db57a2)

## After
![image](https://github.com/user-attachments/assets/4327a401-0d28-40f0-88eb-87c2e018a5f3)
