### PR TITLE
chore(ClusterMemberSelector) remove duplicate and confusing setMember callback

### DIFF
--- a/src/pages/cluster/ClusterMemberSelector.tsx
+++ b/src/pages/cluster/ClusterMemberSelector.tsx
@@ -1,37 +1,21 @@
 import type { SelectProps } from "@canonical/react-components";
 import { Select } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { fetchClusterMembers } from "api/cluster";
 import type { FC } from "react";
-import { useEffect } from "react";
-import { queryKeys } from "util/queryKeys";
 import { useIsClustered } from "context/useIsClustered";
+import { useClusterMembers } from "context/useClusterMembers";
 
 interface Props {
-  setMember?: (member: string) => void;
   disableReason?: string;
 }
 
 const ClusterMemberSelector: FC<SelectProps & Props> = ({
   label,
   disabled,
-  setMember,
   disableReason,
   ...props
 }) => {
   const isClustered = useIsClustered();
-  const { data: clusterMembers = [], isLoading: clusterMembersLoading } =
-    useQuery({
-      queryKey: [queryKeys.cluster],
-      queryFn: fetchClusterMembers,
-      enabled: isClustered,
-    });
-
-  useEffect(() => {
-    if (clusterMembers.length > 0 && setMember) {
-      setMember(clusterMembers[0].server_name);
-    }
-  }, [clusterMembers]);
+  const { data: clusterMembers = [], isLoading } = useClusterMembers();
 
   return isClustered ? (
     <Select
@@ -43,7 +27,7 @@ const ClusterMemberSelector: FC<SelectProps & Props> = ({
           value: clusterMember.server_name,
         };
       })}
-      disabled={disabled || clusterMembersLoading || !!disableReason}
+      disabled={disabled || isLoading || !!disableReason}
       help={disableReason ?? props.help}
     />
   ) : null;

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -36,6 +36,7 @@ import InstanceFileTypeSelector from "./InstanceFileTypeSelector";
 import ClusterMemberSelector from "pages/cluster/ClusterMemberSelector";
 import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
+import { useClusterMembers } from "context/useClusterMembers";
 
 interface Props {
   close: () => void;
@@ -64,6 +65,7 @@ const UploadExternalFormatFileForm: FC<Props> = ({
   const eventQueue = useEventQueue();
   const queryClient = useQueryClient();
   const { data: settings } = useSettings();
+  const { data: clusterMembers = [] } = useClusterMembers();
 
   const handleUploadProgress = (
     instanceName: string,
@@ -181,12 +183,13 @@ const UploadExternalFormatFileForm: FC<Props> = ({
     initialValues: {
       name: defaultInstanceName || "",
       pool: "",
-      member: "",
+      member: clusterMembers?.[0]?.server_name,
       file: null,
       formatConversion: true,
       virtioConversion: false,
       architecture: archOptions[0]?.value,
     },
+    enableReinitialize: true,
     validateOnMount: true,
     validationSchema: Yup.object().shape({
       name: instanceNameValidation(
@@ -264,7 +267,6 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           {...formik.getFieldProps("member")}
           id="member"
           label="Target cluster member"
-          setMember={(member) => void formik.setFieldValue("member", member)}
         />
         <StoragePoolSelector
           value={formik.values.pool}


### PR DESCRIPTION
## Done

- chore(ClusterMemberSelector) remove duplicate and confusing setMember callback
Fixes [list issues/bugs if needed]