### PR TITLE
Avoid infinite render loop on empty image list

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -128,7 +128,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     .sort();
   const variantAll = [...new Set(images.map((item) => item.variant))].sort();
 
-  if (!isLoading && !archAll.includes(arch)) {
+  if (!isLoading && !archAll.includes(arch) && archAll.length > 0) {
     setArch(archAll[0]);
   }
 


### PR DESCRIPTION
## Done

-  Avoid infinite render loop on empty image list, when selecting an image on instance creation.

Fixes #1156