### PR TITLE
Fix instance validation on duplication and create from snapshot, remove stateful duplication field

### DIFF
--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -168,7 +168,6 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
       instanceName: instanceNameValidation(
         instance.project,
         controllerState,
-        instance.name,
       ).required(),
     }),
 

--- a/src/pages/instances/forms/DuplicateInstanceForm.tsx
+++ b/src/pages/instances/forms/DuplicateInstanceForm.tsx
@@ -41,7 +41,6 @@ export interface LxdInstanceDuplicate {
   targetStoragePool: string;
   allowInconsistent: boolean;
   instanceOnly: boolean;
-  stateful: boolean;
 }
 
 const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
@@ -93,7 +92,6 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
       targetProject: instance.project,
       allowInconsistent: false,
       instanceOnly: false,
-      stateful: false,
       targetClusterMember: isClustered ? instance.location : "",
       targetStoragePool:
         (instance.devices["root"] as LxdDiskDevice)?.pool ??
@@ -120,7 +118,6 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
             type: "copy",
             project: instance.project,
           },
-          stateful: values.stateful,
           devices: {
             ...instance.devices,
             root: {
@@ -242,12 +239,6 @@ const DuplicateInstanceForm: FC<Props> = ({ instance, close }) => {
           error={
             formik.touched.instanceOnly ? formik.errors.instanceOnly : null
           }
-        />
-        <Input
-          {...formik.getFieldProps("stateful")}
-          type="checkbox"
-          label="Copy stateful"
-          error={formik.touched.stateful ? formik.errors.stateful : null}
         />
         {/* hidden submit to enable enter key in inputs */}
         <Input type="submit" hidden value="Hidden input" />

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -37,9 +37,19 @@ export const instanceNameValidation = (
     .test(
       "deduplicate",
       "An instance with this name already exists",
-      async (value) =>
-        oldName === value ||
-        checkDuplicateName(value, project, controllerState, "instances"),
+      async (value, context) => {
+        // in some cases like duplicate instance or create instance from snapshot
+        // we let the user choose a target project in the form. We should use
+        // the target project instead of the current project in those cases.
+        const targetProject =
+          (context.parent as { targetProject?: string }).targetProject ??
+          project;
+
+        return (
+          oldName === value ||
+          checkDuplicateName(value, targetProject, controllerState, "instances")
+        );
+      },
     )
     .test(
       "size",


### PR DESCRIPTION
## Done

- fix(instance) fix instance name validation on creating instance from a snapshot
- fix(instance) remove stateful field from instance duplication, no stateful duplication is available
- fix(instance) validate name of instance for duplication and creation from snapshot in the target project, not in the source project

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - duplicate an instance into another project without changing the name (should be possible and pass validation)
    - create an instance from a snapshot with the same name as the source instance into a different project (should be possible and pass validation)
    - repeat both with target project unchanges, should block both cases with validation error