### PR TITLE
feat(instance) show mac address in side panel.

### DIFF
--- a/src/components/NetworkListTable.tsx
+++ b/src/components/NetworkListTable.tsx
@@ -40,7 +40,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
     },
     { content: "Type", sortKey: "type", className: "u-text--muted" },
     {
-      content: "Mac Address",
+      content: "MAC address",
       sortKey: "macAddress",
       className: "u-text--muted u-hide--small u-hide--medium",
     },
@@ -96,7 +96,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
           {
             content: instance?.config?.[`volatile.${deviceName}.hwaddr`] || "-",
             role: "cell",
-            "aria-label": "Mac Address",
+            "aria-label": "MAC address",
           },
         ],
         sortData: {

--- a/src/pages/instances/InstaceMACAddresses.tsx
+++ b/src/pages/instances/InstaceMACAddresses.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "react";
+import type { LxdInstance } from "types/instance";
+import ExpandableList from "components/ExpandableList";
+
+interface Props {
+  instance: LxdInstance;
+}
+
+const InstanceMACAddresses: FC<Props> = ({ instance }) => {
+  const extractAddressesFromConfig = () => {
+    const hwaddrs = [];
+
+    for (const [key, value] of Object.entries(instance.config)) {
+      if (
+        key.startsWith("volatile.") &&
+        key.endsWith(".hwaddr") &&
+        key.split(".").length === 3
+      ) {
+        hwaddrs.push(value);
+      }
+    }
+    return hwaddrs;
+  };
+
+  const macAddresses = extractAddressesFromConfig();
+
+  return macAddresses.length ? (
+    <ExpandableList
+      items={macAddresses.map((macAddress) => (
+        <div
+          key={macAddress}
+          className="ip u-truncate"
+          title={`MAC address ${macAddress}`}
+        >
+          {macAddress}
+        </div>
+      ))}
+    />
+  ) : (
+    <>-</>
+  );
+};
+
+export default InstanceMACAddresses;

--- a/src/pages/instances/InstanceDetailPanelContent.tsx
+++ b/src/pages/instances/InstanceDetailPanelContent.tsx
@@ -12,6 +12,7 @@ import { useSettings } from "context/useSettings";
 import { isNicDevice } from "util/devices";
 import { getIpAddresses } from "util/networks";
 import { useInstanceLoading } from "context/instanceLoading";
+import InstanceMACAddresses from "pages/instances/InstaceMACAddresses";
 
 const RECENT_SNAPSHOT_LIMIT = 5;
 
@@ -82,6 +83,12 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
           <th className="u-text--muted">IPv6</th>
           <td key={getIpAddresses(instance, "inet6").length}>
             <InstanceIps instance={instance} family="inet6" />
+          </td>
+        </tr>
+        <tr>
+          <th className="u-text--muted">MAC addresses</th>
+          <td key={getIpAddresses(instance, "inet6").length}>
+            <InstanceMACAddresses instance={instance} />
           </td>
         </tr>
         <tr>

--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -46,7 +46,7 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
 
   const headers = [
     { content: "Hostname", sortKey: "hostname" },
-    { content: "Mac Address", sortKey: "mac_address" },
+    { content: "MAC address", sortKey: "mac_address" },
     { content: "IP Address", sortKey: "address" },
     { content: "Type", sortKey: "type" },
   ];


### PR DESCRIPTION
## Done

- feat(instance) show mac address in side panel. 

Fixes #1331

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - click on an instance (not the link) in the instance list, in the side panel ensure the mac address fields shows.

## Screenshots

![image](https://github.com/user-attachments/assets/33e13a18-5b23-465e-ae20-23b0b6ce7ce1)
