### PR TITLE
fix custom iso volumes in clusters

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -394,6 +394,15 @@ const CreateInstance: FC = () => {
     } else if (isContainerOnlyImage(image)) {
       formik.setFieldValue("instanceType", "container");
     }
+
+    if (image.volume?.location && image.volume.location !== "none") {
+      // custom ISOs can only run locally to the instance
+      // preselect the target by the location of its volume
+      formik.setFieldValue("target", image.volume?.location);
+      formik.setFieldValue("targetSelectedByVolume", true);
+    } else {
+      formik.setFieldValue("targetSelectedByVolume", undefined);
+    }
   };
 
   useEffect(() => {

--- a/src/pages/instances/forms/InstanceLocationSelect.tsx
+++ b/src/pages/instances/forms/InstanceLocationSelect.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { Select } from "@canonical/react-components";
+import { Input, Select } from "@canonical/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
@@ -65,6 +65,22 @@ const InstanceLocationSelect: FC<Props> = ({ formik }) => {
 
   const availableMembers =
     clusterGroups.find((group) => group.name === selectedGroup)?.members ?? [];
+
+  const isPreselected = (formik.values as { targetSelectedByVolume?: boolean })
+    .targetSelectedByVolume;
+
+  if (isPreselected) {
+    return (
+      <Input
+        id="clusterMember"
+        label="Cluster member"
+        value={formik.values.target}
+        disabled
+        help="Member is determined by the selected ISO volume and can't be changed."
+        type="text"
+      />
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Done

- fix custom iso volumes in clusters: ISO volumes stored on a local storage pool in a cluster can only be used for instances on the member they are saved on

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in a clustered backend:
      - upload a custom ISO to a storage pool that is local to each cluster member
      - use the custom ISO, ensure only the member that the ISO resides on can be selected for the instance target
      - create an instance, ensure you can place it on any cluster member.
      - upload a custom ISO to a storage pool that is cluster wide (todo: this is failing, might be a backend bug).
    - in a non-clustered backend:
      - create an instance 