### PR TITLE
fix: [WD-23504] Amend Cephobject pool helptext

### DIFF
--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -71,7 +71,8 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const cephObjectNotice = (
     <>
       Rados gateway must be enabled for Ceph Object driver to work. If using
-      microcloud or microceph, run <code>microceph enable rgw</code>.
+      microcloud or microceph, run <code>microceph enable rgw --port 8080</code>
+      .
     </>
   );
 


### PR DESCRIPTION
## Done

- [Adds pool specificity to microceph cli instruction in the cephobject pool creation helptext.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
  - Head to the pool creation page.
  - Select the Cephobject driver.
  - Observe the amended helptext instruction and verify the port number is included.

## Screenshots

![image](https://github.com/user-attachments/assets/aa847d33-a837-4ccc-908f-e34112c6779e)