### PR TITLE
Ensure instances in foreign projects are shown with project in the network topology. Avoid mixup of projects for instance metrics.

### DIFF
--- a/src/pages/networks/NetworkTopology.tsx
+++ b/src/pages/networks/NetworkTopology.tsx
@@ -165,8 +165,20 @@ const NetworkTopology: FC<Props> = ({ formik, project, isServerClustered }) => {
             .slice(0, isInstancesCollapsed ? 5 : instances.length)
             .map((item) => {
               const instanceUrl = `/ui/project/${item.project}/instance/${item.name}`;
+              const projectUrl = `/ui/project/${item.project}`;
+              const isExternalProject = item.project !== project;
               return (
                 <div key={instanceUrl} className="downstream-item">
+                  {isExternalProject && (
+                    <>
+                      <ResourceLink
+                        type="project"
+                        value={item.project}
+                        to={projectUrl}
+                      />{" "}
+                      /{" "}
+                    </>
+                  )}
                   <ResourceLink
                     type="instance"
                     value={item.name}

--- a/src/util/formChangeCount.spec.ts
+++ b/src/util/formChangeCount.spec.ts
@@ -244,4 +244,85 @@ describe("formChangeCount", () => {
 
     expect(result).toBe(1);
   });
+
+  it("counts rename of a device as one", () => {
+    const formik = {
+      initialValues: {
+        devices: [
+          {
+            name: "eth0",
+            type: "nic",
+          },
+        ],
+      },
+      values: {
+        devices: [
+          {
+            name: "eth1",
+            type: "nic",
+          },
+        ],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(1);
+  });
+
+  it("counts rename and detail change of a device as two", () => {
+    const formik = {
+      initialValues: {
+        devices: [
+          {
+            name: "eth0",
+            network: "foo",
+            type: "nic",
+          },
+        ],
+      },
+      values: {
+        devices: [
+          {
+            name: "eth1",
+            network: "bar",
+            type: "nic",
+          },
+        ],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(2);
+  });
+
+  it("counts rename and removal as two", () => {
+    const formik = {
+      initialValues: {
+        devices: [
+          {
+            name: "eth0",
+            type: "nic",
+          },
+          {
+            name: "eth1",
+            type: "nic",
+          },
+        ],
+      },
+      values: {
+        devices: [
+          {
+            name: "eth2",
+            type: "nic",
+          },
+        ],
+      },
+    } as ConfigurationRowFormikProps;
+
+    const result = getFormChangeCount(formik);
+
+    expect(result).toBe(2);
+  });
 });

--- a/src/util/formChangeCount.tsx
+++ b/src/util/formChangeCount.tsx
@@ -124,10 +124,12 @@ const getDeviceChanges = (formik: ConfigurationRowFormikProps): number => {
   let addCount = 0;
   let removeCount = 0;
 
+  const removedDevices: FormDevice[] = [];
   initNames.forEach((init, initIndex) => {
     const valueIndex = names.indexOf(init);
     if (valueIndex === -1) {
       removeCount++;
+      removedDevices.push(initDevices[initIndex]);
     } else {
       changeCount += getDevicePairFieldChanges(
         initDevices[initIndex],
@@ -139,7 +141,18 @@ const getDeviceChanges = (formik: ConfigurationRowFormikProps): number => {
   names.forEach((init) => {
     const oldIndex = initNames.indexOf(init);
     if (oldIndex === -1) {
-      addCount++;
+      const newDevice = devices.find((device) => device.name === init);
+      const oldDevice = removedDevices.find(
+        (device) => device.type === newDevice?.type,
+      );
+      const wasRenamed = !!oldDevice;
+      if (wasRenamed && newDevice && oldDevice) {
+        // For rename detection, pair an old device if the type is the same and it was removed.
+        // subtract -1, because it was already counted as a removal.
+        changeCount += getDevicePairFieldChanges(oldDevice, newDevice) - 1;
+      } else {
+        addCount++;
+      }
     }
   });
 

--- a/src/util/metricSelectors.tsx
+++ b/src/util/metricSelectors.tsx
@@ -24,7 +24,11 @@ export const getInstanceMetrics = (
   const memValue = (metricKey: string) =>
     metrics
       .find((item) => item.name === metricKey)
-      ?.metrics.find((item) => item.labels.name === instance.name)?.value;
+      ?.metrics.find(
+        (item) =>
+          item.labels.name === instance.name &&
+          item.labels.project === instance.project,
+      )?.value;
 
   const memFree = memValue("lxd_memory_MemFree_bytes");
   const memCached = memValue("lxd_memory_Cached_bytes");
@@ -43,7 +47,9 @@ export const getInstanceMetrics = (
       .find((item) => item.name === metricKey)
       ?.metrics.find(
         (item) =>
-          item.labels.name === instance.name && item.labels.mountpoint === "/",
+          item.labels.name === instance.name &&
+          item.labels.project === instance.project &&
+          item.labels.mountpoint === "/",
       )?.value;
 
   const diskFree = diskValue("lxd_filesystem_free_bytes");


### PR DESCRIPTION
## Done

- Ensure instances in foreign projects are shown with a parent project in the network topology
- Ensure to pick instance metrics from the right project. do not confuse instances with the same name on different projects

Fixes #1149

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instances in different projects, assign them to the same network
    - browse the network detail page, ensure the instances in foreign projects show up with their project next to them.
    - With two instances having the same name from different projects, ensure the metrics displayed are belonging to the right instance.