### PR TITLE
fix(instance) handle instances in status Ready correctly

### DIFF
--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -19,6 +19,7 @@ import AttachIsoBtn from "pages/instances/actions/AttachIsoBtn";
 import NotificationRow from "components/NotificationRow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import { isInstanceRunning } from "util/instanceStatus";
 
 interface Props {
   instance: LxdInstance;
@@ -32,7 +33,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
   const { canUpdateInstanceState, canAccessInstanceConsole } =
     useInstanceEntitlements();
 
-  const isRunning = instance.status === "Running";
+  const isRunning = isInstanceRunning(instance);
 
   const onFailure = (title: string, e: unknown, message?: string) => {
     notify.failure(title, e, message);

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -9,6 +9,7 @@ import Loader from "components/Loader";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import type { LxdInstance } from "types/instance";
 import { useNotify } from "@canonical/react-components";
+import { isInstanceRunning } from "util/instanceStatus";
 
 declare global {
   interface Window {
@@ -41,7 +42,7 @@ const InstanceGraphicConsole: FC<Props> = ({
   const spiceRef = useRef<HTMLDivElement>(null);
   const [isVgaLoading, setVgaLoading] = useState<boolean>(false);
 
-  const isRunning = instance.status === "Running";
+  const isRunning = isInstanceRunning(instance);
 
   const handleError = (e: object) => {
     onFailure("Error", e);

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -22,6 +22,7 @@ import {
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import { isInstanceRunning } from "util/instanceStatus";
 
 const XTERM_OPTIONS = {
   theme: {
@@ -148,7 +149,7 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
     return [data, control];
   };
 
-  const isRunning = instance.status === "Running";
+  const isRunning = isInstanceRunning(instance);
   const isBooting = isRunning && (instance.state?.processes ?? 0) < 1;
   const canConnect = isRunning && !isBooting;
   const canExec = canExecInstance(instance);

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -15,6 +15,7 @@ import { unstable_usePrompt as usePrompt } from "react-router-dom";
 import Xterm from "components/Xterm";
 import type { Terminal } from "xterm";
 import { useNotify } from "@canonical/react-components";
+import { isInstanceRunning } from "util/instanceStatus";
 
 interface Props {
   instance: LxdInstance;
@@ -52,7 +53,7 @@ const InstanceTextConsole: FC<Props> = ({
   };
   useEventListener("beforeunload", handleCloseTab);
 
-  const isRunning = instance.status === "Running";
+  const isRunning = isInstanceRunning(instance);
 
   const handleError = (e: object) => {
     onFailure("Error", e);

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -10,6 +10,7 @@ import { useToastNotification } from "context/toastNotificationProvider";
 import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import { isInstanceRunning } from "util/instanceStatus";
 
 interface Props {
   instance: LxdInstance;
@@ -68,7 +69,7 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
 
   const isDisabled =
     isLoading ||
-    instance.status !== "Running" ||
+    !isInstanceRunning(instance) ||
     instanceLoading.getType(instance) === "Migrating";
 
   return (

--- a/src/util/instanceStatus.tsx
+++ b/src/util/instanceStatus.tsx
@@ -1,0 +1,5 @@
+import type { LxdInstance } from "types/instance";
+
+export const isInstanceRunning = (instance: LxdInstance) => {
+  return ["Ready", "Running"].includes(instance.status);
+};


### PR DESCRIPTION
## Done

- fix(instance) handle instances in status Ready correctly: Allow terminal or console and to freeze

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start an instance, in the yaml editor set the config `volatile.last_state.ready: "1"` The instance is now shown in ready state.
    - In the ready status: Ensure the console, terminal work just as in the running status and that the freeze button is enabled and working.