### PR TITLE
feat(acl) add download acl log button

### DIFF
--- a/src/api/network-acls.tsx
+++ b/src/api/network-acls.tsx
@@ -1,4 +1,8 @@
-import { handleEtagResponse, handleResponse } from "util/helpers";
+import {
+  handleEtagResponse,
+  handleResponse,
+  handleTextResponse,
+} from "util/helpers";
 import type { LxdNetworkAcl } from "types/network";
 import type { LxdApiResponse } from "types/apiResponse";
 import { addEntitlements } from "util/entitlements/api";
@@ -37,6 +41,22 @@ export const fetchNetworkAcl = async (
     .then(handleEtagResponse)
     .then((data) => {
       return data as LxdNetworkAcl;
+    });
+};
+
+export const fetchNetworkAclLog = async (
+  name: string,
+  project: string,
+): Promise<string> => {
+  const params = new URLSearchParams();
+  params.set("project", project);
+
+  return fetch(
+    `/1.0/network-acls/${encodeURIComponent(name)}/log?${params.toString()}`,
+  )
+    .then(handleTextResponse)
+    .then((data: string) => {
+      return data;
     });
 };
 

--- a/src/pages/networks/NetworkAclDetailHeader.tsx
+++ b/src/pages/networks/NetworkAclDetailHeader.tsx
@@ -12,6 +12,7 @@ import ResourceLink from "components/ResourceLink";
 import DeleteNetworkAclBtn from "pages/networks/actions/DeleteNetworkAclBtn";
 import { useNetworkAclEntitlements } from "util/entitlements/network-acls";
 import { renameNetworkAcl } from "api/network-acls";
+import DownloadNetworkAclLogBtn from "pages/networks/actions/DownloadNetworkAclLogBtn";
 
 interface Props {
   name: string;
@@ -99,7 +100,13 @@ const NetworkAclDetailHeader: FC<Props> = ({ name, networkAcl, project }) => {
       renameDisabledReason={getRenameDisableReason()}
       controls={
         networkAcl && (
-          <DeleteNetworkAclBtn networkAcl={networkAcl} project={project} />
+          <>
+            <DownloadNetworkAclLogBtn
+              networkAcl={networkAcl}
+              project={project}
+            />
+            <DeleteNetworkAclBtn networkAcl={networkAcl} project={project} />
+          </>
         )
       }
       isLoaded={Boolean(networkAcl)}

--- a/src/pages/networks/actions/DownloadNetworkAclLogBtn.tsx
+++ b/src/pages/networks/actions/DownloadNetworkAclLogBtn.tsx
@@ -1,0 +1,62 @@
+import type { FC } from "react";
+import type { LxdNetworkAcl } from "types/network";
+import {
+  Button,
+  Icon,
+  useToastNotification,
+} from "@canonical/react-components";
+import ResourceLabel from "components/ResourceLabel";
+import { useSmallScreen } from "context/useSmallScreen";
+import { fetchNetworkAclLog } from "api/network-acls";
+
+interface Props {
+  networkAcl: LxdNetworkAcl;
+  project: string;
+}
+
+const DownloadNetworkAclLogBtn: FC<Props> = ({ networkAcl, project }) => {
+  const isSmallScreen = useSmallScreen();
+  const toastNotify = useToastNotification();
+
+  const startDownload = () => {
+    fetchNetworkAclLog(networkAcl.name, project)
+      .then((logData) => {
+        const blob = new Blob([logData], { type: "text/plain" });
+        const url = URL.createObjectURL(blob);
+        const currentTime = new Date()
+          .toISOString()
+          .replaceAll(":", "-")
+          .split(".")[0];
+        const backupName = `${networkAcl.name}-${currentTime}.log`;
+
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = backupName;
+        a.click();
+        window.URL.revokeObjectURL(url);
+
+        toastNotify.success(
+          <>
+            Log download for ACL{" "}
+            <ResourceLabel bold type="network-acl" value={networkAcl.name} />{" "}
+            started.
+          </>,
+        );
+      })
+      .catch((error) => {
+        toastNotify.failure(
+          `Failed to download log for ACL ${networkAcl.name}`,
+          error,
+        );
+      });
+  };
+
+  return (
+    <Button appearance="" type="button" onClick={startDownload} hasIcon>
+      {!isSmallScreen && <Icon name="begin-downloading" />}
+      <span>Download log</span>
+    </Button>
+  );
+};
+
+export default DownloadNetworkAclLogBtn;


### PR DESCRIPTION
## Done

- feat(acl) add download acl log button

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to networks > acls, create an acl, browse the detail page and click "download log"
    - this will fail for lxd hosts that do not have ovn setup, which is expected
    - this only works if all cluster member have active log lines, reported to lxd in https://github.com/canonical/lxd/issues/15984

## Screenshots

![image](https://github.com/user-attachments/assets/e3d316f4-6f51-49de-a4a8-6f1fb25f0b5b)