### PR TITLE
fix(onboarding) simplify chrome on linux browser certificate import steps

### DIFF
--- a/src/pages/login/BrowserImport.tsx
+++ b/src/pages/login/BrowserImport.tsx
@@ -105,16 +105,13 @@ const BrowserImport: FC = () => {
             <ul className="p-list--divided u-no-margin--bottom">
               {downloadPfx}
               <li className="p-list__item">
-                Go to Chrome&apos;s certificate manager:
+                Go to the import certificate page within Chrome&apos;s
+                certificate manager:
                 <pre className="p-code-snippet__block u-no-margin--bottom">
-                  <code>chrome://certificate-manager</code>
+                  <code>
+                    chrome://certificate-manager/clientcerts/platformclientcerts
+                  </code>
                 </pre>
-              </li>
-              <li className="p-list__item">
-                Click <b>Your certificates</b>
-              </li>
-              <li className="p-list__item">
-                Go to <b>View imported certificates from Linux</b>
               </li>
               <li className="p-list__item">
                 Select <b>Import</b> and choose the .pfx file you just


### PR DESCRIPTION
## Done

- simplify chrome on linux browser certificate import steps

Fixes #1426

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open onboarding steps from chrome

## Screenshots

<img width="1922" height="959" alt="image" src="https://github.com/user-attachments/assets/651eda19-fff0-455e-8e15-97a88f31411f" />