### PR TITLE
feat(groups) sort identities that are selected to the top when editing an auth group

### DIFF
--- a/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
@@ -28,7 +28,10 @@ import useSortTableData from "util/useSortTableData";
 import { isUnrestricted } from "util/helpers";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
-import { getIdentityName } from "util/permissionIdentities";
+import {
+  getIdentityIdsForGroup,
+  getIdentityName,
+} from "util/permissionIdentities";
 
 interface IdentityEditHistory {
   identitiesAdded: Set<string>;
@@ -97,6 +100,14 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
         !selectedIdentities.has(id) && !desiredState.identitiesRemoved.has(id),
     ),
   );
+
+  const preselectedIdentities = new Set();
+  groups.forEach((group) => {
+    getIdentityIdsForGroup(group).forEach((id) =>
+      preselectedIdentities.add(id),
+    );
+  });
+  const hasPreselectedIdentities = preselectedIdentities.size > 0;
 
   const calculatedModifiedIdentities = () => {
     const modifiedIdentities = new Set<string>();
@@ -245,13 +256,15 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
       ],
       sortData: {
         name: name.toLowerCase(),
+        isPreselected: preselectedIdentities.has(identity.id),
       },
     };
   });
 
   const { rows: sortedRows } = useSortTableData({
     rows,
-    defaultSort: "name",
+    defaultSort: hasPreselectedIdentities ? "isPreselected" : "name",
+    defaultSortDirection: hasPreselectedIdentities ? "descending" : "ascending",
   });
 
   const content = (

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -293,6 +293,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
               selected={identities}
               setSelected={setIdentities}
               groupName={group.name}
+              group={group}
             />
           )}
           {subForm === "permission" && (

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -5,11 +5,10 @@ export type ChangeSummary = Record<
   { added: Set<string>; removed: Set<string>; name: string }
 >;
 
-export const getIdentityIdsForGroup = (group: LxdGroup): string[] => {
+export const getIdentityIdsForGroup = (group?: LxdGroup): string[] => {
   const oidcIdentityIds = group?.identities?.oidc || [];
   const tlsIdentityIds = group?.identities?.tls || [];
-  const allIdentityIds = oidcIdentityIds.concat(tlsIdentityIds);
-  return allIdentityIds;
+  return [...oidcIdentityIds, ...tlsIdentityIds];
 };
 
 // Given a set of lxd groups and some identities


### PR DESCRIPTION
## Done

- feat(groups) sort identities that are selected to the top when editing an auth group

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > groups and edit a group
    - also bulk edit a group
    - ensure in both cases, that when going to identities of the group, that the selected identities are on the top
    - especially ensure the identities are not moving around in the lists.

## Screenshots

<img width="1917" height="960" alt="image" src="https://github.com/user-attachments/assets/35500be2-51c0-4db5-bc23-4acc22d462df" />
