### PR TITLE
fix(identities) avoid closing tab on deleting identity

### DIFF
--- a/src/pages/permissions/actions/BulkDeleteIdentitiesBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteIdentitiesBtn.tsx
@@ -63,7 +63,6 @@ const BulkDeleteIdentitiesBtn: FC<Props> = ({ identities }) => {
         });
         toastNotify.success(successMessage);
         setLoading(false);
-        close();
       })
       .catch((e) => {
         notify.failure(`Identity deletion failed`, e);


### PR DESCRIPTION
## Done

- fix(identities) avoid closing tab on deleting identity

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - delete an identity in firefox
    - ensure the lxd ui stays open and won't close