### PR TITLE
feat(network) extend columns and optimize layout of ipam and network leases. reduce layout shift when editing network acls

### DIFF
--- a/src/pages/networks/NetworkIPAM.tsx
+++ b/src/pages/networks/NetworkIPAM.tsx
@@ -20,6 +20,8 @@ import { fetchNetworkAllocations } from "api/networks";
 import type { LxdUsedBy } from "util/usedBy";
 import { filterUsedByType } from "util/usedBy";
 import UsedByItem from "components/UsedByItem";
+import ResourceLink from "components/ResourceLink";
+import ScrollableTable from "components/ScrollableTable";
 
 const NetworkIPAM: FC = () => {
   const docBaseLink = useDocs();
@@ -49,8 +51,9 @@ const NetworkIPAM: FC = () => {
     { content: "Type", sortKey: "type", className: "type" },
     { content: "Used by", sortKey: "usedBy", className: "usedBy" },
     { content: "Address", sortKey: "address", className: "address" },
+    { content: "Network", sortKey: "network", className: "network" },
     { content: "NAT", sortKey: "nat", className: "nat" },
-    { content: "Hardware Address", sortKey: "hwaddress", className: "hwaddr" },
+    { content: "MAC address", sortKey: "hwaddress", className: "hwaddr" },
   ];
 
   const rows = allocations.map((allocation) => {
@@ -101,6 +104,17 @@ const NetworkIPAM: FC = () => {
           className: "address",
         },
         {
+          content: (
+            <ResourceLink
+              type="network"
+              value={allocation.network}
+              to={`/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(allocation.network)}`}
+            />
+          ),
+          role: "cell",
+          className: "network",
+        },
+        {
           content: allocation.nat ? "Yes" : "No",
           role: "cell",
           className: "nat",
@@ -117,6 +131,7 @@ const NetworkIPAM: FC = () => {
         type: allocation.type,
         nat: allocation.nat,
         hwaddress: allocation.hwaddr,
+        network: allocation.network?.toLowerCase(),
       },
     };
   });
@@ -145,14 +160,21 @@ const NetworkIPAM: FC = () => {
       <NotificationRow />
       <Row>
         {allocations.length > 0 && (
-          <MainTable
-            className="network-ipam-table"
-            headers={headers}
-            rows={rows}
-            responsive
-            sortable
-            emptyStateMsg="No data to display"
-          />
+          <ScrollableTable
+            dependencies={allocations}
+            tableId="network-ipam-table"
+            belowIds={["status-bar"]}
+          >
+            <MainTable
+              className="network-ipam-table"
+              id="network-ipam-table"
+              headers={headers}
+              rows={rows}
+              responsive
+              sortable
+              emptyStateMsg="No data to display"
+            />
+          </ScrollableTable>
         )}
         {!isLoading && allocations.length === 0 && (
           <EmptyState

--- a/src/pages/networks/forms/NetworkFormMain.tsx
+++ b/src/pages/networks/forms/NetworkFormMain.tsx
@@ -127,6 +127,8 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
             <NetworkVlanField formik={formik} />
           </>
         )}
+        {typesWithAcls.includes(formik.values.networkType) &&
+          isManagedNetwork && <NetworkAcls project={project} formik={formik} />}
         {!hasParent && isManagedNetwork && (
           <>
             <IpAddress
@@ -196,8 +198,6 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
             />
           </>
         )}
-        {typesWithAcls.includes(formik.values.networkType) &&
-          isManagedNetwork && <NetworkAcls project={project} formik={formik} />}
         {!formik.values.isCreating &&
           typesWithStatistics.includes(formik.values.networkType) && (
             <NetworkStatistics formik={formik} project={project} />

--- a/src/sass/_network_ipam.scss
+++ b/src/sass/_network_ipam.scss
@@ -8,6 +8,6 @@
   }
 
   .hwaddr {
-    width: 12rem;
+    width: 10rem;
   }
 }


### PR DESCRIPTION
## Done

- feat(network) extend columns and optimize layout of ipam and network leases.
- reduce layout shift when editing network acls

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open network > ipam and ensure the page is 1. responsive 2. sorting correctly 3. linking correctly
    - open network > some bridge or ovn network > leases and ensure the page is 1. responsive 2. sorting correctly 3. linking correctly
    - open network > some bridge > edit the acl and ensure the content layout shift is minimal

## Screenshots

![image](https://github.com/user-attachments/assets/428e18b2-8f2f-4c9a-a611-c602f36f38b6)

![image](https://github.com/user-attachments/assets/2748e6c4-949c-4e21-8a09-abbba099a75d)

![image](https://github.com/user-attachments/assets/777e5e85-4af7-4491-909d-a7fe6359a866)
