### PR TITLE
fix(certificates) adjust onboarding steps for tls cert in chrome and chromium on linux

### DIFF
--- a/src/pages/login/BrowserImport.tsx
+++ b/src/pages/login/BrowserImport.tsx
@@ -90,8 +90,8 @@ const BrowserImport: FC = () => {
                 click Import
               </li>
               <li className="p-list__item">
-                Select the file you just downloaded (ending in .pfx). If you
-                created a password for the certificate, type it in now.
+                Select the .pfx file you just downloaded. If you created a
+                password for the certificate, type it in now.
               </li>
               <li className="p-list__item">
                 <b>Restart the browser.</b>
@@ -105,17 +105,21 @@ const BrowserImport: FC = () => {
             <ul className="p-list--divided u-no-margin--bottom">
               {downloadPfx}
               <li className="p-list__item">
-                Go to Chrome&apos;s certificate settings:
+                Go to Chrome&apos;s certificate manager:
                 <pre className="p-code-snippet__block u-no-margin--bottom">
-                  <code>chrome://settings/certificates</code>
+                  <code>chrome://certificate-manager</code>
                 </pre>
               </li>
               <li className="p-list__item">
-                Click <b>Import</b>
+                Click <b>Your certificates</b>
               </li>
               <li className="p-list__item">
-                Select the file you just downloaded (ending in .pfx). If you
-                created a password for the certificate, type it in now.
+                Go to <b>View imported certificates from Linux</b>
+              </li>
+              <li className="p-list__item">
+                Select <b>Import</b> and choose the .pfx file you just
+                downloaded. If you created a password for the certificate, type
+                it in now.
               </li>
               <li className="p-list__item">
                 <b>Restart the browser.</b>


### PR DESCRIPTION
## Done

- fix(certificates) adjust onboarding steps for tls cert in chrome and chromium on linux

Fixes #1337

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the onboarding steps for chrome on linux

## Screenshots

![image](https://github.com/user-attachments/assets/52a3f079-e87f-4c69-82ff-a903b69e6346)

