### PR TITLE
fix(translation) ensure app does not crash on using chrome translation

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -230,6 +230,7 @@ export const getConfigurationRow = ({
     ),
     override: renderOverride(),
     name: `${label as string}-${name ?? ""}-${metadata.value}-${metadata.configField?.shortdesc}`,
+    edit: formik.values.readOnly ? "read" : "edit",
   });
 };
 
@@ -239,6 +240,7 @@ interface BaseProps {
   override: ReactNode;
   className?: string;
   name?: string;
+  edit?: string;
 }
 
 export const getConfigurationRowBase = ({
@@ -247,6 +249,7 @@ export const getConfigurationRowBase = ({
   override,
   className,
   name,
+  edit,
 }: BaseProps): MainTableRow => {
   return {
     name,
@@ -254,14 +257,17 @@ export const getConfigurationRowBase = ({
     className,
     columns: [
       {
+        key: `configuration-${name}-${edit}`,
         content: configuration,
         className: "configuration",
       },
       {
+        key: `inherited-${name}-${edit}`,
         content: inherited,
         className: "inherited",
       },
       {
+        key: `override-${name}-${edit}`,
         content: override,
         className: "override",
       },

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -7,6 +7,7 @@ import useEventListener from "util/useEventListener";
 
 interface CommonProps {
   className?: string;
+  key?: string;
 }
 
 // Header components
@@ -22,9 +23,12 @@ const HeaderControls: FC<PropsWithChildren & CommonProps> = ({
 const HeaderTitle: FC<PropsWithChildren & CommonProps> = ({
   children,
   className,
+  key,
 }) => {
   return (
-    <h2 className={classnames("p-panel__title", className)}>{children}</h2>
+    <h2 className={classnames("p-panel__title", className)} key={key}>
+      {children}
+    </h2>
   );
 };
 

--- a/src/components/ToastNotification.tsx
+++ b/src/components/ToastNotification.tsx
@@ -46,6 +46,7 @@ const ToastNotification: FC<Props> = ({ notification, onDismiss, show }) => {
               timestamp={notification.timestamp}
               titleElement="div"
               role="alert"
+              key={notification.id}
             >
               {notification.message}
             </Notification>

--- a/src/components/forms/NetworkDevicesForm.tsx
+++ b/src/components/forms/NetworkDevicesForm.tsx
@@ -131,6 +131,8 @@ or remove the originating item"
             | CustomNetworkDevice;
 
           return getConfigurationRowBase({
+            name: `devices.${index}.name`,
+            edit: readOnly ? "read" : "edit",
             configuration: (
               <>
                 {readOnly || device.type === "custom-nic" ? (

--- a/src/pages/instances/InstanceDetailPanelContent.tsx
+++ b/src/pages/instances/InstanceDetailPanelContent.tsx
@@ -10,6 +10,8 @@ import { List } from "@canonical/react-components";
 import ItemName from "components/ItemName";
 import { useSettings } from "context/useSettings";
 import { isNicDevice } from "util/devices";
+import { getIpAddresses } from "util/networks";
+import { useInstanceLoading } from "context/instanceLoading";
 
 const RECENT_SNAPSHOT_LIMIT = 5;
 
@@ -22,6 +24,9 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
   const networkDevices = Object.values(instance?.expanded_devices ?? {}).filter(
     isNicDevice,
   );
+
+  const instanceLoading = useInstanceLoading();
+  const loadingType = instanceLoading.getType(instance);
 
   const pid =
     !instance.state || instance.state.pid === 0 ? "-" : instance.state.pid;
@@ -49,7 +54,7 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
         </tr>
         <tr>
           <th className="u-text--muted">Status</th>
-          <td>
+          <td key={instance.status + loadingType}>
             <InstanceStatusIcon instance={instance} />
           </td>
         </tr>
@@ -69,13 +74,13 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
         </tr>
         <tr>
           <th className="u-text--muted">IPv4</th>
-          <td>
+          <td key={getIpAddresses(instance, "inet").length}>
             <InstanceIps instance={instance} family="inet" />
           </td>
         </tr>
         <tr>
           <th className="u-text--muted">IPv6</th>
-          <td>
+          <td key={getIpAddresses(instance, "inet6").length}>
             <InstanceIps instance={instance} family="inet6" />
           </td>
         </tr>

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -338,7 +338,7 @@ const InstanceList: FC = () => {
             ? [
                 {
                   content: (
-                    <i>
+                    <i key={JSON.stringify(operation.metadata ?? {})}>
                       {Object.entries(operation.metadata ?? {})
                         .slice(0, 1)
                         .map(([key, value], index) => (
@@ -400,6 +400,8 @@ const InstanceList: FC = () => {
       const ipv6 = getIpAddresses(instance, "inet6")
         .filter((val) => !val.address.startsWith("fe80"))
         .map((val) => val.address);
+
+      const loadingType = instanceLoading.getType(instance);
 
       return {
         key: instance.name,
@@ -481,6 +483,7 @@ const InstanceList: FC = () => {
             style: { width: `${COLUMN_WIDTHS[DESCRIPTION]}px` },
           },
           {
+            key: `ipv4-${ipv4.length}`,
             content: ipv4.length > 1 ? `${ipv4.length} addresses` : ipv4,
             role: "cell",
             className: "u-align--right clickable-cell",
@@ -489,6 +492,7 @@ const InstanceList: FC = () => {
             style: { width: `${COLUMN_WIDTHS[IPV4]}px` },
           },
           {
+            key: `ipv6-${ipv6.length}`,
             content: ipv6.length > 1 ? `${ipv6.length} addresses` : ipv6,
             role: "cell",
             "aria-label": IPV6,
@@ -505,6 +509,7 @@ const InstanceList: FC = () => {
             style: { width: `${COLUMN_WIDTHS[SNAPSHOTS]}px` },
           },
           {
+            key: instance.status + loadingType,
             content: <InstanceStatusIcon instance={instance} />,
             role: "cell",
             className: "clickable-cell",

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -17,6 +17,7 @@ import type { LxdDevices } from "types/device";
 import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
 import { useImagesInProject } from "context/useImages";
+import { getIpAddresses } from "util/networks";
 
 interface Props {
   instance: LxdInstance;
@@ -93,13 +94,13 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
               </tr>
               <tr>
                 <th className="u-text--muted">IPv4</th>
-                <td>
+                <td key={getIpAddresses(instance, "inet").length}>
                   <InstanceIps instance={instance} family="inet" />
                 </td>
               </tr>
               <tr>
                 <th className="u-text--muted">IPv6</th>
-                <td>
+                <td key={getIpAddresses(instance, "inet6").length}>
                   <InstanceIps instance={instance} family="inet6" />
                 </td>
               </tr>

--- a/src/pages/instances/InstanceOverviewMetrics.tsx
+++ b/src/pages/instances/InstanceOverviewMetrics.tsx
@@ -99,7 +99,7 @@ const InstanceOverviewMetrics: FC<Props> = ({ instance, onFailure }) => {
             )}
             <tr className="metric-row">
               <th className="u-text--muted">CPU</th>
-              <td>
+              <td key={instanceMetrics.memory?.free}>
                 {instanceMetrics.memory ? (
                   <InstanceUsageCpu instance={instance} />
                 ) : (

--- a/src/pages/instances/InstanceUsageCpu.tsx
+++ b/src/pages/instances/InstanceUsageCpu.tsx
@@ -68,14 +68,15 @@ const InstanceUsageCpu: FC<Props> = ({ instance }) => {
   const cpuUsage = calculateCpuUsage();
   if (cpuUsage === null) {
     return (
-      <>
-        <div className="u-text--muted p-text--small">
-          loading
-          {loadingSeconds > 0
-            ? `, ${loadingSeconds} seconds remaining to first CPU snapshot`
-            : " takes longer than expected"}
-        </div>
-      </>
+      <div
+        className="u-text--muted p-text--small"
+        key={loadingSeconds > 0 ? loadingSeconds : "long"}
+      >
+        loading
+        {loadingSeconds > 0
+          ? `, ${loadingSeconds} seconds remaining to first CPU snapshot`
+          : " takes longer than expected"}
+      </div>
     );
   }
 

--- a/src/pages/instances/MigrateInstanceModal.tsx
+++ b/src/pages/instances/MigrateInstanceModal.tsx
@@ -67,9 +67,25 @@ const MigrateInstanceModal: FC<Props> = ({ close, instance }) => {
     <Modal
       close={close}
       className="migrate-instance-modal"
-      title={modalTitle}
       onKeyDown={handleEscKey}
+      aria-labelledby="migrate-title"
     >
+      <header className="p-modal__header">
+        <h2
+          className="p-modal__title"
+          key={type ? (target ? "confirm" : "select") : "start"}
+          id="migrate-title"
+        >
+          {modalTitle}
+        </h2>
+        <button
+          className="p-modal__close"
+          aria-label="Close active modal"
+          onClick={close}
+        >
+          Close
+        </button>
+      </header>
       {!type && (
         <div className="choose-migration-type">
           {isClustered && (

--- a/src/pages/networks/forms/IpAddress.tsx
+++ b/src/pages/networks/forms/IpAddress.tsx
@@ -11,7 +11,9 @@ const IpAddress: FC<Props> = ({ row }) => {
       <div className="general-field-label can-edit">
         {row.columns?.[0].content}
       </div>
-      <div className="general-field-content">{row.columns?.[2].content}</div>
+      <div className="general-field-content" key={row.columns?.[2].key}>
+        {row.columns?.[2].content}
+      </div>
     </div>
   );
 };

--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -16,7 +16,10 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
   return (
     <div className="general-field">
       <div className="general-field-label">ACLs</div>
-      <div className="general-field-content">
+      <div
+        className="general-field-content"
+        key={formik.values.readOnly ? "read" : "edit"}
+      >
         {formik.values.readOnly && (
           <>
             {formik.values.security_acls.length === 0 ? (

--- a/src/pages/networks/forms/NetworkDescriptionField.tsx
+++ b/src/pages/networks/forms/NetworkDescriptionField.tsx
@@ -22,6 +22,7 @@ const NetworkDescriptionField: FC<Props> = ({ props, formik }) => {
         className={classnames("general-field-content", {
           "description-readonly": formik.values.readOnly,
         })}
+        key={formik.values.readOnly ? "read" : "edit"}
       >
         {formik.values.readOnly ? (
           <>

--- a/src/pages/networks/forms/NetworkParentSelector.tsx
+++ b/src/pages/networks/forms/NetworkParentSelector.tsx
@@ -137,7 +137,10 @@ const NetworkParentSelector: FC<Props> = ({ props, formik, isClustered }) => {
           Parent
         </Label>
       </div>
-      <div className="general-field-content">
+      <div
+        className="general-field-content"
+        key={formik.values.readOnly ? "read" : "edit"}
+      >
         {formik.values.readOnly ? (
           <>
             {formik.values.parent}

--- a/src/pages/networks/forms/UplinkSelector.tsx
+++ b/src/pages/networks/forms/UplinkSelector.tsx
@@ -81,7 +81,10 @@ const UplinkSelector: FC<Props> = ({ project: projectName, props, formik }) => {
           Uplink
         </Label>
       </div>
-      <div className="general-field-content">
+      <div
+        className="general-field-content"
+        key={formik.values.readOnly ? "read" : "edit"}
+      >
         {formik.values.readOnly ? (
           <>
             {formik.values.network}

--- a/src/pages/permissions/panels/CreateGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateGroupPanel.tsx
@@ -129,7 +129,7 @@ const CreateGroupPanel: FC = () => {
         })}
       >
         <SidePanel.Header>
-          <SidePanel.HeaderTitle>
+          <SidePanel.HeaderTitle key={subForm ?? "start"}>
             <GroupHeaderTitle subForm={subForm} setSubForm={setSubForm} />
           </SidePanel.HeaderTitle>
         </SidePanel.Header>

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -251,7 +251,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
         onClose={closePanel}
       >
         <SidePanel.Header>
-          <SidePanel.HeaderTitle>
+          <SidePanel.HeaderTitle key={subForm ?? "start"}>
             <GroupHeaderTitle
               subForm={subForm}
               setSubForm={setSubForm}


### PR DESCRIPTION
## Done

- fix(translation) ensure app does not crash on using chrome translation

Fixes #1004

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - translate the app to a local language (non english) in google chrome, while being translated try the following actions:
    - remove a network interface from an instance
    - edit the network interface for an instance
    - edit a network
    - edit a permission group and switch between start of the side panel and edit identities/permissions screens
    - migrate an instance modal workflow
    - migrate a volume modal workflow
    - All the above would crash the app previously while translation is enabled. They should work now as usually.

More context in https://github.com/facebook/react/issues/11538 Used the extension https://www.npmjs.com/package/remove-child-node-error-debugger locally to identify the components causing the crash.