### PR TITLE
chore(docs) create screenshots for the documentation with a test suite

### DIFF
--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "./fixtures/lxd-test";
+import { gotoURL } from "./helpers/navigate";
+import { deleteInstance, visitInstance } from "./helpers/instances";
+import { createPool, deletePool } from "./helpers/storagePool";
+
+test.beforeEach(() => {
+  test.skip(
+    Boolean(process.env.CI),
+    "This suite is only run manually to create screenshots for the documentation",
+  );
+});
+
+// x,y is top left coordinate, xx,yy is bottom right coordinate
+// gimp provides the coordinates of the area easily
+const getClipPosition = (x: number, y: number, xx: number, yy: number) => {
+  return {
+    x: x,
+    y: y,
+    width: xx - x,
+    height: yy - y,
+  };
+};
+
+test("instances", async ({ page }) => {
+  const pool = "other-pool";
+  await createPool(page, pool, "dir");
+
+  const instance = "comic-glider";
+  await gotoURL(page, "/ui/");
+  await page.getByText("Instances", { exact: true }).click();
+  await page.getByText("Create instance").click();
+  await page.getByPlaceholder("Enter name").fill(instance);
+  await page.getByRole("button", { name: "Browse images" }).click();
+  await page
+    .locator("tr")
+    .filter({ hasText: "Ubuntu24.04 LTS" })
+    .first()
+    .getByRole("button")
+    .click();
+  await page.getByText("Disk").click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/create_instance_form_disk_devices.png",
+    clip: getClipPosition(240, 0, 1280, 675),
+  });
+
+  await page.getByRole("button", { name: "Create override" }).click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/create_instance_form.png",
+    clip: getClipPosition(240, 0, 1280, 675),
+  });
+
+  await page.getByText("Network", { exact: true }).click();
+  await expect(page.getByText("Attach network")).toBeVisible();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/networks/network_add_to_instance.png",
+    clip: getClipPosition(240, 0, 1280, 675),
+  });
+
+  await page.getByRole("button", { name: "Attach network" }).click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/networks/network_attach_instance.png",
+    clip: getClipPosition(490, 70, 1245, 340),
+  });
+
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForSelector(`text=Created instance ${instance}.`);
+  await visitInstance(page, instance);
+
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/instance_overview_page.png",
+    clip: getClipPosition(240, 0, 1280, 600),
+  });
+
+  await page.getByRole("button", { name: "Migrate", exact: true }).click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/move_instance_modal.png",
+    clip: getClipPosition(305, 228, 974, 492),
+  });
+
+  await page
+    .getByText("Move instance root storage to a different pool")
+    .click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/move_instance_modal_2.png",
+    clip: getClipPosition(17, 80, 1262, 640),
+  });
+
+  await page.getByText(pool).click();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/instances/move_confirmation_modal.png",
+    clip: getClipPosition(264, 262, 1015, 458),
+  });
+
+  await deleteInstance(page, instance);
+  await deletePool(page, pool);
+});
+
+test("networks", async ({ page }) => {
+  page.setViewportSize({ width: 1440, height: 750 });
+  const network = "lxdbr1";
+  await gotoURL(page, "/ui/");
+  await page.getByText("Networking").click();
+  await page.getByText("Networks").click();
+  await page.getByText("Create network").click();
+  await page.getByPlaceholder("Enter name").fill(network);
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/networks/network_create.png",
+    clip: getClipPosition(240, 0, 1420, 710),
+  });
+});


### PR DESCRIPTION
## Done

- chore(docs) create screenshots for the documentation with a test suite

## QA

1. Run the LXD-UI:
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run the new docs suite locally and see the output screens. Execute `npx playwright test --project chromium:lxd-5.0-edge --ui` and manually run the `doc-screenshots` suite from the interface
    - compare to lxd docs at https://github.com/canonical/lxd/tree/main/doc You can copy over the generated screenshot folder in test/screenshots/docs into a lxd checkout and see the local diff between screenshots

# Screenshots
![create_instance_form](https://github.com/user-attachments/assets/fa16c381-5cf0-40c1-8295-d0fd3db76240)
![create_instance_form_disk_devices](https://github.com/user-attachments/assets/76139b49-76b3-4716-9fae-b25771b3011b)
![instance_overview_page](https://github.com/user-attachments/assets/0b8789b2-d583-4935-84b2-137ac81e0a82)
![move_confirmation_modal](https://github.com/user-attachments/assets/a1a321eb-fc8f-465b-a451-5dafb4bb92a2)
![move_instance_modal](https://github.com/user-attachments/assets/f07d3245-f84a-4139-aec3-9c1288295ae2)
![move_instance_modal_2](https://github.com/user-attachments/assets/45cc7e9f-9261-4583-916f-fd93a69a09f9)
![network_add_to_instance](https://github.com/user-attachments/assets/43d932b9-c618-4c11-af56-9ab9fb6ad012)
![network_attach_instance](https://github.com/user-attachments/assets/afeb3721-e8e7-41f9-b6f1-e34e4030e394)
![network_create](https://github.com/user-attachments/assets/4d44c450-aba8-4337-a2f3-db67dbae542d)
