### PR TITLE
Use link instead of anchor to avoid full page load

### DIFF
--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Icon } from "@canonical/react-components";
-import { Navigate } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { useAuth } from "context/auth";
 import Loader from "components/Loader";
 import { useSettings } from "context/useSettings";
@@ -35,12 +35,12 @@ const Login: FC = () => {
                 <span>Login with SSO</span>
               </a>
             )}
-            <a
+            <Link
               className={classnames(" has-icon", {
                 "p-button--positive": !hasOidc,
                 "p-button": hasOidc,
               })}
-              href="/ui/login/certificate-generate"
+              to="/ui/login/certificate-generate"
             >
               <Icon
                 name="certificate"
@@ -49,7 +49,7 @@ const Login: FC = () => {
                 })}
               />
               <span>Login with TLS</span>
-            </a>
+            </Link>
           </div>
         </>
       </div>

--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Icon, Row, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import StoragePoolHeader from "pages/storage/StoragePoolHeader";
@@ -47,12 +47,12 @@ const StoragePoolDetail: FC = () => {
     "Configuration",
     {
       component: () => (
-        <a
-          href={`/ui/project/${project}/storage/volumes?pool=${pool.name}`}
+        <Link
+          to={`/ui/project/${project}/storage/volumes?pool=${pool.name}`}
           className="p-tabs__link"
         >
           Volumes <Icon name="external-link" />
-        </a>
+        </Link>
       ),
       label: "Volumes",
     },


### PR DESCRIPTION
## Done

- Use link instead of anchor to avoid full page load in storage and login section.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to storage pool detail page, click "Volumes". Ensure the page does not refresh fully, but the link works.
    - go to login page, click "Login with TLS" and ensure the page does not refresh fully, but the link works.