### PR TITLE
feat(network) add network lease tab to network detail page

### DIFF
--- a/src/api/network-leases.tsx
+++ b/src/api/network-leases.tsx
@@ -1,0 +1,14 @@
+import { handleResponse } from "util/helpers";
+import type { LxdNetworkLease } from "types/network";
+import type { LxdApiResponse } from "types/apiResponse";
+
+export const fetchNetworkLeases = async (
+  network: string,
+  project: string,
+): Promise<LxdNetworkLease[]> => {
+  return fetch(`/1.0/networks/${network}/leases?project=${project}&recursion=1`)
+    .then(handleResponse)
+    .then((data: LxdApiResponse<LxdNetworkLease[]>) => {
+      return data.metadata;
+    });
+};

--- a/src/pages/networks/NetworkDetail.tsx
+++ b/src/pages/networks/NetworkDetail.tsx
@@ -10,6 +10,7 @@ import CustomLayout from "components/CustomLayout";
 import TabLinks from "components/TabLinks";
 import NetworkForwards from "pages/networks/NetworkForwards";
 import { useNetwork } from "context/useNetworks";
+import NetworkLeases from "pages/networks/NetworkLeases";
 
 const NetworkDetail: FC = () => {
   const notify = useNotify();
@@ -49,7 +50,7 @@ const NetworkDetail: FC = () => {
       return ["Configuration"];
     }
 
-    return ["Configuration", "Forwards"];
+    return ["Configuration", "Forwards", "Leases"];
   };
 
   return (
@@ -74,6 +75,11 @@ const NetworkDetail: FC = () => {
         {activeTab === "forwards" && (
           <div role="tabpanel" aria-labelledby="forwards">
             {network && <NetworkForwards network={network} project={project} />}
+          </div>
+        )}
+        {activeTab === "leases" && (
+          <div role="tabpanel" aria-labelledby="leases">
+            {network && <NetworkLeases network={network} project={project} />}
           </div>
         )}
       </Row>

--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -1,0 +1,135 @@
+import type { FC } from "react";
+import {
+  EmptyState,
+  Icon,
+  MainTable,
+  Row,
+  useNotify,
+} from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import type { LxdNetwork } from "types/network";
+import Loader from "components/Loader";
+import { useDocs } from "context/useDocs";
+import ScrollableTable from "components/ScrollableTable";
+import { fetchNetworkLeases } from "api/network-leases";
+
+interface Props {
+  network: LxdNetwork;
+  project: string;
+}
+
+const NetworkLeases: FC<Props> = ({ network, project }) => {
+  const docBaseLink = useDocs();
+  const notify = useNotify();
+
+  const {
+    data: leases = [],
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [
+      queryKeys.projects,
+      project,
+      queryKeys.networks,
+      network.name,
+      queryKeys.leases,
+    ],
+    queryFn: async () => fetchNetworkLeases(network.name, project),
+  });
+
+  if (error) {
+    notify.failure("Loading network leases failed", error);
+  }
+
+  const hasNetworkLeases = leases.length > 0;
+
+  const headers = [
+    { content: "Hostname", sortKey: "hostname" },
+    { content: "Mac Address", sortKey: "mac_address" },
+    { content: "IP Address", sortKey: "address" },
+    { content: "Type", sortKey: "type" },
+  ];
+
+  const rows = leases.map((lease) => {
+    return {
+      key: lease.address,
+      columns: [
+        {
+          content: lease.hostname,
+          role: "rowheader",
+          "aria-label": "Listen address",
+        },
+        {
+          content: lease.hwaddr,
+          role: "cell",
+          "aria-label": "Description",
+        },
+        {
+          content: lease.address,
+          role: "cell",
+          "aria-label": "Default target address",
+        },
+        {
+          content: lease.type,
+          role: "cell",
+          "aria-label": "Default target address",
+        },
+      ],
+      sortData: {
+        hostname: lease.hostname,
+        mac_address: lease.hwaddr,
+        address: lease.address,
+        type: lease.type,
+      },
+    };
+  });
+
+  if (isLoading) {
+    return <Loader isMainComponent />;
+  }
+
+  return (
+    <Row>
+      {hasNetworkLeases && (
+        <ScrollableTable
+          dependencies={leases}
+          tableId="network-lease-table"
+          belowIds={["status-bar"]}
+        >
+          <MainTable
+            id="network-lease-table"
+            headers={headers}
+            expanding
+            rows={rows}
+            paginate={30}
+            sortable
+            className="u-table-layout--auto"
+            emptyStateMsg="No data to display"
+          />
+        </ScrollableTable>
+      )}
+      {!isLoading && !hasNetworkLeases && (
+        <EmptyState
+          className="empty-state"
+          image={<Icon className="empty-state-icon" name="exposed" />}
+          title="No network leases found"
+        >
+          <p>There are no network leases in this project.</p>
+          <p>
+            <a
+              href={`${docBaseLink}/howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more about network leases
+              <Icon className="external-link-icon" name="external-link" />
+            </a>
+          </p>
+        </EmptyState>
+      )}
+    </Row>
+  );
+};
+
+export default NetworkLeases;

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -151,3 +151,12 @@ export interface LxdNetworkAcl {
   used_by?: string[];
   access_entitlements?: string[];
 }
+
+export interface LxdNetworkLease {
+  address: "string";
+  hostname: "string";
+  hwaddr: "string";
+  location: "string";
+  project: "string";
+  type: "string";
+}

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -7,15 +7,11 @@ export const storageTabs: string[] = [
   "Custom ISOs",
   "Buckets",
 ];
-export const storageTabToName: Record<string, string> = {
-  pools: "Pools",
-  volumes: "Volumes",
-  "custom-isos": "Custom ISOs",
-};
 export const storageTabPaths = storageTabs.map((tab) => slugify(tab));
 export const projectSubpages = [
   "instances",
   "profiles",
+  "network-acls",
   "networks",
   "images",
   "storage",
@@ -31,6 +27,14 @@ export const getSubpageFromUrl = (url: string): string | undefined => {
 
   if (mainSubpage === "storage" && storageTabPaths.includes(tabSubpage)) {
     return `${mainSubpage}/${tabSubpage}`;
+  }
+
+  if (mainSubpage === "network") {
+    return "networks";
+  }
+
+  if (mainSubpage === "storage") {
+    return "storage/pools";
   }
 
   if (projectSubpages.includes(mainSubpage)) {

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -9,6 +9,7 @@ export const queryKeys = {
   instances: "instances",
   customVolumes: "customVolumes",
   isoVolumes: "isoVolumes",
+  leases: "leases",
   logs: "logs",
   members: "members",
   metrics: "metrics",


### PR DESCRIPTION
## Done

- feat(network) add network lease tab to network detail page

Fixes #1321

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open network detail page, check leases

## Screenshots

![image](https://github.com/user-attachments/assets/513a0a0a-6fbd-4f85-8ed1-56a94069e0fb)
