### PR TITLE
fix(groups) fix a bug when opening the group edit for an identity and navigating forwards and backwards

### DIFF
--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -69,7 +69,7 @@ const GroupSelection: FC<Props> = ({
     const selectedParentsText =
       (parentItems?.length || 0) > 1
         ? `all selected ${pluralize(parentItemName, 2)}`
-        : `${parentItemName} ${parentItems?.[0].name}`;
+        : `${parentItemName} ${parentItems?.[0]?.name}`;
     const modifiedTitle = groupAdded
       ? `Group will be added to ${selectedParentsText}`
       : groupRemoved


### PR DESCRIPTION
## Done

- fix(groups) fix a bug when opening the group edit for an identity and navigating forwards and backwards

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > identities open the "edit group" panel for any identity. Then navigate to "warnings" in the side nav. Now navigate back in the browser. No error should appear. Previously a null pointer exception was raised.