### PR TITLE
fix(buckets) ensure storage bucket detail pages highlight the main navigation item

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -390,7 +390,10 @@ const Navigation: FC = () => {
                                 title="Pools"
                                 onClick={softToggleMenu}
                                 className="accordion-nav-secondary"
-                                ignoreUrlMatches={["volumes/custom"]}
+                                ignoreUrlMatches={[
+                                  "volumes/custom",
+                                  "/bucket/",
+                                ]}
                               >
                                 Pools
                               </NavLink>
@@ -432,6 +435,7 @@ const Navigation: FC = () => {
                                 title="Buckets"
                                 onClick={softToggleMenu}
                                 className="accordion-nav-secondary"
+                                activeUrlMatches={["/bucket/"]}
                               >
                                 Buckets
                               </NavLink>


### PR DESCRIPTION
## Done

- fix(buckets) ensure storage bucket detail pages highlight the main navigation item

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a storage bucket detail page
    - ensure the buckets link in the main navigation is active and not the pools link in it.

## Screenshots

<img width="1915" height="950" alt="image" src="https://github.com/user-attachments/assets/238e9fe9-7a96-4008-9099-dca3f55f0dc5" />
