### PR TITLE
fix(volume) hide cluster member selector on volume edit if we are not in a cluster environment

### DIFF
--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -65,26 +65,30 @@ const StorageVolumeFormMain: FC<Props> = ({
                 : "Use the migrate button in the header to move the volume to a different storage pool.",
             }}
           />
-          {formik.values.clusterMember !== undefined && (
-            <Select
-              id="clusterMember"
-              label="Cluster member"
-              onChange={(e) => {
-                formik.setFieldValue("clusterMember", e.target.value);
-              }}
-              value={formik.values.clusterMember}
-              options={clusterMembers.map((member) => {
-                return { label: member.server_name, value: member.server_name };
-              })}
-              disabled={!formik.values.isCreating}
-              required={formik.values.isCreating}
-              help={
-                formik.values.isCreating
-                  ? undefined
-                  : "Cluster member is immutable after creation."
-              }
-            />
-          )}
+          {formik.values.clusterMember !== undefined &&
+            formik.values.clusterMember !== "none" && (
+              <Select
+                id="clusterMember"
+                label="Cluster member"
+                onChange={(e) => {
+                  formik.setFieldValue("clusterMember", e.target.value);
+                }}
+                value={formik.values.clusterMember}
+                options={clusterMembers.map((member) => {
+                  return {
+                    label: member.server_name,
+                    value: member.server_name,
+                  };
+                })}
+                disabled={!formik.values.isCreating}
+                required={formik.values.isCreating}
+                help={
+                  formik.values.isCreating
+                    ? undefined
+                    : "Cluster member is immutable after creation."
+                }
+              />
+            )}
           <Input
             {...getFormProps(formik, "name")}
             type="text"


### PR DESCRIPTION
## Done

- hide cluster member selector in volume edit page, if the environment is not clustered
- the location of a volume on a non-clustered backend is set to `none`. If this value is used, we should not show the cluster member selector in the configuration page of a volume.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](../CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in a environment that is not clustered.
    - go to storage > volumes, create a custom volume
    - browse the volume detail page > configuration
    - ensure the cluster member selector is not visible.
