### PR TITLE
fix(scss) ensure our scsss settings are used in react components scss

### DIFF
--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -1,3 +1,6 @@
+// This file should only contain variables. Because it is included in the vite.config.ts file,
+// so our local settings are applied to react-components SCSS
+
 $font-use-subset-latin: true;
 $breakpoint-large: 1090px;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,12 +10,17 @@ if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
 }
 
+// Provide the SCSS settings from the _settings.scss file.
+// SCSS in react-components can reference variables like customized $breakpoint-large and should use our settings.
+const scssSettings = fs.readFileSync("src/sass/_settings.scss", "utf-8").trim();
+
 export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
         api: "modern-compiler",
         silenceDeprecations: ["mixed-decls", "global-builtin", "import"],
+        additionalData: scssSettings,
       },
     },
   },


### PR DESCRIPTION
## Done

- fix(scss) ensure our scsss settings are used in react components scss

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check the network > IPAM table. It uses scrollable table component from react components which has scss referencing a customized variable `$breakpoint-large`. The variable defaults to `1030` and we set it to `1090`. Ensure in the range between the two, the table is displayed correctly.

# Screenshots

## Before

<img width="1166" height="903" alt="image" src="https://github.com/user-attachments/assets/65547e1c-7986-4490-8ba4-609f38ec7c5f" />

## With fix

<img width="1166" height="903" alt="image" src="https://github.com/user-attachments/assets/578d5984-561f-497f-b1a9-ef3a6dfeb310" />
