### PR TITLE
fix(permission) proper truncation of identities, groups and idp groups on create, edit and delete, use icons with truncated entity names in confirmation modals consistently.

### DIFF
--- a/src/components/BulkDeleteButton.tsx
+++ b/src/components/BulkDeleteButton.tsx
@@ -54,9 +54,11 @@ const BulkDeleteButton: FC<Props> = ({
         </>
       )}
       <p className={breakdown.length > 0 ? "u-no-padding--top" : ""}>
-        This will permanently delete <b>{deleteCount}</b>{" "}
-        {pluralize(entityType, deleteCount)}.{"\n"}This action cannot be undone,
-        and can result in data loss.
+        This will permanently delete{" "}
+        <strong>
+          {deleteCount} {pluralize(entityType, deleteCount)}
+        </strong>
+        .{"\n"}This action cannot be undone, and can result in data loss.
       </p>
     </>
   );

--- a/src/components/IdentityResource.tsx
+++ b/src/components/IdentityResource.tsx
@@ -5,9 +5,10 @@ import ResourceLabel from "./ResourceLabel";
 interface Props {
   identity: LxdIdentity;
   truncate?: boolean;
+  bold?: boolean;
 }
 
-const IdentityResource: FC<Props> = ({ identity, truncate }) => {
+const IdentityResource: FC<Props> = ({ identity, truncate, bold }) => {
   const identityIconType =
     identity.authentication_method == "tls" ? "certificate" : "oidc-identity";
 
@@ -16,6 +17,7 @@ const IdentityResource: FC<Props> = ({ identity, truncate }) => {
       type={identityIconType}
       value={identity.type}
       truncate={truncate}
+      bold={bold}
     />
   );
 };

--- a/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import ItemName from "components/ItemName";
 import { deleteClusterGroup } from "api/cluster";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -10,7 +9,7 @@ import {
   useNotify,
   useToastNotification,
 } from "@canonical/react-components";
-import ResourceLink from "components/ResourceLink";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   group: string;
@@ -30,12 +29,7 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
         navigate(`/ui/cluster`);
         toastNotify.success(
           <>
-            Cluster group{" "}
-            <ResourceLink
-              type="cluster-group"
-              value={group}
-              to={`/ui/cluster`}
-            />{" "}
+            Cluster group <ResourceLabel type="cluster-group" value={group} />{" "}
             deleted.
           </>,
         );
@@ -69,7 +63,7 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
         confirmMessage: (
           <p>
             This will permanently delete cluster group{" "}
-            <ItemName item={{ name: group }} bold />. <br />
+            <ResourceLabel type="cluster-group" value={group} bold />. <br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import { useState } from "react";
-import ItemName from "components/ItemName";
 import { postClusterMemberState } from "api/cluster";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -13,6 +12,7 @@ import {
 } from "@canonical/react-components";
 import ResourceLink from "components/ResourceLink";
 import { useEventQueue } from "context/eventQueue";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   member: LxdClusterMember;
@@ -124,7 +124,12 @@ const EvacuateClusterMemberBtn: FC<Props> = ({ member }) => {
             />
             <p>
               This will evacuate cluster member{" "}
-              <ItemName item={{ name: member.server_name }} bold />.
+              <ResourceLabel
+                type="cluster-member"
+                value={member.server_name}
+                bold
+              />
+              .
             </p>
           </>
         ),

--- a/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
@@ -1,6 +1,5 @@
 import type { FC } from "react";
 import { useState } from "react";
-import ItemName from "components/ItemName";
 import { postClusterMemberState } from "api/cluster";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -13,6 +12,7 @@ import {
 } from "@canonical/react-components";
 import ResourceLink from "components/ResourceLink";
 import { useEventQueue } from "context/eventQueue";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   member: LxdClusterMember;
@@ -111,7 +111,12 @@ const RestoreClusterMemberBtn: FC<Props> = ({ member }) => {
             </p>
             <p>
               This will restore cluster member{" "}
-              <ItemName item={{ name: member.server_name }} bold />.
+              <ResourceLabel
+                type="cluster-member"
+                value={member.server_name}
+                bold
+              />
+              .
             </p>
           </>
         ),

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -71,7 +71,8 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete image <b>{description}</b>.<br />
+            This will permanently delete image{" "}
+            <ResourceLabel type="image" value={description} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -418,7 +418,7 @@ const InstanceList: FC = () => {
             content: <InstanceLink instance={instance} />,
             className: "u-truncate",
             title: `Instance ${instance.name}`,
-            role: "cell",
+            role: "rowheader",
             style: { width: `${COLUMN_WIDTHS[NAME]}px` },
             "aria-label": NAME,
             onClick: openSummary,

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -24,6 +24,7 @@ import InstanceAddSnapshotBtn from "./actions/snapshots/InstanceAddSnapshotBtn";
 import { isSnapshotsDisabled } from "util/snapshots";
 import useSortTableData from "util/useSortTableData";
 import NotificationRow from "components/NotificationRow";
+import ResourceLink from "components/ResourceLink";
 
 const collapsedViewMaxWidth = 1250;
 export const figureCollapsedScreen = (): boolean =>
@@ -299,7 +300,12 @@ const InstanceSnapshots = (props: Props) => {
             {project && snapshotsDisabled ? (
               <>
                 Snapshots are disabled for project{" "}
-                <ItemName item={project} bold />.
+                <ResourceLink
+                  type="project"
+                  value={project.name}
+                  to={`/ui/project/${project.name}/configuration`}
+                />
+                .
               </>
             ) : (
               "There are no snapshots of this instance."

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { deleteInstance } from "api/instances";
 import type { LxdInstance } from "types/instance";
 import { useNavigate } from "react-router-dom";
-import ItemName from "components/ItemName";
 import { deletableStatuses } from "util/instanceDelete";
 import {
   ConfirmationButton,
@@ -106,7 +105,8 @@ const DeleteInstanceBtn: FC<Props> = ({ instance, classname, onClose }) => {
         children: (
           <p>
             This will permanently delete instance{" "}
-            <ItemName item={instance} bold />.<br />
+            <ResourceLabel type={instance.type} value={instance.name} bold />.
+            <br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -10,10 +10,10 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
-import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { isInstanceRunning } from "util/instanceStatus";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   instance: LxdInstance;
@@ -83,7 +83,8 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
         title: "Confirm freeze",
         children: (
           <p>
-            This will freeze instance <ItemName item={instance} bold />.
+            This will freeze instance{" "}
+            {<ResourceLabel type={instance.type} value={instance.name} bold />}.
           </p>
         ),
         onConfirm: handleFreeze,

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -12,9 +12,9 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
-import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   instance: LxdInstance;
@@ -75,7 +75,8 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
         title: "Confirm restart",
         children: (
           <p>
-            This will restart instance <ItemName item={instance} bold />.
+            This will restart instance{" "}
+            <ResourceLabel type="instance" value={instance.name} bold />.
           </p>
         ),
         onConfirm: handleRestart,

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -12,9 +12,9 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
-import ItemName from "components/ItemName";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   instance: LxdInstance;
@@ -87,7 +87,8 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
         title: "Confirm stop",
         children: (
           <p>
-            This will stop instance <ItemName item={instance} bold />.
+            This will stop instance{" "}
+            <ResourceLabel type={instance.type} value={instance.name} bold />.
           </p>
         ),
         confirmExtra: (

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
@@ -9,7 +9,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { ConfirmationButton, Icon, List } from "@canonical/react-components";
 import classnames from "classnames";
-import ItemName from "components/ItemName";
 import ConfirmationForce from "components/ConfirmationForce";
 import { useEventQueue } from "context/eventQueue";
 import InstanceEditSnapshotBtn from "./InstanceEditSnapshotBtn";
@@ -137,7 +136,8 @@ const InstanceSnapshotActions: FC<Props> = ({
               title: "Confirm restore",
               children: (
                 <p>
-                  This will restore snapshot <ItemName item={snapshot} bold />.
+                  This will restore snapshot{" "}
+                  <ResourceLabel type="snapshot" value={snapshot.name} bold />.
                   <br />
                   This action cannot be undone, and can result in data loss.
                 </p>
@@ -185,7 +185,8 @@ const InstanceSnapshotActions: FC<Props> = ({
               children: (
                 <p>
                   This will permanently delete snapshot{" "}
-                  <ItemName item={snapshot} bold />.<br />
+                  <ResourceLabel type="snapshot" value={snapshot.name} bold />.
+                  <br />
                   This action cannot be undone, and can result in data loss.
                 </p>
               ),

--- a/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import ItemName from "components/ItemName";
 import type { LxdNetworkAcl } from "types/network";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -80,7 +79,8 @@ const DeleteNetworkAclBtn: FC<Props> = ({ networkAcl, project }) => {
         children: (
           <p>
             Are you sure you want to delete the ACL{" "}
-            <ItemName item={networkAcl} bold />?<br />
+            <ResourceLabel type="network-acl" value={networkAcl.name} bold />?
+            <br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/networks/actions/DeleteNetworkBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkBtn.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import ItemName from "components/ItemName";
 import type { LxdNetwork } from "types/network";
 import { deleteNetwork } from "api/networks";
 import { queryKeys } from "util/queryKeys";
@@ -84,7 +83,7 @@ const DeleteNetworkBtn: FC<Props> = ({ network, project }) => {
         children: (
           <p>
             Are you sure you want to delete the network{" "}
-            <ItemName item={network} bold />?<br />
+            <ResourceLabel type="network" value={network.name} bold />?<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
@@ -11,6 +11,7 @@ import {
 } from "@canonical/react-components";
 import { deleteNetworkForward } from "api/network-forwards";
 import { useNetworkEntitlements } from "util/entitlements/networks";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   network: LxdNetwork;
@@ -30,7 +31,15 @@ const DeleteNetworkForwardBtn: FC<Props> = ({ network, forward, project }) => {
     deleteNetworkForward(network, forward, project)
       .then(() => {
         toastNotify.success(
-          `Network forward with listen address ${forward.listen_address} deleted.`,
+          <>
+            Network forward with listen address{" "}
+            <ResourceLabel
+              type="network-forward"
+              value={forward.listen_address}
+              bold
+            />{" "}
+            deleted.
+          </>,
         );
         queryClient.invalidateQueries({
           predicate: (query) =>
@@ -61,7 +70,13 @@ const DeleteNetworkForwardBtn: FC<Props> = ({ network, forward, project }) => {
         children: (
           <p>
             Are you sure you want to delete the network forward with listen
-            address {forward.listen_address}?<br />
+            address{" "}
+            <ResourceLabel
+              type="network-forward"
+              value={forward.listen_address}
+              bold
+            />
+            ?<br />
           </p>
         ),
         onConfirm: handleDelete,

--- a/src/pages/operations/OperationInstanceName.tsx
+++ b/src/pages/operations/OperationInstanceName.tsx
@@ -1,8 +1,8 @@
 import type { FC } from "react";
-import ItemName from "components/ItemName";
 import type { LxdOperation } from "types/operation";
 import ResourceLink from "components/ResourceLink";
 import { getInstanceName, getProjectName } from "util/operations";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   operation: LxdOperation;
@@ -48,11 +48,7 @@ const OperationInstanceName: FC<Props> = ({ operation }) => {
 
   return (
     <div className="u-truncate u-text--muted">
-      <ItemName
-        item={{
-          name: instanceName,
-        }}
-      />
+      <ResourceLabel type="instance" value={instanceName} />
     </div>
   );
 };

--- a/src/pages/permissions/CreateIdentityModal.tsx
+++ b/src/pages/permissions/CreateIdentityModal.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { Button, Icon, Modal } from "@canonical/react-components";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   onClose: () => void;
@@ -30,7 +31,7 @@ const CreateIdentityModal: FC<Props> = ({ onClose, token, identityName }) => {
     <Modal
       close={onClose}
       className="create-tls-identity"
-      title={`Identity ${identityName} created`}
+      title="Identity created"
       buttonRow={
         <>
           {token && (
@@ -66,7 +67,7 @@ const CreateIdentityModal: FC<Props> = ({ onClose, token, identityName }) => {
         <>
           <p>
             The trust token below can be used to log in with the newly created
-            identity.{" "}
+            identity <ResourceLabel type="certificate" value={identityName} /> .{" "}
             <b>
               Once this modal is closed, the trust token can&rsquo;t be
               generated again.

--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -245,7 +245,9 @@ const PermissionGroups: FC = () => {
       <Button
         className="empty-state-button"
         appearance="positive"
-        onClick={panelParams.openCreateGroup}
+        onClick={() => {
+          panelParams.openCreateGroup();
+        }}
         disabled={!canCreateGroups()}
         title={
           canCreateGroups() ? "" : "You do not have permission to create groups"
@@ -305,7 +307,9 @@ const PermissionGroups: FC = () => {
                   <Button
                     appearance="positive"
                     className="u-no-margin--bottom u-float-right"
-                    onClick={panelParams.openCreateGroup}
+                    onClick={() => {
+                      panelParams.openCreateGroup();
+                    }}
                     disabled={!canCreateGroups()}
                     title={
                       canCreateGroups()

--- a/src/pages/permissions/actions/DeleteGroupModal.tsx
+++ b/src/pages/permissions/actions/DeleteGroupModal.tsx
@@ -117,10 +117,14 @@ const DeleteGroupModal: FC<Props> = ({ groups, close }) => {
     ) : null;
 
     const deleteText = hasOneGroup ? (
-      <b>{deletableGroups[0].name}</b>
+      <>
+        {" "}
+        the group{" "}
+        <ResourceLabel type="auth-group" value={deletableGroups[0].name} bold />
+      </>
     ) : (
       <>
-        <b>{deletableGroups.length}</b>{" "}
+        <strong>{deletableGroups.length}</strong>{" "}
         {pluralize("group", deletableGroups.length)}
       </>
     );

--- a/src/pages/permissions/actions/DeleteIdentityBtn.tsx
+++ b/src/pages/permissions/actions/DeleteIdentityBtn.tsx
@@ -9,13 +9,12 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import type { LxdIdentity } from "types/permissions";
-import ItemName from "components/ItemName";
 import { deleteIdentity } from "api/auth-identities";
-import IdentityResource from "components/IdentityResource";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import LoggedInUserNotification from "pages/permissions/panels/LoggedInUserNotification";
 import { useSettings } from "context/useSettings";
 import { logout } from "util/helpers";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   identity: LxdIdentity;
@@ -52,7 +51,14 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
         });
         toastNotify.success(
           <>
-            Identity <IdentityResource identity={identity} /> deleted.
+            Identity{" "}
+            <ResourceLabel
+              type="certificate"
+              value={identity.name}
+              bold
+              truncate
+            />{" "}
+            deleted.
           </>,
         );
         setDeleting(false);
@@ -63,7 +69,12 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
         notify.failure(
           `Identity deletion failed`,
           e,
-          <IdentityResource identity={identity} />,
+          <ResourceLabel
+            type="certificate"
+            value={identity.name}
+            bold
+            truncate
+          />,
         );
       });
   };
@@ -84,7 +95,9 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
           <>
             <LoggedInUserNotification isVisible={isSelf} />
             <p>
-              This will permanently delete <ItemName item={identity} bold />.
+              This will permanently delete identity{" "}
+              <ResourceLabel type="certificate" value={identity.name} bold />
+              .
               <br />
               This action cannot be undone, and can result in data loss.
             </p>

--- a/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
+++ b/src/pages/permissions/actions/DeleteIdpGroupBtn.tsx
@@ -3,6 +3,7 @@ import { ConfirmationButton, Icon } from "@canonical/react-components";
 import type { IdpGroup } from "types/permissions";
 import { useIdpGroupEntitlements } from "util/entitlements/idp-groups";
 import { useDeleteIdpGroups } from "util/permissionIdpGroups";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   idpGroup: IdpGroup;
@@ -35,9 +36,13 @@ const DeleteIdpGroupBtn: FC<Props> = ({ idpGroup }) => {
         className: "permission-confirm-modal",
         children: (
           <p>
-            Are you sure you want to delete{" "}
-            <strong>{deletableIdpGroups[0]?.name}</strong>? This action is
-            permanent and can not be undone.
+            Are you sure you want to delete the IDP group{" "}
+            <ResourceLabel
+              type="idp-group"
+              value={deletableIdpGroups[0]?.name}
+              bold
+            />
+            ?
           </p>
         ),
       }}

--- a/src/pages/permissions/panels/CreateGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateGroupPanel.tsx
@@ -35,9 +35,13 @@ const CreateGroupPanel: FC = () => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
-  const [subForm, setSubForm] = useState<GroupSubForm>(null);
   const [identities, setIdentities] = useState<FormIdentity[]>([]);
   const [permissions, setPermissions] = useState<FormPermission[]>([]);
+
+  const subForm = panelParams.subForm;
+  const setSubForm = (newSubForm: GroupSubForm) => {
+    panelParams.openCreateGroup(newSubForm);
+  };
 
   const closePanel = () => {
     panelParams.clear();

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -54,7 +54,6 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
-  const [subForm, setSubForm] = useState<GroupSubForm>(panelParams.subForm);
   const [confirming, setConfirming] = useState(false);
   const [identities, setIdentities] = useState<FormIdentity[]>(
     getIdentityIdsForGroup(group).map((id) => ({ id: id })) as FormIdentity[],
@@ -65,6 +64,11 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
   const { data: settings } = useSettings();
   const loggedInIdentityID = settings?.auth_user_name ?? "";
   const { canEditGroup } = useGroupEntitlements();
+
+  const subForm = panelParams.subForm;
+  const setSubForm = (newSubForm: GroupSubForm) => {
+    panelParams.openEditGroup(panelParams.group ?? "", newSubForm);
+  };
 
   // We initialize the identities state with id only,
   // to get the correct counts on initial render.
@@ -251,7 +255,10 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
         onClose={closePanel}
       >
         <SidePanel.Header>
-          <SidePanel.HeaderTitle key={subForm ?? "start"}>
+          <SidePanel.HeaderTitle
+            key={subForm ?? "start"}
+            className="u-truncate"
+          >
             <GroupHeaderTitle
               subForm={subForm}
               setSubForm={setSubForm}

--- a/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
+++ b/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
@@ -166,7 +166,9 @@ const EditIdentityGroupsPanel: FC<Props> = ({ identities, onClose }) => {
         onClose={closePanel}
       >
         <SidePanel.Header>
-          <SidePanel.HeaderTitle>{panelTitle}</SidePanel.HeaderTitle>
+          <SidePanel.HeaderTitle className="u-truncate">
+            {panelTitle}
+          </SidePanel.HeaderTitle>
         </SidePanel.Header>
         <NotificationRow className="u-no-padding" />
         <SidePanel.Content className="u-no-padding">

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -206,7 +206,7 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
       onClose={onClose}
     >
       <SidePanel.Header>
-        <SidePanel.HeaderTitle>{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
+        <SidePanel.HeaderTitle className="u-truncate">{`Edit IDP group ${idpGroup?.name}`}</SidePanel.HeaderTitle>
       </SidePanel.Header>
       <NotificationRow className="u-no-padding" />
       <NameWithGroupForm formik={formik} />

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { deleteProfile } from "api/profiles";
 import { useNavigate } from "react-router-dom";
 import type { LxdProfile } from "types/profile";
-import ItemName from "components/ItemName";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import {
   ConfirmationButton,
@@ -92,7 +91,7 @@ const DeleteProfileBtn: FC<Props> = ({
         children: (
           <p>
             This will permanently delete profile{" "}
-            <ItemName item={profile} bold />.<br />
+            <ResourceLabel type="profile" value={profile.name} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -5,7 +5,6 @@ import type { LxdProject } from "types/project";
 import { deleteProject } from "api/projects";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
-import ItemName from "components/ItemName";
 import { isProjectEmpty } from "util/projects";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import {
@@ -141,7 +140,7 @@ const DeleteProjectBtn: FC<Props> = ({ project }) => {
         children: (
           <p>
             This will permanently delete project{" "}
-            <ItemName item={project} bold />.<br />
+            <ResourceLabel type="project" value={project.name} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/storage/StorageVolumeSnapshots.tsx
+++ b/src/pages/storage/StorageVolumeSnapshots.tsx
@@ -27,6 +27,7 @@ import { queryKeys } from "util/queryKeys";
 import { isSnapshotsDisabled } from "util/snapshots";
 import { figureCollapsedScreen } from "util/storageVolume";
 import useSortTableData from "util/useSortTableData";
+import ResourceLink from "components/ResourceLink";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -297,7 +298,12 @@ const StorageVolumeSnapshots: FC<Props> = ({ volume }) => {
             {project && snapshotsDisabled ? (
               <>
                 Snapshots are disabled for project{" "}
-                <ItemName item={project} bold />.
+                <ResourceLink
+                  type="project"
+                  value={project.name}
+                  to={`/ui/project/${project.name}/configuration`}
+                />
+                .
               </>
             ) : (
               "There are no snapshots for this volume."

--- a/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
@@ -67,7 +67,8 @@ const DeleteStorageBucketBtn: FC<Props> = ({
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete bucket <b>{bucket.name}</b>.<br />
+            This will permanently delete bucket{" "}
+            <ResourceLabel type="bucket" value={bucket.name} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
@@ -72,7 +72,9 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete key <b>{bucketKey.name}</b>.<br />
+            This will permanently delete key{" "}
+            <ResourceLabel type="bucket-key" value={bucketKey.name} bold />.
+            <br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
+++ b/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
@@ -9,7 +9,6 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteStoragePool } from "api/storage-pools";
 import classnames from "classnames";
-import ItemName from "components/ItemName";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import { useNavigate } from "react-router-dom";
 import type { LxdStoragePool } from "types/storage";
@@ -75,7 +74,8 @@ const DeleteStoragePoolBtn: FC<Props> = ({
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete storage <ItemName item={pool} bold />.
+            This will permanently delete storage pool{" "}
+            <ResourceLabel type="pool" value={pool.name} bold />.
             <br />
             This action cannot be undone, and can result in data loss.
           </p>

--- a/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageVolumeBtn.tsx
@@ -11,6 +11,7 @@ import {
 import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 import { deleteStorageVolume } from "api/storage-volumes";
 import classNames from "classnames";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -99,7 +100,8 @@ const DeleteStorageVolumeBtn: FC<Props> = ({
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete volume <b>{volume.name}</b>.<br />
+            This will permanently delete volume{" "}
+            <ResourceLabel type="volume" value={volume.name} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotActions.tsx
@@ -15,7 +15,6 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import classnames from "classnames";
-import ItemName from "components/ItemName";
 import { useEventQueue } from "context/eventQueue";
 import VolumeEditSnapshotBtn from "./VolumeEditSnapshotBtn";
 import ResourceLabel from "components/ResourceLabel";
@@ -132,7 +131,8 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
               title: "Confirm restore",
               children: (
                 <p>
-                  This will restore snapshot <ItemName item={snapshot} bold />.
+                  This will restore snapshot{" "}
+                  <ResourceLabel type="snapshot" value={snapshot.name} bold />.
                   <br />
                   This action cannot be undone, and can result in data loss.
                 </p>
@@ -161,7 +161,8 @@ const VolumeSnapshotActions: FC<Props> = ({ volume, snapshot }) => {
               children: (
                 <p>
                   This will permanently delete snapshot{" "}
-                  <ItemName item={snapshot} bold />.<br />
+                  <ResourceLabel type="snapshot" value={snapshot.name} bold />.
+                  <br />
                   This action cannot be undone, and can result in data loss.
                 </p>
               ),

--- a/src/pages/warnings/actions/BulkDeleteWarningBtn.tsx
+++ b/src/pages/warnings/actions/BulkDeleteWarningBtn.tsx
@@ -62,7 +62,10 @@ const BulkDeleteWarningBtn: FC<Props> = ({ warningIds, onStart, onFinish }) => {
         title: "Confirm delete",
         children: (
           <p>
-            This will permanently delete the warning.
+            This will permanently delete{" "}
+            <strong>
+              {warningIds.length} {pluralize("warning", warningIds.length)}
+            </strong>
             <br />
             This action cannot be undone, and can result in data loss.
           </p>

--- a/src/sass/_resources.scss
+++ b/src/sass/_resources.scss
@@ -27,6 +27,11 @@
 }
 
 .resource-label {
+  // truncate resource label text
+  display: inline-block;
+  max-width: 50%;
+  vertical-align: bottom;
+
   i {
     background-size: contain !important;
     margin-right: $sph--x-small;

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -19,7 +19,7 @@ export interface PanelHelper {
   openInstanceSummary: (instance: string, project: string) => void;
   openProfileSummary: (profile: string, project: string) => void;
   openIdentityGroups: (identity?: string) => void;
-  openCreateGroup: () => void;
+  openCreateGroup: (subForm?: GroupSubForm) => void;
   openEditGroup: (group: string, subForm?: GroupSubForm) => void;
   openGroupIdentities: (group?: string) => void;
   openCreateIdpGroup: () => void;
@@ -127,8 +127,12 @@ const usePanelParams = (): PanelHelper => {
       setPanelParams(panels.identityGroups, Object.fromEntries(newParams));
     },
 
-    openCreateGroup: () => {
-      setPanelParams(panels.createGroup);
+    openCreateGroup: (subForm) => {
+      const params: ParamMap = {};
+      if (subForm) {
+        params["sub-form"] = subForm;
+      }
+      setPanelParams(panels.createGroup, params);
     },
 
     openEditGroup: (group, subForm) => {


### PR DESCRIPTION
## Done

- fix(permission) proper truncation of identities, groups and idp groups on create, edit and delete
- raise group edit sub form state to url
- use resource label in all confirmation modals to ensure truncation of long entity names. And ensure an icon is displayed.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > identities, create, edit and delete an identity with a very long name (>50 characters). Ensure messaging is correctly truncating the values displayed
    - repeat with permissions > groups
    - repeat with permissions > idp groups
    - check edit permissions > groups and go to sub form, also open the form from the blue links in the groups list to directly edit identities or permissions. Ensure it works well and the state of the sub form is available in the url. Ensure on reload the right form and sub form opens.