### PR TITLE
fix(auth) show errors on loading authentication. fixes #1366

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,9 @@ import NoMatch from "components/NoMatch";
 import { logout } from "util/helpers";
 import lazy from "util/lazyWithRetry";
 import { useSettings } from "context/useSettings";
+import NotificationRow from "components/NotificationRow";
+import { useNotify } from "@canonical/react-components";
+import CustomLayout from "components/CustomLayout";
 import { applyTheme, loadTheme } from "pages/settings/SettingThemeSwitcher";
 
 const CertificateAdd = lazy(async () => import("pages/login/CertificateAdd"));
@@ -98,8 +101,14 @@ const PermissionIdpGroups = lazy(
 const HOME_REDIRECT_PATHS = ["/", "/ui", "/ui/project"];
 
 const App: FC = () => {
-  const { defaultProject, hasNoProjects, isAuthLoading, isAuthenticated } =
-    useAuth();
+  const {
+    defaultProject,
+    hasNoProjects,
+    isAuthLoading,
+    isAuthenticated,
+    authError,
+  } = useAuth();
+  const notify = useNotify();
   const { data: settings } = useSettings();
   const hasOidc = settings?.auth_methods?.includes("oidc");
   const hasCertificate = settings?.client_certificate;
@@ -112,6 +121,26 @@ const App: FC = () => {
 
   if (isAuthLoading) {
     return <Loader isMainComponent />;
+  }
+
+  if (authError) {
+    const title = "Authentication failed";
+    if (notify.notification?.title !== title) {
+      const logoutAction = [
+        {
+          label: "Logout",
+          onClick: () => (window.location.href = "/oidc/logout"),
+        },
+      ];
+
+      notify.failure(title, authError, null, logoutAction);
+    }
+
+    return (
+      <CustomLayout contentClassName="login">
+        <NotificationRow />
+      </CustomLayout>
+    );
   }
 
   if (!isAuthenticated && hasOidc != undefined && hasCertificate != undefined) {


### PR DESCRIPTION
## Done

- fix(auth) show errors on loading authentication.
- on misconfiguration of oidc (see linked ticket) surface an error, instead of having the UI automatically logging out and ending up in an infinite loop.

Fixes #1366

## Screenshots

![image](https://github.com/user-attachments/assets/e9ae79a2-da14-432a-9918-5575fcffb6ce)