### PR TITLE
fix(permissions) add titles to group and permission selection side panels

### DIFF
--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -144,6 +144,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
       columns: [
         {
           content: permission.entity_type,
+          title: permission.entity_type,
           role: "cell",
           "aria-label": "Resource type",
           className: "resource-type",

--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -87,6 +87,7 @@ const GroupSelection: FC<Props> = ({
       columns: [
         {
           content: group.name,
+          title: group.name,
           onClick: toggleRow,
           role: "cell",
           className: "name u-truncate clickable-cell",


### PR DESCRIPTION
## Done

- fix(permissions) add titles to group and permission selection side panels

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check group create/edit, group selection and permission selection rows should have a title on hover, to surface truncated values.