### PR TITLE
fix(volumes) add cluster member selector for volume form

### DIFF
--- a/src/pages/storage/forms/CreateStorageVolume.tsx
+++ b/src/pages/storage/forms/CreateStorageVolume.tsx
@@ -57,7 +57,8 @@ const CreateStorageVolume: FC = () => {
     validationSchema: StorageVolumeSchema,
     onSubmit: (values) => {
       const volume = volumeFormToPayload(values, project);
-      createStorageVolume(values.pool, project, volume)
+
+      createStorageVolume(values.pool, project, volume, values.clusterMember)
         .then(() => {
           queryClient.invalidateQueries({
             queryKey: [queryKeys.storage],

--- a/src/pages/storage/forms/StorageVolumeForm.tsx
+++ b/src/pages/storage/forms/StorageVolumeForm.tsx
@@ -30,6 +30,8 @@ import { slugify } from "util/slugify";
 import { driversWithFilesystemSupport } from "util/storageOptions";
 import { getUnhandledKeyValues } from "util/formFields";
 import { useStoragePools } from "context/useStoragePools";
+import { useSettings } from "context/useSettings";
+import { useClusterMembers } from "context/useClusterMembers";
 
 export interface StorageVolumeFormValues {
   name: string;
@@ -56,6 +58,7 @@ export interface StorageVolumeFormValues {
   isCreating: boolean;
   entityType: "storageVolume";
   editRestriction?: string;
+  clusterMember?: string;
 }
 
 export const volumeFormToPayload = (
@@ -138,7 +141,9 @@ const StorageVolumeForm: FC<Props> = ({ formik, section, setSection }) => {
     return <>Missing project</>;
   }
 
+  const { data: clusterMembers = [] } = useClusterMembers();
   const { data: pools = [], error } = useStoragePools();
+  const { data: settings } = useSettings();
 
   if (error) {
     notify.failure("Loading storage pools failed", error);
@@ -182,7 +187,12 @@ const StorageVolumeForm: FC<Props> = ({ formik, section, setSection }) => {
       <Row className="form-contents">
         <Col size={12}>
           {section === slugify(MAIN_CONFIGURATION) && (
-            <StorageVolumeFormMain formik={formik} />
+            <StorageVolumeFormMain
+              formik={formik}
+              clusterMembers={clusterMembers}
+              pools={pools}
+              settings={settings}
+            />
           )}
           {section === slugify(SNAPSHOTS) && (
             <StorageVolumeFormSnapshots formik={formik} />

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -10,13 +10,26 @@ import { optionTrueFalse } from "util/instanceOptions";
 import StoragePoolSelector from "pages/storage/StoragePoolSelector";
 import ScrollableForm from "components/ScrollableForm";
 import { ensureEditMode } from "util/instanceEdit";
+import { hasMemberLocalVolumes } from "util/hasMemberLocalVolumes";
+import type { LxdStoragePool } from "types/storage";
+import type { LxdSettings } from "types/server";
+import type { LxdClusterMember } from "types/cluster";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
   poolError?: string;
+  clusterMembers?: LxdClusterMember[];
+  pools?: LxdStoragePool[];
+  settings?: LxdSettings;
 }
 
-const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
+const StorageVolumeFormMain: FC<Props> = ({
+  formik,
+  poolError,
+  clusterMembers = [],
+  pools = [],
+  settings,
+}) => {
   return (
     <ScrollableForm>
       <Row>
@@ -29,7 +42,20 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
           </Label>
           <StoragePoolSelector
             value={formik.values.pool}
-            setValue={(val) => void formik.setFieldValue("pool", val)}
+            setValue={(pool) => {
+              void formik.setFieldValue("pool", pool);
+              if (
+                hasMemberLocalVolumes(pool, pools, settings) &&
+                clusterMembers.length > 0
+              ) {
+                formik.setFieldValue(
+                  "clusterMember",
+                  clusterMembers[0].server_name,
+                );
+              } else {
+                formik.setFieldValue("clusterMember", undefined);
+              }
+            }}
             hidePoolsWithUnsupportedDrivers
             selectProps={{
               id: "storage-pool-selector-volume",
@@ -40,6 +66,25 @@ const StorageVolumeFormMain: FC<Props> = ({ formik, poolError }) => {
                 : "Use the migrate button in the header to move the volume to a different storage pool.",
             }}
           />
+          {formik.values.clusterMember !== undefined && (
+            <Select
+              id="clusterMember"
+              label="Cluster member"
+              onChange={(e) => {
+                formik.setFieldValue("clusterMember", e.target.value);
+              }}
+              value={formik.values.clusterMember}
+              options={clusterMembers.map((member) => {
+                return { label: member.server_name, value: member.server_name };
+              })}
+              disabled={!formik.values.isCreating}
+              help={
+                formik.values.isCreating
+                  ? undefined
+                  : "Cluster member is immutable after creation."
+              }
+            />
+          )}
           <Input
             {...getFormProps(formik, "name")}
             type="text"

--- a/src/util/hasMemberLocalVolumes.tsx
+++ b/src/util/hasMemberLocalVolumes.tsx
@@ -1,0 +1,20 @@
+import type { LxdStoragePool } from "types/storage";
+import type { LxdSettings } from "types/server";
+
+// Some storage pool drivers have their volumes assigned a location on one dedicated cluster member.
+// Other pool drivers like ceph are cluster wide, so they are not member local in that sense.
+// Identify if the pool at hand is in the first category.
+export const hasMemberLocalVolumes = (
+  poolName: string,
+  pools: LxdStoragePool[],
+  settings?: LxdSettings,
+) => {
+  const pool = pools.find((pool) => pool.name === poolName);
+  const driverDetails = settings?.environment?.storage_supported_drivers.find(
+    (driver) => driver.Name === pool?.driver,
+  );
+  if (!driverDetails) {
+    return false;
+  }
+  return !driverDetails.Remote;
+};

--- a/src/util/storageVolumeEdit.tsx
+++ b/src/util/storageVolumeEdit.tsx
@@ -30,5 +30,6 @@ export const getStorageVolumeEditValues = (
     isCreating: false,
     entityType: "storageVolume",
     editRestriction,
+    clusterMember: volume.location,
   };
 };


### PR DESCRIPTION


## Done

- fix(volumes) add cluster member selector for volume creation in a clustered backend for a pool that is not cluster wide

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check volume creation in a cluster and non-cluster backend. The "cluster member" selector should only be visible on creation in the clustered backend, when a local aware pool (like on backed by the directory driver) is selected.