### PR TITLE
fix(cluster) avoid sending invalid mode on cluster member evacuate and restore

### DIFF
--- a/src/api/cluster.tsx
+++ b/src/api/cluster.tsx
@@ -22,7 +22,6 @@ export const postClusterMemberState = async (
     method: "POST",
     body: JSON.stringify({
       action: action,
-      mode: "start",
     }),
   })
     .then(handleResponse)


### PR DESCRIPTION
## Done

- fix(cluster) avoid sending invalid mode on cluster member evacuate and restore.

Fixes #1291