### PR TITLE
fix(auth-group) pending permission or identity edits in side panel should persist a tab change

### DIFF
--- a/src/api/auth-groups.tsx
+++ b/src/api/auth-groups.tsx
@@ -15,6 +15,9 @@ export const fetchGroups = async (
   return fetch(`/1.0/auth/groups?${params.toString()}`)
     .then(handleResponse)
     .then((data: LxdApiResponse<LxdGroup[]>) => {
+      data.metadata.map((group) => {
+        group.access_entitlements?.sort();
+      });
       return data.metadata;
     });
 };

--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -15,6 +15,9 @@ export const fetchIdentities = async (
   return fetch(`/1.0/auth/identities?${params.toString()}`)
     .then(handleResponse)
     .then((data: LxdApiResponse<LxdIdentity[]>) => {
+      data.metadata.map((identity) => {
+        identity.access_entitlements?.sort();
+      });
       return data.metadata;
     });
 };


### PR DESCRIPTION
## Done

- fix(auth-group) pending permission or identity edits in side panel should persist a tab change

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > groups and edit a group, add or remove an identity from the group and add or remove some permission from the group. Do not save the changes.
    - change the tab back and forth
    - ensure the pending changes do not reset, this would previously happen.