### PR TITLE
feat(warnings) allow bulk delete of server warnings

### DIFF
--- a/src/api/warnings.tsx
+++ b/src/api/warnings.tsx
@@ -2,6 +2,7 @@ import { handleResponse } from "util/helpers";
 import type { LxdWarning } from "types/warning";
 import type { LxdApiResponse } from "types/apiResponse";
 import { withEntitlementsQuery } from "util/entitlements/api";
+import { continueOrFinish, pushFailure, pushSuccess } from "util/promises";
 
 export const warningEntitlements = ["can_delete"];
 
@@ -23,8 +24,29 @@ export const fetchWarnings = async (
   });
 };
 
-export const deleteWarning = async (warning: LxdWarning): Promise<unknown> => {
-  return fetch(`/1.0/warnings/${warning.uuid}`, {
+export const deleteWarning = async (warningId: string): Promise<unknown> => {
+  return fetch(`/1.0/warnings/${warningId}`, {
     method: "DELETE",
   }).then(handleResponse);
+};
+
+export const deleteWarningBulk = async (
+  warningIds: string[],
+): Promise<PromiseSettledResult<void>[]> => {
+  const results: PromiseSettledResult<void>[] = [];
+  return new Promise((resolve, reject) => {
+    Promise.allSettled(
+      warningIds.map(async (warningId) => {
+        return deleteWarning(warningId)
+          .then(() => {
+            pushSuccess(results);
+            continueOrFinish(results, warningIds.length, resolve);
+          })
+          .catch((e) => {
+            pushFailure(results, e instanceof Error ? e.message : "");
+            continueOrFinish(results, warningIds.length, resolve);
+          });
+      }),
+    ).catch(reject);
+  });
 };

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -1,21 +1,29 @@
 import type { FC } from "react";
-import { MainTable, Row, useNotify } from "@canonical/react-components";
+import { useState, useEffect } from "react";
+import { Row, useNotify } from "@canonical/react-components";
 import { fetchWarnings } from "api/warnings";
 import { isoTimeToString } from "util/helpers";
-import BaseLayout from "components/BaseLayout";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import Loader from "components/Loader";
 import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
 import { useDocs } from "context/useDocs";
-import DeleteWarningBtn from "pages/warnings/actions/DeleteWarningBtn";
+import BulkDeleteWarningBtn from "pages/warnings/actions/BulkDeleteWarningBtn";
 import { useAuth } from "context/auth";
+import SelectableMainTable from "components/SelectableMainTable";
+import ScrollableTable from "components/ScrollableTable";
+import PageHeader from "components/PageHeader";
+import CustomLayout from "components/CustomLayout";
+import { useWarningEntitlements } from "util/entitlements/warnings";
 
 const WarningList: FC = () => {
   const docBaseLink = useDocs();
   const notify = useNotify();
   const { isFineGrained } = useAuth();
+  const [selectedNames, setSelectedNames] = useState<string[]>([]);
+  const [processingNames, setProcessingNames] = useState<string[]>([]);
+  const { canDeleteWarning } = useWarningEntitlements();
 
   const {
     data: warnings = [],
@@ -31,73 +39,83 @@ const WarningList: FC = () => {
     notify.failure("Loading warnings failed", error);
   }
 
+  useEffect(() => {
+    const validNames = new Set(warnings?.map((warning) => warning.uuid));
+    const validSelections = selectedNames.filter((name) =>
+      validNames.has(name),
+    );
+    if (validSelections.length !== selectedNames.length) {
+      setSelectedNames(validSelections);
+    }
+  }, [warnings]);
+
   const headers = [
-    { content: "Type", sortKey: "type" },
-    { content: "Last message", sortKey: "lastMessage" },
-    { content: "Status", sortKey: "status" },
-    { content: "Severity", sortKey: "severity" },
-    { content: "Count", sortKey: "count", className: "u-align--right" },
-    { content: "Project", sortKey: "project" },
-    { content: "First seen", sortKey: "firstSeen" },
-    { content: "Last seen", sortKey: "lastSeen" },
-    { "aria-label": "Actions", className: "u-align--right actions" },
+    { content: "Type", sortKey: "type", className: "type" },
+    {
+      content: "Last message",
+      sortKey: "lastMessage",
+      className: "last_message",
+    },
+    { content: "Status", sortKey: "status", className: "status" },
+    { content: "Severity", sortKey: "severity", className: "severity" },
+    { content: "Count", sortKey: "count", className: "count u-align--right" },
+    { content: "Project", sortKey: "project", className: "project" },
+    { content: "First seen", sortKey: "firstSeen", className: "first_seen_at" },
+    { content: "Last seen", sortKey: "lastSeen", className: "last_seen_at" },
   ];
 
   const rows = warnings.map((warning) => {
     return {
       key: warning.uuid,
+      name: warning.uuid,
       columns: [
         {
           content: warning.type,
           role: "rowheader",
           "aria-label": "Type",
+          className: "type",
         },
         {
           content: warning.last_message,
           role: "cell",
           "aria-label": "Last message",
+          className: "last_message",
         },
         {
           content: warning.status,
           role: "cell",
           "aria-label": "Status",
+          className: "status",
         },
         {
           content: warning.severity,
           role: "cell",
           "aria-label": "Severity",
+          className: "severity",
         },
         {
           content: warning.count,
           role: "cell",
-          className: "u-align--right",
+          className: "count u-align--right",
           "aria-label": "Count",
         },
         {
           content: warning.project,
           role: "cell",
-          className: "u-align--center",
+          className: "project u-align--center",
           "aria-label": "Project",
         },
         {
           content: isoTimeToString(warning.first_seen_at),
           role: "cell",
           "aria-label": "First seen",
+          className: "first_seen_at",
         },
         {
           content: isoTimeToString(warning.last_seen_at),
           role: "cell",
           "aria-label": "Last seen",
-        },
-        {
-          content: (
-            <div>
-              <DeleteWarningBtn warning={warning} />
-            </div>
-          ),
-          role: "cell",
-          className: "u-align--right actions",
-          "aria-label": "Actions",
+          className: "last_seen_at",
         },
       ],
       sortData: {
@@ -114,26 +132,50 @@ const WarningList: FC = () => {
   });
 
   return (
-    <>
-      <BaseLayout
-        title={
-          <HelpLink
-            href={`${docBaseLink}/howto/troubleshoot/`}
-            title="Learn more about troubleshooting"
-          >
-            Warnings
-          </HelpLink>
-        }
-      >
-        <NotificationRow />
-        <Row>
-          <MainTable
+    <CustomLayout
+      mainClassName="images-list"
+      contentClassName="u-no-padding--bottom"
+      header={
+        <PageHeader>
+          <PageHeader.Left>
+            <PageHeader.Title>
+              <HelpLink
+                href={`${docBaseLink}/howto/troubleshoot/`}
+                title="Learn more about troubleshooting"
+              >
+                Warnings
+              </HelpLink>
+            </PageHeader.Title>
+            {selectedNames.length > 0 && (
+              <BulkDeleteWarningBtn
+                warningIds={selectedNames}
+                canDeleteWarnings={canDeleteWarning(warnings[0])}
+                onStart={() => {
+                  setProcessingNames(selectedNames);
+                }}
+                onFinish={() => {
+                  setProcessingNames([]);
+                }}
+              />
+            )}
+          </PageHeader.Left>
+        </PageHeader>
+      }
+    >
+      <NotificationRow />
+      <Row>
+        <ScrollableTable
+          dependencies={[warnings]}
+          tableId="warning-table"
+          belowIds={["status-bar"]}
+        >
+          <SelectableMainTable
+            id="warning-table"
             headers={headers}
             rows={rows}
             paginate={30}
-            responsive
             sortable
-            className="u-table-layout--auto"
+            className="warnings-table"
             emptyStateMsg={
               isLoading ? (
                 <Loader text="Loading warnings..." />
@@ -141,10 +183,16 @@ const WarningList: FC = () => {
                 "No data to display"
               )
             }
+            itemName="warning"
+            parentName="server"
+            selectedNames={selectedNames}
+            setSelectedNames={setSelectedNames}
+            filteredNames={rows.map((item) => item.name)}
+            disabledNames={processingNames}
           />
-        </Row>
-      </BaseLayout>
-    </>
+        </ScrollableTable>
+      </Row>
+    </CustomLayout>
   );
 };
 

--- a/src/sass/_warnings_table.scss
+++ b/src/sass/_warnings_table.scss
@@ -1,0 +1,67 @@
+.warnings-table {
+  .type {
+    width: 12rem;
+  }
+
+  .last_message {
+    width: 24rem;
+  }
+
+  .status {
+    width: 6rem;
+  }
+
+  .severity {
+    width: 6rem;
+  }
+
+  .count {
+    width: 4rem;
+  }
+
+  .project {
+    width: 6rem;
+  }
+
+  .first_seen_at {
+    width: 12rem;
+  }
+
+  .last_seen_at {
+    width: 12rem;
+  }
+
+  @media screen and (width < 1900px) {
+    .first_seen_at,
+    .last_seen_at {
+      width: 8rem;
+    }
+  }
+
+  @media screen and (width < 1740px) {
+    .type {
+      width: 8rem;
+    }
+  }
+
+  @media screen and (width < 1470px) {
+    .first_seen_at {
+      display: none !important;
+    }
+  }
+
+  @media screen and (width < 1360px) {
+    .project {
+      display: none !important;
+    }
+
+    .type,
+    .status,
+    .severity,
+    .count,
+    .last_seen_at,
+    .last_message {
+      width: inherit;
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -139,6 +139,7 @@ $border-thin: 1px solid $color-mid-light !default;
 @import "toast";
 @import "upload_instance_modal";
 @import "upper_controls_bar";
+@import "warnings_table";
 
 body {
   // needed for notification list expanding animation


### PR DESCRIPTION
## Done

- feat(warnings) allow bulk delete of server warnings

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open server warning page
    - ensure warnings page is responsive in smaller resolutions
    - bulk select / delete warnings

## Screenshots

![image](https://github.com/user-attachments/assets/dd19b293-6350-4e26-a564-e54edea6c96e)
