### PR TITLE
feat: [WD-19726] TLS Identity creation with groups

### DIFF
--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -108,13 +108,15 @@ export const deleteIdentities = async (
 };
 
 export const createFineGrainedTlsIdentity = async (
-  clientName: string,
+  name: string,
+  groups: string[],
 ): Promise<TlsIdentityTokenDetail> => {
   return new Promise((resolve, reject) => {
     fetch(`/1.0/auth/identities/tls`, {
       method: "POST",
       body: JSON.stringify({
-        name: clientName,
+        name: name,
+        groups: groups,
         token: true,
       }),
     })

--- a/src/pages/permissions/CreateTLSIdentity.tsx
+++ b/src/pages/permissions/CreateTLSIdentity.tsx
@@ -1,0 +1,40 @@
+import { useState, type FC } from "react";
+import CreateIdentityModal from "./CreateIdentityModal";
+import CreateTLSIdentityPanel from "./panels/CreateTLSIdentityPanel";
+import { usePortal } from "@canonical/react-components";
+import usePanelParams, { panels } from "util/usePanelParams";
+
+const CreateTLSIdentity: FC = () => {
+  const panelParams = usePanelParams();
+  const { openPortal, closePortal, isOpen, Portal } = usePortal({
+    programmaticallyOpen: true,
+  });
+  const [token, setToken] = useState("");
+  const [identityName, setIdentityName] = useState("");
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <CreateIdentityModal
+            onClose={closePortal}
+            token={token}
+            identityName={identityName}
+          />
+        </Portal>
+      )}
+
+      {panelParams.panel === panels.createTLSIdentity && (
+        <CreateTLSIdentityPanel
+          onSuccess={(identityName: string, token: string) => {
+            setIdentityName(identityName);
+            setToken(token);
+            openPortal();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreateTLSIdentity;

--- a/src/pages/permissions/CreateTlsIdentityBtn.tsx
+++ b/src/pages/permissions/CreateTlsIdentityBtn.tsx
@@ -1,26 +1,22 @@
 import { Button, Icon } from "@canonical/react-components";
 import { useSmallScreen } from "context/useSmallScreen";
 import type { FC } from "react";
-import { usePortal } from "@canonical/react-components";
-import CreateIdentityModal from "./CreateIdentityModal";
 import { useServerEntitlements } from "util/entitlements/server";
 
-const CreateTlsIdentityBtn: FC = () => {
+interface Props {
+  openPanel: () => void;
+}
+
+const CreateTlsIdentityBtn: FC<Props> = ({ openPanel }) => {
   const isSmallScreen = useSmallScreen();
-  const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const { canCreateIdentities } = useServerEntitlements();
 
   return (
     <>
-      {isOpen && (
-        <Portal>
-          <CreateIdentityModal onClose={closePortal} />
-        </Portal>
-      )}
       <Button
         appearance="positive"
         className="u-float-right u-no-margin--bottom"
-        onClick={openPortal}
+        onClick={openPanel}
         hasIcon={!isSmallScreen}
         title={
           canCreateIdentities()

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -38,6 +38,7 @@ import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import { pluralize } from "util/instanceBulkActions";
 import { getIdentityName } from "util/permissionIdentities";
+import CreateTLSIdentity from "./CreateTLSIdentity";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -284,7 +285,9 @@ const PermissionIdentities: FC = () => {
               )}
             </PageHeader.Left>
             <PageHeader.BaseActions>
-              <CreateTlsIdentityBtn />
+              <CreateTlsIdentityBtn
+                openPanel={panelParams.openCreateTLSIdentity}
+              />
             </PageHeader.BaseActions>
           </PageHeader>
         }
@@ -326,6 +329,8 @@ const PermissionIdentities: FC = () => {
           </ScrollableTable>
         </Row>
       </CustomLayout>
+      <CreateTLSIdentity />
+
       {panelParams.panel === panels.identityGroups && (
         <EditIdentityGroupsPanel
           identities={selectedIdentities}

--- a/src/pages/permissions/forms/NameWithGroupForm.tsx
+++ b/src/pages/permissions/forms/NameWithGroupForm.tsx
@@ -5,12 +5,16 @@ import type { FormikProps } from "formik/dist/types";
 export interface IdpGroupFormValues {
   name: string;
 }
-
-interface Props {
-  formik: FormikProps<IdpGroupFormValues>;
+export interface TLSIdentityFormValues {
+  name: string;
+  groups?: string[];
 }
 
-const IdpGroupForm: FC<Props> = ({ formik }) => {
+interface Props {
+  formik: FormikProps<IdpGroupFormValues | TLSIdentityFormValues>;
+}
+
+const NameWithGroupForm: FC<Props> = ({ formik }) => {
   return (
     <Form onSubmit={formik.handleSubmit}>
       {/* hidden submit to enable enter key in inputs */}
@@ -32,4 +36,4 @@ const IdpGroupForm: FC<Props> = ({ formik }) => {
   );
 };
 
-export default IdpGroupForm;
+export default NameWithGroupForm;

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -13,8 +13,8 @@ import type { IdpGroup } from "types/permissions";
 import { renameIdpGroup, updateIdpGroup } from "api/auth-idp-groups";
 import { testDuplicateIdpGroupName } from "util/permissionIdpGroups";
 import useEditHistory from "util/useEditHistory";
-import type { IdpGroupFormValues } from "../forms/IdpGroupForm";
-import IdpGroupForm from "../forms/IdpGroupForm";
+import type { IdpGroupFormValues } from "../forms/NameWithGroupForm";
+import NameWithGroupForm from "../forms/NameWithGroupForm";
 import GroupSelection from "./GroupSelection";
 import GroupSelectionActions from "../actions/GroupSelectionActions";
 import ResourceLink from "components/ResourceLink";
@@ -211,7 +211,7 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
           <SidePanel.HeaderTitle>{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
         </SidePanel.Header>
         <NotificationRow className="u-no-padding" />
-        <IdpGroupForm formik={formik} />
+        <NameWithGroupForm formik={formik} />
         <p>Map groups to this idp group</p>
         <SidePanel.Content className="u-no-padding">
           <GroupSelection

--- a/src/sass/_permission_confirm_modal.scss
+++ b/src/sass/_permission_confirm_modal.scss
@@ -52,6 +52,7 @@
 .token-code-block {
   background-color: rgb(0 0 0 / 5%);
   margin-bottom: 1.5rem;
+  padding: 0.5rem 1rem;
 
   code {
     background-color: transparent;

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -361,8 +361,7 @@ body {
 
 .create-instance-from-snapshot-modal,
 .duplicate-instances-modal,
-.create-image-from-instance-modal,
-.create-tls-identity {
+.create-image-from-instance-modal {
   .p-modal__dialog {
     @include large {
       width: 35rem;
@@ -370,7 +369,8 @@ body {
   }
 }
 
-.host-path-device-modal {
+.host-path-device-modal,
+.create-tls-identity {
   .p-modal__dialog {
     @include large {
       width: 40rem;

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -20,6 +20,7 @@ export interface PanelHelper {
   openGroupIdentities: (group?: string) => void;
   openCreateIdpGroup: () => void;
   openEditIdpGroup: (group: string) => void;
+  openCreateTLSIdentity: () => void;
 }
 
 export const panels = {
@@ -32,6 +33,7 @@ export const panels = {
   groupIdentities: "group-identities",
   createIdpGroup: "create-idp-groups",
   editIdpGroup: "edit-idp-groups",
+  createTLSIdentity: "create-tls-identity",
 };
 
 type ParamMap = Record<string, string>;
@@ -127,6 +129,10 @@ const usePanelParams = (): PanelHelper => {
       setPanelParams(panels.editIdpGroup, {
         "idp-group": idpGroup || "",
       });
+    },
+
+    openCreateTLSIdentity: () => {
+      setPanelParams(panels.createTLSIdentity);
     },
   };
 };


### PR DESCRIPTION
## Done

- Allow group selection into the userflow for creating TLS identities

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to the "Identities" page in the UI and attempt to create an identity (with the correct permissions). Observe that a panel should appear and a token should be able to be generated by creating an identity with a name and 0 or more groups.

## Screenshots

![image](https://github.com/user-attachments/assets/872902d5-e1b2-42a6-8651-1d5bca34a534)