### PR TITLE
fix(forms) show browser warning when leaving an edit form with pending changes

### DIFF
--- a/src/components/forms/FormSubmitBtn.tsx
+++ b/src/components/forms/FormSubmitBtn.tsx
@@ -3,15 +3,37 @@ import { ActionButton } from "@canonical/react-components";
 import { pluralize } from "util/instanceBulkActions";
 import type { ConfigurationRowFormikProps } from "components/ConfigurationRow";
 import { getFormChangeCount } from "util/formChangeCount";
+import { unstable_usePrompt as usePrompt } from "react-router";
+import useEventListener from "util/useEventListener";
 
 interface Props {
   formik: ConfigurationRowFormikProps;
+  baseUrl: string;
   disabled: boolean;
   isYaml?: boolean;
 }
 
-const FormSubmitBtn: FC<Props> = ({ formik, disabled, isYaml = false }) => {
+const FormSubmitBtn: FC<Props> = ({
+  formik,
+  baseUrl,
+  disabled,
+  isYaml = false,
+}) => {
   const changeCount = getFormChangeCount(formik);
+
+  usePrompt({
+    when: (data) => {
+      return changeCount > 0 && !data.nextLocation.pathname.startsWith(baseUrl);
+    },
+    message: "Changes you made have not been saved. Leave site?",
+  });
+
+  const handleCloseTab = (e: BeforeUnloadEvent) => {
+    if (changeCount > 0) {
+      e.returnValue = "Changes you made have not been saved.";
+    }
+  };
+  useEventListener("beforeunload", handleCloseTab);
 
   return (
     <ActionButton

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -168,12 +168,13 @@ const EditInstance: FC<Props> = ({ instance }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project}/instance/${instance.name}/configuration`;
+
   const updateSection = (newSection: string) => {
     if (Boolean(formik.values.yaml) && newSection !== YAML_CONFIGURATION) {
       formik.setFieldValue("yaml", undefined);
     }
 
-    const baseUrl = `/ui/project/${project}/instance/${instance.name}/configuration`;
     if (newSection === MAIN_CONFIGURATION) {
       navigate(baseUrl);
     } else {
@@ -303,6 +304,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
             </Button>
             <FormSubmitBtn
               formik={formik}
+              baseUrl={baseUrl}
               isYaml={section === slugify(YAML_CONFIGURATION)}
               disabled={hasDiskError(formik) || hasNetworkError(formik)}
             />

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -168,13 +168,14 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
     updateSection(initialSection);
   }, [initialSection]);
 
+  const baseUrl = `/ui/project/${project}/network/${network.name}`;
+
   const setSection = (newSection: string, source: "click" | "scroll") => {
     if (source === "scroll" && section === slugify(YAML_CONFIGURATION)) {
       return;
     }
 
     if (source === "click") {
-      const baseUrl = `/ui/project/${project}/network/${network.name}`;
       if (newSection === GENERAL) {
         navigate(baseUrl);
       } else {
@@ -230,6 +231,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
             </Button>
             <FormSubmitBtn
               formik={formik}
+              baseUrl={baseUrl}
               isYaml={section === slugify(YAML_CONFIGURATION)}
               disabled={isNetworkFormInvalid(formik, clusterMembers)}
             />

--- a/src/pages/networks/forms/EditNetworkAcl.tsx
+++ b/src/pages/networks/forms/EditNetworkAcl.tsx
@@ -92,8 +92,9 @@ const EditNetworkAcl: FC<Props> = ({ networkAcl, project }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project}/network-acl/${networkAcl.name}`;
+
   const setSection = (newSection: string) => {
-    const baseUrl = `/ui/project/${project}/network-acl/${networkAcl.name}`;
     if (newSection === GENERAL) {
       navigate(baseUrl);
     } else {
@@ -136,6 +137,7 @@ const EditNetworkAcl: FC<Props> = ({ networkAcl, project }) => {
             </Button>
             <FormSubmitBtn
               formik={formik}
+              baseUrl={baseUrl}
               disabled={false}
               isYaml={section === slugify(YAML_CONFIGURATION)}
             />

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -158,8 +158,9 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project}/profile/${profile.name}/configuration`;
+
   const updateSection = (newSection: string) => {
-    const baseUrl = `/ui/project/${project}/profile/${profile.name}/configuration`;
     if (newSection === MAIN_CONFIGURATION) {
       navigate(baseUrl);
     } else {
@@ -287,6 +288,7 @@ const EditProfile: FC<Props> = ({ profile, featuresProfiles }) => {
             </Button>
             <FormSubmitBtn
               formik={formik}
+              baseUrl={baseUrl}
               isYaml={section === slugify(YAML_CONFIGURATION)}
               disabled={hasDiskError(formik) || hasNetworkError(formik)}
             />

--- a/src/pages/projects/EditProject.tsx
+++ b/src/pages/projects/EditProject.tsx
@@ -102,8 +102,9 @@ const EditProject: FC<Props> = ({ project }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project.name}/configuration`;
+
   const setSection = (newSection: string) => {
-    const baseUrl = `/ui/project/${project.name}/configuration`;
     if (newSection === PROJECT_DETAILS) {
       navigate(baseUrl);
     } else {
@@ -133,7 +134,11 @@ const EditProject: FC<Props> = ({ project }) => {
               >
                 Cancel
               </Button>
-              <FormSubmitBtn formik={formik} disabled={!formik.values.name} />
+              <FormSubmitBtn
+                formik={formik}
+                baseUrl={baseUrl}
+                disabled={!formik.values.name}
+              />
             </>
           )}
         </FormFooterLayout>

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -127,8 +127,9 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project}/storage/pool/${pool.name}/configuration`;
+
   const updateSection = (newSection: string) => {
-    const baseUrl = `/ui/project/${project}/storage/pool/${pool.name}/configuration`;
     if (newSection === MAIN_CONFIGURATION) {
       navigate(baseUrl);
     } else {
@@ -170,6 +171,7 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
             </Button>
             <FormSubmitBtn
               formik={formik}
+              baseUrl={baseUrl}
               isYaml={section === slugify(YAML_CONFIGURATION)}
               disabled={!formik.values.name}
             />

--- a/src/pages/storage/forms/EditStorageVolume.tsx
+++ b/src/pages/storage/forms/EditStorageVolume.tsx
@@ -90,8 +90,9 @@ const EditStorageVolume: FC<Props> = ({ volume }) => {
     },
   });
 
+  const baseUrl = `/ui/project/${project}/storage/pool/${volume.pool}/volumes/${volume.type}/${volume.name}/configuration`;
+
   const setSection = (newSection: string) => {
-    const baseUrl = `/ui/project/${project}/storage/pool/${volume.pool}/volumes/${volume.type}/${volume.name}/configuration`;
     if (newSection === MAIN_CONFIGURATION) {
       navigate(baseUrl);
     } else {
@@ -117,7 +118,11 @@ const EditStorageVolume: FC<Props> = ({ volume }) => {
             >
               Cancel
             </Button>
-            <FormSubmitBtn formik={formik} disabled={!formik.values.name} />
+            <FormSubmitBtn
+              formik={formik}
+              baseUrl={baseUrl}
+              disabled={!formik.values.name}
+            />
           </>
         )}
       </FormFooterLayout>


### PR DESCRIPTION
## Done

- fix(forms) show browser warning when leaving an edit form with pending changes

Fixes WD-20455

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit a resource (instance, profile, network, network acl, project, storage pool, storage volume) then leave the site to another page or reload the page. A warning should appear, prompting to confirm losing pending changes.

## Screenshots

![image](https://github.com/user-attachments/assets/55df9ea1-d9d3-414a-83c8-02539ecb22d9)
