### PR TITLE
feat: [WD-22253] Manage storage bucket keys

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,9 @@ const CreateStorageVolume = lazy(
 const StorageVolumeDetail = lazy(
   async () => import("pages/storage/StorageVolumeDetail"),
 );
+const StorageBucketDetail = lazy(
+  async () => import("pages/storage/StorageBucketDetail"),
+);
 const WarningList = lazy(async () => import("pages/warnings/WarningList"));
 const PermissionIdentities = lazy(
   async () => import("pages/permissions/PermissionIdentities"),
@@ -422,6 +425,10 @@ const App: FC = () => {
         <Route
           path="/ui/project/:project/storage/pool/:pool/member/:member/volumes/:type/:volume/:activeTab/:section"
           element={<ProtectedRoute outlet={<StorageVolumeDetail />} />}
+        />
+        <Route
+          path="/ui/project/:project/storage/pool/:pool/bucket/:bucket"
+          element={<ProtectedRoute outlet={<StorageBucketDetail />} />}
         />
         <Route
           path="/ui/project/:project/images"

--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -22,7 +22,7 @@ interface Props {
   controls?: ReactNode;
   isLoaded: boolean;
   renameDisabledReason?: string;
-  formik: FormikProps<RenameHeaderValues>;
+  formik?: FormikProps<RenameHeaderValues>;
 }
 
 const RenameHeader: FC<Props> = ({

--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -5,6 +5,7 @@ export type InstanceIconType = "container" | "virtual-machine" | "instance";
 
 export type ResourceIconType =
   | "bucket"
+  | "bucket-key"
   | "container"
   | "virtual-machine"
   | "instance"
@@ -50,6 +51,7 @@ const resourceIcons: Record<ResourceIconType, string> = {
   device: "units",
   setting: "settings",
   bucket: "status-queued-small",
+  "bucket-key": "private-key",
 };
 
 interface Props {

--- a/src/context/useBuckets.tsx
+++ b/src/context/useBuckets.tsx
@@ -2,15 +2,86 @@ import { queryKeys } from "util/queryKeys";
 import { useAuth } from "./auth";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
-import type { LxdStorageBucket } from "types/storage";
-import { fetchAllStorageBuckets } from "api/storage-buckets";
+import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
+import {
+  fetchAllStorageBuckets,
+  fetchStorageBucket,
+  fetchStorageBucketKey,
+  fetchStorageBucketKeys,
+} from "api/storage-buckets";
 
-export const useLoadBuckets = (
+export const useBuckets = (
   project: string,
 ): UseQueryResult<LxdStorageBucket[]> => {
   const { isFineGrained } = useAuth();
   return useQuery({
-    queryKey: [queryKeys.buckets, project],
+    queryKey: [queryKeys.storage, project, queryKeys.buckets],
     queryFn: async () => fetchAllStorageBuckets(isFineGrained, project),
+  });
+};
+
+export const useBucket = (
+  bucketName: string,
+  pool: string,
+  project: string,
+  target?: string,
+): UseQueryResult<LxdStorageBucket> => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [
+      queryKeys.storage,
+      pool,
+      project,
+      queryKeys.buckets,
+      bucketName,
+      target,
+    ],
+    queryFn: async () =>
+      fetchStorageBucket(
+        pool,
+        project,
+        bucketName,
+        isFineGrained,
+        target ?? null,
+      ),
+  });
+};
+
+export const useBucketKey = (
+  bucket: LxdStorageBucket,
+  keyName: string,
+  project: string,
+): UseQueryResult<LxdStorageBucketKey> => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [
+      queryKeys.storage,
+      bucket.pool,
+      project,
+      queryKeys.buckets,
+      bucket.name,
+      queryKeys.keys,
+      keyName,
+    ],
+    queryFn: async () =>
+      fetchStorageBucketKey(bucket, keyName, isFineGrained, project),
+  });
+};
+
+export const useBucketKeys = (
+  bucket: LxdStorageBucket,
+  project: string,
+): UseQueryResult<LxdStorageBucketKey[]> => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [
+      queryKeys.storage,
+      bucket.pool,
+      project,
+      queryKeys.buckets,
+      bucket.name,
+      queryKeys.keys,
+    ],
+    queryFn: async () => fetchStorageBucketKeys(bucket, isFineGrained, project),
   });
 };

--- a/src/pages/storage/StorageBucketDetail.tsx
+++ b/src/pages/storage/StorageBucketDetail.tsx
@@ -1,0 +1,79 @@
+import type { FC } from "react";
+import { useParams } from "react-router-dom";
+import { Row, useNotify } from "@canonical/react-components";
+import Loader from "components/Loader";
+import CustomLayout from "components/CustomLayout";
+import { useBucket } from "context/useBuckets";
+import StorageBucketHeader from "./StorageBucketHeader";
+import StorageBucketKeys from "./StorageBucketKeys";
+import usePanelParams, { panels } from "util/usePanelParams";
+import CreateStorageBucketKeyPanel from "./panels/CreateStorageBucketKeyPanel";
+import EditStorageBucketPanel from "./panels/EditStorageBucketPanel";
+import EditStorageBucketKeyPanel from "./panels/EditStorageBucketKeyPanel";
+
+const StorageBucketDetail: FC = () => {
+  const notify = useNotify();
+  const {
+    pool,
+    project,
+    member,
+    bucket: bucketName,
+  } = useParams<{
+    bucket: string;
+    pool: string;
+    project: string;
+    member?: string;
+  }>();
+
+  if (!pool) {
+    return <>Missing storage pool</>;
+  }
+  if (!project) {
+    return <>Missing project</>;
+  }
+  if (!bucketName) {
+    return <>Missing bucket</>;
+  }
+  const {
+    data: bucket,
+    error,
+    isLoading,
+  } = useBucket(bucketName, pool, project, member);
+
+  const panelParams = usePanelParams();
+
+  if (error) {
+    notify.failure("Loading storage bucket failed", error);
+  }
+
+  if (isLoading) {
+    return <Loader isMainComponent />;
+  } else if (!bucket) {
+    return <>Loading storage bucket failed</>;
+  }
+
+  return (
+    <>
+      <CustomLayout
+        header={<StorageBucketHeader bucket={bucket} project={project} />}
+        contentClassName="detail-page u-no-padding--bottom"
+      >
+        <Row>
+          <StorageBucketKeys bucket={bucket} />
+        </Row>
+      </CustomLayout>
+
+      {panelParams.panel === panels.editStorageBucket && (
+        <EditStorageBucketPanel bucket={bucket} />
+      )}
+      {panelParams.panel === panels.createStorageBucketKey && (
+        <CreateStorageBucketKeyPanel bucket={bucket} />
+      )}
+      {panelParams.panel === panels.editStorageBucketKey && (
+        <EditStorageBucketKeyPanel bucket={bucket} />
+      )}
+    </>
+  );
+};
+
+export default StorageBucketDetail;

--- a/src/pages/storage/StorageBucketHeader.tsx
+++ b/src/pages/storage/StorageBucketHeader.tsx
@@ -1,0 +1,33 @@
+import type { FC } from "react";
+import { Link } from "react-router-dom";
+import RenameHeader from "components/RenameHeader";
+import type { LxdStorageBucket } from "types/storage";
+import StorageBucketActions from "./actions/StorageBucketActions";
+
+interface Props {
+  bucket: LxdStorageBucket;
+  project: string;
+}
+
+const StorageBucketHeader: FC<Props> = ({ bucket, project }) => {
+  return (
+    <RenameHeader
+      name={bucket.name}
+      parentItems={[
+        <Link
+          to={`/ui/project/${encodeURIComponent(project)}/storage/buckets`}
+          key={1}
+        >
+          Storage buckets
+        </Link>,
+      ]}
+      controls={
+        bucket ? <StorageBucketActions bucket={bucket} isDetailPage /> : null
+      }
+      isLoaded={true}
+      renameDisabledReason="Storage buckets cannot be renamed"
+    />
+  );
+};
+
+export default StorageBucketHeader;

--- a/src/pages/storage/StorageBucketKeyCount.tsx
+++ b/src/pages/storage/StorageBucketKeyCount.tsx
@@ -1,0 +1,17 @@
+import type { FC } from "react";
+import type { LxdStorageBucket } from "types/storage";
+import { useBucketKeys } from "context/useBuckets";
+import { useCurrentProject } from "context/useCurrentProject";
+
+interface Props {
+  bucket: LxdStorageBucket;
+}
+
+const StorageBucketKeyCount: FC<Props> = ({ bucket }) => {
+  const { project } = useCurrentProject();
+  const { data: bucketKeys = [] } = useBucketKeys(bucket, project?.name ?? "");
+
+  return <>{bucketKeys ? bucketKeys.length : "-"}</>;
+};
+
+export default StorageBucketKeyCount;

--- a/src/pages/storage/StorageBucketKeys.tsx
+++ b/src/pages/storage/StorageBucketKeys.tsx
@@ -1,0 +1,263 @@
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import {
+  EmptyState,
+  Icon,
+  SearchBox,
+  TablePagination,
+  useNotify,
+} from "@canonical/react-components";
+import ItemName from "components/ItemName";
+import SelectableMainTable from "components/SelectableMainTable";
+import { useCurrentProject } from "context/useCurrentProject";
+import ScrollableTable from "components/ScrollableTable";
+import SelectedTableNotification from "components/SelectedTableNotification";
+import { useDocs } from "context/useDocs";
+import useSortTableData from "util/useSortTableData";
+import NotificationRow from "components/NotificationRow";
+import CreateStorageBucketKeyBtn from "./actions/CreateStorageBucketKeyBtn";
+import type { LxdStorageBucket } from "types/storage";
+import { useBucketKeys } from "context/useBuckets";
+import StorageBucketKeyActions from "./actions/StorageBucketKeyActions";
+import StorageBucketKeyBulkDelete from "./actions/StorageBucketKeyBulkDelete";
+import { capitalizeFirstLetter } from "util/helpers";
+
+interface Props {
+  bucket: LxdStorageBucket;
+}
+
+const StorageBucketKeys: FC<Props> = ({ bucket }) => {
+  const docBaseLink = useDocs();
+  const [query, setQuery] = useState<string>("");
+  const notify = useNotify();
+  const [selectedNames, setSelectedNames] = useState<string[]>([]);
+  const [processingNames, setProcessingNames] = useState<string[]>([]);
+  const { project } = useCurrentProject();
+  const { data: keys = [] } = useBucketKeys(bucket, project?.name ?? "");
+
+  useEffect(() => {
+    const validNames = new Set(keys?.map((key) => key.name));
+    const validSelections = selectedNames.filter((name) =>
+      validNames.has(name),
+    );
+    if (validSelections.length !== selectedNames.length) {
+      setSelectedNames(validSelections);
+    }
+  }, [keys]);
+
+  const filteredKeys =
+    keys?.filter((key) => {
+      if (query) {
+        const q = query.toLowerCase();
+
+        return (
+          key.name.toLowerCase().includes(q) ||
+          key.role.toLowerCase().includes(q) ||
+          key.description.toLowerCase().includes(q) ||
+          key["access-key"].toLowerCase().includes(q) ||
+          key["secret-key"].toLowerCase().includes(q)
+        );
+      }
+      return true;
+    }) ?? [];
+
+  const hasKeys = keys && keys.length > 0;
+
+  const headers = [
+    {
+      content: "Name",
+      sortKey: "name",
+      className: "name",
+    },
+    {
+      content: "Role",
+      sortKey: "role",
+      className: "role",
+    },
+    {
+      content: "Description",
+      sortKey: "description",
+      className: "description",
+    },
+    { content: "Access key", className: "key-field", sortKey: "access-key" },
+    { content: "Secret key", className: "key-field", sortKey: "secret-key" },
+    { "aria-label": "Actions", className: "actions" },
+  ];
+
+  const rows = filteredKeys.map((key) => {
+    return {
+      key: key.name,
+      className: "u-row",
+      name: key.name,
+      columns: [
+        {
+          content: (
+            <div className="u-truncate" title={`Key ${key.name}`}>
+              <ItemName item={key} />
+            </div>
+          ),
+          role: "rowheader",
+          "aria-label": "Name",
+          className: "name",
+        },
+        {
+          content: capitalizeFirstLetter(key.role),
+          role: "cell",
+          "aria-label": "Role",
+          className: "role",
+        },
+        {
+          content: key.description || "-",
+          title: key.description,
+          role: "cell",
+          "aria-label": "Description",
+          className: "description u-truncate",
+        },
+        {
+          content: key["access-key"],
+          role: "cell",
+          "aria-label": "Access key",
+          className: "key-field",
+        },
+        {
+          content: key["secret-key"],
+          role: "cell",
+          "aria-label": "Secret key",
+          className: "key-field",
+        },
+        {
+          content: <StorageBucketKeyActions bucketKey={key} bucket={bucket} />,
+          role: "cell",
+          "aria-label": "Actions",
+          className: "u-align--right actions",
+        },
+      ],
+      sortData: {
+        name: key.name.toLowerCase(),
+        role: key.role,
+        description: key.description.toLowerCase(),
+        "access-key": key["access-key"],
+        "secret-key": key["secret-key"],
+      },
+    };
+  });
+
+  const selectedKeys = keys.filter((key) => {
+    return selectedNames.includes(key.name);
+  });
+
+  const { rows: sortedRows, updateSort } = useSortTableData({
+    rows,
+    defaultSort: "name",
+    defaultSortDirection: "ascending",
+  });
+
+  return (
+    <div className="storage-bucket-key-list">
+      {hasKeys && (
+        <div className="upper-controls-bar">
+          {selectedNames.length === 0 ? (
+            <>
+              <div className="search-box-wrapper">
+                <SearchBox
+                  name="search-snapshot"
+                  className="search-box margin-right"
+                  type="text"
+                  onChange={(value) => {
+                    setQuery(value);
+                  }}
+                  placeholder="Search for keys"
+                  value={query}
+                  aria-label="Search for keys"
+                />
+              </div>
+              <CreateStorageBucketKeyBtn />
+            </>
+          ) : (
+            <div className="p-panel__controls">
+              <StorageBucketKeyBulkDelete
+                keys={selectedKeys}
+                bucket={bucket}
+                onStart={() => {
+                  setProcessingNames(selectedNames);
+                }}
+                onFinish={() => {
+                  setProcessingNames([]);
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+      <NotificationRow />
+      {hasKeys ? (
+        <>
+          <ScrollableTable
+            dependencies={[filteredKeys, notify.notification]}
+            tableId="buckets-key-table"
+            belowIds={["status-bar"]}
+          >
+            <TablePagination
+              data={sortedRows}
+              id="pagination"
+              itemName="key"
+              className="u-no-margin--top"
+              aria-label="Table pagination control"
+              description={
+                selectedNames.length > 0 && (
+                  <SelectedTableNotification
+                    totalCount={keys?.length ?? 0}
+                    itemName="key"
+                    parentName="bucket"
+                    selectedNames={selectedNames}
+                    setSelectedNames={setSelectedNames}
+                    filteredNames={filteredKeys.map((item) => item.name)}
+                  />
+                )
+              }
+            >
+              <SelectableMainTable
+                id="buckets-key-table"
+                headers={headers}
+                rows={sortedRows}
+                sortable
+                emptyStateMsg="No key found matching this search"
+                itemName="key"
+                parentName="bucket"
+                selectedNames={selectedNames}
+                setSelectedNames={setSelectedNames}
+                disabledNames={processingNames}
+                filteredNames={filteredKeys.map((item) => item.name)}
+                onUpdateSort={updateSort}
+                defaultSort="name"
+                defaultSortDirection="ascending"
+                responsive
+              />
+            </TablePagination>
+          </ScrollableTable>
+        </>
+      ) : (
+        <EmptyState
+          className="empty-state"
+          image={<Icon name="private-key" className="empty-state-icon" />}
+          title="No keys"
+        >
+          <p>This bucket does not contain any keys.</p>
+          <p>
+            <a
+              href={`${docBaseLink}/explanation/storage/`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more about storage
+              <Icon className="external-link-icon" name="external-link" />
+            </a>
+          </p>
+          <CreateStorageBucketKeyBtn />
+        </EmptyState>
+      )}
+    </div>
+  );
+};
+
+export default StorageBucketKeys;

--- a/src/pages/storage/StorageBucketLink.tsx
+++ b/src/pages/storage/StorageBucketLink.tsx
@@ -1,0 +1,25 @@
+import type { FC } from "react";
+import { Link } from "react-router-dom";
+import ItemName from "components/ItemName";
+import type { LxdStorageBucket } from "types/storage";
+import { getStorageBucketURL } from "util/storageBucket";
+
+interface Props {
+  bucket: LxdStorageBucket;
+  project: string;
+}
+
+const StorageBucketLink: FC<Props> = ({ bucket, project }) => {
+  return (
+    <Link
+      to={getStorageBucketURL(bucket.name, bucket.pool, project)}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      <ItemName item={bucket} />
+    </Link>
+  );
+};
+
+export default StorageBucketLink;

--- a/src/pages/storage/StorageBuckets.tsx
+++ b/src/pages/storage/StorageBuckets.tsx
@@ -20,13 +20,16 @@ import {
   NAME_COL,
   SIZE_COL,
   URL_COL,
+  DESCRIPTION_COL,
+  COLUMN_WIDTHS,
+  KEY_COL,
 } from "util/storageBucketTable";
 import useSortTableData from "util/useSortTableData";
 import CustomLayout from "components/CustomLayout";
 import PageHeader from "components/PageHeader";
 import HelpLink from "components/HelpLink";
 import NotificationRow from "components/NotificationRow";
-import { useLoadBuckets } from "context/useBuckets";
+import { useBuckets } from "context/useBuckets";
 import type { StorageBucketsFilterType } from "./StorageBucketsFilter";
 import StorageBucketActions from "./actions/StorageBucketActions";
 import CreateStorageBucketBtn from "./actions/CreateStorageBucketBtn";
@@ -38,6 +41,8 @@ import StorageBucketBulkDelete from "./actions/StorageBucketBulkDelete";
 import type { LxdStorageBucket } from "types/storage";
 import CreateStorageBucketPanel from "./panels/CreateStorageBucketPanel";
 import EditStorageBucketPanel from "./panels/EditStorageBucketPanel";
+import StorageBucketLink from "./StorageBucketLink";
+import StorageBucketKeyCount from "./StorageBucketKeyCount";
 
 const StorageBuckets: FC = () => {
   const docBaseLink = useDocs();
@@ -58,7 +63,7 @@ const StorageBuckets: FC = () => {
     return <>Missing project</>;
   }
 
-  const { data: buckets = [], error, isLoading } = useLoadBuckets(project);
+  const { data: buckets = [], error, isLoading } = useBuckets(project);
 
   const getBucketKey = (bucket: LxdStorageBucket) => {
     return `${bucket.name}-${bucket.pool}-${bucket.location || ""}`;
@@ -81,24 +86,39 @@ const StorageBuckets: FC = () => {
       content: NAME_COL,
       sortKey: "name",
       className: "name",
+      style: { width: COLUMN_WIDTHS[NAME_COL] },
     },
     {
       content: POOL_COL,
       sortKey: "pool",
       className: "pool",
+      style: { width: COLUMN_WIDTHS[POOL_COL] },
     },
     {
       content: SIZE_COL,
       sortKey: "size",
       className: "size",
+      style: { width: COLUMN_WIDTHS[SIZE_COL] },
+    },
+    {
+      content: DESCRIPTION_COL,
+      className: "description",
+      style: { width: COLUMN_WIDTHS[DESCRIPTION_COL] },
     },
     {
       content: URL_COL,
       sortKey: "s3_url",
+      style: { width: COLUMN_WIDTHS[URL_COL] },
+    },
+    {
+      content: KEY_COL,
+      style: { width: COLUMN_WIDTHS[KEY_COL] },
+      className: "keys",
     },
     {
       className: "actions u-align--right",
       "aria-label": "Actions",
+      style: { width: COLUMN_WIDTHS[ACTIONS_COL] },
     },
   ];
 
@@ -119,13 +139,10 @@ const StorageBuckets: FC = () => {
       className: "u-row",
       columns: [
         {
-          content: (
-            <div className="u-truncate" title={bucket.name}>
-              {bucket.name}
-            </div>
-          ),
+          content: <StorageBucketLink bucket={bucket} project={project} />,
           role: "rowheader",
           "aria-label": NAME_COL,
+          style: { width: COLUMN_WIDTHS[NAME_COL] },
         },
         {
           content: (
@@ -137,11 +154,20 @@ const StorageBuckets: FC = () => {
           ),
           role: "cell",
           "aria-label": POOL_COL,
+          style: { width: COLUMN_WIDTHS[POOL_COL] },
         },
         {
           content: bucket.config?.size ?? "-",
           role: "cell",
           "aria-label": SIZE_COL,
+          style: { width: COLUMN_WIDTHS[SIZE_COL] },
+        },
+        {
+          content: bucket.description || "-",
+          role: "cell",
+          "aria-label": DESCRIPTION_COL,
+          style: { width: COLUMN_WIDTHS[DESCRIPTION_COL] },
+          className: "description u-truncate",
         },
         {
           content: (
@@ -151,6 +177,14 @@ const StorageBuckets: FC = () => {
           ),
           role: "cell",
           "aria-label": URL_COL,
+          style: { width: COLUMN_WIDTHS[URL_COL] },
+        },
+        {
+          content: <StorageBucketKeyCount bucket={bucket} />,
+          role: "cell",
+          "aria-label": KEY_COL,
+          style: { width: COLUMN_WIDTHS[KEY_COL] },
+          className: "keys",
         },
         {
           className: "actions u-align--right",
@@ -162,6 +196,7 @@ const StorageBuckets: FC = () => {
           ),
           role: "cell",
           "aria-label": ACTIONS_COL,
+          style: { width: COLUMN_WIDTHS[ACTIONS_COL] },
         },
       ],
       sortData: {
@@ -214,6 +249,7 @@ const StorageBuckets: FC = () => {
         >
           <SelectableMainTable
             id="bucket-table"
+            className="storage-buckets-table"
             headers={headers}
             rows={sortedRows}
             sortable
@@ -226,6 +262,7 @@ const StorageBuckets: FC = () => {
             filteredNames={filteredBuckets.map(getBucketKey)}
             onUpdateSort={updateSort}
             defaultSortDirection="descending"
+            responsive
           />
         </TablePagination>
       </ScrollableTable>

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -1,15 +1,14 @@
-import type { FC } from "react";
-import { useState } from "react";
+import { useState, type FC } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import type { RenameHeaderValues } from "components/RenameHeader";
 import RenameHeader from "components/RenameHeader";
-import { useFormik } from "formik";
-import * as Yup from "yup";
+import type { RenameHeaderValues } from "components/RenameHeader";
 import type { LxdStoragePool } from "types/storage";
-import { renameStoragePool } from "api/storage-pools";
 import DeleteStoragePoolBtn from "pages/storage/actions/DeleteStoragePoolBtn";
-import { testDuplicateStoragePoolName } from "util/storagePool";
 import { useNotify, useToastNotification } from "@canonical/react-components";
+import * as Yup from "yup";
+import { testDuplicateStoragePoolName } from "util/storagePool";
+import { useFormik } from "formik";
+import { renameStoragePool } from "api/storage-pools";
 import ResourceLink from "components/ResourceLink";
 
 interface Props {
@@ -83,7 +82,6 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
         />,
       ]}
       isLoaded
-      formik={formik}
       renameDisabledReason="Cannot rename storage pools"
     />
   );

--- a/src/pages/storage/StorageUsedBy.tsx
+++ b/src/pages/storage/StorageUsedBy.tsx
@@ -153,7 +153,11 @@ const StorageUsedBy: FC<Props> = ({ storage, project }) => {
                   item={item}
                   activeProject={project}
                   type="bucket"
-                  to={getStorageBucketURL(item.project)}
+                  to={getStorageBucketURL(
+                    item.name,
+                    storage.name,
+                    item.project,
+                  )}
                 />
               ))}
             />

--- a/src/pages/storage/StorageVolumeDetail.tsx
+++ b/src/pages/storage/StorageVolumeDetail.tsx
@@ -64,7 +64,7 @@ const StorageVolumeDetail: FC = () => {
   return (
     <CustomLayout
       header={<StorageVolumeHeader volume={volume} project={project} />}
-      contentClassName="detail-page sotrage-volume-form u-no-padding--bottom"
+      contentClassName="detail-page storage-volume-form u-no-padding--bottom"
     >
       <Row>
         <TabLinks

--- a/src/pages/storage/actions/CreateStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/CreateStorageBucketKeyBtn.tsx
@@ -1,0 +1,39 @@
+import type { FC } from "react";
+import { Button, Icon } from "@canonical/react-components";
+import { useSmallScreen } from "context/useSmallScreen";
+import { useProjectEntitlements } from "util/entitlements/projects";
+import { useCurrentProject } from "context/useCurrentProject";
+import usePanelParams from "util/usePanelParams";
+
+interface Props {
+  className?: string;
+}
+
+const CreateStorageBucketKeyBtn: FC<Props> = ({ className }) => {
+  const isSmallScreen = useSmallScreen();
+  const { canCreateStorageBuckets } = useProjectEntitlements();
+  const { project } = useCurrentProject();
+  const panelParams = usePanelParams();
+
+  return (
+    <Button
+      appearance="positive"
+      hasIcon={!isSmallScreen}
+      onClick={() => {
+        panelParams.openCreateStorageBucketKey(project?.name || "");
+      }}
+      className={className}
+      disabled={!canCreateStorageBuckets(project)}
+      title={
+        canCreateStorageBuckets(project)
+          ? "Create bucket key"
+          : "You do not have permission to create keys for this bucket"
+      }
+    >
+      {!isSmallScreen && <Icon name="plus" light />}
+      <span>Create key</span>
+    </Button>
+  );
+};
+
+export default CreateStorageBucketKeyBtn;

--- a/src/pages/storage/actions/EditStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/EditStorageBucketKeyBtn.tsx
@@ -1,35 +1,25 @@
 import type { FC } from "react";
-import type { LxdStorageBucket } from "types/storage";
+import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
 import { Button, Icon } from "@canonical/react-components";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import usePanelParams from "util/usePanelParams";
 
 interface Props {
+  bucketKey: LxdStorageBucketKey;
   bucket: LxdStorageBucket;
-  classname?: string;
-  isDetailPage?: boolean;
 }
 
-const EditStorageBucketBtn: FC<Props> = ({
-  bucket,
-  classname,
-  isDetailPage,
-}) => {
+const EditStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
   const panelParams = usePanelParams();
   const { canEditBucket } = useStorageBucketEntitlements();
 
   return (
     <Button
-      key={`${bucket.name}-edit`}
-      className={classname}
-      appearance={isDetailPage ? "default" : "base"}
+      className="has-icon"
+      appearance="base"
       hasIcon
       onClick={() => {
-        panelParams.openEditStorageBucket(
-          bucket.name,
-          bucket.pool,
-          bucket.location,
-        );
+        panelParams.openEditStorageBucketKey(bucketKey.name);
       }}
       title={
         canEditBucket(bucket)
@@ -38,9 +28,8 @@ const EditStorageBucketBtn: FC<Props> = ({
       }
     >
       <Icon name="edit" />
-      {isDetailPage && <span>Configure</span>}
     </Button>
   );
 };
 
-export default EditStorageBucketBtn;
+export default EditStorageBucketKeyBtn;

--- a/src/pages/storage/actions/StorageBucketActions.tsx
+++ b/src/pages/storage/actions/StorageBucketActions.tsx
@@ -1,44 +1,82 @@
-import type { FC } from "react";
+import { cloneElement, useState, type FC } from "react";
 import classnames from "classnames";
-import { List, useToastNotification } from "@canonical/react-components";
+import { ContextualMenu, List } from "@canonical/react-components";
 import type { LxdStorageBucket } from "types/storage";
-import ResourceLabel from "components/ResourceLabel";
 import DeleteStorageBucketBtn from "./DeleteStorageBucketBtn";
 import EditStorageBucketBtn from "./EditStorageBucketBtn";
+import { isWidthBelow } from "util/helpers";
+import useEventListener from "util/useEventListener";
 
 interface Props {
   bucket: LxdStorageBucket;
+  isDetailPage?: boolean;
   className?: string;
 }
 
-const StorageBucketActions: FC<Props> = ({ bucket, className }) => {
-  const toastNotify = useToastNotification();
+const StorageBucketActions: FC<Props> = ({
+  bucket,
+  className,
+  isDetailPage,
+}) => {
+  const [isSmallScreen, setIsSmallScreen] = useState(isWidthBelow(1200));
 
-  return (
+  useEventListener("resize", () => {
+    setIsSmallScreen(isWidthBelow(1200));
+  });
+
+  const classname = isDetailPage
+    ? isSmallScreen
+      ? "p-contextual-menu__link"
+      : "p-segmented-control__button"
+    : "";
+
+  const menuElements = [
+    <EditStorageBucketBtn
+      key="edit"
+      classname={classnames(classname, "has-icon", {
+        "is-dense": !isDetailPage,
+      })}
+      bucket={bucket}
+      isDetailPage={isDetailPage}
+    />,
+    <DeleteStorageBucketBtn
+      key="delete"
+      classname={classnames(classname, "has-icon", {
+        "is-dense": !isDetailPage,
+      })}
+      bucket={bucket}
+      isDetailPage={isDetailPage}
+    />,
+  ];
+  return isDetailPage ? (
+    <>
+      {isSmallScreen ? (
+        <ContextualMenu
+          closeOnOutsideClick={false}
+          toggleLabel="Actions"
+          position="left"
+          hasToggleIcon
+          title="actions"
+        >
+          {(close: () => void) => (
+            <span>
+              {[...menuElements].map((item) =>
+                cloneElement(item, { onClose: close }),
+              )}
+            </span>
+          )}
+        </ContextualMenu>
+      ) : (
+        <div className="p-segmented-control">
+          <div className="p-segmented-control__list">{menuElements}</div>
+        </div>
+      )}
+    </>
+  ) : (
     <List
       inline
       className={classnames(className, "actions-list")}
-      items={[
-        <EditStorageBucketBtn
-          key="edit"
-          classname="is-dense has-icon"
-          bucket={bucket}
-        />,
-        <DeleteStorageBucketBtn
-          classname="is-dense has-icon"
-          key="delete"
-          bucket={bucket}
-          onFinish={() => {
-            toastNotify.success(
-              <>
-                Storage bucket{" "}
-                <ResourceLabel bold type="bucket" value={bucket.name} />{" "}
-                deleted.
-              </>,
-            );
-          }}
-        />,
-      ]}
+      items={menuElements}
     />
   );
 };

--- a/src/pages/storage/actions/StorageBucketBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketBulkDelete.tsx
@@ -67,7 +67,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
         }
 
         queryClient.invalidateQueries({
-          queryKey: [queryKeys.buckets, projectName],
+          queryKey: [queryKeys.storage, projectName, queryKeys.buckets],
         });
         setLoading(false);
         onFinish();

--- a/src/pages/storage/actions/StorageBucketKeyActions.tsx
+++ b/src/pages/storage/actions/StorageBucketKeyActions.tsx
@@ -1,0 +1,34 @@
+import type { FC } from "react";
+import { List } from "@canonical/react-components";
+import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
+import DeleteStorageBucketKeyBtn from "./DeleteStorageBucketKeyBtn";
+import EditStorageBucketKeyBtn from "./EditStorageBucketKeyBtn";
+
+interface Props {
+  bucketKey: LxdStorageBucketKey;
+  bucket: LxdStorageBucket;
+}
+
+const StorageBucketKeyActions: FC<Props> = ({ bucketKey, bucket }) => {
+  const menuElements = [
+    <EditStorageBucketKeyBtn
+      key="edit"
+      bucketKey={bucketKey}
+      bucket={bucket}
+    />,
+    <DeleteStorageBucketKeyBtn
+      key="delete"
+      bucketKey={bucketKey}
+      bucket={bucket}
+    />,
+  ];
+  return (
+    <List
+      inline
+      className="u-no-margin--bottom actions-list"
+      items={menuElements}
+    />
+  );
+};
+
+export default StorageBucketKeyActions;

--- a/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
@@ -1,0 +1,128 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { pluralize } from "util/instanceBulkActions";
+import { queryKeys } from "util/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
+import BulkDeleteButton from "components/BulkDeleteButton";
+import { useToastNotification } from "@canonical/react-components";
+import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
+import { deleteStorageBucketKeyBulk } from "api/storage-buckets";
+import { getPromiseSettledCounts } from "util/promises";
+import { useCurrentProject } from "context/useCurrentProject";
+import ResourceLink from "components/ResourceLink";
+import { getStorageBucketURL } from "util/storageBucket";
+
+interface Props {
+  keys: LxdStorageBucketKey[];
+  bucket: LxdStorageBucket;
+  onStart: () => void;
+  onFinish: () => void;
+}
+
+const StorageBucketKeyBulkDelete: FC<Props> = ({
+  keys,
+  bucket,
+  onStart,
+  onFinish,
+}) => {
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const [isLoading, setLoading] = useState(false);
+  const { project } = useCurrentProject();
+  const projectName = project?.name || "";
+  const totalCount = keys.length;
+
+  const buttonText = `Delete ${keys.length} ${pluralize("key", keys.length)}`;
+
+  const handleDelete = () => {
+    setLoading(true);
+    onStart();
+    const successMessage = (
+      <>
+        {keys.length} {pluralize("key", keys.length)} deleted for bucket{" "}
+        <ResourceLink
+          type="bucket"
+          value={bucket.name}
+          to={getStorageBucketURL(
+            bucket.name,
+            bucket.pool,
+            project?.name ?? "",
+          )}
+        />
+        .
+      </>
+    );
+
+    deleteStorageBucketKeyBulk(bucket, keys, projectName)
+      .then((results) => {
+        const { fulfilledCount, rejectedCount } =
+          getPromiseSettledCounts(results);
+
+        if (fulfilledCount === totalCount) {
+          toastNotify.success(successMessage);
+        } else if (rejectedCount === totalCount) {
+          toastNotify.failure(
+            "Key bulk deletion failed",
+            undefined,
+            <>
+              <b>{totalCount}</b> {pluralize("key", totalCount)} could not be
+              deleted.
+            </>,
+          );
+        } else {
+          toastNotify.failure(
+            "Key bulk deletion partially failed",
+            undefined,
+            <>
+              <b>{fulfilledCount}</b> {pluralize("key", fulfilledCount)}{" "}
+              deleted.
+              <br />
+              <b>{rejectedCount}</b> {pluralize("key", rejectedCount)} could not
+              be deleted.
+            </>,
+          );
+        }
+
+        queryClient.invalidateQueries({
+          queryKey: [
+            queryKeys.storage,
+            bucket.pool,
+            project?.name ?? "",
+            queryKeys.buckets,
+            bucket.name,
+            queryKeys.keys,
+          ],
+        });
+        setLoading(false);
+        onFinish();
+      })
+      .catch((e) => {
+        setLoading(false);
+        toastNotify.failure(
+          `Key bulk deletion failed for bucket ${bucket.name}`,
+          e,
+        );
+      });
+  };
+
+  return (
+    <BulkDeleteButton
+      entities={keys}
+      deletableEntities={keys}
+      entityType="key"
+      onDelete={handleDelete}
+      disabledReason={
+        totalCount === 0
+          ? `You do not have permission to delete the selected ${pluralize("key", keys.length)}`
+          : undefined
+      }
+      confirmationButtonProps={{
+        disabled: isLoading || totalCount === 0,
+        loading: isLoading,
+      }}
+      buttonLabel={buttonText}
+    />
+  );
+};
+
+export default StorageBucketKeyBulkDelete;

--- a/src/pages/storage/forms/StorageBucketKeyForm.tsx
+++ b/src/pages/storage/forms/StorageBucketKeyForm.tsx
@@ -1,0 +1,99 @@
+import type { FC, ReactNode } from "react";
+import { Form, Input, Select } from "@canonical/react-components";
+import type { FormikProps } from "formik/dist/types";
+import AutoExpandingTextArea from "components/AutoExpandingTextArea";
+import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
+import type { LxdStorageBucket } from "types/storage";
+
+export interface StorageBucketKeyFormValues {
+  name: string;
+  role?: string;
+  description?: string;
+  "access-key"?: string;
+  "secret-key"?: string;
+}
+
+interface Props {
+  formik: FormikProps<StorageBucketKeyFormValues>;
+  bucket?: LxdStorageBucket;
+}
+
+const StorageBucketKeyForm: FC<Props> = ({ formik, bucket }) => {
+  const { canEditBucket } = useStorageBucketEntitlements();
+  const getFormProps = (
+    id: "name" | "description" | "access-key" | "secret-key",
+  ) => {
+    return {
+      id: id,
+      name: id,
+      onBlur: formik.handleBlur,
+      onChange: formik.handleChange,
+      value: formik.values[id] ?? "",
+      error: formik.touched[id] ? (formik.errors[id] as ReactNode) : null,
+      placeholder: `Enter ${id.replaceAll("-", " ")}`,
+    };
+  };
+
+  const isEditing = !!bucket;
+
+  const bucketEditRestriction =
+    !isEditing || canEditBucket(bucket)
+      ? ""
+      : "You do not have permission to edit this bucket";
+
+  return (
+    <Form onSubmit={formik.handleSubmit} className={"bucket-create-form"}>
+      {/* hidden submit to enable enter key in inputs */}
+      <Input type="submit" hidden value="Hidden input" />
+      <Input
+        {...getFormProps("name")}
+        type="text"
+        label="Name"
+        required
+        autoFocus
+        disabled={!!bucketEditRestriction || isEditing}
+        title={bucketEditRestriction}
+      />
+      <Select
+        id="bucketKey"
+        label="Role"
+        onChange={(e) => {
+          formik.setFieldValue("role", e.target.value);
+        }}
+        value={formik.values.role}
+        options={[
+          {
+            label: "Admin",
+            value: "admin",
+          },
+          {
+            label: "Read-only",
+            value: "read-only",
+          },
+        ]}
+      />
+      <AutoExpandingTextArea
+        {...getFormProps("description")}
+        label="Description"
+        disabled={!!bucketEditRestriction}
+        title={bucketEditRestriction}
+      />
+      <Input
+        {...getFormProps("access-key")}
+        type="text"
+        label="Access Key"
+        disabled={!!bucketEditRestriction}
+        title={bucketEditRestriction}
+      />
+      <Input
+        {...getFormProps("secret-key")}
+        type="text"
+        label="Secret Key"
+        disabled={!!bucketEditRestriction}
+        title={bucketEditRestriction}
+      />
+    </Form>
+  );
+};
+
+export default StorageBucketKeyForm;

--- a/src/pages/storage/panels/CreateStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketPanel.tsx
@@ -42,14 +42,14 @@ const CreateStorageBucketPanel: FC = () => {
       .required("Bucket name is required"),
   });
 
-  const handleSuccess = (bucketName: string) => {
+  const handleSuccess = (bucketName: string, pool: string) => {
     toastNotify.success(
       <>
         Bucket{" "}
         <ResourceLink
           type="bucket"
           value={bucketName}
-          to={getStorageBucketURL(panelParams.project)}
+          to={getStorageBucketURL(bucketName, pool, panelParams.project)}
         />{" "}
         created.
       </>,
@@ -77,9 +77,13 @@ const CreateStorageBucketPanel: FC = () => {
       )
         .then(() => {
           queryClient.invalidateQueries({
-            queryKey: [queryKeys.buckets, panelParams.project],
+            queryKey: [
+              queryKeys.storage,
+              panelParams.project,
+              queryKeys.buckets,
+            ],
           });
-          handleSuccess(values.name);
+          handleSuccess(values.name, values.pool);
         })
         .catch((e) => {
           formik.setSubmitting(false);

--- a/src/sass/_storage.scss
+++ b/src/sass/_storage.scss
@@ -7,6 +7,40 @@
   }
 }
 
+.storage-bucket-key-list {
+  .actions {
+    min-width: 5rem;
+  }
+
+  .description {
+    width: 15rem;
+  }
+
+  .name,
+  .role {
+    width: 10rem;
+  }
+
+  .p-panel__controls {
+    padding-top: 0;
+  }
+
+  .pagination {
+    margin-top: 0;
+  }
+
+  .key-field {
+    min-width: 15rem;
+  }
+
+  @media screen and (width > 1090px) and (width < 1400px) {
+    .description,
+    .role {
+      display: none;
+    }
+  }
+}
+
 .storage-pool-table {
   .size {
     width: 14rem;
@@ -98,6 +132,15 @@
 
     @media screen and (width < 500px) {
       .actions {
+        display: none;
+      }
+    }
+  }
+
+  .storage-buckets-table {
+    @media screen and (width > 1090px) and (width < 1400px) {
+      .description,
+      .keys {
         display: none;
       }
     }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -41,6 +41,7 @@
 @include vf-p-icon-pods;
 @include vf-p-icon-power-off;
 @include vf-p-icon-priority-low;
+@include vf-p-icon-private-key;
 @include vf-p-icon-profile;
 @include vf-p-icon-profiles;
 @include vf-p-icon-repository;

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -78,6 +78,14 @@ export interface LxdStorageBucket {
   pool: string;
 }
 
+export interface LxdStorageBucketKey {
+  name: string;
+  description: string;
+  role: string;
+  "access-key": string;
+  "secret-key": string;
+}
+
 export interface LxdStorageVolumeState {
   usage: {
     used: number;

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -1,5 +1,6 @@
 export const queryKeys = {
   buckets: "buckets",
+  keys: "keys",
   certificates: "certificates",
   cluster: "cluster",
   configOptions: "configOptions",

--- a/src/util/storageBucket.tsx
+++ b/src/util/storageBucket.tsx
@@ -2,6 +2,7 @@ import type { AnyObject, TestContext, TestFunction } from "yup";
 import { checkDuplicateName } from "./helpers";
 import type { AbortControllerState } from "./helpers";
 import type { StorageBucketFormValues } from "pages/storage/forms/StorageBucketForm";
+import type { LxdStorageBucket } from "types/storage";
 
 export const testDuplicateStorageBucketName = (
   project: string,
@@ -28,6 +29,33 @@ export const testDuplicateStorageBucketName = (
   ];
 };
 
-export const getStorageBucketURL = (project: string) => {
-  return `/ui/project/${encodeURIComponent(project)}/storage/buckets`;
+export const testDuplicateBucketKeyName = (
+  project: string,
+  bucket: LxdStorageBucket,
+  controllerState: AbortControllerState,
+  excludeName?: string,
+): [string, string, TestFunction<string | undefined, AnyObject>] => {
+  return [
+    "deduplicate",
+    "A key with this name already exists",
+    async (value?: string) => {
+      return (
+        (excludeName && value === excludeName) ||
+        checkDuplicateName(
+          value,
+          project,
+          controllerState,
+          `storage-pools/${encodeURIComponent(bucket.pool)}/buckets/${encodeURIComponent(bucket.name)}/keys`,
+        )
+      );
+    },
+  ];
+};
+
+export const getStorageBucketURL = (
+  name: string,
+  pool: string,
+  project: string,
+) => {
+  return `/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(pool)}/bucket/${encodeURIComponent(name)}`;
 };

--- a/src/util/storageBucketTable.tsx
+++ b/src/util/storageBucketTable.tsx
@@ -1,13 +1,17 @@
 export const NAME_COL = "Name";
 export const POOL_COL = "Pool";
 export const SIZE_COL = "Size";
+export const DESCRIPTION_COL = "Description";
 export const URL_COL = "S3 URL";
+export const KEY_COL = "Keys";
 export const ACTIONS_COL = "Actions";
 
 export const COLUMN_WIDTHS: Record<string, string> = {
-  [NAME_COL]: "19%",
-  [POOL_COL]: "9%",
-  [SIZE_COL]: "7%",
-  [URL_COL]: "15%",
-  [ACTIONS_COL]: "14%",
+  [NAME_COL]: "8rem",
+  [POOL_COL]: "8rem",
+  [SIZE_COL]: "5rem",
+  [DESCRIPTION_COL]: "10rem",
+  [URL_COL]: "15rem",
+  [KEY_COL]: "3rem",
+  [ACTIONS_COL]: "8.5rem",
 };

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -12,6 +12,7 @@ export interface PanelHelper {
   subForm: GroupSubForm;
   project: string;
   bucket: string | null;
+  key: string | null;
   pool: string | null;
   target: string | null;
   clear: () => void;
@@ -26,6 +27,8 @@ export interface PanelHelper {
   openCreateTLSIdentity: () => void;
   openCreateStorageBucket: (project: string) => void;
   openEditStorageBucket: (bucket: string, pool: string, target: string) => void;
+  openCreateStorageBucketKey: (project: string) => void;
+  openEditStorageBucketKey: (key: string) => void;
 }
 
 export const panels = {
@@ -38,8 +41,10 @@ export const panels = {
   createIdpGroup: "create-idp-groups",
   editIdpGroup: "edit-idp-groups",
   createTLSIdentity: "create-tls-identity",
-  createStorageBucket: "create-storage-bucket",
-  editStorageBucket: "edit-storage-bucket",
+  createStorageBucket: "create-bucket",
+  editStorageBucket: "edit-bucket",
+  createStorageBucketKey: "create-bucket-key",
+  editStorageBucketKey: "edit-bucket-key",
 };
 
 type ParamMap = Record<string, string>;
@@ -77,6 +82,7 @@ const usePanelParams = (): PanelHelper => {
     newParams.delete("panel-project");
     newParams.delete("sub-form");
     newParams.delete("bucket");
+    newParams.delete("bucket-key");
     newParams.delete("panel-pool");
     newParams.delete("target");
     setParams(newParams);
@@ -93,6 +99,7 @@ const usePanelParams = (): PanelHelper => {
     idpGroup: params.get("idp-group"),
     subForm: params.get("sub-form") as GroupSubForm,
     bucket: params.get("bucket"),
+    key: params.get("bucket-key"),
     pool: params.get("panel-pool"),
     target: params.get("target") ?? "",
 
@@ -161,6 +168,17 @@ const usePanelParams = (): PanelHelper => {
         target: target || "",
       };
       setPanelParams(panels.editStorageBucket, params);
+    },
+
+    openCreateStorageBucketKey: () => {
+      setPanelParams(panels.createStorageBucketKey);
+    },
+
+    openEditStorageBucketKey: (key) => {
+      const params: ParamMap = {
+        "bucket-key": key || "",
+      };
+      setPanelParams(panels.editStorageBucketKey, params);
     },
   };
 };


### PR DESCRIPTION
## Done
Storage bucket keys can be:
[ :+1: ] created,
[ :+1: ]  edited
[ :+1: ] deleted 
[ :+1: ] bulk delete
[ :+1: ] explored in the UI.

Additionally
[ :+1: ] URL routing

> Due another round of testing with a fresh backend before marking as ready for final review(s).
- Test bulk delete behaviour :heavy_check_mark: 
- Test update Key behaviour :heavy_check_mark: 
- Verify update bucket behaviour :heavy_check_mark: 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Verify CRUD operations on Storage bucket keys
    - Verify CRUD operations on Storage buckets

## Screenshots

![image](https://github.com/user-attachments/assets/dffad5f9-1fd5-481e-a54b-2e5be7b37852)
![image](https://github.com/user-attachments/assets/0d4e9e6a-b4e4-4692-961b-27274e10099b)
![image](https://github.com/user-attachments/assets/9f6093bc-3ed7-4a1e-a4a5-c2fde483be82)
