### PR TITLE
fix(settings) use metadata api to determine clustered server settings

### DIFF
--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -50,13 +50,8 @@ const SettingForm: FC<Props> = ({
   // Special cases
   const isTrustPassword = configField.key === "core.trust_password";
   const isLokiAuthPassword = configField.key === "loki.auth.password";
-  const isMaasMachine = configField.key === "maas.machine";
   const isSecret = isTrustPassword || isLokiAuthPassword;
-  const isAddress = configField.key.endsWith("_address");
-  const isVolume = configField.key.endsWith("_volume");
-  const isSyslogSocket = configField.key === "core.syslog_socket";
-  const isClusteredInput =
-    isClustered && (isMaasMachine || isAddress || isVolume || isSyslogSocket);
+  const isClusteredInput = isClustered && configField.scope === "local";
 
   const settingLabel = (
     <ResourceLabel bold type="setting" value={configField.key} />


### PR DESCRIPTION
## Done

- fix(settings) use metadata api to determine clustered server settings
- ensure core.bgp_routerid is node specific

Fixes #1317

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in a clustered backend open settings
    - ensure core.bgp_routerid is node specific