### PR TITLE
fix(image) enable image export detection 

### DIFF
--- a/src/pages/images/actions/DownloadImageBtn.tsx
+++ b/src/pages/images/actions/DownloadImageBtn.tsx
@@ -14,7 +14,8 @@ const DownloadImageBtn: FC<Props> = ({ image, project }) => {
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
   const description = image.properties?.description ?? image.fingerprint;
-  const isUnifiedTarball = image.update_source == null; //Only Split Tarballs have an update_source.
+  const isUnifiedTarball =
+    image.update_source == null || image.update_source.server === ""; //Only Split Tarballs have an update_source.
   const url = `/1.0/images/${image.fingerprint}/export?project=${project}`;
 
   const handleExport = () => {


### PR DESCRIPTION
## Done

- enable image export detection for empty update source server after change in lxd led to image update source always being set
- Before the image.update_source would be null for images created from an instance. Now the field is filled and looks like this: 
![image](https://github.com/user-attachments/assets/0750a55c-c4f7-4769-9ae7-a72e8b3dc451)
