### PR TITLE
fix(group) allow to add permissions when creating a group

### DIFF
--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -43,8 +43,9 @@ const EditGroupPermissionsForm: FC<Props> = ({
   const [search, setSearch] = useState("");
   const { canViewPermissions } = useServerEntitlements();
   const { canEditGroup } = useGroupEntitlements();
+
   const getEditRestriction = () => {
-    if (!canEditGroup(group)) {
+    if (group && !canEditGroup(group)) {
       return "You do not have permission to edit this group";
     }
 

--- a/tests/helpers/permission-groups.ts
+++ b/tests/helpers/permission-groups.ts
@@ -130,14 +130,21 @@ export const createGroup = async (
   page: Page,
   groupName: string,
   description: string,
+  withPermissions = false,
 ) => {
   await visitGroups(page);
   await page.getByRole("button", { name: "Create group" }).click();
   await page.getByPlaceholder("Enter name").fill(groupName);
   await page.getByPlaceholder("Enter description").click();
   await page.getByPlaceholder("Enter description").fill(description);
+
+  if (withPermissions) {
+    await page.getByRole("button", { name: "Add permissions" }).click();
+    await addPermission(page, "Server", "server", "admin");
+  }
+
   await page
-    .getByLabel("Side panel")
+    .locator("#panel-footer")
     .getByRole("button", { name: "Create group" })
     .click();
   await page.waitForSelector(`text=Group ${groupName} created`);

--- a/tests/permission-groups.spec.ts
+++ b/tests/permission-groups.spec.ts
@@ -157,3 +157,12 @@ test("bulk delete groups", async ({ page, lxdVersion }) => {
     .click();
   await page.waitForSelector(`text=2 groups deleted.`);
 });
+
+test("create group with permissions", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+  const group = randomGroupName();
+  await visitGroups(page);
+  const withPermission = true;
+  await createGroup(page, group, `${group}-desc`, withPermission);
+  await deleteGroup(page, group);
+});


### PR DESCRIPTION
## Done

- fix(group) allow to add permissions when creating a group

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a group and add permissions right while creating it.