### PR TITLE
fix(panels) ensure side panels for instances and profiles are sticky when scrolling

### DIFF
--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -27,47 +27,45 @@ const InstanceDetailPanel: FC = () => {
     <SidePanel
       loading={isLoading}
       hasError={!instance}
-      className="u-hide--medium u-hide--small"
+      className="u-hide--medium u-hide--small detail-panel instance-detail-panel"
       width="narrow"
       pinned
     >
-      <SidePanel.Container className="detail-panel instance-detail-panel">
-        <SidePanel.Sticky>
-          <SidePanel.Header>
-            <SidePanel.HeaderTitle>Instance summary</SidePanel.HeaderTitle>
-            <SidePanel.HeaderControls>
-              <Button
-                appearance="base"
-                className="u-no-margin--bottom"
-                hasIcon
-                onClick={panelParams.clear}
-                aria-label="Close"
-              >
-                <Icon name="close" />
-              </Button>
-            </SidePanel.HeaderControls>
-          </SidePanel.Header>
-          {instance && (
-            <div className="actions">
-              <List
-                inline
-                className="primary actions-list"
-                items={[
-                  <OpenTerminalBtn key="terminal" instance={instance} />,
-                  <OpenConsoleBtn key="console" instance={instance} />,
-                ]}
-              />
-              <div className="state">
-                <InstanceStateActions instance={instance} />
-              </div>
+      <SidePanel.Sticky>
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Instance summary</SidePanel.HeaderTitle>
+          <SidePanel.HeaderControls>
+            <Button
+              appearance="base"
+              className="u-no-margin--bottom"
+              hasIcon
+              onClick={panelParams.clear}
+              aria-label="Close"
+            >
+              <Icon name="close" />
+            </Button>
+          </SidePanel.HeaderControls>
+        </SidePanel.Header>
+        {instance && (
+          <div className="actions">
+            <List
+              inline
+              className="primary actions-list"
+              items={[
+                <OpenTerminalBtn key="terminal" instance={instance} />,
+                <OpenConsoleBtn key="console" instance={instance} />,
+              ]}
+            />
+            <div className="state">
+              <InstanceStateActions instance={instance} />
             </div>
-          )}
-        </SidePanel.Sticky>
+          </div>
+        )}
+      </SidePanel.Sticky>
 
-        <SidePanel.Content>
-          {instance && <InstanceDetailPanelContent instance={instance} />}
-        </SidePanel.Content>
-      </SidePanel.Container>
+      <SidePanel.Content>
+        {instance && <InstanceDetailPanelContent instance={instance} />}
+      </SidePanel.Content>
     </SidePanel>
   );
 };

--- a/src/pages/profiles/ProfileDetailPanel.tsx
+++ b/src/pages/profiles/ProfileDetailPanel.tsx
@@ -31,33 +31,31 @@ const ProfileDetailPanel: FC = () => {
     <SidePanel
       loading={isLoading}
       hasError={!profile || !project}
-      className="u-hide--medium u-hide--small"
+      className="u-hide--medium u-hide--small detail-panel profile-detail-panel"
       width="narrow"
       pinned
     >
-      <SidePanel.Container className="detail-panel profile-detail-panel">
-        <SidePanel.Sticky>
-          <SidePanel.Header>
-            <SidePanel.HeaderTitle>Profile summary</SidePanel.HeaderTitle>
-            <SidePanel.HeaderControls>
-              <Button
-                appearance="base"
-                className="u-no-margin--bottom"
-                hasIcon
-                onClick={panelParams.clear}
-                aria-label="Close"
-              >
-                <Icon name="close" />
-              </Button>
-            </SidePanel.HeaderControls>
-          </SidePanel.Header>
-        </SidePanel.Sticky>
-        <SidePanel.Content>
-          {!!(profile && project) && (
-            <ProfileDetailPanelContent profile={profile} project={project} />
-          )}
-        </SidePanel.Content>
-      </SidePanel.Container>
+      <SidePanel.Sticky>
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Profile summary</SidePanel.HeaderTitle>
+          <SidePanel.HeaderControls>
+            <Button
+              appearance="base"
+              className="u-no-margin--bottom"
+              hasIcon
+              onClick={panelParams.clear}
+              aria-label="Close"
+            >
+              <Icon name="close" />
+            </Button>
+          </SidePanel.HeaderControls>
+        </SidePanel.Header>
+      </SidePanel.Sticky>
+      <SidePanel.Content>
+        {!!(profile && project) && (
+          <ProfileDetailPanelContent profile={profile} project={project} />
+        )}
+      </SidePanel.Content>
     </SidePanel>
   );
 };


### PR DESCRIPTION
## Done

- fix(panels) ensure side panels for instances and profiles are sticky when scrolling

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance list and click on any row of instances
    - see detail panel next to the list
    - shrink browser window height, ensure the top part of the detail panel stays sticky
    - repeat with profile detail panel on profile list

## Screenshots

<img width="1289" height="614" alt="image" src="https://github.com/user-attachments/assets/a9e72875-dab8-4e67-ac1e-4adb8939901f" />
