### PR TITLE
fix(settings) surface error on loading cluster member specific values in server settings page

### DIFF
--- a/src/context/useSettings.tsx
+++ b/src/context/useSettings.tsx
@@ -21,5 +21,6 @@ export const useClusteredSettings = (): UseQueryResult<
     queryKey: [queryKeys.settings, queryKeys.cluster],
     queryFn: async () => fetchSettingsFromClusterMembers(clusterMembers),
     enabled: clusterMembers.length > 0,
+    retry: false,
   });
 };

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -43,7 +43,12 @@ const Settings: FC = () => {
     queryKey: [queryKeys.configOptions],
     queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
   });
-  const { data: clusteredSettings = [] } = useClusteredSettings();
+  const { data: clusteredSettings = [], error: clusterError } =
+    useClusteredSettings();
+
+  if (clusterError) {
+    notify.failure("Loading clustered settings failed", clusterError);
+  }
 
   if (isConfigOptionsLoading || isSettingsLoading) {
     return <Loader isMainComponent />;


### PR DESCRIPTION
## Done

- fix(settings) surface error on loading cluster member specific values in server settings page

Fixes #1319

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - have a clustered backend
    - switch off one of the cluster nodes (except the one you are using the api from to still be able to load it)
    - go to server settings
    - ensure an error message is displayed informing about the unavailable member.

## Screenshots

![image](https://github.com/user-attachments/assets/82ffabe1-a046-4419-9b6d-42baab70618f)