### PR TITLE
fix(ceph) add ceph.rbd.du setting to storage pools

### DIFF
--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -109,6 +109,7 @@ const getClusterAndMemberPoolPayload = (pool: Partial<LxdStoragePool>) => {
     "zfs.pool_name",
     "lvm.thinpool_name",
     "lvm.vg_name",
+    "volatile.initial_source",
   ]);
   const configKeys = Object.keys(pool.config || {});
   const memberConfig: LxdStoragePool["config"] = {};

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -54,6 +54,7 @@ export interface StoragePoolFormValues {
   ceph_cluster_name?: string;
   ceph_osd_pg_num?: string;
   ceph_rbd_clone_copy?: string;
+  ceph_rbd_du?: string;
   ceph_user_name?: string;
   ceph_rbd_features?: string;
   cephfs_cluster_name?: string;
@@ -122,6 +123,7 @@ export const toStoragePool = (
         [getPoolKey("ceph_cluster_name")]: values.ceph_cluster_name,
         [getPoolKey("ceph_osd_pg_num")]: values.ceph_osd_pg_num?.toString(),
         [getPoolKey("ceph_rbd_clone_copy")]: values.ceph_rbd_clone_copy,
+        [getPoolKey("ceph_rbd_du")]: values.ceph_rbd_du,
         [getPoolKey("ceph_user_name")]: values.ceph_user_name,
         [getPoolKey("ceph_rbd_features")]: values.ceph_rbd_features,
         source: values.source,

--- a/src/pages/storage/forms/StoragePoolFormCeph.tsx
+++ b/src/pages/storage/forms/StoragePoolFormCeph.tsx
@@ -42,6 +42,13 @@ const StoragePoolFormCeph: FC<Props> = ({ formik }) => {
         }),
         getConfigurationRow({
           formik,
+          label: "RBD disk usage",
+          name: "ceph_rbd_du",
+          defaultValue: "",
+          children: <Select options={optionTrueFalse} />,
+        }),
+        getConfigurationRow({
+          formik,
           label: "Ceph user name",
           name: "ceph_user_name",
           defaultValue: "",

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -17,6 +17,7 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   ceph_cluster_name: "ceph.cluster_name",
   ceph_osd_pg_num: "ceph.osd.pg_num",
   ceph_rbd_clone_copy: "ceph.rbd.clone_copy",
+  ceph_rbd_du: "ceph.rbd.du",
   ceph_user_name: "ceph.user.name",
   ceph_rbd_features: "ceph.rbd.features",
   cephfs_cluster_name: "cephfs.cluster_name",

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -53,6 +53,7 @@ export const toStoragePoolFormValues = (
     ceph_cluster_name: pool.config?.["ceph.cluster_name"],
     ceph_osd_pg_num: pool.config?.["ceph.osd.pg_num"],
     ceph_rbd_clone_copy: pool.config?.["ceph.rbd.clone_copy"],
+    ceph_rbd_du: pool.config?.["ceph.rbd.du"],
     ceph_user_name: pool.config?.["ceph.user.name"],
     ceph_rbd_features: pool.config?.["ceph.rbd.features"],
     cephfs_cluster_name: pool.config?.["cephfs.cluster_name"],


### PR DESCRIPTION
## Done

- fix(ceph) add ceph.rbd.du setting to storage pools
- filter out volatile.initial_source as a member local storage pool setting

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Have a ceph pool on a clustered backend
    - Check the pool config, enable the `Ceph disk usage` option
    - Create an instance and/or a custom volume on the ceph pool.
    - Go to the volume list and see the "size" column filled.
    - Disable the config and ensure you can't read the sizes anymore on the volume list.

# Screenshot
![image](https://github.com/user-attachments/assets/16f84ed9-228f-41c5-8af9-96c5bbda7417)
