### PR TITLE
feat: [WD-15524] Add target member selection for volume duplication

### DIFF
--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -70,3 +70,7 @@ export const driversWithFilesystemSupport = [
   cephDriver,
   pureStorage,
 ];
+
+export const isRemoteStorage = (driver: string) => {
+  return [cephDriver, cephFSDriver, powerFlex].includes(driver);
+};


### PR DESCRIPTION
## Done

- Added cluster member selector which conditionally renders whenever the storage pool is not remote.
- To do: (Testing) selecting a cluster member does not duplicate the volume in the correct cluster. Troubleshoot why.
- To do: (Discovery) Identify all remote storage drivers to be included in the list.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to the storage volumes page and identify a custom storage volume.
    - Navigate to custom storage volume overview page and attempt to duplicate the volume using the button in the top right.
    - 

## Screenshots

![image](https://github.com/user-attachments/assets/01b8ced5-48b3-429a-ac9d-5622e32909c3)