### PR TITLE
fix(instance) avoid many queries when showing instance log files

### DIFF
--- a/src/pages/instances/FileRow.tsx
+++ b/src/pages/instances/FileRow.tsx
@@ -23,13 +23,7 @@ const FileRow: FC<FileRowProps> = ({ instance, path }) => {
     isLoading,
     isSuccess,
   } = useQuery({
-    queryKey: [
-      queryKeys.instances,
-      instance.name,
-      instance.project,
-      queryKeys.logs,
-      fileName,
-    ],
+    queryKey: [queryKeys.logs, instance.name, instance.project, fileName],
     queryFn: async () =>
       fetchInstanceLogFile(instance.name, instance.project, fileName),
     enabled: isOpen,

--- a/src/pages/instances/InstanceLogs.tsx
+++ b/src/pages/instances/InstanceLogs.tsx
@@ -12,12 +12,7 @@ interface Props {
 
 const InstanceLogs: FC<Props> = ({ instance }) => {
   const { data: logs = [], isLoading } = useQuery({
-    queryKey: [
-      queryKeys.instances,
-      instance.name,
-      instance.project,
-      queryKeys.logs,
-    ],
+    queryKey: [queryKeys.logs, instance.name, instance.project],
     queryFn: async () => fetchInstanceLogs(instance.name, instance.project),
   });
 


### PR DESCRIPTION
## Done

- fix(instance) avoid many queries when showing instance log files

Fixes https://github.com/canonical/lxd-ui/issues/1403

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance detail page > logs
    - monitor the network tab
    - expand log file
    - collapse log file content
    - expand again
    - ensure there is just one query to fetch the log content. before this would trigger a loop to fetch the log contents over and over again.