### PR TITLE
feat: [WD-23499] Instance side panel chips

### DIFF
--- a/src/pages/instances/InstanceDetailPanelContent.tsx
+++ b/src/pages/instances/InstanceDetailPanelContent.tsx
@@ -7,12 +7,14 @@ import InstanceIps from "./InstanceIps";
 import { getRootPool, isoTimeToString } from "util/helpers";
 import { Link } from "react-router-dom";
 import { List } from "@canonical/react-components";
-import ItemName from "components/ItemName";
 import { useSettings } from "context/useSettings";
 import { isNicDevice } from "util/devices";
 import { getIpAddresses } from "util/networks";
 import { useInstanceLoading } from "context/instanceLoading";
 import InstanceMACAddresses from "pages/instances/InstaceMACAddresses";
+import ResourceLink from "components/ResourceLink";
+import InstanceClusterMemberChip from "./InstanceClusterMemberChip";
+import { getImageLink } from "util/instances";
 
 const RECENT_SNAPSHOT_LIMIT = 5;
 
@@ -49,7 +51,7 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
               className="u-truncate base-image"
               title={instance.config["image.description"]}
             >
-              {instance.config["image.description"] ?? "-"}
+              {getImageLink(instance)}
             </div>
           </td>
         </tr>
@@ -98,17 +100,21 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
         <tr>
           <th className="u-text--muted">Cluster member</th>
           <td>
-            {settings?.environment?.server_clustered ? instance.location : "-"}
+            {settings?.environment?.server_clustered ? (
+              <InstanceClusterMemberChip instance={instance} />
+            ) : (
+              "-"
+            )}
           </td>
         </tr>
         <tr>
           <th className="u-text--muted">Root storage pool</th>
           <td>
-            <Link
+            <ResourceLink
+              type="pool"
+              value={rootPool}
               to={`/ui/project/${encodeURIComponent(instance.project)}/storage/pool/${encodeURIComponent(rootPool)}`}
-            >
-              {rootPool}
-            </Link>
+            />
           </td>
         </tr>
         <tr>
@@ -137,12 +143,12 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
             <List
               className="list"
               items={instance.profiles.map((name) => (
-                <Link
+                <ResourceLink
                   key={name}
+                  type="profile"
+                  value={name}
                   to={`/ui/project/${encodeURIComponent(instance.project)}/profile/${encodeURIComponent(name)}`}
-                >
-                  {name}
-                </Link>
+                />
               ))}
             />
           </td>
@@ -156,12 +162,12 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
               <List
                 className="list"
                 items={networkDevices.map((item) => (
-                  <Link
+                  <ResourceLink
                     key={item.network}
+                    type="network"
+                    value={item.network}
                     to={`/ui/project/${encodeURIComponent(instance.project)}/network/${encodeURIComponent(item.network)}`}
-                  >
-                    {item.network}
-                  </Link>
+                  />
                 ))}
               />
             </td>
@@ -205,11 +211,13 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
               .slice(0, RECENT_SNAPSHOT_LIMIT)
               .map((snapshot) => (
                 <tr key={snapshot.name} className="u-no-border">
-                  <th
-                    title={snapshot.name}
-                    className="snapshot-name u-truncate"
-                  >
-                    <ItemName item={snapshot} />
+                  <th>
+                    <ResourceLink
+                      key={snapshot.name}
+                      type="snapshot"
+                      value={snapshot.name}
+                      to={`/ui/project/${encodeURIComponent(instance.project)}/instance/${encodeURIComponent(instance.name)}/snapshots`}
+                    />
                   </th>
                   <td className="u-text--muted">
                     <i>{isoTimeToString(snapshot.created_at)}</i>

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -15,9 +15,8 @@ import DeviceListTable from "components/DeviceListTable";
 import NetworkListTable from "components/NetworkListTable";
 import type { LxdDevices } from "types/device";
 import ResourceLink from "components/ResourceLink";
-import ResourceLabel from "components/ResourceLabel";
-import { useImagesInProject } from "context/useImages";
 import { getIpAddresses } from "util/networks";
+import { getImageLink } from "util/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -26,7 +25,6 @@ interface Props {
 const InstanceOverview: FC<Props> = ({ instance }) => {
   const notify = useNotify();
   const { data: settings } = useSettings();
-  const { data: images = [] } = useImagesInProject(instance.project);
 
   const onFailure = (title: string, e: unknown) => {
     notify.failure(title, e);
@@ -41,29 +39,6 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
   const pid =
     !instance.state || instance.state.pid === 0 ? "-" : instance.state.pid;
 
-  const getImageLink = () => {
-    const imageDescription = instance.config["image.description"];
-    const imageFound = images?.some(
-      (image) => image.properties?.description === imageDescription,
-    );
-
-    if (!imageDescription) {
-      return "-";
-    }
-
-    if (!imageFound) {
-      return <ResourceLabel type="image" value={imageDescription} />;
-    }
-
-    return (
-      <ResourceLink
-        type="image"
-        value={imageDescription}
-        to={`/ui/project/${encodeURIComponent(instance.project)}/images`}
-      />
-    );
-  };
-
   return (
     <div className="instance-overview-tab">
       <NotificationRow />
@@ -76,7 +51,7 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
             <tbody>
               <tr>
                 <th className="u-text--muted">Base image</th>
-                <td>{getImageLink()}</td>
+                <td>{getImageLink(instance)}</td>
               </tr>
               <tr>
                 <th className="u-text--muted">Description</th>

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -7,6 +7,9 @@ import * as Yup from "yup";
 import InstanceLinkChip from "pages/instances/InstanceLinkChip";
 import type { InstanceIconType } from "components/ResourceIcon";
 import type { LxdInstance } from "types/instance";
+import { useImagesInProject } from "context/useImages";
+import ResourceLabel from "components/ResourceLabel";
+import ResourceLink from "components/ResourceLink";
 
 export const instanceLinkFromOperation = (args: {
   operation?: LxdOperationResponse;
@@ -66,4 +69,28 @@ export const instanceNameValidation = (
 
 export const getInstanceKey = (instance: LxdInstance) => {
   return `${instance.name} ${instance.project}`;
+};
+
+export const getImageLink = (instance: LxdInstance) => {
+  const { data: images = [] } = useImagesInProject(instance.project);
+  const imageDescription = instance.config["image.description"];
+  const imageFound = images?.some(
+    (image) => image.properties?.description === imageDescription,
+  );
+
+  if (!imageDescription) {
+    return "-";
+  }
+
+  if (!imageFound) {
+    return <ResourceLabel type="image" value={imageDescription} />;
+  }
+
+  return (
+    <ResourceLink
+      type="image"
+      value={imageDescription}
+      to={`/ui/project/${encodeURIComponent(instance.project)}/images`}
+    />
+  );
 };


### PR DESCRIPTION
## Done

- Added Chip links for cluster, profile, network, snapshot and storage pool entities in the instance detail panel.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open an instance detail side panel by clicking on the instance row in the instance list, and observe the new design for entity chips in the panel.

## Screenshots
Example 1:
![image](https://github.com/user-attachments/assets/8a4161e4-5611-4ba5-91f9-015472a8290d)
Example 2:
![image](https://github.com/user-attachments/assets/f96b0a30-4971-4183-9609-7596a13ffbc3)
