### PR TITLE
fix(instance) display custom networks with nictype on the instance overview page

### DIFF
--- a/src/components/NetworkListTable.tsx
+++ b/src/components/NetworkListTable.tsx
@@ -25,10 +25,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices }) => {
     onFailure("Loading networks failed", error);
   }
 
-  const networkDevices = Object.values(devices ?? {})
-    .filter(isNicDevice)
-    .map((network) => network.network);
-
+  const networkDevices = Object.values(devices ?? {}).filter(isNicDevice);
   const instanceHasNetworks = networkDevices.length > 0;
   const userHasNetworks = networks.length > 0;
 
@@ -47,15 +44,21 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices }) => {
     },
   ];
 
-  const networksRows = networks
-    .filter((network) => networkDevices.includes(network.name))
-    .map((network) => {
-      const interfaceNames = Object.entries(devices ?? {})
-        .filter(
-          ([_key, value]) =>
-            value.type === "nic" && value.network === network.name,
-        )
-        .map(([key]) => key);
+  const networksRows = Object.entries(devices ?? {})
+    .map(([deviceName, networkDevice]) => {
+      if (networkDevice.type !== "nic") {
+        return null;
+      }
+
+      const network = networks.find(
+        (item) =>
+          item.name === networkDevice.network ||
+          item.name === networkDevice.parent,
+      );
+
+      if (!network) {
+        return null;
+      }
 
       return {
         key: network.name,
@@ -72,7 +75,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices }) => {
             "aria-label": "Name",
           },
           {
-            content: interfaceNames.length > 0 ? interfaceNames.join(" ") : "-",
+            content: deviceName,
             role: "cell",
             "aria-label": "Interface",
           },
@@ -91,10 +94,11 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices }) => {
           name: network.name.toLowerCase(),
           type: network.type,
           managed: network.managed,
-          interfaceName: interfaceNames.join(" "),
+          interfaceName: deviceName.toLowerCase(),
         },
       };
-    });
+    })
+    .filter((row) => row !== null);
 
   const getContent = () => {
     if (isLoading) {

--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -20,6 +20,8 @@ export interface LxdIsoDevice {
 
 export interface LxdNicDevice {
   name?: string;
+  nictype?: string;
+  parent?: string;
   network: string;
   type: "nic";
 }


### PR DESCRIPTION
…erview page. 

## Done

- fix(instance) display custom networks with nictype on the instance overview page

Fixes #1232

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Custom nic types can be added to an instance with the yaml editor. Ensure the parent is a valid non-managed interface on the host:
    ```
  eth5:
    name: eth5
    nictype: bridged
    parent: lxcbr0
    type: nic
```
  - such nics are displayed as "custom" in the instance configuration, this PR ensures to display their details correctly on the instance overview page. Previously those devices were not displayed on the overview page.

# Screenshots
![image](https://github.com/user-attachments/assets/9ca926e2-54fb-41f3-9293-706a34dacd4d)
