### PR TITLE
network forwards for bridged networks in clustered backends

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,6 +281,14 @@ const App: FC = () => {
           }
         />
         <Route
+          path="/ui/project/:project/network/:network/member/:memberName/forwards/:forwardAddress/edit"
+          element={
+            <ProtectedRoute
+              outlet={<ProjectLoader outlet={<EditNetworkForward />} />}
+            />
+          }
+        />
+        <Route
           path="/ui/project/:project/configuration"
           element={
             <ProtectedRoute

--- a/src/api/network-forwards.tsx
+++ b/src/api/network-forwards.tsx
@@ -10,7 +10,15 @@ export const fetchNetworkForwards = async (
     fetch(`/1.0/networks/${network}/forwards?project=${project}&recursion=1`)
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdNetworkForward[]>) => {
-        resolve(data.metadata);
+        resolve(
+          data.metadata.sort(
+            (a, b) =>
+              a.listen_address.localeCompare(b.listen_address) * 10 +
+              (a.location && b.location
+                ? a.location.localeCompare(b.location)
+                : 0),
+          ),
+        );
       })
       .catch(reject);
   });
@@ -20,10 +28,12 @@ export const fetchNetworkForward = async (
   network: string,
   listenAddress: string,
   project: string,
+  location?: string,
 ): Promise<LxdNetworkForward> => {
+  const target = location ? `&target=${location}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/networks/${network}/forwards/${listenAddress}?project=${project}&recursion=1`,
+      `/1.0/networks/${network}/forwards/${listenAddress}?project=${project}&recursion=1${target}`,
     )
       .then(handleResponse)
       .then((data: LxdApiResponse<LxdNetworkForward>) => {
@@ -38,8 +48,9 @@ export const createNetworkForward = async (
   forward: Partial<LxdNetworkForward>,
   project: string,
 ): Promise<string> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
-    fetch(`/1.0/networks/${network}/forwards?project=${project}`, {
+    fetch(`/1.0/networks/${network}/forwards?project=${project}${target}`, {
       method: "POST",
       body: JSON.stringify(forward),
     })
@@ -58,9 +69,10 @@ export const updateNetworkForward = async (
   forward: Partial<LxdNetworkForward>,
   project: string,
 ): Promise<void> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/networks/${network}/forwards/${forward.listen_address}?project=${project}`,
+      `/1.0/networks/${network}/forwards/${forward.listen_address}?project=${project}${target}`,
       {
         method: "PUT",
         body: JSON.stringify(forward),
@@ -77,9 +89,10 @@ export const deleteNetworkForward = async (
   forward: LxdNetworkForward,
   project: string,
 ): Promise<void> => {
+  const target = forward.location ? `&target=${forward.location}` : "";
   return new Promise((resolve, reject) => {
     fetch(
-      `/1.0/networks/${network.name}/forwards/${forward.listen_address}?project=${project}`,
+      `/1.0/networks/${network.name}/forwards/${forward.listen_address}?project=${project}${target}`,
       {
         method: "DELETE",
       },

--- a/src/pages/cluster/ClusterMemberSelector.tsx
+++ b/src/pages/cluster/ClusterMemberSelector.tsx
@@ -44,7 +44,7 @@ const ClusterMemberSelector: FC<SelectProps & Props> = ({
         };
       })}
       disabled={disabled || clusterMembersLoading || !!disableReason}
-      help={disableReason}
+      help={disableReason ?? props.help}
     />
   ) : null;
 };

--- a/src/pages/networks/EditNetworkForward.tsx
+++ b/src/pages/networks/EditNetworkForward.tsx
@@ -31,10 +31,12 @@ const EditNetworkForward: FC = () => {
     network: networkName,
     project,
     forwardAddress,
+    memberName,
   } = useParams<{
     network: string;
     project: string;
     forwardAddress: string;
+    memberName?: string;
   }>();
 
   const { data: network, error } = useNetwork(networkName ?? "", project ?? "");
@@ -53,12 +55,15 @@ const EditNetworkForward: FC = () => {
       networkName,
       queryKeys.forwards,
       forwardAddress,
+      queryKeys.members,
+      memberName,
     ],
     queryFn: async () =>
       fetchNetworkForward(
         networkName ?? "",
         forwardAddress ?? "",
         project ?? "",
+        memberName ?? "",
       ),
   });
 
@@ -74,6 +79,7 @@ const EditNetworkForward: FC = () => {
           targetAddress: port.target_address,
           targetPort: port.target_port,
         })) ?? [],
+      location: forward?.location,
     },
     enableReinitialize: true,
     validationSchema: NetworkForwardSchema,
@@ -89,6 +95,18 @@ const EditNetworkForward: FC = () => {
               queryKeys.networks,
               networkName,
               queryKeys.forwards,
+            ],
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              queryKeys.projects,
+              project,
+              queryKeys.networks,
+              networkName,
+              queryKeys.forwards,
+              forwardAddress,
+              queryKeys.members,
+              memberName,
             ],
           });
           navigate(`/ui/project/${project}/network/${networkName}/forwards`);

--- a/src/pages/networks/NetworkForwardCount.tsx
+++ b/src/pages/networks/NetworkForwardCount.tsx
@@ -21,7 +21,6 @@ const NetworkForwardCount: FC<Props> = ({ network, project }) => {
       queryKeys.networks,
       network,
       queryKeys.forwards,
-      project,
     ],
     queryFn: async () => fetchNetworkForwards(network.name, project),
   });


### PR DESCRIPTION
## Done

- in clustered environments, ovn network forwards are cluster wide. But managed bridges are cluster member specific.
- Introduce the cluster member specific concept to network forwards for bridged networks in clustered backends

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a network forward on a clustered backend. ensure the location selector appears and you can create similar forwards with same listen and target address for different cluster members. ensure editing of them works as expected.