### PR TITLE
fix: bump react-components to 2.7.9 to fix step's width

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test-report-coverage": "cp coverage/unit/coverage-final.json coverage/playwright/ ; nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir coverage/playwright --report-dir coverage/playwright-report --exclude 'src/lib/**' --exclude 'src/types/**'"
   },
   "dependencies": {
-    "@canonical/react-components": "2.7.8",
+    "@canonical/react-components": "2.7.9",
     "@monaco-editor/react": "4.6.0",
     "@tanstack/react-query": "5.63.0",
     "axios": "1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,10 +313,10 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
-"@canonical/react-components@2.7.8":
-  version "2.7.8"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.7.8.tgz#60062a59154eec5c56d007407221b8b3cdb91ccc"
-  integrity sha512-fA6MXen6pXU48DrwBf0sshUtZ4EVaE+ek28hHoXSpYKr4WLh3POvTf0vc7ecktjfEMJoJxixqrzWyWdWvQV9Jw==
+"@canonical/react-components@2.7.9":
+  version "2.7.9"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.7.9.tgz#681154bc9cc27ee63e5124d43d59678a5b6e8e5e"
+  integrity sha512-nnVV8+rptpUloW+f0D4LTKbZQ0wl/5dtIdVurW/hS0DK8y++/U2oHOP22lINEi8nXuQQumkA9PptTgwrS5CV9g==
   dependencies:
     "@types/jest" "29.5.14"
     "@types/node" "20.17.19"


### PR DESCRIPTION
## Done

- The step's width is fixed for vertical steppers in 2.7.9

**Before:**
<img width="1185" alt="Screenshot 2025-07-04 at 2 21 27 PM" src="https://github.com/user-attachments/assets/017ae215-f047-4241-89c1-0787a14d1a0b" />
<img width="1183" alt="Screenshot 2025-07-04 at 2 21 36 PM" src="https://github.com/user-attachments/assets/461ca8f4-2e1d-4e8b-8847-ccb0f552ae8f" />

**After:**
<img width="1181" alt="Screenshot 2025-07-04 at 2 23 21 PM" src="https://github.com/user-attachments/assets/37a2493c-d9f5-4440-b29d-8c35cba83962" />

<img width="1181" alt="Screenshot 2025-07-04 at 2 23 12 PM" src="https://github.com/user-attachments/assets/2b1e0185-12c2-4ee9-88df-85cad6bf5200" />

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]
