### PR TITLE
fix(network) avoid setting security.acls field if no acls are selected for a network

### DIFF
--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -150,7 +150,10 @@ export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
       [getNetworkKey("network")]: values.network,
       [getNetworkKey("ovn_ingress_mode")]: values.ovn_ingress_mode,
       [getNetworkKey("parent")]: values.parent,
-      [getNetworkKey("security_acls")]: values.security_acls.join(","),
+      [getNetworkKey("security_acls")]:
+        values.security_acls.length > 0
+          ? values.security_acls.join(",")
+          : undefined,
     },
   };
 };


### PR DESCRIPTION
## Done

- fix(network) avoid setting security.acls field if no acls are selected for a network

Fixes #1256

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create/edit a network
    - ensure the security.acls field on the network is not set to empty string if no acls are selected.

## Screenshots

before:

![image](https://github.com/user-attachments/assets/69df81f9-b56a-40d8-b623-644e4bbafc15)

after:

![image](https://github.com/user-attachments/assets/015ffa29-323c-49ef-8453-2eff5372ec20)
