### PR TITLE
feat(grafana) custom grafana url support

### DIFF
--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -14,6 +14,7 @@ import TabLinks from "components/TabLinks";
 import { useSettings } from "context/useSettings";
 import type { TabLink } from "@canonical/react-components/dist/components/Tabs/Tabs";
 import { useInstance } from "context/useInstances";
+import { buildGrafanaUrl } from "util/grafanaUrl";
 
 const tabs: string[] = [
   "Overview",
@@ -49,15 +50,15 @@ const InstanceDetail: FC = () => {
 
   const renderTabs: (string | TabLink)[] = [...tabs];
 
-  const grafanaBaseUrl = settings?.config?.["user.grafana_base_url"] ?? "";
-  if (grafanaBaseUrl) {
+  const grafanaUrl = buildGrafanaUrl(name, project, settings);
+  if (grafanaUrl) {
     renderTabs.push({
       label: (
         <div>
           <Icon name="external-link" /> Metrics
         </div>
       ) as unknown as string,
-      href: `${grafanaBaseUrl}&var-job=lxd&var-project=${project}&var-name=${instance?.name}&var-top=5`,
+      href: grafanaUrl,
       target: "_blank",
       rel: "noopener noreferrer",
     });

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -107,9 +107,10 @@ const Settings: FC = () => {
     key: "user.grafana_base_url",
     category: "user",
     default: "",
-    longdesc: "e.g. https://192.0.2.1:3000/d/bGY-LSB7k/lxd?orgId=1",
+    longdesc:
+      "e.g. https://example.org/dashboard?project={project}&name={instance}\n or https://192.0.2.1:3000/d/bGY-LSB7k/lxd?orgId=1",
     shortdesc:
-      " See {ref}`grafana` for more information. Pages link to metrics, when set.",
+      "LXD will replace `{instance}` and `{project}` with project and instance names for deep-linking to individual grafana pages.\nSee {ref}`grafana` for more information.",
     type: "string",
   });
 

--- a/src/util/grafanaUrl.tsx
+++ b/src/util/grafanaUrl.tsx
@@ -1,0 +1,20 @@
+import type { LxdSettings } from "types/server";
+
+export const buildGrafanaUrl = (
+  instance: string,
+  project: string,
+  settings?: LxdSettings,
+): string => {
+  const baseUrl = settings?.config?.["user.grafana_base_url"] ?? "";
+  if (!baseUrl) {
+    return "";
+  }
+
+  const templateUrl = baseUrl.includes("{instance}")
+    ? baseUrl
+    : `${baseUrl}&var-job=lxd&var-project={project}&var-name={instance}&var-top=5`;
+
+  return templateUrl
+    .replace("{instance}", encodeURIComponent(instance))
+    .replace("{project}", encodeURIComponent(project));
+};


### PR DESCRIPTION
## Done

- feat(grafana) custom grafana url support

Fixes #1278

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check settings > grafana_base_url

## Screenshots

<img width="1923" height="958" alt="image" src="https://github.com/user-attachments/assets/cd6d0e80-75e1-46c9-abdc-49e3ba9c430f" />

