### PR TITLE
feat(tests): Add e2e view-only permissions tests [WD-22228]

### DIFF
--- a/src/pages/cluster/actions/EnableClusteringBtn.tsx
+++ b/src/pages/cluster/actions/EnableClusteringBtn.tsx
@@ -1,15 +1,27 @@
 import type { FC } from "react";
 import { Button, Icon, usePortal } from "@canonical/react-components";
 import EnableClusteringModal from "pages/cluster/EnableClusteringModal";
+import { useServerEntitlements } from "util/entitlements/server";
 
 const EnableClusteringBtn: FC = () => {
+  const { canEditServerConfiguration } = useServerEntitlements();
   const { openPortal, closePortal, isOpen, Portal } = usePortal({
     programmaticallyOpen: true,
   });
 
+  const editRestriction = canEditServerConfiguration()
+    ? "Enable clustering"
+    : "You do not have permission to edit the server";
+
   return (
     <>
-      <Button appearance="positive" hasIcon onClick={openPortal}>
+      <Button
+        appearance="positive"
+        hasIcon
+        onClick={openPortal}
+        disabled={!!editRestriction}
+        title={editRestriction}
+      >
         <Icon name="plus" light />
         <span>Enable clustering</span>
       </Button>

--- a/src/pages/networks/forms/NetworkAclForm.tsx
+++ b/src/pages/networks/forms/NetworkAclForm.tsx
@@ -184,6 +184,7 @@ const NetworkAclForm: FC<Props> = ({ formik, getYaml, section }) => {
                     onEdit={(index) => {
                       openEditRuleModal("ingress", index);
                     }}
+                    editRestriction={formik.values.editRestriction}
                   />
                 </>
               )}
@@ -213,6 +214,7 @@ const NetworkAclForm: FC<Props> = ({ formik, getYaml, section }) => {
                     onEdit={(index) => {
                       openEditRuleModal("egress", index);
                     }}
+                    editRestriction={formik.values.editRestriction}
                   />
                 </>
               )}

--- a/src/pages/networks/forms/NetworkAclRuleTable.tsx
+++ b/src/pages/networks/forms/NetworkAclRuleTable.tsx
@@ -80,7 +80,10 @@ const NetworkAclRuleTable: FC<Props> = ({
                     hasIcon
                     appearance="base"
                     disabled={!!editRestriction}
-                    title={editRestriction ?? "Edit rule"}
+                    title={
+                      "Edit rule" +
+                      (editRestriction ? ` - ${editRestriction}` : "")
+                    }
                   >
                     <Icon name="edit" />
                   </Button>
@@ -93,7 +96,10 @@ const NetworkAclRuleTable: FC<Props> = ({
                     hasIcon
                     appearance="base"
                     disabled={!!editRestriction}
-                    title={editRestriction ?? "Remove rule"}
+                    title={
+                      "Remove rule" +
+                      (editRestriction ? ` - ${editRestriction}` : "")
+                    }
                   >
                     <Icon name="delete" />
                   </Button>

--- a/src/pages/permissions/actions/GroupActions.tsx
+++ b/src/pages/permissions/actions/GroupActions.tsx
@@ -12,7 +12,7 @@ interface Props {
 const GroupActions: FC<Props> = ({ group }) => {
   const panelParams = usePanelParams();
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
-  const { canDeleteGroup } = useGroupEntitlements();
+  const { canDeleteGroup, canEditGroup } = useGroupEntitlements();
 
   return (
     <>
@@ -29,7 +29,12 @@ const GroupActions: FC<Props> = ({ group }) => {
               panelParams.openEditGroup(group.name);
             }}
             type="button"
-            title="Edit group"
+            title={
+              canEditGroup(group)
+                ? "Edit group"
+                : "Edit group - You do not have permission to edit this group"
+            }
+            disabled={!canEditGroup(group)}
           >
             <Icon name="edit" />
           </Button>,
@@ -43,7 +48,7 @@ const GroupActions: FC<Props> = ({ group }) => {
             title={
               canDeleteGroup(group)
                 ? "Delete group"
-                : "You do not have permission to delete this group"
+                : "Delete group - You do not have permission to delete this group"
             }
             disabled={!canDeleteGroup(group)}
           >

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -1,10 +1,15 @@
 import type { Page } from "@playwright/test";
 import { expect } from "../fixtures/lxd-test";
 import { gotoURL } from "./navigate";
+import { randomNameSuffix } from "./name";
 
 // These identities are created by the setup_test script in tests/scripts
 export const identityBar = "bar@bar.com";
 export const identityFoo = "foo@foo.com";
+
+export const randomIdentityName = (): string => {
+  return `playwright-identity-${randomNameSuffix()}`;
+};
 
 export const visitIdentities = async (page: Page) => {
   await gotoURL(page, "/ui/");

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -7,6 +7,10 @@ export const randomVolumeName = (): string => {
   return `playwright-volume-${randomNameSuffix()}`;
 };
 
+export const randomIsoName = (): string => {
+  return `playwright-iso-${randomNameSuffix()}`;
+};
+
 export const createVolume = async (
   page: Page,
   volume: string,

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -1,22 +1,17 @@
 import { test, expect } from "./fixtures/lxd-test";
-import { randomNameSuffix } from "./helpers/name";
 import { deleteInstance, randomInstanceName } from "./helpers/instances";
 import { assertTextVisible } from "./helpers/permissions";
 import { activateOverride } from "./helpers/configuration";
 import { gotoURL } from "./helpers/navigate";
+import { randomIsoName } from "./helpers/storageVolume";
 
 const ISO_FILE = "./tests/fixtures/foo.iso";
-
-export const randomIso = (): string => {
-  return `playwright-iso-${randomNameSuffix()}`;
-};
-
 test("upload and delete custom iso", async ({ page, lxdVersion }) => {
   test.skip(
     lxdVersion === "5.0-edge",
     "custom storage volume iso import not supported in lxd v5.0/edge",
   );
-  const isoName = randomIso();
+  const isoName = randomIsoName();
 
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage", exact: true }).click();
@@ -57,7 +52,7 @@ test("use custom iso for instance launch", async ({ page, lxdVersion }) => {
   );
 
   const instance = randomInstanceName();
-  const isoName = randomIso();
+  const isoName = randomIsoName();
 
   await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Instances", exact: true }).click();

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -1,0 +1,477 @@
+import { test, expect } from "./fixtures/lxd-test";
+import { randomInstanceName, visitInstance } from "./helpers/instances";
+import { gotoURL } from "./helpers/navigate";
+import { execSync } from "child_process";
+import { randomProfileName, visitProfile } from "./helpers/profile";
+import { randomNetworkName, visitNetwork } from "./helpers/network";
+import { randomPoolName, visitPool } from "./helpers/storagePool";
+import {
+  randomIsoName,
+  randomVolumeName,
+  visitVolume,
+} from "./helpers/storageVolume";
+import { randomNetworkAclName, visitNetworkAcl } from "./helpers/network-acls";
+import { randomGroupName } from "./helpers/permission-groups";
+import { randomIdentityName } from "./helpers/permission-identities";
+import { openInstancePanel } from "./helpers/instancePanel";
+
+test.beforeEach(() => {
+  test.skip(
+    Boolean(process.env.CI),
+    "This suite is currently only run manually to test View-Only user permissions.",
+  );
+});
+
+test.describe("Given a user with Viewer Server permissions...", () => {
+  const ISO_FILE = "./tests/fixtures/foo.iso";
+
+  const instanceName = randomInstanceName();
+  const profileName = randomProfileName();
+  const networkName = randomNetworkName();
+  const poolName = randomPoolName();
+  const volumeName = randomVolumeName();
+  const customISOName = randomIsoName();
+  const aclName = randomNetworkAclName();
+  const identityName = randomIdentityName();
+  const groupName = randomGroupName();
+  const idpGroupName = "idp-" + randomGroupName();
+
+  test.beforeAll(() => {
+    try {
+      console.log(
+        "[Switch Project]",
+        execSync(`lxc project switch default`).toString(),
+      );
+      console.log(
+        "[Instance Created]",
+        execSync(`lxc init ubuntu:24.04 ${instanceName}`).toString(),
+      );
+      console.log(
+        "[Profile Created]",
+        execSync(`lxc profile create ${profileName}`).toString(),
+      );
+      console.log(
+        "[Network Created]",
+        execSync(`lxc network create ${networkName}`).toString(),
+      );
+      console.log(
+        "[Storage Pool Created]",
+        execSync(`lxc storage create ${poolName} dir`).toString(),
+      );
+      console.log(
+        "[Custom Volume Created]",
+        execSync(
+          `lxc storage volume create ${poolName} ${volumeName}`,
+        ).toString(),
+      );
+      console.log(
+        "[Custom ISO Imported]",
+        execSync(
+          `lxc storage volume import ${poolName} ${ISO_FILE} ${customISOName}`,
+        ).toString(),
+      );
+      console.log(
+        "[ACL Created]",
+        execSync(`lxc network acl create ${aclName}`).toString(),
+      );
+      console.log(
+        "[Add Network ACL Rule]",
+        execSync(
+          `lxc network acl rule add ${aclName} ingress action=allow`,
+        ).toString(),
+      );
+      console.log(
+        "[Identity Trusted]",
+        execSync(`lxc auth identity create tls/${identityName}`).toString(),
+      );
+      console.log(
+        "[Group Created]",
+        execSync(`lxc auth group create ${groupName}`).toString(),
+      );
+      console.log(
+        "[IDP Group Created]",
+        execSync(
+          `lxc auth identity-provider-group create ${idpGroupName}`,
+        ).toString(),
+      );
+    } catch (err) {
+      console.error("Error occurred:", err);
+    }
+  });
+
+  test.afterAll(() => {
+    try {
+      console.log(
+        "[Instance Deleted]",
+        execSync(`lxc delete ${instanceName} --force`).toString(),
+      );
+      console.log(
+        "[Profile Deleted]",
+        execSync(`lxc profile delete ${profileName}`).toString(),
+      );
+      console.log(
+        "[Network Deleted]",
+        execSync(`lxc network delete ${networkName}`).toString(),
+      );
+      console.log(
+        "[Storage Volume Deleted]",
+        execSync(
+          `lxc storage volume delete ${poolName} ${volumeName}`,
+        ).toString(),
+      );
+      console.log(
+        "[Custom ISO Volume Deleted]",
+        execSync(
+          `lxc storage volume delete ${poolName} ${customISOName}`,
+        ).toString(),
+      );
+      console.log(
+        "[Storage Pool Deleted]",
+        execSync(`lxc storage delete ${poolName}`).toString(),
+      );
+      console.log(
+        "[ACL Deleted]",
+        execSync(`lxc network acl delete ${aclName}`).toString(),
+      );
+      console.log(
+        "[Identity Untrusted]",
+        execSync(`lxc auth identity delete tls/${identityName}`).toString(),
+      );
+      console.log(
+        "[Group Deleted]",
+        execSync(`lxc auth group delete ${groupName}`).toString(),
+      );
+      console.log(
+        "[IDP Group Deleted]",
+        execSync(
+          `lxc auth identity-provider-group delete ${idpGroupName}`,
+        ).toString(),
+      );
+    } catch (err) {
+      console.error("Cleanup error:", err);
+    }
+  });
+
+  test("Cannot interact with instances", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByRole("link", { name: "Instances", exact: true }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Create instance" }),
+    ).toBeDisabled();
+    const title = await page
+      .getByRole("button", { name: "Create instance" })
+      .getAttribute("title");
+    expect(title).toContain("You do not have permission to create instances");
+
+    // Bulk actions on instance list page
+    await page
+      .locator("#instances-table span")
+      .filter({ hasText: "Select all" })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Start", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Restart", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Freeze", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Stop", exact: true }),
+    ).toBeDisabled();
+    await page
+      .locator("#instances-table span")
+      .filter({ hasText: "Select all" })
+      .click();
+
+    // Cannot start, restart, pause or stop instances from the instance list page on hover.
+    await page.getByPlaceholder("Search").click();
+    await page.getByPlaceholder("Search").fill(instanceName);
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Escape");
+    await page
+      .locator("#instances-table")
+      .getByRole("rowheader", { name: `Select ${instanceName} default` })
+      .hover();
+    await expect(
+      page.getByRole("button", { name: "Start", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to restart this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to freeze this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to stop this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+
+    // Cannot start, restart, pause or stop instances from the instance detail panel.
+    await openInstancePanel(page, instanceName);
+    await expect(
+      page.getByRole("button", { name: "Start", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to restart this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to freeze this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to stop this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+
+    // Cannot start, restart, pause or stop instances from the detail page.
+    await visitInstance(page, instanceName);
+    await expect(
+      page.getByRole("button", { name: "Start", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to restart this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to freeze this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to stop this instance",
+        exact: true,
+      }),
+    ).toBeDisabled();
+
+    // Cannot Migrate, Create Images from Instances, Copy, Export or stop Delete instances from the detail page.
+    await expect(
+      page.getByRole("button", { name: "Migrate", exact: true }),
+    ).toBeDisabled();
+    await expect(page.getByLabel("Create Image")).toBeDisabled();
+    await expect(page.getByLabel("Copy")).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Export", exact: true }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Delete", exact: true }),
+    ).toBeDisabled();
+  });
+
+  test("Cannot interact with Profiles", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Profiles", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create profile" }),
+    ).toBeDisabled();
+
+    await visitProfile(page, profileName);
+    await expect(page.getByRole("button", { name: "Delete" })).toBeDisabled();
+    await page.getByTestId("tab-link-Configuration").click();
+    await expect(page.getByLabel("Description")).toBeDisabled();
+  });
+
+  test("Cannot interact with Networks", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+
+    // Networks
+    await page.getByText("Networking", { exact: true }).click();
+    await page.getByText("Networks", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create network" }),
+    ).toBeDisabled();
+
+    await visitNetwork(page, networkName);
+    await expect(
+      page.getByRole("button", { name: "Delete network" }),
+    ).toBeDisabled();
+
+    await page.getByTestId("tab-link-Forwards").click();
+    await expect(
+      page.getByRole("button", { name: "Create forward" }),
+    ).toBeDisabled();
+
+    // Network ACLs
+    await page.getByRole("link", { name: "ACLs" }).click();
+    await expect(
+      page.getByRole("button", { name: "Create ACL" }),
+    ).toBeDisabled();
+
+    await visitNetworkAcl(page, aclName);
+    await expect(
+      page.getByRole("button", { name: "Delete ACL" }),
+    ).toBeDisabled();
+
+    await expect(
+      page.getByRole("button", { name: "Edit rule" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Remove rule" }),
+    ).toBeDisabled();
+  });
+
+  test("Cannot interact with Storage", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Storage", { exact: true }).click();
+
+    // Storage Pools
+    await page.getByText("Pools", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create pool" }),
+    ).toBeDisabled();
+    await visitPool(page, poolName);
+    await expect(
+      page.getByRole("button", { name: "Delete pool" }),
+    ).toBeDisabled();
+    await page.getByTestId("tab-link-Configuration").click();
+    await expect(page.getByLabel("Description")).toBeDisabled();
+
+    // Storage Volumes
+    await page
+      .getByLabel("main navigation", { exact: true })
+      .getByRole("link", { name: "Volumes" })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Create volume" }),
+    ).toBeDisabled();
+
+    await visitVolume(page, volumeName);
+    await page.getByTestId("tab-link-Configuration").click();
+    await expect(page.getByLabel("Size", { exact: true })).toBeDisabled();
+
+    await page.getByTestId("tab-link-Snapshots").click();
+    await expect(
+      page.getByRole("button", { name: "Create snapshot" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "See configuration" }),
+    ).toBeDisabled();
+
+    // Custom ISOs
+    await page.getByText("Custom ISOs", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Upload custom ISO" }),
+    ).toBeDisabled();
+
+    await page.getByPlaceholder("Search").click();
+    await page.getByPlaceholder("Search").fill(customISOName);
+    await expect(page.getByRole("link", { name: poolName })).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to create instances",
+      }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", {
+        name: "You do not have permission to delete this volume",
+      }),
+    ).toBeDisabled();
+
+    //Buckets
+    await page.getByText("Buckets", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create bucket" }),
+    ).toBeDisabled();
+  });
+
+  test("Cannot interact with Images", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Images", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Upload image" }),
+    ).toBeDisabled();
+  });
+
+  test("Cannot interact with the Project", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByRole("button", { name: "default" }).click();
+    await expect(
+      page.getByRole("button", { name: "Create project" }),
+    ).toBeDisabled();
+    await page.getByRole("button", { name: "default" }).click();
+
+    await page.getByText("Configuration", { exact: true }).click();
+    await expect(page.getByLabel("Description")).toBeDisabled();
+  });
+
+  test("Cannot interact with Server settings", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Server", { exact: true }).click();
+    await page.getByTestId("tab-link-Clustering").click();
+    await expect(
+      page.getByRole("button", { name: "Enable clustering" }),
+    ).toBeDisabled();
+
+    await page.getByText("Settings", { exact: true }).click();
+    await page.waitForSelector(
+      "text=You do not have permission to view or edit server settings",
+    );
+  });
+
+  test("Cannot interact with Identities", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Permissions", { exact: true }).click();
+    await page.getByText("Identities", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create TLS identity" }),
+    ).toBeDisabled();
+
+    await page.getByPlaceholder("Filter").click();
+    await page.getByPlaceholder("Filter").fill(identityName);
+    await page.keyboard.press("Enter");
+    await expect(page.getByLabel("Manage groups")).toBeDisabled();
+    await expect(page.getByLabel("Delete identity")).toBeDisabled();
+  });
+
+  test("Cannot interact with Groups", async ({ page }) => {
+    await gotoURL(page, "/ui/");
+    await page.getByText("Permissions", { exact: true }).click();
+    await page.getByText("Groups", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create group" }),
+    ).toBeDisabled();
+
+    await page.getByPlaceholder("Search").click();
+    await page.getByPlaceholder("Search").fill(groupName);
+    await page.keyboard.press("Enter");
+    await expect(
+      page.getByRole("button", { name: "Edit group" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Delete group" }),
+    ).toBeDisabled();
+
+    // IDP Groups
+    await page.getByText("IDP groups", { exact: true }).click();
+    await expect(
+      page.getByRole("button", { name: "Create IDP group" }),
+    ).toBeDisabled();
+
+    await page.getByPlaceholder("Search").click();
+    await page.getByPlaceholder("Search").fill(idpGroupName);
+    await page.keyboard.press("Enter");
+    await expect(page.getByLabel("Edit IDP group details")).toBeDisabled();
+    await expect(page.getByLabel("Delete IDP group")).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Done

- Adds tests for interactions with different LXD entities given a Read-only user.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a TLS identity (Easier to run playwright tests with a TLS identity than OIDC) with Server Viewer permissions, and run the test suite locally.

## Screenshots

N/A