### PR TITLE
feat: [WD-22927] CephObject driver SB creation helptext

### DIFF
--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -68,6 +68,13 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
     ? "Cannot rename storage pools"
     : undefined;
 
+  const cephObjectNotice = (
+    <>
+      Rados gateway must be enabled for Ceph Object driver to work. If using
+      microcloud or microceph, run <code>microceph enable rgw</code>.
+    </>
+  );
+
   return (
     <ScrollableForm>
       <Row>
@@ -98,7 +105,9 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 ? "Driver can't be changed"
                 : formik.values.driver === zfsDriver
                   ? "ZFS gives best performance and reliability"
-                  : undefined
+                  : formik.values.driver === cephObject
+                    ? cephObjectNotice
+                    : undefined
             }
             label="Driver"
             options={storageDriverOptions}


### PR DESCRIPTION
## Done

- Adds instructional helptext for users selecting CephObject drivers.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to Storage>Buckets and click create a bucket.
    - Select a CephObject driver (default list of drivers) and observe the Ceph-object specific helptext.
    - Select a non-cephobject driver (Can comment out line 73 of StorageBucketForm.tsx to include typically invalid drivers) and verify that the helptext changes.

## Screenshots

![image](https://github.com/user-attachments/assets/3bff3261-a8ac-456f-be51-40d3286de16e)
![image](https://github.com/user-attachments/assets/3a5324d0-57fd-40b9-ac78-22696f179080)
