### PR TITLE
fix(permission) avoid panels from rendering a pending 0 above main content, simplify

### DIFF
--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -56,7 +56,7 @@ const PermissionGroups: FC = () => {
     if (panelParams.group) {
       setSelectedGroupNames([panelParams.group]);
     }
-  }, [panelParams.group]);
+  }, [panelParams.group, groups]);
 
   const headers = [
     { content: "Name", className: "name", sortKey: "name" },

--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -62,7 +62,7 @@ const PermissionIdpGroups: FC = () => {
     if (panelParams.idpGroup) {
       setSelectedGroupNames([panelParams.idpGroup]);
     }
-  }, [panelParams.idpGroup]);
+  }, [panelParams.idpGroup, groups]);
 
   const headers = [
     { content: "Name", className: "name", sortKey: "name" },
@@ -341,14 +341,15 @@ const PermissionIdpGroups: FC = () => {
 
       {panelParams.panel === panels.createIdpGroup && <CreateIdpGroupPanel />}
 
-      {panelParams.panel === panels.editIdpGroup && selectedGroups.length && (
-        <EditIdpGroupPanel
-          idpGroup={selectedGroups[0]}
-          onClose={() => {
-            setSelectedGroupNames([]);
-          }}
-        />
-      )}
+      {panelParams.panel === panels.editIdpGroup &&
+        selectedGroups.length > 0 && (
+          <EditIdpGroupPanel
+            idpGroup={selectedGroups[0]}
+            onClose={() => {
+              setSelectedGroupNames([]);
+            }}
+          />
+        )}
     </>
   );
 };

--- a/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
@@ -111,56 +111,54 @@ const CreateIdpGroupPanel: FC = () => {
   });
 
   return (
-    <>
-      <SidePanel isOverlay loading={isLoading} hasError={!groups}>
-        <SidePanel.Header>
-          <SidePanel.HeaderTitle>Create IDP group</SidePanel.HeaderTitle>
-        </SidePanel.Header>
-        <NotificationRow className="u-no-padding" />
-        <NameWithGroupForm formik={formik} />
-        <p>Groups</p>
-        <SidePanel.Content className="u-no-padding">
-          <GroupSelection
-            groups={groups}
-            modifiedGroups={desiredState.groupsAdded}
-            parentItemName=""
-            selectedGroups={desiredState.groupsAdded}
-            setSelectedGroups={modifyGroups}
-            toggleGroup={(group: string) => {
-              const newGroups = new Set([...desiredState.groupsAdded]);
-              if (newGroups.has(group)) {
-                newGroups.delete(group);
-              } else {
-                newGroups.add(group);
-              }
-              modifyGroups([...newGroups], newGroups.size === 0);
-            }}
-            scrollDependencies={[
-              groups,
-              desiredState.groupsAdded.size,
-              notify.notification,
-              formik,
-            ]}
-          />
-        </SidePanel.Content>
-        <SidePanel.Footer className="u-align--right">
-          <GroupSelectionActions
-            modifiedGroups={desiredState.groupsAdded}
-            undoChange={undoMappingChanges}
-            closePanel={closePanel}
-            onSubmit={() => void formik.submitForm()}
-            actionText="mapped"
-            loading={formik.isSubmitting}
-            disabled={
-              !formik.isValid ||
-              (!formik.values.name &&
-                !desiredState.groupsAdded.size &&
-                !formik.touched.name)
+    <SidePanel isOverlay loading={isLoading} hasError={!groups}>
+      <SidePanel.Header>
+        <SidePanel.HeaderTitle>Create IDP group</SidePanel.HeaderTitle>
+      </SidePanel.Header>
+      <NotificationRow className="u-no-padding" />
+      <NameWithGroupForm formik={formik} />
+      <p>Groups</p>
+      <SidePanel.Content className="u-no-padding">
+        <GroupSelection
+          groups={groups}
+          modifiedGroups={desiredState.groupsAdded}
+          parentItemName=""
+          selectedGroups={desiredState.groupsAdded}
+          setSelectedGroups={modifyGroups}
+          toggleGroup={(group: string) => {
+            const newGroups = new Set([...desiredState.groupsAdded]);
+            if (newGroups.has(group)) {
+              newGroups.delete(group);
+            } else {
+              newGroups.add(group);
             }
-          />
-        </SidePanel.Footer>
-      </SidePanel>
-    </>
+            modifyGroups([...newGroups], newGroups.size === 0);
+          }}
+          scrollDependencies={[
+            groups,
+            desiredState.groupsAdded.size,
+            notify.notification,
+            formik,
+          ]}
+        />
+      </SidePanel.Content>
+      <SidePanel.Footer className="u-align--right">
+        <GroupSelectionActions
+          modifiedGroups={desiredState.groupsAdded}
+          undoChange={undoMappingChanges}
+          closePanel={closePanel}
+          onSubmit={() => void formik.submitForm()}
+          actionText="mapped"
+          loading={formik.isSubmitting}
+          disabled={
+            !formik.isValid ||
+            (!formik.values.name &&
+              !desiredState.groupsAdded.size &&
+              !formik.touched.name)
+          }
+        />
+      </SidePanel.Footer>
+    </SidePanel>
   );
 };
 

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -200,49 +200,47 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
     (nameModified && nameIsValid) || (nameIsValid && groupsModified);
 
   return (
-    <>
-      <SidePanel
-        isOverlay
-        loading={isLoading}
-        hasError={!groups}
-        onClose={onClose}
-      >
-        <SidePanel.Header>
-          <SidePanel.HeaderTitle>{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
-        </SidePanel.Header>
-        <NotificationRow className="u-no-padding" />
-        <NameWithGroupForm formik={formik} />
-        <p>Map groups to this idp group</p>
-        <SidePanel.Content className="u-no-padding">
-          <GroupSelection
-            groups={groups}
-            modifiedGroups={modifiedGroups}
-            parentItemName="IDP group"
-            parentItems={[idpGroup]}
-            selectedGroups={selectedGroups}
-            setSelectedGroups={modifyGroups}
-            toggleGroup={toggleRow}
-            scrollDependencies={[
-              groups,
-              modifiedGroups.size,
-              notify.notification,
-              formik,
-            ]}
-          />
-        </SidePanel.Content>
-        <SidePanel.Footer className="u-align--right">
-          <GroupSelectionActions
-            modifiedGroups={modifiedGroups}
-            undoChange={undoMappingChanges}
-            closePanel={closePanel}
-            onSubmit={() => void formik.submitForm()}
-            loading={formik.isSubmitting}
-            disabled={!enableSubmission}
-            isEdit
-          />
-        </SidePanel.Footer>
-      </SidePanel>
-    </>
+    <SidePanel
+      isOverlay
+      loading={isLoading}
+      hasError={!groups}
+      onClose={onClose}
+    >
+      <SidePanel.Header>
+        <SidePanel.HeaderTitle>{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
+      </SidePanel.Header>
+      <NotificationRow className="u-no-padding" />
+      <NameWithGroupForm formik={formik} />
+      <p>Map groups to this idp group</p>
+      <SidePanel.Content className="u-no-padding">
+        <GroupSelection
+          groups={groups}
+          modifiedGroups={modifiedGroups}
+          parentItemName="IDP group"
+          parentItems={[idpGroup]}
+          selectedGroups={selectedGroups}
+          setSelectedGroups={modifyGroups}
+          toggleGroup={toggleRow}
+          scrollDependencies={[
+            groups,
+            modifiedGroups.size,
+            notify.notification,
+            formik,
+          ]}
+        />
+      </SidePanel.Content>
+      <SidePanel.Footer className="u-align--right">
+        <GroupSelectionActions
+          modifiedGroups={modifiedGroups}
+          undoChange={undoMappingChanges}
+          closePanel={closePanel}
+          onSubmit={() => void formik.submitForm()}
+          loading={formik.isSubmitting}
+          disabled={!enableSubmission}
+          isEdit
+        />
+      </SidePanel.Footer>
+    </SidePanel>
   );
 };
 


### PR DESCRIPTION
## Done

- fix(permission) avoid panels from rendering a pending 0 above main content, simplify

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > idp groups and edit a group, then reload the page. Previously, a 0 would appear on the screen. Now the form should open with correct state
    - same for the groups > edit permissions and groups > edit identities and groups > edit panels