### PR TITLE
fix(instance) use su -l as default command for launching instance terminal

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -333,7 +333,7 @@ export const connectInstanceExec = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        command: [payload.command],
+        command: payload.command.split(" "),
         "wait-for-websocket": true,
         environment: payload.environment.reduce(
           (a, v) => ({ ...a, [v.key]: v.value }),

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -30,27 +30,33 @@ const XTERM_OPTIONS = {
   },
 };
 
-const getDefaultPayload = (instance: LxdInstance): TerminalConnectPayload => {
-  const imageDescription = instance.config["image.description"];
-  const isAlpine = imageDescription?.toLowerCase().includes("alpine");
-  const isNixOs = imageDescription?.toLowerCase().includes("nixos");
-  const command = isAlpine || isNixOs ? "sh" : "bash";
-
-  return {
-    command: command,
-    environment: [
-      {
-        key: "TERM",
-        value: "xterm-256color",
-      },
-      {
-        key: "HOME",
-        value: "/root",
-      },
-    ],
-    user: 0,
-    group: 0,
-  };
+const defaultPayload: TerminalConnectPayload = {
+  command: "su -l",
+  environment: [
+    {
+      key: "TERM",
+      value: "xterm-256color",
+    },
+    {
+      key: "HOME",
+      value: "/root",
+    },
+    {
+      key: "PATH",
+      value:
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin",
+    },
+    {
+      key: "LANG",
+      value: "C.UTF-8",
+    },
+    {
+      key: "USER",
+      value: "root",
+    },
+  ],
+  user: 0,
+  group: 0,
 };
 
 interface Props {
@@ -68,7 +74,6 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
   const [isLoading, setLoading] = useState(false);
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
-  const defaultPayload = getDefaultPayload(instance);
   const [payload, setPayload] = useState(defaultPayload);
   const [fitAddon] = useState<FitAddon>(new FitAddon());
   const [userInteracted, setUserInteracted] = useState(false);


### PR DESCRIPTION
## Done

- use su -l as default command for launching instance terminal
- This is similar to what lxc shell is doing and happily distro agnostic

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start a ubuntu and alpine container
    - open a terminal in the ui and ensure the terminal is usable.