### PR TITLE
Add security.csm configuration to profiles and instances

### DIFF
--- a/src/components/forms/SecurityPoliciesForm.tsx
+++ b/src/components/forms/SecurityPoliciesForm.tsx
@@ -27,6 +27,7 @@ export interface SecurityPoliciesFormValues {
   security_devlxd?: string;
   security_devlxd_images?: string;
   security_secureboot?: string;
+  security_csm?: string;
 }
 
 export const securityPoliciesPayload = (
@@ -46,6 +47,7 @@ export const securityPoliciesPayload = (
     [getInstanceKey("security_devlxd")]: values.security_devlxd,
     [getInstanceKey("security_devlxd_images")]: values.security_devlxd_images,
     [getInstanceKey("security_secureboot")]: values.security_secureboot,
+    [getInstanceKey("security_csm")]: values.security_csm,
   };
 };
 
@@ -219,6 +221,21 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           formik,
           label: "Enable secureboot (VMs only)",
           name: "security_secureboot",
+          defaultValue: "",
+          disabled: isVmOnlyDisabled,
+          disabledReason: isVmOnlyDisabled
+            ? "Only available for virtual machines"
+            : undefined,
+          readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
+          children: (
+            <Select options={optionTrueFalse} disabled={isVmOnlyDisabled} />
+          ),
+        }),
+
+        getConfigurationRow({
+          formik,
+          label: "Enable CSM (VMs only)",
+          name: "security_csm",
           defaultValue: "",
           disabled: isVmOnlyDisabled,
           disabledReason: isVmOnlyDisabled

--- a/src/util/instanceConfigFields.tsx
+++ b/src/util/instanceConfigFields.tsx
@@ -15,6 +15,7 @@ const instanceConfigFormFieldsToPayload: Record<string, string> = {
   security_devlxd: "security.devlxd",
   security_devlxd_images: "security.devlxd.images",
   security_secureboot: "security.secureboot",
+  security_csm: "security.csm",
   snapshots_pattern: "snapshots.pattern",
   snapshots_expiry: "snapshots.expiry",
   snapshots_schedule: "snapshots.schedule",

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -47,6 +47,7 @@ const getEditValues = (
     security_devlxd: item.config["security.devlxd"],
     security_devlxd_images: item.config["security.devlxd.images"],
     security_secureboot: item.config["security.secureboot"],
+    security_csm: item.config["security.csm"],
 
     snapshots_pattern: item.config["snapshots.pattern"],
     snapshots_expiry: item.config["snapshots.expiry"],


### PR DESCRIPTION
## Done

- Add security.csm configuration to profiles and instances

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance and profile config > security policies. Enable / Disable the CSM option.