### PR TITLE
Snapshot fixes

### DIFF
--- a/src/components/forms/SnapshotForm.tsx
+++ b/src/components/forms/SnapshotForm.tsx
@@ -64,7 +64,7 @@ const SnapshotForm: FC<Props> = (props) => {
           onBlur={formik.handleBlur}
           value={formik.values.name}
           error={
-            formik.touched.name || isEdit ? (
+            (formik.touched.name || isEdit) && formik.errors.name ? (
               <div className="name-error">{formik.errors.name}</div>
             ) : null
           }

--- a/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
@@ -78,21 +78,12 @@ const InstanceConfigureSnapshotModal: FC<Props> = ({
       title="Snapshot configuration"
       buttonRow={
         formik.values.readOnly ? (
-          <div className="u-space-between u-flex-row-reverse">
-            <Button
-              className="u-no-margin--bottom u-no-margin--right"
-              onClick={close}
-            >
-              Close
-            </Button>
-            <Button
-              className="u-no-margin--bottom"
-              type="button"
-              onClick={async () => formik.setFieldValue("readOnly", false)}
-            >
-              Edit configuration
-            </Button>
-          </div>
+          <Button
+            className="u-no-margin--bottom u-no-margin--right"
+            onClick={close}
+          >
+            Close
+          </Button>
         ) : (
           <>
             <Button

--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
@@ -77,21 +77,12 @@ const VolumeConfigureSnapshotModal: FC<Props> = ({ volume, close }) => {
       title="Snapshot configuration"
       buttonRow={
         formik.values.readOnly ? (
-          <div className="u-space-between u-flex-row-reverse">
-            <Button
-              className="u-no-margin--bottom u-no-margin--right"
-              onClick={close}
-            >
-              Close
-            </Button>
-            <Button
-              className="u-no-margin--bottom"
-              type="button"
-              onClick={async () => formik.setFieldValue("readOnly", false)}
-            >
-              Edit configuration
-            </Button>
-          </div>
+          <Button
+            className="u-no-margin--bottom u-no-margin--right"
+            onClick={close}
+          >
+            Close
+          </Button>
         ) : (
           <>
             <Button

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -84,7 +84,7 @@ test("storage volume edit snapshot configuration", async ({
   await visitVolume(page, volume);
   await page.getByTestId("tab-link-Snapshots").click();
   await page.getByText("See configuration").click();
-  await page.getByText("Edit configuration").click();
+  await page.getByRole("button", { name: "Create override" }).first().click();
 
   await setInput(
     page,


### PR DESCRIPTION
## Done

- avoid error status on snapshot name when no error is present
- remove edit link in snapshot configuration form for instances and volumes. We go into edit mode directly now, no edit button needed anymore.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create snapshot for an instance and a volume, ensure the name field is not in an error state with a valid name
    - edit configuration on the instance and volume snapshot page, ensure the "edit" button in the modal is gone and the layout still works.