### PR TITLE
feat(export) add help text to hint no compression is faster

### DIFF
--- a/src/pages/instances/forms/ExportInstanceModal.tsx
+++ b/src/pages/instances/forms/ExportInstanceModal.tsx
@@ -159,6 +159,7 @@ const ExportInstanceModal: FC<Props> = ({ instance, close }) => {
           {...formik.getFieldProps("compression")}
           id="project"
           label="Compression"
+          help="No compression will be faster, but larger"
           options={[
             { value: "gzip", label: "Gzip" },
             { value: "none", label: "None" },


### PR DESCRIPTION
## Done

- feat(export) add help text to hint no compression is faster

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start instance export, check help text