### PR TITLE
feat(network) add bridge.external_interfaces config option

### DIFF
--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -45,6 +45,7 @@ export interface NetworkFormValues {
   description?: string;
   networkType: LxdNetworkType;
   bridge_driver?: LxdNetworkBridgeDriver;
+  bridge_external_interfaces?: string;
   bridge_hwaddr?: string;
   bridge_mtu?: string;
   dns_domain?: string;
@@ -118,6 +119,8 @@ export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
     config: {
       ...missingConfigFields,
       [getNetworkKey("bridge_driver")]: values.bridge_driver,
+      [getNetworkKey("bridge_external_interfaces")]:
+        values.bridge_external_interfaces,
       [getNetworkKey("bridge_hwaddr")]: values.bridge_hwaddr,
       [getNetworkKey("bridge_mtu")]: values.bridge_mtu,
       [getNetworkKey("dns_domain")]: values.dns_domain,

--- a/src/pages/networks/forms/NetworkFormBridge.tsx
+++ b/src/pages/networks/forms/NetworkFormBridge.tsx
@@ -58,6 +58,13 @@ const NetworkFormBridge: FC<Props> = ({ formik, filterRows }) => {
               />
             ),
           }),
+          getConfigurationRow({
+            formik,
+            name: "bridge_external_interfaces",
+            label: "External interfaces",
+            defaultValue: "",
+            children: <Input type="text" />,
+          }),
         ]
       : []),
   ]);

--- a/src/pages/networks/forms/NetworkTypeSelector.tsx
+++ b/src/pages/networks/forms/NetworkTypeSelector.tsx
@@ -61,6 +61,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
         if (e.target.value === "ovn") {
           formik.setFieldValue("networkType", "ovn");
           formik.setFieldValue("bridge_driver", undefined);
+          formik.setFieldValue("bridge_external_interfaces", undefined);
           formik.setFieldValue("dns_mode", undefined);
           formik.setFieldValue("parent", undefined);
           formik.setFieldValue("parentPerClusterMember", undefined);
@@ -83,6 +84,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           formik.setFieldValue("networkType", "physical");
           formik.setFieldValue("network", undefined);
           formik.setFieldValue("bridge_driver", undefined);
+          formik.setFieldValue("bridge_external_interfaces", undefined);
           formik.setFieldValue("bridge_hwaddr", undefined);
           formik.setFieldValue("bridge_mtu", undefined);
           formik.setFieldValue("dns_domain", undefined);

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -28,6 +28,8 @@ export const toNetworkFormValues = (
     bridge_driver: network.config[
       getNetworkKey("bridge_driver")
     ] as LxdNetworkBridgeDriver,
+    bridge_external_interfaces:
+      network.config[getNetworkKey("bridge_external_interfaces")],
     bridge_hwaddr: network.config[getNetworkKey("bridge_hwaddr")],
     bridge_mtu: network.config[getNetworkKey("bridge_mtu")],
     dns_domain: network.config[getNetworkKey("dns_domain")],

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -23,6 +23,7 @@ export const networkFormFieldToPayloadName: Record<
   keyof LxdNetworkConfig
 > = {
   bridge_driver: "bridge.driver",
+  bridge_external_interfaces: "bridge.external_interfaces",
   bridge_hwaddr: "bridge.hwaddr",
   bridge_mtu: "bridge.mtu",
   dns_domain: "dns.domain",


### PR DESCRIPTION
## Done

- feat(network) add bridge.external_interfaces config option

Fixes #1315

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a network of type bridge, ensure the option bridge > external interfaces is available and properly saved on create and edit. ensure the option is not available for ovn or physical networks.

## Screenshots

![image](https://github.com/user-attachments/assets/289b5af5-ed48-40b2-a6de-c0cc9b380b92)
