### PR TITLE
fix network forward success message

### DIFF
--- a/src/api/network-forwards.tsx
+++ b/src/api/network-forwards.tsx
@@ -1,4 +1,4 @@
-import { handleResponse } from "util/helpers";
+import { handleRawResponse, handleResponse } from "util/helpers";
 import type { LxdNetwork, LxdNetworkForward } from "types/network";
 import type { LxdApiResponse } from "types/apiResponse";
 
@@ -37,14 +37,18 @@ export const createNetworkForward = async (
   network: string,
   forward: Partial<LxdNetworkForward>,
   project: string,
-): Promise<void> => {
+): Promise<string> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/networks/${network}/forwards?project=${project}`, {
       method: "POST",
       body: JSON.stringify(forward),
     })
-      .then(handleResponse)
-      .then(resolve)
+      .then(handleRawResponse)
+      .then((response) => {
+        const locationHeader = response.headers.get("Location");
+        const listenAddress = locationHeader?.split("/").pop() ?? "";
+        resolve(listenAddress);
+      })
       .catch(reject);
   });
 };

--- a/src/pages/networks/CreateNetworkForward.tsx
+++ b/src/pages/networks/CreateNetworkForward.tsx
@@ -62,7 +62,7 @@ const CreateNetworkForward: FC = () => {
     onSubmit: (values) => {
       const forward = toNetworkForward(values);
       createNetworkForward(networkName ?? "", forward, project ?? "")
-        .then(() => {
+        .then((listenAddress) => {
           queryClient.invalidateQueries({
             queryKey: [
               queryKeys.projects,
@@ -74,7 +74,7 @@ const CreateNetworkForward: FC = () => {
           });
           navigate(`/ui/project/${project}/network/${networkName}/forwards`);
           toastNotify.success(
-            `Network forward ${forward.listen_address} created.`,
+            `Network forward with listen address ${listenAddress} created.`,
           );
         })
         .catch((e) => {

--- a/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
@@ -30,7 +30,7 @@ const DeleteNetworkForwardBtn: FC<Props> = ({ network, forward, project }) => {
     deleteNetworkForward(network, forward, project)
       .then(() => {
         toastNotify.success(
-          `Network forward for ${forward.listen_address} deleted`,
+          `Network forward with listen address ${forward.listen_address} deleted.`,
         );
         queryClient.invalidateQueries({
           predicate: (query) =>

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -100,6 +100,16 @@ export const handleTextResponse = async (
   return response.text();
 };
 
+export const handleRawResponse = async (
+  response: Response,
+): Promise<Response> => {
+  if (!response.ok) {
+    const result = (await response.json()) as ErrorResponse;
+    throw Error(result.error);
+  }
+  return response;
+};
+
 export const humanFileSize = (bytes: number): string => {
   if (Math.abs(bytes) < 1000) {
     return `${bytes} B`;

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -93,7 +93,9 @@ export const createNetworkForward = async (page: Page, network: string) => {
   await addressInput.fill(targetAddress);
   await page.getByRole("button", { name: "Create" }).click();
 
-  await page.getByText(`Network forward ${listenAddress} created.`).click();
+  await page
+    .getByText(`Network forward with listen address ${listenAddress} created.`)
+    .click();
   await page.getByText(`:80 → ${targetAddress}:80 (tcp)`).click();
   await page
     .getByText(`:23,443-455 → ${targetAddress}:23,443-455 (tcp)`)


### PR DESCRIPTION
## Done

- Update network forward success message.
  - For auto assigned and custom addresses on network forward creation: Show the listen address in the success message.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a network forward on a bridge, specify a listen address, then specify no listen address and rely on auto assignment of it.
    - for auto assignment, OVN needs to be setup, such as with microcloud and microovn.