### PR TITLE
fix(forms) disable submit buttons when form is submitting. fixes #1227

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -95,7 +95,11 @@ const RenameHeader: FC<Props> = ({
                   <ActionButton
                     appearance="positive"
                     loading={formik.isSubmitting}
-                    disabled={!formik.isValid || name === formik.values.name}
+                    disabled={
+                      !formik.isValid ||
+                      formik.isSubmitting ||
+                      name === formik.values.name
+                    }
                     onClick={() => void formik.submitForm()}
                   >
                     Save

--- a/src/components/forms/FormSubmitBtn.tsx
+++ b/src/components/forms/FormSubmitBtn.tsx
@@ -39,7 +39,9 @@ const FormSubmitBtn: FC<Props> = ({
     <ActionButton
       appearance="positive"
       loading={formik.isSubmitting}
-      disabled={!formik.isValid || disabled || changeCount === 0}
+      disabled={
+        !formik.isValid || formik.isSubmitting || disabled || changeCount === 0
+      }
       onClick={() => void formik.submitForm()}
     >
       {changeCount === 0 || isYaml

--- a/src/components/forms/SnapshotForm.tsx
+++ b/src/components/forms/SnapshotForm.tsx
@@ -45,7 +45,7 @@ const SnapshotForm: FC<Props> = (props) => {
           <ActionButton
             appearance="positive"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid}
+            disabled={!formik.isValid || formik.isSubmitting}
             onClick={() => void formik.submitForm()}
           >
             {isEdit ? "Save changes" : "Create snapshot"}

--- a/src/pages/cluster/ClusterGroupForm.tsx
+++ b/src/pages/cluster/ClusterGroupForm.tsx
@@ -189,7 +189,9 @@ const ClusterGroupForm: FC<Props> = ({ group }) => {
             <ActionButton
               appearance="positive"
               loading={formik.isSubmitting}
-              disabled={!formik.isValid || !formik.values.name}
+              disabled={
+                !formik.isValid || formik.isSubmitting || !formik.values.name
+              }
               onClick={() => void formik.submitForm()}
             >
               {group ? "Save changes" : "Create"}

--- a/src/pages/images/actions/forms/UploadImageForm.tsx
+++ b/src/pages/images/actions/forms/UploadImageForm.tsx
@@ -166,7 +166,9 @@ const UploadImageForm: FC<Props> = ({ close, projectName }) => {
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid || !formik.values.fileList}
+            disabled={
+              !formik.isValid || formik.isSubmitting || !formik.values.fileList
+            }
             onClick={() => void formik.submitForm()}
           >
             Upload image

--- a/src/pages/instances/forms/CopyInstanceForm.tsx
+++ b/src/pages/instances/forms/CopyInstanceForm.tsx
@@ -177,7 +177,12 @@ const CopyInstanceForm: FC<Props> = ({ instance, close }) => {
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid || storagePoolsLoading || projectsLoading}
+            disabled={
+              !formik.isValid ||
+              formik.isSubmitting ||
+              storagePoolsLoading ||
+              projectsLoading
+            }
             onClick={() => void formik.submitForm()}
           >
             Copy

--- a/src/pages/instances/forms/CreateImageFromInstanceForm.tsx
+++ b/src/pages/instances/forms/CreateImageFromInstanceForm.tsx
@@ -140,7 +140,7 @@ const CreateImageFromInstanceForm: FC<Props> = ({ instance, close }) => {
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid}
+            disabled={!formik.isValid || formik.isSubmitting}
             onClick={() => void formik.submitForm()}
           >
             Create image

--- a/src/pages/instances/forms/CreateImageFromInstanceSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateImageFromInstanceSnapshotForm.tsx
@@ -148,7 +148,7 @@ const CreateImageFromInstanceSnapshotForm: FC<Props> = ({
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid}
+            disabled={!formik.isValid || formik.isSubmitting}
             onClick={() => void formik.submitForm()}
           >
             Create image

--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -235,7 +235,12 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid || storagePoolsLoading || projectsLoading}
+            disabled={
+              !formik.isValid ||
+              formik.isSubmitting ||
+              storagePoolsLoading ||
+              projectsLoading
+            }
             onClick={() => void formik.submitForm()}
           >
             Create

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -339,7 +339,12 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           appearance="positive"
           className="u-no-margin--bottom"
           loading={formik.isSubmitting || !!uploadState}
-          disabled={!formik.isValid || isLoading || !formik.values.file}
+          disabled={
+            !formik.isValid ||
+            formik.isSubmitting ||
+            isLoading ||
+            !formik.values.file
+          }
           onClick={() => void formik.submitForm()}
         >
           Upload and create

--- a/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
+++ b/src/pages/instances/forms/UploadInstanceBackupFileForm.tsx
@@ -234,7 +234,12 @@ const UploadInstanceBackupFileForm: FC<Props> = ({
           appearance="positive"
           className="u-no-margin--bottom"
           loading={formik.isSubmitting || !!uploadState}
-          disabled={!formik.isValid || isLoading || !formik.values.instanceFile}
+          disabled={
+            !formik.isValid ||
+            formik.isSubmitting ||
+            isLoading ||
+            !formik.values.instanceFile
+          }
           onClick={() => void formik.submitForm()}
         >
           Upload and create

--- a/src/pages/networks/CreateNetworkForward.tsx
+++ b/src/pages/networks/CreateNetworkForward.tsx
@@ -106,7 +106,11 @@ const CreateNetworkForward: FC = () => {
         </Link>
         <ActionButton
           loading={formik.isSubmitting}
-          disabled={!formik.isValid || !formik.values.listenAddress}
+          disabled={
+            !formik.isValid ||
+            formik.isSubmitting ||
+            !formik.values.listenAddress
+          }
           onClick={() => void formik.submitForm()}
         >
           Create

--- a/src/pages/networks/EditNetworkForward.tsx
+++ b/src/pages/networks/EditNetworkForward.tsx
@@ -144,7 +144,11 @@ const EditNetworkForward: FC = () => {
         <ActionButton
           appearance="positive"
           loading={formik.isSubmitting}
-          disabled={!formik.isValid || !formik.values.listenAddress}
+          disabled={
+            !formik.isValid ||
+            formik.isSubmitting ||
+            !formik.values.listenAddress
+          }
           onClick={() => void formik.submitForm()}
         >
           Update

--- a/src/pages/permissions/panels/CreateGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateGroupPanel.tsx
@@ -178,7 +178,9 @@ const CreateGroupPanel: FC = () => {
             loading={formik.isSubmitting}
             onClick={() => void formik.submitForm()}
             className="u-no-margin--bottom"
-            disabled={!formik.isValid || !formik.values.name}
+            disabled={
+              !formik.isValid || formik.isSubmitting || !formik.values.name
+            }
           >
             Create group
           </ActionButton>

--- a/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
@@ -152,6 +152,7 @@ const CreateIdpGroupPanel: FC = () => {
           loading={formik.isSubmitting}
           disabled={
             !formik.isValid ||
+            formik.isSubmitting ||
             (!formik.values.name &&
               !desiredState.groupsAdded.size &&
               !formik.touched.name)

--- a/src/pages/permissions/panels/CreateTLSIdentityPanel.tsx
+++ b/src/pages/permissions/panels/CreateTLSIdentityPanel.tsx
@@ -137,6 +137,7 @@ const CreateTLSIdentityPanel: FC<Props> = ({ onSuccess }) => {
             loading={formik.isSubmitting}
             disabled={
               !formik.isValid ||
+              formik.isSubmitting ||
               (!formik.values.name &&
                 !desiredState.groupsAdded.size &&
                 !formik.touched.name)

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -310,7 +310,10 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
             onClick={() => void formik.submitForm()}
             className="u-no-margin--bottom"
             disabled={
-              !formik.isValid || !formik.values.name || changeCount === 0
+              !formik.isValid ||
+              formik.isSubmitting ||
+              !formik.values.name ||
+              changeCount === 0
             }
           >
             {changeCount === 0

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -287,6 +287,7 @@ const CreateProfile: FC = () => {
           loading={formik.isSubmitting}
           disabled={
             !formik.isValid ||
+            formik.isSubmitting ||
             !formik.values.name ||
             hasDiskError(formik) ||
             hasNetworkError(formik)

--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -210,7 +210,9 @@ const CreateProject: FC = () => {
         <ActionButton
           appearance="positive"
           loading={formik.isSubmitting}
-          disabled={!formik.isValid || !formik.values.name}
+          disabled={
+            !formik.isValid || formik.isSubmitting || !formik.values.name
+          }
           onClick={() => void formik.submitForm()}
         >
           Create

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -140,6 +140,7 @@ const CreateStoragePool: FC = () => {
           loading={formik.isSubmitting}
           disabled={
             !formik.isValid ||
+            formik.isSubmitting ||
             !formik.values.name ||
             isPowerflexIncomplete(formik) ||
             isPureStorageIncomplete(formik)

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -112,7 +112,7 @@ const CustomVolumeCreateModal: FC<Props> = ({
           appearance="positive"
           className="u-no-margin--bottom"
           onClick={() => void formik.submitForm()}
-          disabled={!formik.isValid || !validPool}
+          disabled={!formik.isValid || formik.isSubmitting || !validPool}
           loading={formik.isSubmitting}
         >
           Create volume

--- a/src/pages/storage/forms/CopyVolumeForm.tsx
+++ b/src/pages/storage/forms/CopyVolumeForm.tsx
@@ -180,7 +180,12 @@ const CopyVolumeForm: FC<Props> = ({ volume, close }) => {
             appearance="positive"
             className="u-no-margin--bottom"
             loading={formik.isSubmitting}
-            disabled={!formik.isValid || projectsLoading || volumesLoading}
+            disabled={
+              !formik.isValid ||
+              formik.isSubmitting ||
+              projectsLoading ||
+              volumesLoading
+            }
             onClick={() => void formik.submitForm()}
           >
             Copy

--- a/src/pages/storage/forms/CreateStorageVolume.tsx
+++ b/src/pages/storage/forms/CreateStorageVolume.tsx
@@ -112,7 +112,7 @@ const CreateStorageVolume: FC = () => {
         <ActionButton
           appearance="positive"
           loading={formik.isSubmitting}
-          disabled={!formik.isValid}
+          disabled={!formik.isValid || formik.isSubmitting}
           onClick={() => void formik.submitForm()}
         >
           Create


### PR DESCRIPTION
## Done

- Disable submit btn on form loading

Fixes #1227

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - upload an image or instance -- while the form is submitting, ensure the submit button is not clickable any more.