### PR TITLE
fix(images) show local images immediately when filtering cached images

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -104,12 +104,12 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const { data: localImages = [], isLoading: isLocalImageLoading } =
     useImagesInProject(project ?? "default");
 
+  const isRemoteImagesLoading =
+    !hideRemote && (isCiLoading || isMinimalLoading || isImagesLxdLoading);
+
   const isLoading =
-    isCiLoading ||
-    isMinimalLoading ||
-    isImagesLxdLoading ||
-    isLocalImageLoading ||
-    isSettingsLoading;
+    isRemoteImagesLoading || isLocalImageLoading || isSettingsLoading;
+
   const archSupported = getArchitectureAliases(
     settings?.environment?.architectures ?? [],
   );


### PR DESCRIPTION
## Done

- fix(images) show local images immediately when filtering cached images is enabled and remote images are still loading

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - limit your network speed (i.e. chrome dev tools > networking > throttling > fast 4g, or take a train in germany)
    - create an instance > select base image, enable the "show cached images" checkbox. The local images should show immediately and not wait for the remote image query to continue and fail or succeed.