### PR TITLE
feat: [WD-20438] Select network on project creation

### DIFF
--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Icon,
   Input,
-  Select,
   Tooltip,
   useNotify,
 } from "@canonical/react-components";
@@ -23,6 +22,7 @@ import { getExistingDeviceNames } from "util/devices";
 import { focusField } from "util/formFields";
 import { useNetworks } from "context/useNetworks";
 import { useProfiles } from "context/useProfiles";
+import NetworkSelector from "pages/projects/forms/NetworkSelector";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -82,22 +82,6 @@ const NetworkDevicesForm: FC<Props> = ({ formik, project }) => {
     formik.setFieldValue("devices", copy);
 
     focusNetwork(copy.length - 1);
-  };
-
-  const getNetworkOptions = () => {
-    const options = managedNetworks.map((network) => {
-      return {
-        label: network.name,
-        value: network.name,
-        disabled: false,
-      };
-    });
-    options.unshift({
-      label: options.length === 0 ? "No networks available" : "Select option",
-      value: "",
-      disabled: true,
-    });
-    return options;
   };
 
   const inheritedNetworks = getInheritedNetworks(formik.values, profiles);
@@ -188,16 +172,20 @@ or remove the originating item"
                         {(formik.values.devices[index] as LxdNicDevice).network}
                       </div>
                     ) : (
-                      <Select
-                        label="Network"
-                        name={`devices.${index}.network`}
-                        id={`devices.${index}.network`}
-                        onBlur={formik.handleBlur}
-                        onChange={formik.handleChange}
+                      <NetworkSelector
                         value={
                           (formik.values.devices[index] as LxdNicDevice).network
                         }
-                        options={getNetworkOptions()}
+                        project={project}
+                        onBlur={formik.handleBlur}
+                        setValue={(value) =>
+                          void formik.setFieldValue(
+                            `devices.${index}.network`,
+                            value,
+                          )
+                        }
+                        id={`devices.${index}.network`}
+                        name={`devices.${index}.network`}
                       />
                     )}
                   </div>

--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -5,7 +5,11 @@ import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { checkDuplicateName, getDefaultStoragePool } from "util/helpers";
+import {
+  checkDuplicateName,
+  getDefaultNetwork,
+  getDefaultStoragePool,
+} from "util/helpers";
 import { useNavigate } from "react-router-dom";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import useEventListener from "util/useEventListener";
@@ -101,6 +105,9 @@ const CreateProject: FC = () => {
       default_instance_storage_pool: defaultProjectDefaultProfile
         ? getDefaultStoragePool(defaultProjectDefaultProfile)
         : "",
+      default_project_network: defaultProjectDefaultProfile
+        ? getDefaultNetwork(defaultProjectDefaultProfile)
+        : "",
     },
     enableReinitialize: true,
     validationSchema: ProjectSchema,
@@ -122,6 +129,8 @@ const CreateProject: FC = () => {
         values.features_storage_buckets = undefined;
       }
 
+      const hasNetwork = values.default_project_network !== "none";
+
       createProject(
         JSON.stringify({
           ...projectDetailPayload(values),
@@ -134,7 +143,7 @@ const CreateProject: FC = () => {
       )
         .then(async () => {
           if (
-            !values.default_instance_storage_pool ||
+            (!values.default_instance_storage_pool && !hasNetwork) ||
             values.features_profiles === false
           ) {
             notifySuccess(values);
@@ -151,6 +160,13 @@ const CreateProject: FC = () => {
               pool: values.default_instance_storage_pool,
               type: "disk",
             },
+            ...(hasNetwork && {
+              eth0: {
+                name: "eth0",
+                network: values.default_project_network,
+                type: "nic",
+              },
+            }),
           };
 
           updateProfile(profile, values.name)
@@ -160,7 +176,7 @@ const CreateProject: FC = () => {
             .catch((e: Error) => {
               navigate(`/ui/project/${values.name}/instances`);
               toastNotify.failure(
-                `Successfully created ${profile.name}, Failed to attach storage pool`,
+                `Successfully created ${values.name} project. Failed to attach storage pool${hasNetwork ? " and network" : ""}.`,
                 e,
               );
             });

--- a/src/pages/projects/forms/NetworkSelector.tsx
+++ b/src/pages/projects/forms/NetworkSelector.tsx
@@ -1,0 +1,61 @@
+import { Select } from "@canonical/react-components";
+import type { SelectProps } from "@canonical/react-components";
+import type { FC } from "react";
+import { useNetworks } from "context/useNetworks";
+
+interface Props {
+  value: string;
+  project: string;
+  setValue: (value: string) => void;
+  onBlur?: (e: React.FocusEvent) => void;
+  hasNoneOption?: boolean;
+}
+
+const NetworkSelector: FC<Props & SelectProps> = ({
+  value,
+  project,
+  setValue,
+  onBlur,
+  hasNoneOption = false,
+  ...selectProps
+}) => {
+  const { data: networks = [] } = useNetworks(project);
+
+  const managedNetworks = networks.filter((network) => network.managed);
+
+  const getNetworkOptions = () => {
+    const options = managedNetworks.map((network) => {
+      return {
+        label: network.name,
+        value: network.name,
+        disabled: false,
+      };
+    });
+
+    options.unshift({
+      label: options.length === 0 ? "No networks available" : "Select option",
+      value: "",
+      disabled: true,
+    });
+
+    if (hasNoneOption) {
+      options.push({ label: "No network", value: "none", disabled: false });
+    }
+
+    return options;
+  };
+  return (
+    <Select
+      label="Network"
+      onChange={(e) => {
+        setValue(e.target.value);
+      }}
+      onBlur={onBlur}
+      value={value}
+      {...selectProps}
+      options={getNetworkOptions()}
+    />
+  );
+};
+
+export default NetworkSelector;

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -6,7 +6,7 @@ import type { LxdNetwork, LxdNetworkAcl } from "types/network";
 import type { LxdStorageVolume } from "types/storage";
 import type { Dispatch, SetStateAction } from "react";
 import crypto from "crypto";
-import { isDiskDevice } from "./devices";
+import { isDiskDevice, isNicDevice } from "./devices";
 import { isRootDisk } from "./instanceValidation";
 import type { FormDevice } from "./formDevices";
 import type { LxdIdentity } from "types/permissions";
@@ -321,6 +321,11 @@ export const getDefaultStoragePool = (profile: LxdProfile) => {
       return isRootDisk(device as FormDevice);
     });
   return rootStorage?.pool ?? "";
+};
+
+export const getDefaultNetwork = (profile: LxdProfile) => {
+  const networks = Object.values(profile.devices ?? {}).filter(isNicDevice);
+  return networks[0]?.network ?? "none";
 };
 
 export const isUnrestricted = (identity: LxdIdentity) => {

--- a/src/util/projectEdit.tsx
+++ b/src/util/projectEdit.tsx
@@ -12,7 +12,7 @@ import { instanceRestrictionPayload } from "pages/projects/forms/InstanceRestric
 import { deviceUsageRestrictionPayload } from "pages/projects/forms/DeviceUsageRestrictionForm";
 import { networkRestrictionPayload } from "pages/projects/forms/NetworkRestrictionForm";
 import { getUnhandledKeyValues } from "util/formFields";
-import { getDefaultStoragePool } from "./helpers";
+import { getDefaultNetwork, getDefaultStoragePool } from "./helpers";
 import type { LxdProfile } from "types/profile";
 
 export const getProjectEditValues = (
@@ -26,6 +26,9 @@ export const getProjectEditValues = (
     description: project.description,
     default_instance_storage_pool: defaultProfile
       ? getDefaultStoragePool(defaultProfile)
+      : "",
+    default_project_network: defaultProfile
+      ? getDefaultNetwork(defaultProfile)
       : "",
     restricted: project.config.restricted === "true",
     features_images: project.config["features.images"] === "true",

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -15,6 +15,8 @@ const openProjectCreationForm = async (page: Page) => {
 
   await expect(page.getByText("Project name")).toBeVisible();
   await expect(page.getByText("Loading storage pools")).not.toBeVisible();
+
+  await page.getByLabel("Default profile network").selectOption("No network");
 };
 
 const submitProjectCreationForm = async (page: Page, project: string) => {

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -91,8 +91,8 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
     .getByRole("navigation", { name: "Project form navigation" })
     .getByText("Networks")
     .click();
-  await setTextarea(page, "Available networks", "lxcbr0");
-  await setTextarea(page, "Network uplinks", "lxcbr0");
+  await setTextarea(page, "Available networks", "lxdbr0");
+  await setTextarea(page, "Network uplinks", "lxdbr0");
   await setTextarea(page, "Network zones", "foo,bar");
 
   await page.getByRole("button", { name: "Save 35 changes" }).click();
@@ -153,8 +153,8 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
     .getByRole("navigation", { name: "Project form navigation" })
     .getByText("Networks")
     .click();
-  await assertReadMode(page, "Available networks", "lxcbr0");
-  await assertReadMode(page, "Network uplinks", "lxcbr0");
+  await assertReadMode(page, "Available networks", "lxdbr0");
+  await assertReadMode(page, "Network uplinks", "lxdbr0");
   await assertReadMode(page, "Network zones", "foo,bar");
 
   await deleteProject(page, project);


### PR DESCRIPTION
## Done

- On project creation, add a network selector for the “default network” to be set on the default profile in the new project. Similar to the default storage pool.
- Options should be all networks in the default project,
- A a “none” option should be includued.
- Default selected should be the network in the default profile of the default project.
- If the user choses features > custom > networks to isolate networks, set default network in the form to none and disable the selector.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
On creation (form)
![image](https://github.com/user-attachments/assets/a952c094-b505-418b-819e-71d88d7063ee)
On creation (overview)
![image](https://github.com/user-attachments/assets/e6bd5a6a-fae5-4ee2-8719-5a703d34f269)
