### PR TITLE
feat: [WD-22116] Adds Ceph Object storage driver

### DIFF
--- a/src/pages/storage/StoragePoolDetail.tsx
+++ b/src/pages/storage/StoragePoolDetail.tsx
@@ -11,6 +11,8 @@ import { useClusterMembers } from "context/useClusterMembers";
 import TabLinks from "components/TabLinks";
 import type { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
 import { useStoragePool } from "context/useStoragePools";
+import classnames from "classnames";
+import { cephObject } from "util/storageOptions";
 
 const StoragePoolDetail: FC = () => {
   const notify = useNotify();
@@ -29,8 +31,8 @@ const StoragePoolDetail: FC = () => {
   }
 
   const member = clusterMembers[0]?.server_name ?? undefined;
-
   const { data: pool, error, isLoading } = useStoragePool(name, member);
+  const isVolumeCompatible = pool?.driver !== cephObject;
 
   if (error) {
     notify.failure("Loading storage details failed", error);
@@ -46,14 +48,27 @@ const StoragePoolDetail: FC = () => {
     "Overview",
     "Configuration",
     {
-      component: () => (
-        <Link
-          to={`/ui/project/${project}/storage/volumes?pool=${pool.name}`}
-          className="p-tabs__link"
-        >
-          Volumes <Icon name="external-link" />
-        </Link>
-      ),
+      component: () => {
+        return (
+          <Link
+            to={
+              isVolumeCompatible
+                ? `/ui/project/${project}/storage/volumes?pool=${pool.name}`
+                : "#"
+            }
+            className={classnames("p-tabs__link", {
+              "is-disabled": !isVolumeCompatible,
+            })}
+            title={
+              isVolumeCompatible
+                ? "Volumes"
+                : "Volumes are not supported on this pool"
+            }
+          >
+            Volumes <Icon name="external-link" />
+          </Link>
+        );
+      },
       label: "Volumes",
     },
   ];

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -4,8 +4,7 @@ import type { CustomSelectOption } from "@canonical/react-components";
 import { CustomSelect, useNotify } from "@canonical/react-components";
 import Loader from "components/Loader";
 import type { Props as SelectProps } from "@canonical/react-components/dist/components/Select/Select";
-import { useSettings } from "context/useSettings";
-import { getSupportedStorageDrivers } from "util/storageOptions";
+import { cephObject } from "util/storageOptions";
 import StoragePoolOptionLabel from "./StoragePoolOptionLabel";
 import StoragePoolOptionHeader from "./StoragePoolOptionHeader";
 import { useStoragePools } from "context/useStoragePools";
@@ -14,27 +13,21 @@ interface Props {
   value: string;
   setValue: (value: string) => void;
   selectProps?: SelectProps;
-  hidePoolsWithUnsupportedDrivers?: boolean;
+  invalidDrivers?: string[];
 }
 
 const StoragePoolSelector: FC<Props> = ({
   value,
   setValue,
   selectProps,
-  hidePoolsWithUnsupportedDrivers = false,
+  invalidDrivers = [cephObject],
 }) => {
   const notify = useNotify();
-  const { data: settings } = useSettings();
   const { data: pools = [], error, isLoading } = useStoragePools();
 
-  const supportedStorageDrivers = getSupportedStorageDrivers(settings);
-  const poolsWithSupportedDriver = pools.filter((pool) =>
-    supportedStorageDrivers.has(pool.driver),
-  );
-
-  const poolsToUse = hidePoolsWithUnsupportedDrivers
-    ? poolsWithSupportedDriver
-    : pools;
+  const poolsToUse = pools.filter((pool) => {
+    return !invalidDrivers.includes(pool.driver);
+  });
 
   useEffect(() => {
     if (!value && poolsToUse.length > 0) {

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -13,6 +13,7 @@ import StoragePoolFormMain from "./StoragePoolFormMain";
 import StoragePoolFormMenu, {
   CEPH_CONFIGURATION,
   CEPHFS_CONFIGURATION,
+  CEPHOBJECT_CONFIGURATION,
   MAIN_CONFIGURATION,
   POWERFLEX,
   PURE_STORAGE,
@@ -26,6 +27,7 @@ import {
   btrfsDriver,
   cephDriver,
   cephFSDriver,
+  cephObject,
   getSupportedStorageDrivers,
   powerFlex,
   pureStorage,
@@ -45,6 +47,7 @@ import { ensureEditMode } from "util/instanceEdit";
 import StoragePoolFormCephFS from "pages/storage/forms/StoragePoolFormCephFS";
 import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 import StoragePoolFormPure from "pages/storage/forms/StoragePoolFormPure";
+import StoragePoolFormCephObject from "./StoragePoolFormCephObject";
 
 export interface StoragePoolFormValues {
   barePool?: LxdStoragePool;
@@ -59,6 +62,10 @@ export interface StoragePoolFormValues {
   cephfs_osd_pg_num?: string;
   cephfs_path?: string;
   cephfs_user_name?: string;
+  cephobject_radosgw_endpoint?: string;
+  cephobject_cluster_name?: string;
+  cephobject_user_name?: string;
+  cephobject_bucket_name_prefix?: string;
   description: string;
   driver: string;
   entityType: "storagePool";
@@ -106,6 +113,7 @@ export const toStoragePool = (
   const isPowerFlexDriver = values.driver === powerFlex;
   const isPureDriver = values.driver === pureStorage;
   const isZFSDriver = values.driver === zfsDriver;
+  const isCephObjectDriver = values.driver === cephObject;
   const hasValidSize = values.size?.match(/^\d/);
 
   const getConfig = () => {
@@ -128,6 +136,16 @@ export const toStoragePool = (
         [getPoolKey("cephfs_path")]: values.cephfs_path,
         [getPoolKey("cephfs_user_name")]: values.cephfs_user_name,
         source: values.source,
+      };
+    }
+    if (isCephObjectDriver) {
+      return {
+        [getPoolKey("cephobject_radosgw_endpoint")]:
+          values.cephobject_radosgw_endpoint,
+        [getPoolKey("cephobject_cluster_name")]: values.cephobject_cluster_name,
+        [getPoolKey("cephobject_user_name")]: values.cephobject_user_name,
+        [getPoolKey("cephobject_bucket_name_prefix")]:
+          values.cephobject_bucket_name_prefix,
       };
     }
     if (isPowerFlexDriver) {
@@ -248,6 +266,9 @@ const StoragePoolForm: FC<Props> = ({
           )}
           {section === slugify(CEPHFS_CONFIGURATION) && (
             <StoragePoolFormCephFS formik={formik} />
+          )}
+          {section === slugify(CEPHOBJECT_CONFIGURATION) && (
+            <StoragePoolFormCephObject formik={formik} />
           )}
           {section === slugify(POWERFLEX) && (
             <StoragePoolFormPowerflex formik={formik} />

--- a/src/pages/storage/forms/StoragePoolFormCephObject.tsx
+++ b/src/pages/storage/forms/StoragePoolFormCephObject.tsx
@@ -1,0 +1,44 @@
+import type { FormikProps } from "formik";
+import type { FC } from "react";
+import type { StoragePoolFormValues } from "./StoragePoolForm";
+import { getConfigurationRow } from "components/ConfigurationRow";
+import { Input } from "@canonical/react-components";
+import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+}
+
+const StoragePoolFormCephObject: FC<Props> = ({ formik }) => {
+  return (
+    <ScrollableConfigurationTable
+      rows={[
+        getConfigurationRow({
+          formik,
+          label: "Bucket name prefix",
+          name: "cephobject_bucket_name_prefix",
+          defaultValue: "",
+          children: (
+            <Input type="text" placeholder="Enter bucket name prefix" />
+          ),
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Cluster name",
+          name: "cephobject_cluster_name",
+          defaultValue: "",
+          children: <Input type="text" placeholder="Enter cluster name" />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Ceph user name",
+          name: "cephobject_user_name",
+          defaultValue: "",
+          children: <Input type="text" placeholder="Enter pool name" />,
+        }),
+      ]}
+    />
+  );
+};
+
+export default StoragePoolFormCephObject;

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -10,11 +10,13 @@ import {
   powerFlex,
   pureStorage,
   cephFSDriver,
+  cephObject,
 } from "util/storageOptions";
 import type { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import {
+  getCephObjectPoolFormFields,
   getCephPoolFormFields,
   getPowerflexPoolFormFields,
   getPureStoragePoolFormFields,
@@ -52,11 +54,12 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
 
   const isCephDriver = formik.values.driver === cephDriver;
   const isCephFSDriver = formik.values.driver === cephFSDriver;
+  const isCephObjectDriver = formik.values.driver === cephObject;
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
   const storageDriverOptions = getStorageDriverOptions(settings);
   const hasClusterWideSource = isCephDriver || isCephFSDriver;
-  const hasSource = !isPureDriver && !isPowerFlexDriver;
+  const hasSource = !isPureDriver && !isPowerFlexDriver && !isCephObjectDriver;
 
   const sourceHelpText = formik.values.isCreating
     ? getSourceHelpForDriver(formik.values.driver)
@@ -104,6 +107,12 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
               if (val !== cephDriver) {
                 const cephFields = getCephPoolFormFields();
                 for (const field of cephFields) {
+                  formik.setFieldValue(field, undefined);
+                }
+              }
+              if (val !== cephObject) {
+                const cephobjectFields = getCephObjectPoolFormFields();
+                for (const field of cephobjectFields) {
                   formik.setFieldValue(field, undefined);
                 }
               }
@@ -193,6 +202,22 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 disabledReason={formik.values.editRestriction}
               />
             ))}
+          {isCephObjectDriver && (
+            <>
+              <Input
+                {...formik.getFieldProps("cephobject_radosgw_endpoint")}
+                type="text"
+                label="Rados gateway endpoint"
+                placeholder="Enter rados gateway endpoint"
+                help="URL of the rados gateway process"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
+                required
+              />
+            </>
+          )}
           {isPowerFlexDriver && (
             <>
               <Input

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -9,6 +9,7 @@ import type { StoragePoolFormValues } from "./StoragePoolForm";
 import {
   cephDriver,
   cephFSDriver,
+  cephObject,
   powerFlex,
   pureStorage,
   zfsDriver,
@@ -21,6 +22,7 @@ import {
 export const MAIN_CONFIGURATION = "Main configuration";
 export const CEPH_CONFIGURATION = "Ceph";
 export const CEPHFS_CONFIGURATION = "CephFS";
+export const CEPHOBJECT_CONFIGURATION = "Ceph Object";
 export const POWERFLEX = "Powerflex";
 export const ZFS_CONFIGURATION = "ZFS";
 export const YAML_CONFIGURATION = "YAML configuration";
@@ -47,6 +49,7 @@ const StoragePoolFormMenu: FC<Props> = ({
 
   const isCephDriver = formik.values.driver === cephDriver;
   const isCephFSDriver = formik.values.driver === cephFSDriver;
+  const isCephObjectDriver = formik.values.driver === cephObject;
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
   const isZfsDriver = formik.values.driver === zfsDriver;
@@ -88,6 +91,13 @@ const StoragePoolFormMenu: FC<Props> = ({
           {isCephFSDriver && (
             <MenuItem
               label={CEPHFS_CONFIGURATION}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
+          {isCephObjectDriver && (
+            <MenuItem
+              label={CEPHOBJECT_CONFIGURATION}
               {...menuItemProps}
               disableReason={disableReason}
             />

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -56,7 +56,6 @@ const StorageVolumeFormMain: FC<Props> = ({
                 formik.setFieldValue("clusterMember", undefined);
               }
             }}
-            hidePoolsWithUnsupportedDrivers
             selectProps={{
               id: "storage-pool-selector-volume",
               disabled: !formik.values.isCreating,

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -7,6 +7,7 @@ export const lvmDriver = "lvm";
 export const zfsDriver = "zfs";
 export const cephDriver = "ceph";
 export const cephFSDriver = "cephfs";
+export const cephObject = "cephobject";
 export const powerFlex = "powerflex";
 export const pureStorage = "pure";
 
@@ -19,6 +20,7 @@ const storageDriverLabels: { [key: string]: string } = {
   [cephFSDriver]: "CephFS",
   [powerFlex]: "Dell PowerFlex",
   [pureStorage]: "Pure Storage",
+  [cephObject]: "Ceph Object",
 };
 
 export const getStorageDriverOptions = (
@@ -69,8 +71,9 @@ export const driversWithFilesystemSupport = [
   lvmDriver,
   cephDriver,
   pureStorage,
+  cephObject,
 ];
 
 export const isRemoteStorage = (driver: string) => {
-  return [cephDriver, cephFSDriver, powerFlex].includes(driver);
+  return [cephDriver, cephFSDriver, cephObject, powerFlex].includes(driver);
 };

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -25,6 +25,10 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   cephfs_osd_pg_num: "cephfs.osd_pg_num",
   cephfs_path: "cephfs.path",
   cephfs_user_name: "cephfs.user.name",
+  cephobject_radosgw_endpoint: "cephobject.radosgw.endpoint",
+  cephobject_cluster_name: "cephobject.cluster_name",
+  cephobject_user_name: "cephobject.user.name",
+  cephobject_bucket_name_prefix: "cephobject.bucket.name_prefix",
   powerflex_clone_copy: "powerflex.clone_copy",
   powerflex_domain: "powerflex.domain",
   powerflex_gateway: "powerflex.gateway",
@@ -64,6 +68,12 @@ export const getCephPoolFormFields = () => {
   );
 };
 
+export const getCephObjectPoolFormFields = () => {
+  return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
+    item.startsWith("cephobject_"),
+  );
+};
+
 export const getPowerflexPoolFormFields = () => {
   return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
     item.startsWith("powerflex_"),
@@ -91,6 +101,7 @@ const storagePoolDriverToOptionKey: Record<string, LxdConfigOptionsKeys> = {
   cephfs: "storage-cephfs",
   powerflex: "storage-powerflex",
   pure: "storage-pure",
+  cephobject: "storage-cephobject",
 };
 
 export const storagePoolFormDriverToOptionKey = (

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -61,6 +61,11 @@ export const toStoragePoolFormValues = (
     cephfs_osd_pg_num: pool.config?.["cephfs.osd_pg_num"],
     cephfs_path: pool.config?.["cephfs.path"],
     cephfs_user_name: pool.config?.["cephfs.user.name"],
+    cephobject_radosgw_endpoint: pool.config?.["cephobject.radosgw.endpoint"],
+    cephobject_cluster_name: pool.config?.["cephobject.cluster_name"],
+    cephobject_user_name: pool.config?.["cephobject.user.name"],
+    cephobject_bucket_name_prefix:
+      pool.config?.["cephobject.bucket.name_prefix"],
     description: pool.description,
     driver: pool.driver,
     entityType: "storagePool",


### PR DESCRIPTION
## Done

- Added Cephobject storage as a driver
- Implemented the workflow to create a cephobject pool in the UI
- Tested the creation of storage buckets :+1: 

Fixes:
- Lack of a Cephobject storage driver

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
![image](https://github.com/user-attachments/assets/e7a7b9ce-587d-4de8-9c59-2ab5663a71fc)
![image](https://github.com/user-attachments/assets/207b9517-3296-4ef2-b2ed-b65d58b27621)

Created storage buckets:
![image](https://github.com/user-attachments/assets/c06145aa-80ed-46ad-96a2-413a5af93071)
