### PR TITLE
fix(network) remove 'range' from ipv4 and ipv6 address labels in network form

### DIFF
--- a/src/pages/networks/forms/NetworkFormMain.tsx
+++ b/src/pages/networks/forms/NetworkFormMain.tsx
@@ -108,7 +108,7 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
               row={getConfigurationRow({
                 formik,
                 name: "ipv4_address",
-                label: "IPv4 address range",
+                label: "IPv4 address",
                 defaultValue: "auto",
                 children: (
                   <IpAddressSelector
@@ -140,7 +140,7 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
               row={getConfigurationRow({
                 formik,
                 name: "ipv6_address",
-                label: "IPv6 address range",
+                label: "IPv6 address",
                 defaultValue: "auto",
                 children: (
                   <IpAddressSelector


### PR DESCRIPTION
## Done

- fix(network) remove 'range' from ipv4 and ipv6 address labels in network form

Fixes #1253

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open network detail page, check ipv4 and ipv6 address field labels. they should be without the "range" suffix.

## Screenshots

![image](https://github.com/user-attachments/assets/fb72a80c-bcb8-4450-aded-0a3ac9716501)