### PR TITLE
Instance: Allow adding unmanaged networks

### DIFF
--- a/src/components/forms/NetworkDevicesOptions.tsx
+++ b/src/components/forms/NetworkDevicesOptions.tsx
@@ -1,0 +1,88 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { Button, Input, Notification } from "@canonical/react-components";
+import type { InstanceAndProfileFormikProps } from "./instanceAndProfileFormValues";
+import type { EditInstanceFormValues } from "pages/instances/EditInstance";
+import type { CustomNetworkDevice } from "util/formDevices";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { fetchConfigOptions } from "api/server";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { toConfigFields } from "util/config";
+import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
+import type { LxdMetadata } from "types/config";
+import type { LxdNicDevice } from "types/device";
+
+interface Props {
+  formik: InstanceAndProfileFormikProps;
+  index: number;
+}
+
+const NetworkDeviceOptions: FC<Props> = ({ formik, index }) => {
+  const [isAdvanced, setIsAdvanced] = useState(false);
+  const { hasMetadataConfiguration } = useSupportedFeatures();
+  const { data: configOptions } = useQuery({
+    queryKey: [queryKeys.configOptions],
+    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
+  });
+
+  const readOnly = (formik.values as EditInstanceFormValues).readOnly;
+
+  const device = formik.values.devices[index] as CustomNetworkDevice;
+  const optionKey =
+    `device-nic-${device.bare.nictype}` as keyof LxdMetadata["configs"];
+  const rawOptions = configOptions?.configs[optionKey];
+  const configFields = rawOptions ? toConfigFields(rawOptions) : [];
+
+  if (readOnly) {
+    return null;
+  }
+
+  return (
+    <>
+      <Notification severity="information">
+        The network is unmanaged.
+      </Notification>
+      <Button
+        onClick={() => {
+          setIsAdvanced(!isAdvanced);
+        }}
+        appearance="link"
+        type="button"
+      >
+        {isAdvanced ? "Hide advanced options" : "Show advanced options"}
+      </Button>
+      {isAdvanced &&
+        configFields.map((configField) => {
+          const field = configField.key as keyof LxdNicDevice;
+          if (field === "network" || field === "parent") {
+            return null;
+          }
+
+          return (
+            <Input
+              id={field}
+              key={field}
+              name={field}
+              label={field}
+              value={device.bare[field] ?? ""}
+              onChange={(e) => {
+                void formik.setFieldValue(
+                  `devices.${index}.bare.${field}`,
+                  e.target.value,
+                );
+              }}
+              help={
+                <ConfigFieldDescription
+                  description={configField.longdesc}
+                  className="p-form-help-text"
+                />
+              }
+              type="text"
+            />
+          );
+        })}
+    </>
+  );
+};
+export default NetworkDeviceOptions;

--- a/src/pages/projects/forms/NetworkSelector.tsx
+++ b/src/pages/projects/forms/NetworkSelector.tsx
@@ -9,6 +9,7 @@ interface Props {
   setValue: (value: string) => void;
   onBlur?: (e: React.FocusEvent) => void;
   hasNoneOption?: boolean;
+  isManaged?: boolean;
 }
 
 const NetworkSelector: FC<Props & SelectProps> = ({
@@ -17,14 +18,17 @@ const NetworkSelector: FC<Props & SelectProps> = ({
   setValue,
   onBlur,
   hasNoneOption = false,
+  isManaged,
   ...selectProps
 }) => {
   const { data: networks = [] } = useNetworks(project);
 
-  const managedNetworks = networks.filter((network) => network.managed);
+  const filteredNetworks = networks.filter((network) => {
+    return isManaged === undefined || network.managed === isManaged;
+  });
 
   const getNetworkOptions = () => {
-    const options = managedNetworks.map((network) => {
+    const options = filteredNetworks.map((network) => {
       return {
         label: network.name,
         value: network.name,

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -195,6 +195,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             hasNoneOption
             label="Default profile network"
             disabled={hasNoProfiles || hasIsolatedNetworks || isEdit}
+            isManaged={true}
             help={
               isEdit ? (
                 <>


### PR DESCRIPTION
## Done

- Instance: Allow adding unmanaged networks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - configure an instance, add a network that is unmanaged

## Screenshots

![image](https://github.com/user-attachments/assets/8a20e6b8-6903-4f5f-95ab-306768c6481f)

![image](https://github.com/user-attachments/assets/fc703a6b-1fb2-4d91-bda6-3f9d0fff204a)

![image](https://github.com/user-attachments/assets/b5a172ec-d951-4c14-862e-23227482f6b5)

## Todo

- show network list with indicators of which ones are managed and unmanaged. maybe put the managed ones first and use a table for the options
- refine layout for custom fields
- refine warning on using unmanaged networks