### PR TITLE
fix(instance) ensure only one instance is in loading state

### DIFF
--- a/src/components/forms/BootForm.tsx
+++ b/src/components/forms/BootForm.tsx
@@ -7,7 +7,7 @@ import type {
 } from "./instanceAndProfileFormValues";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 
 export interface BootFormValues {
@@ -20,14 +20,14 @@ export interface BootFormValues {
 
 export const bootPayload = (values: InstanceAndProfileFormValues) => {
   return {
-    [getInstanceKey("boot_autostart")]: values.boot_autostart?.toString(),
-    [getInstanceKey("boot_autostart_delay")]:
+    [getInstanceField("boot_autostart")]: values.boot_autostart?.toString(),
+    [getInstanceField("boot_autostart_delay")]:
       values.boot_autostart_delay?.toString(),
-    [getInstanceKey("boot_autostart_priority")]:
+    [getInstanceField("boot_autostart_priority")]:
       values.boot_autostart_priority?.toString(),
-    [getInstanceKey("boot_host_shutdown_timeout")]:
+    [getInstanceField("boot_host_shutdown_timeout")]:
       values.boot_host_shutdown_timeout?.toString(),
-    [getInstanceKey("boot_stop_priority")]:
+    [getInstanceField("boot_stop_priority")]:
       values.boot_stop_priority?.toString(),
   };
 };

--- a/src/components/forms/CloudInitForm.tsx
+++ b/src/components/forms/CloudInitForm.tsx
@@ -7,7 +7,7 @@ import type {
 } from "./instanceAndProfileFormValues";
 import { getConfigurationRowBase } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { ensureEditMode } from "util/instanceEdit";
 import classnames from "classnames";
 import { getConfigRowMetadata } from "util/configInheritance";
@@ -20,10 +20,10 @@ export interface CloudInitFormValues {
 
 export const cloudInitPayload = (values: InstanceAndProfileFormValues) => {
   return {
-    [getInstanceKey("cloud_init_network_config")]:
+    [getInstanceField("cloud_init_network_config")]:
       values.cloud_init_network_config,
-    [getInstanceKey("cloud_init_user_data")]: values.cloud_init_user_data,
-    [getInstanceKey("cloud_init_vendor_data")]: values.cloud_init_vendor_data,
+    [getInstanceField("cloud_init_user_data")]: values.cloud_init_user_data,
+    [getInstanceField("cloud_init_vendor_data")]: values.cloud_init_vendor_data,
   };
 };
 

--- a/src/components/forms/InstanceSnapshotsForm.tsx
+++ b/src/components/forms/InstanceSnapshotsForm.tsx
@@ -7,7 +7,7 @@ import type {
 } from "./instanceAndProfileFormValues";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 import SnapshotScheduleInput from "components/SnapshotScheduleInput";
 import { useCurrentProject } from "context/useCurrentProject";
@@ -23,11 +23,11 @@ export interface SnapshotFormValues {
 
 export const snapshotsPayload = (values: InstanceAndProfileFormValues) => {
   return {
-    [getInstanceKey("snapshots_pattern")]: values.snapshots_pattern,
-    [getInstanceKey("snapshots_schedule_stopped")]:
+    [getInstanceField("snapshots_pattern")]: values.snapshots_pattern,
+    [getInstanceField("snapshots_schedule_stopped")]:
       values.snapshots_schedule_stopped,
-    [getInstanceKey("snapshots_schedule")]: values.snapshots_schedule,
-    [getInstanceKey("snapshots_expiry")]: values.snapshots_expiry,
+    [getInstanceField("snapshots_schedule")]: values.snapshots_schedule,
+    [getInstanceField("snapshots_expiry")]: values.snapshots_expiry,
   };
 };
 

--- a/src/components/forms/MigrationForm.tsx
+++ b/src/components/forms/MigrationForm.tsx
@@ -6,7 +6,7 @@ import type {
 } from "./instanceAndProfileFormValues";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 import {
   clusterEvacuationOptions,
@@ -21,8 +21,8 @@ export interface MigrationFormValues {
 
 export const migrationPayload = (values: InstanceAndProfileFormValues) => {
   return {
-    [getInstanceKey("migration_stateful")]: values.migration_stateful,
-    [getInstanceKey("cluster_evacuate")]: values.cluster_evacuate,
+    [getInstanceField("migration_stateful")]: values.migration_stateful,
+    [getInstanceField("cluster_evacuate")]: values.cluster_evacuate,
   };
 };
 

--- a/src/components/forms/ResourceLimitsForm.tsx
+++ b/src/components/forms/ResourceLimitsForm.tsx
@@ -13,7 +13,7 @@ import type {
 import { DEFAULT_CPU_LIMIT, DEFAULT_MEM_LIMIT } from "util/defaults";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 
 export interface ResourceLimitsFormValues {
@@ -26,14 +26,14 @@ export interface ResourceLimitsFormValues {
 
 export const resourceLimitsPayload = (values: InstanceAndProfileFormValues) => {
   return {
-    [getInstanceKey("limits_cpu")]: cpuLimitToPayload(values.limits_cpu),
-    [getInstanceKey("limits_memory")]: memoryLimitToPayload(
+    [getInstanceField("limits_cpu")]: cpuLimitToPayload(values.limits_cpu),
+    [getInstanceField("limits_memory")]: memoryLimitToPayload(
       values.limits_memory,
     ),
-    [getInstanceKey("limits_memory_swap")]: values.limits_memory_swap,
-    [getInstanceKey("limits_disk_priority")]:
+    [getInstanceField("limits_memory_swap")]: values.limits_memory_swap,
+    [getInstanceField("limits_disk_priority")]:
       values.limits_disk_priority?.toString(),
-    [getInstanceKey("limits_processes")]: values.limits_processes?.toString(),
+    [getInstanceField("limits_processes")]: values.limits_processes?.toString(),
   };
 };
 

--- a/src/components/forms/SecurityPoliciesForm.tsx
+++ b/src/components/forms/SecurityPoliciesForm.tsx
@@ -13,7 +13,7 @@ import type {
 } from "./instanceAndProfileFormValues";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
 
 export interface SecurityPoliciesFormValues {
@@ -34,20 +34,21 @@ export const securityPoliciesPayload = (
   values: InstanceAndProfileFormValues,
 ) => {
   return {
-    [getInstanceKey("security_protection_delete")]:
+    [getInstanceField("security_protection_delete")]:
       values.security_protection_delete,
-    [getInstanceKey("security_privileged")]: values.security_privileged,
-    [getInstanceKey("security_nesting")]: values.security_nesting,
-    [getInstanceKey("security_protection_shift")]:
+    [getInstanceField("security_privileged")]: values.security_privileged,
+    [getInstanceField("security_nesting")]: values.security_nesting,
+    [getInstanceField("security_protection_shift")]:
       values.security_protection_shift,
-    [getInstanceKey("security_idmap_base")]: values.security_idmap_base,
-    [getInstanceKey("security_idmap_size")]:
+    [getInstanceField("security_idmap_base")]: values.security_idmap_base,
+    [getInstanceField("security_idmap_size")]:
       values.security_idmap_size?.toString(),
-    [getInstanceKey("security_idmap_isolated")]: values.security_idmap_isolated,
-    [getInstanceKey("security_devlxd")]: values.security_devlxd,
-    [getInstanceKey("security_devlxd_images")]: values.security_devlxd_images,
-    [getInstanceKey("security_secureboot")]: values.security_secureboot,
-    [getInstanceKey("security_csm")]: values.security_csm,
+    [getInstanceField("security_idmap_isolated")]:
+      values.security_idmap_isolated,
+    [getInstanceField("security_devlxd")]: values.security_devlxd,
+    [getInstanceField("security_devlxd_images")]: values.security_devlxd_images,
+    [getInstanceField("security_secureboot")]: values.security_secureboot,
+    [getInstanceField("security_csm")]: values.security_csm,
   };
 };
 

--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -1,6 +1,7 @@
 import type { FC, ReactNode } from "react";
 import { createContext, useContext, useState } from "react";
 import type { LxdInstance } from "types/instance";
+import { getInstanceKey } from "util/instances";
 
 type LoadingTypes =
   | "Starting"
@@ -33,7 +34,7 @@ export const InstanceLoadingProvider: FC<Props> = ({ children }) => {
   const setLoading = (instance: LxdInstance, loadingType: LoadingTypes) => {
     setInstanceStates((oldMap) => {
       const newMap = new Map(oldMap);
-      newMap.set(instance.name, loadingType);
+      newMap.set(getInstanceKey(instance), loadingType);
       return newMap;
     });
   };
@@ -41,7 +42,7 @@ export const InstanceLoadingProvider: FC<Props> = ({ children }) => {
   const setFinish = (instance: LxdInstance) => {
     setInstanceStates((oldMap) => {
       const newMap = new Map(oldMap);
-      newMap.delete(instance.name);
+      newMap.delete(getInstanceKey(instance));
       return newMap;
     });
   };
@@ -49,7 +50,8 @@ export const InstanceLoadingProvider: FC<Props> = ({ children }) => {
   return (
     <InstanceLoadingContext.Provider
       value={{
-        getType: (instance: LxdInstance) => instanceStates.get(instance.name),
+        getType: (instance: LxdInstance) =>
+          instanceStates.get(getInstanceKey(instance)),
         setLoading,
         setFinish,
       }}

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -58,7 +58,7 @@ import SelectedTableNotification from "components/SelectedTableNotification";
 import CustomLayout from "components/CustomLayout";
 import HelpLink from "components/HelpLink";
 import { useDocs } from "context/useDocs";
-import type { LxdInstance, LxdInstanceStatus } from "types/instance";
+import type { LxdInstanceStatus } from "types/instance";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
 import InstanceDetailPanel from "./InstanceDetailPanel";
@@ -72,6 +72,7 @@ import { useIsClustered } from "context/useIsClustered";
 import { useProject } from "context/useProjects";
 import InstanceClusterMemberChip from "pages/instances/InstanceClusterMemberChip";
 import InstanceProjectChip from "pages/instances/InstanceProjectChip";
+import { getInstanceKey } from "util/instances";
 
 const loadHidden = () => {
   const saved = localStorage.getItem("instanceListHiddenColumns");
@@ -213,10 +214,6 @@ const InstanceList: FC = () => {
     }
     return true;
   });
-
-  const getInstanceKey = (instance: LxdInstance) => {
-    return `${instance.name} ${instance.project}`;
-  };
 
   useEffect(() => {
     const validKeys = new Set(filteredInstances.map(getInstanceKey));

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -226,7 +226,11 @@ const InstanceList: FC = () => {
   useEffect(() => {
     if (panelParams.instance) {
       if (
-        !instances.some((instance) => instance.name === panelParams.instance)
+        !instances.some(
+          (instance) =>
+            instance.name === panelParams.instance &&
+            instance.project === panelParams.project,
+        )
       ) {
         panelParams.clear();
       }

--- a/src/pages/instances/actions/InstanceBulkAction.tsx
+++ b/src/pages/instances/actions/InstanceBulkAction.tsx
@@ -11,6 +11,7 @@ import {
   statusLabel,
 } from "util/instanceBulkActions";
 import { ConfirmationButton, Icon } from "@canonical/react-components";
+import { getInstanceKey } from "util/instances";
 
 interface Props {
   action: LxdInstanceAction;
@@ -59,7 +60,7 @@ const InstanceBulkAction: FC<Props> = ({
     const count = instances.filter(
       (instance) =>
         instance.status === currentState &&
-        !restrictedInstances.includes(instance.name),
+        !restrictedInstances.includes(getInstanceKey(instance)),
     ).length;
 
     if (count === 0) {

--- a/src/pages/instances/actions/InstanceBulkActions.tsx
+++ b/src/pages/instances/actions/InstanceBulkActions.tsx
@@ -15,6 +15,7 @@ import { getPromiseSettledCounts } from "util/promises";
 import { useEventQueue } from "context/eventQueue";
 import { useToastNotification } from "context/toastNotificationProvider";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import { getInstanceKey } from "util/instances";
 
 interface Props {
   instances: LxdInstance[];
@@ -100,7 +101,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
 
   const restrictedInstances = instances
     .filter((instance) => !canUpdateInstanceState(instance))
-    .map((instance) => instance.name);
+    .map(getInstanceKey);
 
   return (
     <div className="p-segmented-control bulk-actions">

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -26,7 +26,7 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { fetchConfigOptions } from "api/server";
 import { toConfigFields } from "util/config";
-import { getInstanceKey } from "util/instanceConfigFields";
+import { getInstanceField } from "util/instanceConfigFields";
 import { useParams } from "react-router-dom";
 import { getProjectKey } from "util/projectConfigFields";
 import type { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
@@ -84,7 +84,7 @@ const getInstanceRowMetadata = (
   const configOptions = getConfigOptions();
 
   const configFields = toConfigFields(configOptions?.configs.instance ?? {});
-  const configKey = getInstanceKey(name);
+  const configKey = getInstanceField(name);
   const configField = configFields.find((item) => item.key === configKey);
 
   const { project } = useParams<{ project: string }>();

--- a/src/util/instanceConfigFields.tsx
+++ b/src/util/instanceConfigFields.tsx
@@ -32,7 +32,7 @@ const instanceConfigFormFieldsToPayload: Record<string, string> = {
   cloud_init_vendor_data: "cloud-init.vendor-data",
 };
 
-export const getInstanceKey = (formField: string): string => {
+export const getInstanceField = (formField: string): string => {
   if (!(formField in instanceConfigFormFieldsToPayload)) {
     throw new Error(
       `Could not find ${formField} in instanceConfigFormFieldsToPayload`,

--- a/src/util/instanceMigration.tsx
+++ b/src/util/instanceMigration.tsx
@@ -117,7 +117,7 @@ export const useInstanceMigration = ({
 
   const handleFinish = () => {
     queryClient.invalidateQueries({
-      queryKey: [queryKeys.instances, instance.name],
+      queryKey: [queryKeys.instances, instance.name, instance.project],
     });
     instanceLoading.setFinish(instance);
   };

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -6,6 +6,7 @@ import { checkDuplicateName, getFileExtension } from "./helpers";
 import * as Yup from "yup";
 import InstanceLinkChip from "pages/instances/InstanceLinkChip";
 import type { InstanceIconType } from "components/ResourceIcon";
+import type { LxdInstance } from "types/instance";
 
 export const instanceLinkFromOperation = (args: {
   operation?: LxdOperationResponse;
@@ -85,4 +86,8 @@ export const fileToInstanceName = (
   const sanitisedFileName = sanitizeInstanceName(fileName);
   const instanceName = truncateInstanceName(sanitisedFileName, suffix);
   return instanceName;
+};
+
+export const getInstanceKey = (instance: LxdInstance) => {
+  return `${instance.name} ${instance.project}`;
 };


### PR DESCRIPTION
## Done

- fix(instance) ensure only one instance is in loading state, when multiple are started/stopped from different projects in the all projects view with the same name
- fix(instances) invalidate correct query key on instance migration
- fix(instances) ensure to clear panel params when instance name and project are invalid
- fix(instances) avoid duplicate instances in other projects to match bulk action permission checks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - have two instances with the same name in two different projects
    - go to the all projects view
    - start one of the duplicated instances
    - ensure only that instances status is marked as loading, the duplicate is not marked as loading.