### PR TITLE
fix(instances) disable ssh key buttons for users without edit instance permission

### DIFF
--- a/src/components/forms/SshKeyForm.tsx
+++ b/src/components/forms/SshKeyForm.tsx
@@ -67,10 +67,10 @@ export const getInheritedSshKeys = (
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
-  readOnly?: boolean;
+  disabledReason?: string;
 }
 
-const SshKeyForm: FC<Props> = ({ formik, readOnly = false }) => {
+const SshKeyForm: FC<Props> = ({ formik, disabledReason }) => {
   const { project } = useParams<{ project: string }>();
   const { hasCloudInitSshKeys } = useSupportedFeatures();
   const { data: profiles = [] } = useProfiles(project ?? "");
@@ -199,6 +199,8 @@ const SshKeyForm: FC<Props> = ({ formik, readOnly = false }) => {
               type="button"
               hasIcon
               appearance="base"
+              disabled={!!disabledReason}
+              title={disabledReason}
             >
               <Icon name="connected" />
               <span>Reattach</span>
@@ -210,6 +212,8 @@ const SshKeyForm: FC<Props> = ({ formik, readOnly = false }) => {
               type="button"
               hasIcon
               appearance="base"
+              disabled={!!disabledReason}
+              title={disabledReason}
             >
               <Icon name="disconnect" />
               <span>Detach</span>
@@ -276,6 +280,8 @@ const SshKeyForm: FC<Props> = ({ formik, readOnly = false }) => {
                 type="button"
                 hasIcon
                 appearance="base"
+                disabled={!!disabledReason}
+                title={disabledReason}
               >
                 <Icon name="delete" />
                 <span>Delete</span>
@@ -319,7 +325,8 @@ const SshKeyForm: FC<Props> = ({ formik, readOnly = false }) => {
           openPortal(e);
         }}
         hasIcon
-        disabled={readOnly}
+        disabled={!!disabledReason}
+        title={disabledReason}
       >
         <Icon name="plus" />
         <span>New SSH key</span>

--- a/src/pages/instances/forms/EditInstanceDetails.tsx
+++ b/src/pages/instances/forms/EditInstanceDetails.tsx
@@ -89,7 +89,10 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
         disabledReason={formik.values.editRestriction}
         initialProfiles={formik.initialValues.profiles}
       />
-      <SshKeyForm formik={formik} />
+      <SshKeyForm
+        formik={formik}
+        disabledReason={formik.values.editRestriction}
+      />
     </ScrollableForm>
   );
 };

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -184,7 +184,14 @@ const InstanceCreateDetailsForm: FC<Props> = ({
             : ""
         }
       />
-      <SshKeyForm formik={formik} readOnly={!formik.values.image} />
+      <SshKeyForm
+        formik={formik}
+        disabledReason={
+          !formik.values.image
+            ? "Please select an image before adding SSH Keys"
+            : ""
+        }
+      />
     </ScrollableForm>
   );
 };


### PR DESCRIPTION
## Done

- fix(instances) disable ssh key buttons for users without edit instance permission

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - given a user that has only view permission on an instance, but not edit view the instance detail page and ensure the ssh key buttons are disabled.