### PR TITLE
fix(groups) make permission selectors responsive

### DIFF
--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -254,6 +254,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
           id="permissions-table"
           headers={headers}
           sortable
+          responsive
           emptyStateMsg={"No permissions match the search criteria."}
           rows={rows}
           className="permissions-table"

--- a/src/sass/_permission_groups.scss
+++ b/src/sass/_permission_groups.scss
@@ -78,7 +78,7 @@
 }
 
 .edit-permissions-panel {
-  width: 46rem !important;
+  width: min(100%, 46rem) !important;
 
   .p-card__title {
     font-size: #{map-get($font-sizes, h3)}rem;
@@ -89,6 +89,16 @@
     display: flex;
     gap: 1rem;
     justify-content: space-evenly;
+
+    // wrap the permission input to columnar on small screens
+    @media screen and (width < 730px) {
+      align-items: inherit;
+      flex-direction: column;
+
+      .p-form__group {
+        width: inherit !important;
+      }
+    }
 
     &:focus {
       outline: none;
@@ -186,14 +196,27 @@
     .entitlement-description {
       width: 25rem;
     }
+  }
 
-    @include mobile-and-tablet {
+  // only show first column in dropdown selections for resources and entitlements in small screens
+  @include mobile {
+    .header,
+    .label {
       .entitlement {
-        width: 8rem;
+        width: 100%;
       }
 
       .entitlement-description {
-        width: 15rem;
+        display: none;
+      }
+
+      .resource {
+        display: none;
+      }
+
+      .resource:first-child {
+        display: block;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
## Done

- fix(groups) make permission selectors responsive

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open permissions > groups and edit/create a group, go to permissions and check the responsiveness of the inputs in the panel

## Screenshots

![image](https://github.com/user-attachments/assets/2a1fb829-cdd1-4025-9b97-e8bf1672eb39)

![image](https://github.com/user-attachments/assets/fd005e1e-8402-4c3a-abd0-7ba2663f25bc)
