### PR TITLE
feat(operations) show instances as a chip with resource link in operations page

### DIFF
--- a/src/pages/operations/OperationInstanceName.tsx
+++ b/src/pages/operations/OperationInstanceName.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import ItemName from "components/ItemName";
 import type { LxdOperation } from "types/operation";
-import InstanceLink from "pages/instances/InstanceLink";
+import ResourceLink from "components/ResourceLink";
 import { getInstanceName, getProjectName } from "util/operations";
 
 interface Props {
@@ -38,14 +38,11 @@ const OperationInstanceName: FC<Props> = ({ operation }) => {
 
   if (isLinkable && projectName) {
     return (
-      <div className="u-truncate u-text--muted">
-        <InstanceLink
-          instance={{
-            name: instanceName,
-            project: projectName,
-          }}
-        />
-      </div>
+      <ResourceLink
+        type="instance"
+        value={instanceName}
+        to={`/ui/project/${encodeURIComponent(projectName)}/instance/${encodeURIComponent(instanceName)}`}
+      />
     );
   }
 


### PR DESCRIPTION
## Done

- feat(operations) show instances as a chip with resource link in operations page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start an instance, open a terminal (to have a running operation)
    - in 2nd tab open the operations page, ensure the instance chip is working as expected

## Screenshots

![image](https://github.com/user-attachments/assets/739b53c6-4cfb-4464-935a-ea74059aba62)
