### PR TITLE
fix(instance) use sh instead of bash on nixos and alpine images for new terminal

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -30,20 +30,27 @@ const XTERM_OPTIONS = {
   },
 };
 
-export const defaultPayload: TerminalConnectPayload = {
-  command: "bash",
-  environment: [
-    {
-      key: "TERM",
-      value: "xterm-256color",
-    },
-    {
-      key: "HOME",
-      value: "/root",
-    },
-  ],
-  user: 0,
-  group: 0,
+const getDefaultPayload = (instance: LxdInstance): TerminalConnectPayload => {
+  const imageDescription = instance.config["image.description"];
+  const isAlpine = imageDescription?.toLowerCase().includes("alpine");
+  const isNixOs = imageDescription?.toLowerCase().includes("nixos");
+  const command = isAlpine || isNixOs ? "sh" : "bash";
+
+  return {
+    command: command,
+    environment: [
+      {
+        key: "TERM",
+        value: "xterm-256color",
+      },
+      {
+        key: "HOME",
+        value: "/root",
+      },
+    ],
+    user: 0,
+    group: 0,
+  };
 };
 
 interface Props {
@@ -61,6 +68,7 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
   const [isLoading, setLoading] = useState(false);
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
+  const defaultPayload = getDefaultPayload(instance);
   const [payload, setPayload] = useState(defaultPayload);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
   const [userInteracted, setUserInteracted] = useState(false);


### PR DESCRIPTION
## Done

- fix(instance) use sh instead of bash on nixos and alpine images for new terminal

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create three new instances, based on ubuntu, alpine nixos base image
    - start the instances and open the terminal page on the three detail pages
    - ensure the terminal connects.