### PR TITLE
feat(network) make bridge.external_interfaces node specific in a clustered setup

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -46,6 +46,7 @@ interface Props {
   help?: string;
   inputHelp?: string;
   readOnlyRenderer?: (value: ReactNode) => string | ReactNode;
+  hideOverrideBtn?: boolean;
 }
 
 export const getConfigurationRow = ({
@@ -59,6 +60,7 @@ export const getConfigurationRow = ({
   help,
   inputHelp,
   readOnlyRenderer = (value: ReactNode) => <>{value}</>,
+  hideOverrideBtn = false,
 }: Props): MainTableRow => {
   const values = formik.values as unknown as Record<string, string | undefined>;
   const value = values[name];
@@ -159,25 +161,27 @@ export const getConfigurationRow = ({
       return (
         <>
           {overrideValue}
-          <Button
-            onClick={() => {
-              ensureEditMode(formik);
-              if (!isOverridden) {
-                enableOverride();
-              }
-              focusField(name);
-            }}
-            className="u-no-margin--bottom"
-            type="button"
-            appearance="base"
-            title={getDisabledReasonOrTitle(
-              isOverridden ? "Edit" : "Create override",
-            )}
-            disabled={isDisabled()}
-            hasIcon
-          >
-            <Icon name="edit" />
-          </Button>
+          {hideOverrideBtn === false && (
+            <Button
+              onClick={() => {
+                ensureEditMode(formik);
+                if (!isOverridden) {
+                  enableOverride();
+                }
+                focusField(name);
+              }}
+              className="u-no-margin--bottom"
+              type="button"
+              appearance="base"
+              title={getDisabledReasonOrTitle(
+                isOverridden ? "Edit" : "Create override",
+              )}
+              disabled={isDisabled()}
+              hasIcon
+            >
+              <Icon name="edit" />
+            </Button>
+          )}
         </>
       );
     }

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -93,6 +93,7 @@ const CreateNetwork: FC = () => {
                 project,
                 clusterMembers,
                 values.parentPerClusterMember,
+                values.bridge_external_interfaces_per_member,
               )
           : async () => createNetwork(network, project);
 

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -54,11 +54,12 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
   const { data: clusterMembers = [] } = useClusterMembers();
   const { canEditNetwork } = useNetworkEntitlements();
 
-  const queryEnabled = network.managed && network.type === "physical";
+  const shouldLoadMemberSpecificSettings =
+    network.managed && ["bridge", "physical"].includes(network.type);
   const { data: networkOnMembers = [], error } = useNetworkFromClusterMembers(
     network.name,
     project,
-    queryEnabled,
+    shouldLoadMemberSpecificSettings,
   );
 
   useEffect(() => {
@@ -108,7 +109,9 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
           return updateClusterNetwork(
             saveNetwork,
             project,
+            clusterMembers,
             values.parentPerClusterMember,
+            values.bridge_external_interfaces_per_member,
           );
         } else {
           return updateNetwork(saveNetwork, project);

--- a/src/pages/networks/forms/ClusteredBridgeInterfaceInput.tsx
+++ b/src/pages/networks/forms/ClusteredBridgeInterfaceInput.tsx
@@ -1,0 +1,48 @@
+import ClusterSpecificInput from "components/forms/ClusterSpecificInput";
+import type { FormikProps } from "formik";
+import type { FC } from "react";
+import { useClusterMembers } from "context/useClusterMembers";
+import type { NetworkFormValues } from "pages/networks/forms/NetworkForm";
+import { ensureEditMode } from "util/instanceEdit";
+import { focusField } from "util/formFields";
+
+interface Props {
+  formik: FormikProps<NetworkFormValues>;
+  helpText?: string;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const ClusteredBridgeInterfaceInput: FC<Props> = ({
+  formik,
+  helpText,
+  disabled,
+  placeholder,
+}) => {
+  const { data: clusterMembers = [] } = useClusterMembers();
+  const memberNames = clusterMembers.map((member) => member.server_name);
+
+  return (
+    <ClusterSpecificInput
+      values={formik.values.bridge_external_interfaces_per_member}
+      id="bridge_external_interfaces_per_member"
+      isReadOnly={formik.values.readOnly}
+      onChange={(value) => {
+        formik.setFieldValue("bridge_external_interfaces_per_member", value);
+      }}
+      toggleReadOnly={() => {
+        ensureEditMode(formik);
+        formik.setFieldValue("bridge_external_interfaces", "");
+        focusField("bridge_external_interfaces_per_member");
+      }}
+      memberNames={memberNames}
+      disabled={disabled}
+      helpText={helpText}
+      placeholder={placeholder}
+      classname=""
+      disabledReason={formik.values.editRestriction}
+    />
+  );
+};
+
+export default ClusteredBridgeInterfaceInput;

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -46,6 +46,7 @@ export interface NetworkFormValues {
   networkType: LxdNetworkType;
   bridge_driver?: LxdNetworkBridgeDriver;
   bridge_external_interfaces?: string;
+  bridge_external_interfaces_per_member?: ClusterSpecificValues;
   bridge_hwaddr?: string;
   bridge_mtu?: string;
   dns_domain?: string;
@@ -120,7 +121,10 @@ export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
       ...missingConfigFields,
       [getNetworkKey("bridge_driver")]: values.bridge_driver,
       [getNetworkKey("bridge_external_interfaces")]:
-        values.bridge_external_interfaces,
+        Object.keys(values.bridge_external_interfaces_per_member ?? {})
+          .length === 0
+          ? values.bridge_external_interfaces
+          : undefined,
       [getNetworkKey("bridge_hwaddr")]: values.bridge_hwaddr,
       [getNetworkKey("bridge_mtu")]: values.bridge_mtu,
       [getNetworkKey("dns_domain")]: values.dns_domain,

--- a/src/pages/networks/forms/NetworkFormBridge.tsx
+++ b/src/pages/networks/forms/NetworkFormBridge.tsx
@@ -7,6 +7,8 @@ import ConfigurationTable from "components/ConfigurationTable";
 import { BRIDGE } from "pages/networks/forms/NetworkFormMenu";
 import { slugify } from "util/slugify";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { useIsClustered } from "context/useIsClustered";
+import ClusteredBridgeInterfaceInput from "pages/networks/forms/ClusteredBridgeInterfaceInput";
 
 interface Props {
   formik: FormikProps<NetworkFormValues>;
@@ -14,6 +16,8 @@ interface Props {
 }
 
 const NetworkFormBridge: FC<Props> = ({ formik, filterRows }) => {
+  const isClustered = useIsClustered();
+
   const rows = filterRows([
     getConfigurationRow({
       formik,
@@ -63,7 +67,28 @@ const NetworkFormBridge: FC<Props> = ({ formik, filterRows }) => {
             name: "bridge_external_interfaces",
             label: "External interfaces",
             defaultValue: "",
-            children: <Input type="text" />,
+            hideOverrideBtn:
+              isClustered && formik.values.bridge_external_interfaces === "set",
+            children: isClustered ? (
+              <ClusteredBridgeInterfaceInput
+                formik={formik}
+                placeholder="Enter interface name"
+              />
+            ) : (
+              <Input type="text" />
+            ),
+            readOnlyRenderer: (value) =>
+              isClustered && value !== "-" && value !== undefined ? (
+                <ClusteredBridgeInterfaceInput
+                  key={JSON.stringify(
+                    formik.values.bridge_external_interfaces_per_member ?? {},
+                  )}
+                  formik={formik}
+                  placeholder="Enter interface name"
+                />
+              ) : (
+                <>{value}</>
+              ),
           }),
         ]
       : []),

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -19,6 +19,16 @@ export const toNetworkFormValues = (
       (parentPerClusterMember[item.memberName] = item.config.parent ?? ""),
   );
 
+  const bridge_external_interfaces_per_member: ClusterSpecificValues = {};
+  networkOnMembers?.forEach(
+    (item) =>
+      (bridge_external_interfaces_per_member[item.memberName] =
+        item.config[getNetworkKey("bridge_external_interfaces")] ?? ""),
+  );
+  const hasBridgeExternalInterfacesPerMember = Object.values(
+    bridge_external_interfaces_per_member,
+  ).find((item) => item.length > 0);
+
   return {
     readOnly: true,
     isCreating: false,
@@ -28,8 +38,10 @@ export const toNetworkFormValues = (
     bridge_driver: network.config[
       getNetworkKey("bridge_driver")
     ] as LxdNetworkBridgeDriver,
-    bridge_external_interfaces:
-      network.config[getNetworkKey("bridge_external_interfaces")],
+    bridge_external_interfaces: hasBridgeExternalInterfacesPerMember
+      ? "set"
+      : network.config[getNetworkKey("bridge_external_interfaces")],
+    bridge_external_interfaces_per_member,
     bridge_hwaddr: network.config[getNetworkKey("bridge_hwaddr")],
     bridge_mtu: network.config[getNetworkKey("bridge_mtu")],
     dns_domain: network.config[getNetworkKey("dns_domain")],


### PR DESCRIPTION
## Done

- feat(network) make bridge.external_interfaces node specific in a clustered setup

Fixes #1315

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a network bridge with and without the bridge.external_interfaces config set, ensure both create fine
    - edit both, ensure it updates correctly.

## Screenshots

![image](https://github.com/user-attachments/assets/9b84912b-b7c8-447f-aa46-0816b9bbd04f)
