### PR TITLE
fix(instance) open instance panel reliably on non-default projects

### DIFF
--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 import type { GroupSubForm } from "pages/permissions/panels/CreateGroupPanel";
+import { useCurrentProject } from "context/useCurrentProject";
 
 export interface PanelHelper {
   panel: string | null;
@@ -39,6 +40,7 @@ export const panels = {
 type ParamMap = Record<string, string>;
 
 const usePanelParams = (): PanelHelper => {
+  const { project } = useCurrentProject();
   const [params, setParams] = useSearchParams();
 
   const craftResizeEvent = () => {
@@ -67,7 +69,7 @@ const usePanelParams = (): PanelHelper => {
     newParams.delete("instance");
     newParams.delete("panel");
     newParams.delete("profile");
-    newParams.delete("project");
+    newParams.delete("panel-project");
     newParams.delete("sub-form");
     setParams(newParams);
     craftResizeEvent();
@@ -77,7 +79,7 @@ const usePanelParams = (): PanelHelper => {
     panel: params.get("panel"),
     instance: params.get("instance"),
     profile: params.get("profile"),
-    project: params.get("project") ?? "default",
+    project: params.get("panel-project") ?? project?.name ?? "default",
     identity: params.get("identity"),
     group: params.get("group"),
     idpGroup: params.get("idp-group"),
@@ -88,7 +90,10 @@ const usePanelParams = (): PanelHelper => {
     },
 
     openInstanceSummary: (instance, project) => {
-      setPanelParams(panels.instanceSummary, { instance, project });
+      setPanelParams(panels.instanceSummary, {
+        instance,
+        "panel-project": project,
+      });
     },
 
     openImageImport: () => {
@@ -96,7 +101,10 @@ const usePanelParams = (): PanelHelper => {
     },
 
     openProfileSummary: (profile, project) => {
-      setPanelParams(panels.profileSummary, { profile, project });
+      setPanelParams(panels.profileSummary, {
+        profile,
+        "panel-project": project,
+      });
     },
 
     openIdentityGroups: (identity) => {


### PR DESCRIPTION
## Done

- fix(instance) open instance panel reliably on non-default projects

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a non-default projects instance list. Click on an instance to open the side panel, ensure the correct instnace data is displayed
    - repeat for the all projects view, select instances from default and non-default project and ensure the side panel shows the right instance details.