### PR TITLE
feat(tests): [WD-22649] Screenshot automation tests

### DIFF
--- a/tests/docs-screenshots-clustered.spec.ts
+++ b/tests/docs-screenshots-clustered.spec.ts
@@ -1,4 +1,5 @@
 import { test } from "./fixtures/lxd-test";
+import { getClipPosition } from "./helpers/doc-screenshots";
 import { gotoURL } from "./helpers/navigate";
 import { createPool, deletePool } from "./helpers/storagePool";
 
@@ -9,20 +10,9 @@ test.beforeEach(() => {
   );
 });
 
-// x,y is top left coordinate, xx,yy is bottom right coordinate
-// gimp provides the coordinates of the area easily
-const getClipPosition = (x: number, y: number, xx: number, yy: number) => {
-  return {
-    x: x,
-    y: y,
-    width: xx - x,
-    height: yy - y,
-  };
-};
-
 //Run in a clustered backend
 
-test("clustered storage pools", async ({ page }) => {
+test("Clustered storage pools", async ({ page }) => {
   //Clustered storage pool creation
   const poolName = "clustered-pool";
   page.setViewportSize({ width: 1440, height: 1000 });
@@ -63,4 +53,26 @@ test("Clustered storage volumes", async ({ page }) => {
     clip: getClipPosition(240, 0, 1420, 750),
   });
   await deletePool(page, poolName);
+});
+
+test("LXD - UI Folder - Clustered", async ({ page }) => {
+  //This test assumes that there is a cluster member named micro2 within the environment. This is the value within the original screenshot, but it can also be changed to accomodate alternative names.
+  const clusterMemberName = "micro2";
+  page.setViewportSize({ width: 1440, height: 800 });
+  await gotoURL(page, "/ui/");
+  await page.getByRole("link", { name: "Instances", exact: true }).click();
+  await page.getByText("Create instance").click();
+  await page.getByPlaceholder("Enter name").fill("Ubuntu-vm-server2");
+  await page.getByRole("button", { name: "Browse images" }).click();
+  await page
+    .locator("tr")
+    .filter({ hasText: "Ubuntu24.04 LTSnoblealldefaultUbuntuSelect" })
+    .getByRole("button")
+    .click();
+  await page.getByLabel("Cluster member").selectOption(clusterMemberName);
+  await page.getByLabel("Cluster member").dblclick();
+  await page.screenshot({
+    path: "tests/screenshots/doc/images/ui/create_instance_ex4.png",
+    clip: getClipPosition(240, 0, 1440, 760),
+  });
 });

--- a/tests/helpers/doc-screenshots.ts
+++ b/tests/helpers/doc-screenshots.ts
@@ -1,0 +1,15 @@
+// x,y is top left coordinate, xx,yy is bottom right coordinate
+// gimp provides the coordinates of the area easily
+export const getClipPosition = (
+  x: number,
+  y: number,
+  xx: number,
+  yy: number,
+) => {
+  return {
+    x: x,
+    y: y,
+    width: xx - x,
+    height: yy - y,
+  };
+};

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -79,6 +79,19 @@ export const saveInstance = async (
   await page.getByRole("button", { name: "Close notification" }).click();
 };
 
+export const forceStopInstance = async (
+  page: Page,
+  instance: string,
+  project = "default",
+) => {
+  await visitInstance(page, instance, project);
+  await page.getByRole("button", { name: "Stop" }).click();
+  await page.getByText("Force stop").click();
+  await page.getByText("Stop", { exact: true }).click();
+  await page.waitForSelector(`text=Instance ${instance} stopped.`);
+  await page.getByTestId("notification-close-button").click();
+};
+
 export const deleteInstance = async (
   page: Page,
   instance: string,

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -25,6 +25,9 @@ export const createNetwork = async (
   if (["physical", "sriov", "macvlan"].includes(type)) {
     await page.getByLabel("Parent").selectOption({ index: 1 });
   }
+  if (type === "ovn") {
+    await page.getByLabel("Uplink").selectOption({ index: 1 });
+  }
   await page.getByRole("button", { name: "Create", exact: true }).click();
   const networkLink = await getNetworkLink(page, network);
   await expect(networkLink).toBeVisible();
@@ -140,6 +143,6 @@ export const getNetworkLink = async (page: Page, network: string) => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Networking" }).click();
   await page.getByRole("link", { name: "Networks", exact: true }).click();
-  const networkLink = page.getByRole("link", { name: network });
+  const networkLink = page.getByRole("link", { name: network, exact: true });
   return networkLink;
 };


### PR DESCRIPTION
## Done

- Captures screenshots for the LXD docs (UI sections)
  - Instances (6) :heavy_check_mark: 
  - Networks (9) :heavy_check_mark: 
  - Storage (18)
    - Pools (4) :heavy_check_mark: 
    - Volumes (8) :heavy_check_mark: 
    - Volume snapshots (6) :heavy_check_mark: 
  - Tutorial (13) :heavy_check_mark: 
  - UI (20) :heavy_check_mark: 

Fixes lack of screenshot automation in the UI.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Locally run tests in docs-screenshots.spec.ts and observe the generated screenshots in screenshots/doc/images/...

## Screenshots

Locally run tests in docs-screenshots.spec.ts and observe the generated screenshots in screenshots/doc/images/...