### PR TITLE
fix(caching) settings and documentation objects files can be considered fresh in cache for up to 1 minute

### DIFF
--- a/src/context/useSettings.tsx
+++ b/src/context/useSettings.tsx
@@ -9,6 +9,7 @@ export const useSettings = (): UseQueryResult<LxdSettings> => {
   return useQuery({
     queryKey: [queryKeys.settings],
     queryFn: async () => fetchSettings(),
+    staleTime: 60_000, // consider cache fresh for 1 minute to avoid excessive API calls
   });
 };
 

--- a/src/pages/settings/ConfigFieldDescription.tsx
+++ b/src/pages/settings/ConfigFieldDescription.tsx
@@ -16,6 +16,7 @@ const ConfigFieldDescription: FC<Props> = ({ description, className }) => {
   const objectsInvTxt = useQuery({
     queryKey: ["documentation/objects.inv.txt"],
     queryFn: async () => fetchDocObjects(hasDocumentationObject),
+    staleTime: 60_000, // consider cache fresh for 1 minutes to avoid excessive API calls
   });
 
   return description ? (


### PR DESCRIPTION
## Done

- fix(caching) settings and documentation objects files can be considered fresh in cache for up to 1 minute
- This is to avoid excessive re-fetching of the same data.
- This should also should fix the e2e tests for 5.0 on Firefox, that triggered a race based on the queries from refetching the data

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure CI passes, no additional QA needed.