### PR TITLE
fix(project) retain custom project selection on browsing pages for all projects

### DIFF
--- a/src/context/useCurrentProject.tsx
+++ b/src/context/useCurrentProject.tsx
@@ -22,12 +22,10 @@ interface ProviderProps {
 }
 
 export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
-  const { defaultProject, isAuthLoading } = useAuth();
+  const { isAuthLoading } = useAuth();
   const location = useLocation();
   const url = location.pathname;
-  const project = url.startsWith("/ui/project/")
-    ? url.split("/")[3]
-    : defaultProject;
+  const project = url.startsWith("/ui/project/") ? url.split("/")[3] : "";
 
   const enabled = project.length > 0;
   const retry = false;

--- a/src/pages/projects/ProjectPermissionWarning.tsx
+++ b/src/pages/projects/ProjectPermissionWarning.tsx
@@ -3,17 +3,24 @@ import { useCurrentProject } from "context/useCurrentProject";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { useEffect } from "react";
 import { useSettings } from "context/useSettings";
+import { useProject } from "context/useProjects";
 
 const ProjectPermissionWarning = () => {
   const { isLoading: isSettingsLoading } = useSettings();
   const { project, isLoading: isProjectLoading } = useCurrentProject();
+  const { data: defaultProject, isLoading: isDefaultProjectLoading } =
+    useProject("default", !project);
+
   const { canViewEvents, canViewOperations } = useProjectEntitlements();
   const { openPortal, closePortal, isOpen, Portal } = usePortal({
     programmaticallyOpen: true,
   });
 
-  const isLoading = isProjectLoading || isSettingsLoading;
-  const hasPermissions = canViewEvents(project) && canViewOperations(project);
+  const currentProject = project ?? defaultProject;
+  const isLoading =
+    isProjectLoading || isSettingsLoading || isDefaultProjectLoading;
+  const hasPermissions =
+    canViewEvents(currentProject) && canViewOperations(currentProject);
   const hasWarning = !isLoading && !hasPermissions;
 
   useEffect(() => {

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -1,6 +1,7 @@
 import { randomNameSuffix } from "./name";
 import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
+import { expect } from "../fixtures/lxd-test";
 
 export const randomProjectName = (): string => {
   return `playwright-project-${randomNameSuffix()}`;
@@ -11,10 +12,12 @@ const openProjectCreationForm = async (page: Page) => {
   await page.waitForLoadState("networkidle");
   await page.getByRole("button", { name: "default" }).click();
   await page.getByRole("button", { name: "Create project" }).click();
+
+  await expect(page.getByText("Project name")).toBeVisible();
+  await expect(page.getByText("Loading storage pools")).not.toBeVisible();
 };
 
 const submitProjectCreationForm = async (page: Page, project: string) => {
-  await page.getByPlaceholder("Enter name").click();
   await page.getByPlaceholder("Enter name").fill(project);
   await page.getByRole("button", { name: "Create" }).click();
   await page.waitForSelector(`text=Project ${project} created.`);

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -159,3 +159,15 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
 
   await deleteProject(page, project);
 });
+
+test("retain custom project selection on browsing pages for all projects", async ({
+  page,
+}) => {
+  const project = randomProjectName();
+  await createProject(page, project);
+  await page.getByRole("link", { name: "Operations" }).click();
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await page.waitForLoadState("networkidle");
+
+  expect(page.getByText("Project" + project)).toBeVisible();
+});


### PR DESCRIPTION
## Done

- fix(project) retain custom project selection on browsing pages for all projects

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to a custom project then to a page for all projects like operations or server settings, ensure you stay on the custom project when going back to instance list or other project specific pages in the navigation.