### PR TITLE
feat: [WD-24077] Enable clustering tests + workflow integration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,6 +85,7 @@ jobs:
       matrix:
         lxd_channel: ["5.0/edge", "5.21/edge", "latest/edge"]
         browser: ["chromium", "firefox"]
+        deployment: ["unclustered", "clustered"]
     outputs:
       job_status: ${{job.status}}
     env:
@@ -131,7 +132,6 @@ jobs:
           sudo lxc config set core.https_address "[::]:8443"
           sudo lxc config trust add keys/lxd-ui.crt
           sudo lxc config set cluster.https_address "127.0.0.1"
-          sudo lxc cluster enable local
 
       - uses: actions/setup-node@v4
         with:
@@ -153,17 +153,17 @@ jobs:
         run: sudo -E ./tests/scripts/setup_test
 
       - name: Run Playwright tests
-        run: npx playwright test --project ${{ matrix.browser }}:lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}
+        run: npx playwright test --project ${{ matrix.browser }}:lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}:${{ matrix.deployment }}
 
       - name: Rename Playwright report
         if: always()
-        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}-report.zip
+        run: mv blob-report/report.zip blob-report/${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}-${{ matrix.deployment }}-report.zip
 
-      - name: Upload ${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }} blob reports to be merged
+      - name: Upload ${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}-${{ matrix.deployment }} blob reports to be merged
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: blob-report-${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}
+          name: blob-report-${{ matrix.browser }}-lxd-${{ steps.lxd-env.outputs.LXD_CHANNEL }}-${{ matrix.deployment }}
           path: blob-report
           retention-days: 1
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-e2e-5.0-edge": "npx playwright test --project chromium:lxd-5.0-edge firefox:lxd-5.0-edge",
     "test-coverage": "yarn test-js-coverage && yarn test-e2e-coverage && yarn test-report-coverage",
     "test-js-coverage": "vitest --run --coverage",
-    "test-e2e-coverage": "rm -rf coverage/playwright* ;  PW_TEST_HTML_REPORT_OPEN='never' npx playwright test --project coverage",
+    "test-e2e-coverage": "rm -rf coverage/playwright* ;  PW_TEST_HTML_REPORT_OPEN='never' npx playwright test --project coverage; npx playwright test --project coverage-clustered",
     "test-report-coverage": "cp coverage/unit/coverage-final.json coverage/playwright/ ; nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir coverage/playwright --report-dir coverage/playwright-report --exclude 'src/lib/**' --exclude 'src/types/**'"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,21 +68,33 @@ const config: PlaywrightTestConfig<TestOptions> = {
       testMatch: "login.spec.ts",
     },
     {
-      name: "chromium:lxd-5.0-edge",
+      name: "enable-clustering-chrome",
+      // enable clustering for subsequent tests
+      use: { ...devices["Desktop Chrome"]},
+      testMatch: "enable-clustering.spec.ts",
+    },
+    {
+      name: "enable-clustering-firefox",
+      // enable clustering for subsequent tests
+      use: { ...devices["Desktop Firefox"]},
+      testMatch: "enable-clustering.spec.ts",
+    },
+    {
+      name: "chromium:lxd-5.0-edge:unclustered",
       use: {
         ...devices["Desktop Chrome"],
         lxdVersion: "5.0-edge",
       },
     },
     {
-      name: "firefox:lxd-5.0-edge",
+      name: "firefox:lxd-5.0-edge:unclustered",
       use: {
         ...devices["Desktop Firefox"],
         lxdVersion: "5.0-edge",
       },
     },
     {
-      name: "chromium:lxd-5.21-edge",
+      name: "chromium:lxd-5.21-edge:unclustered",
       use: {
         ...devices["Desktop Chrome"],
         lxdVersion: "5.21-edge",
@@ -90,7 +102,7 @@ const config: PlaywrightTestConfig<TestOptions> = {
       dependencies: ["login-chromium"],
     },
     {
-      name: "firefox:lxd-5.21-edge",
+      name: "firefox:lxd-5.21-edge:unclustered",
       use: {
         ...devices["Desktop Firefox"],
         lxdVersion: "5.21-edge",
@@ -98,7 +110,7 @@ const config: PlaywrightTestConfig<TestOptions> = {
       dependencies: ["login-firefox"],
     },
     {
-      name: "chromium:lxd-latest-edge",
+      name: "chromium:lxd-latest-edge:unclustered",
       use: {
         ...devices["Desktop Chrome"],
         lxdVersion: "latest-edge",
@@ -106,12 +118,67 @@ const config: PlaywrightTestConfig<TestOptions> = {
       dependencies: ["login-chromium"],
     },
     {
-      name: "firefox:lxd-latest-edge",
+      name: "firefox:lxd-latest-edge:unclustered",
       use: {
         ...devices["Desktop Firefox"],
         lxdVersion: "latest-edge",
       },
       dependencies: ["login-firefox"],
+    },
+    // Clustered tests
+    {
+      name: "chromium:lxd-5.0-edge:clustered",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "5.0-edge",
+      },
+      testMatch: "*-clustered.spec.ts",
+      dependencies: ["enable-clustering-chrome"],
+    },
+    {
+      name: "firefox:lxd-5.0-edge:clustered",
+      use: {
+        ...devices["Desktop Firefox"],
+        lxdVersion: "5.0-edge",
+      },
+      dependencies: ["enable-clustering-firefox"],
+      testMatch: "*-clustered.spec.ts",
+    },
+    {
+      name: "chromium:lxd-5.21-edge:clustered",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "5.21-edge",
+      },
+      dependencies: ["enable-clustering-chrome"],
+      testMatch: "*-clustered.spec.ts",
+    },
+    {
+      name: "firefox:lxd-5.21-edge:clustered",
+      use: {
+        ...devices["Desktop Firefox"],
+        lxdVersion: "5.21-edge",
+      },
+      dependencies: ["enable-clustering-firefox"],
+      testMatch: "*-clustered.spec.ts",
+    },
+    {
+      name: "chromium:lxd-latest-edge:clustered",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+      },
+      dependencies: ["enable-clustering-chrome"],
+      testMatch: "*-clustered.spec.ts",
+    },
+    {
+      name: "firefox:lxd-latest-edge:clustered",
+      use: {
+        ...devices["Desktop Firefox"],
+        lxdVersion: "latest-edge",
+      },
+      dependencies: ["enable-clustering-firefox"],
+      testMatch: "*-clustered.spec.ts",
     },
     {
       name: "coverage",
@@ -121,6 +188,16 @@ const config: PlaywrightTestConfig<TestOptions> = {
         hasCoverage: true,
       },
       dependencies: ["login-chromium"],
+    },
+    {
+      name: "coverage-clustered",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+        hasCoverage: true,
+      },
+      dependencies: ["enable-clustering-chrome"],
+      testMatch: "*-clustered.spec.ts",
     },
   ],
 };

--- a/tests/enable-clustering.spec.ts
+++ b/tests/enable-clustering.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "./fixtures/lxd-test";
+import { skipIfNotSupported } from "./helpers/cluster";
+import { gotoURL } from "./helpers/navigate";
+
+test("check enabling clustering", async ({ page, lxdVersion }, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  test.skip(!testInfo.project.name.includes("enable-clustering"));
+
+  await gotoURL(page, "/ui/");
+  await page.getByText("Server", { exact: true }).click();
+  await page.getByTestId("tab-link-Clustering").click();
+  await expect(page.getByText("This server is not clustered")).toBeVisible();
+  await page.getByRole("button", { name: "Enable clustering" }).click();
+  await page.getByLabel("Server name").fill("test-cluster");
+  await page.getByLabel("Cluster address").fill("127.0.0.1");
+  await page.getByRole("button", { name: "Enable clustering" }).nth(1).click();
+  await page.waitForSelector(`text=Clustering enabled`);
+});

--- a/tests/groups-clustered.spec.ts
+++ b/tests/groups-clustered.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "./fixtures/lxd-test";
+import {
+  createClusterGroup,
+  deleteClusterGroup,
+  getFirstClusterMember,
+  randomGroupName,
+  skipIfNotClustered,
+  skipIfNotSupported,
+  toggleClusterGroupMember,
+} from "./helpers/cluster";
+
+test("cluster group create and delete", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+  const group = randomGroupName();
+  await createClusterGroup(page, group);
+  await deleteClusterGroup(page, group);
+});
+
+test("cluster group add and remove members", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+  const group = randomGroupName();
+  const member = await getFirstClusterMember(page);
+  await createClusterGroup(page, group);
+  await toggleClusterGroupMember(page, group, member);
+
+  await expect(
+    page.getByRole("row", { name: group }).getByText("1"),
+  ).toBeVisible();
+
+  await toggleClusterGroupMember(page, group, member);
+
+  await expect(
+    page.getByRole("row", { name: group }).getByText("0"),
+  ).toBeVisible();
+
+  await deleteClusterGroup(page, group);
+});

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -11,12 +11,18 @@ export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
   );
 };
 
+export const skipIfNotClustered = (projectName: string) => {
+  test.skip(!projectName.includes("-clustered"));
+};
+
 export const isServerClustered = async (page: Page) => {
   await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Clustering" }).click();
-  await page.getByRole("link", { name: "Members" }).click();
-  const count = await page.getByText("This server is not clustered").count();
-  return count === 0;
+
+  if ((await page.getByRole("button", { name: "Clustering" }).count()) === 0) {
+    return false;
+  } else {
+    return true;
+  }
 };
 
 export const randomGroupName = (): string => {

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -194,15 +194,12 @@ export const migrateInstanceRootStorage = async (
   page: Page,
   instance: string,
   pool: string,
-  serverClustered: boolean,
 ) => {
   await visitInstance(page, instance);
   await page.getByRole("button", { name: "Migrate" }).click();
-  if (serverClustered) {
-    await page
-      .getByRole("button", { name: "Move instance root storage" })
-      .click();
-  }
+  await page
+    .getByRole("button", { name: "Move instance root storage" })
+    .click();
   await page
     .getByRole("row")
     .filter({ hasText: pool })

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
 import { expect } from "../fixtures/lxd-test";
 import { gotoURL } from "./navigate";
+import { isServerClustered } from "./cluster";
 
 export const randomVolumeName = (): string => {
   return `playwright-volume-${randomNameSuffix()}`;
@@ -77,6 +78,7 @@ export const migrateVolume = async (
   volume: string,
   targetPool: string,
 ) => {
+  const serverClustered = await isServerClustered(page);
   await visitVolume(page, volume);
   await page.getByRole("button", { name: "Migrate", exact: true }).click();
   await page
@@ -95,7 +97,7 @@ export const migrateVolume = async (
   );
 
   await expect(page).toHaveURL(
-    `/ui/project/default/storage/pool/${targetPool}/member/local/volumes/custom/${volume}`,
+    `/ui/project/default/storage/pool/${targetPool}${serverClustered ? "/member/local" : "/volumes/custom"}/${volume}`,
   );
 };
 

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -31,7 +31,6 @@ import {
 import { assertTextVisible } from "./helpers/permissions";
 import { deleteImage, getImageNameFromAlias } from "./helpers/images";
 import { createPool, deletePool, randomPoolName } from "./helpers/storagePool";
-import { isServerClustered } from "./helpers/cluster";
 import { gotoURL } from "./helpers/navigate";
 import { execSync } from "child_process";
 
@@ -281,7 +280,7 @@ test("Bulk start, pause, unpause and stop instances", async ({ page }) => {
   //Bulk start instances
   await page
     .getByRole("row", {
-      name: "select Name Type Cluster member Status Actions",
+      name: "select Name Type Description Status Actions",
     })
     .getByLabel("multiselect rows")
     .click();
@@ -404,10 +403,9 @@ test("Move instance root storage volume to a different pool", async ({
 }) => {
   const targetPool = randomPoolName();
   await createPool(page, targetPool);
-  const serverClustered = await isServerClustered(page);
-  await migrateInstanceRootStorage(page, instance, targetPool, serverClustered);
+  await migrateInstanceRootStorage(page, instance, targetPool);
   // Migrate back to default so that the Pool can be deleted
-  await migrateInstanceRootStorage(page, instance, "default", serverClustered);
+  await migrateInstanceRootStorage(page, instance, "default");
   await deletePool(page, targetPool);
 });
 

--- a/tests/members-clustered.spec.ts
+++ b/tests/members-clustered.spec.ts
@@ -1,43 +1,17 @@
-import { test, expect } from "./fixtures/lxd-test";
+import { test } from "./fixtures/lxd-test";
 import { gotoURL } from "./helpers/navigate";
 import {
-  createClusterGroup,
-  deleteClusterGroup,
   getFirstClusterMember,
-  randomGroupName,
+  skipIfNotClustered,
   skipIfNotSupported,
-  toggleClusterGroupMember,
 } from "./helpers/cluster";
 
-test("cluster group create and delete", async ({ page, lxdVersion }) => {
+test("cluster member evacuate and restore", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
   skipIfNotSupported(lxdVersion);
-  const group = randomGroupName();
-  await createClusterGroup(page, group);
-  await deleteClusterGroup(page, group);
-});
-
-test("cluster group add and remove members", async ({ page, lxdVersion }) => {
-  skipIfNotSupported(lxdVersion);
-  const group = randomGroupName();
-  const member = await getFirstClusterMember(page);
-  await createClusterGroup(page, group);
-  await toggleClusterGroupMember(page, group, member);
-
-  await expect(
-    page.getByRole("row", { name: group }).getByText("1"),
-  ).toBeVisible();
-
-  await toggleClusterGroupMember(page, group, member);
-
-  await expect(
-    page.getByRole("row", { name: group }).getByText("0"),
-  ).toBeVisible();
-
-  await deleteClusterGroup(page, group);
-});
-
-test("cluster member evacuate and restore", async ({ page, lxdVersion }) => {
-  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
   const member = await getFirstClusterMember(page);
 
   await gotoURL(page, "/ui/");

--- a/tests/projects-clustered.spec.ts
+++ b/tests/projects-clustered.spec.ts
@@ -1,0 +1,44 @@
+import { test } from "./fixtures/lxd-test";
+import { skipIfNotClustered, skipIfNotSupported } from "./helpers/cluster";
+import {
+  assertReadMode,
+  setMultiselectOption,
+  setOption,
+} from "./helpers/configuration";
+import { assertTextVisible } from "./helpers/permissions";
+import {
+  createProject,
+  deleteProject,
+  randomProjectName,
+} from "./helpers/projects";
+
+test("project edit configuration", async ({ page, lxdVersion }, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+  const project = randomProjectName();
+  await createProject(page, project);
+
+  await page.getByRole("link", { name: "Configuration" }).click();
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(2000); // Wait for the form state to be fully loaded
+  await page.getByPlaceholder("Enter description").fill("A-new-description");
+
+  await page.getByText("Allow custom restrictions on a project level").click();
+
+  await page.getByText("Clusters").click();
+  await setMultiselectOption(page, "Cluster groups", "default");
+  await setOption(page, "Direct cluster targeting", "allow");
+
+  await page.getByRole("button", { name: "Save 3 changes" }).click();
+  await page.waitForSelector(`text=Project ${project} updated.`);
+  await page.getByRole("button", { name: "Close notification" }).click();
+
+  await page.getByText("Project details").click();
+
+  await assertTextVisible(page, "DescriptionA-new-description");
+
+  await page.getByText("Clusters").click();
+  await assertReadMode(page, "Cluster groups targeting", "default");
+  await assertReadMode(page, "Direct cluster targeting", "Allow");
+  await deleteProject(page, project);
+});

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from "./fixtures/lxd-test";
 import {
   assertReadMode,
   setInput,
-  setMultiselectOption,
   setOption,
   setTextarea,
 } from "./helpers/configuration";
@@ -62,7 +61,6 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setInput(page, "Max sum of processes", "Enter number", "8");
 
   await page.getByText("Clusters").click();
-  await setMultiselectOption(page, "Cluster groups", "default");
   await setOption(page, "Direct cluster targeting", "allow");
 
   await page
@@ -98,7 +96,7 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setTextarea(page, "Network uplinks", "lxdbr0");
   await setTextarea(page, "Network zones", "foo,bar");
 
-  await page.getByRole("button", { name: "Save 35 changes" }).click();
+  await page.getByRole("button", { name: "Save 34 changes" }).click();
 
   await page.waitForSelector(`text=Project ${project} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
@@ -124,7 +122,7 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await assertReadMode(page, "Max sum of processes", "8");
 
   await page.getByText("Clusters").click();
-  await assertReadMode(page, "Cluster groups targeting", "default");
+  await assertReadMode(page, "Cluster groups targeting", "");
   await assertReadMode(page, "Direct cluster targeting", "Allow");
 
   await page


### PR DESCRIPTION
## Done

- Added cluster-enabling check in server.spec.ts (Needs to be outside of the test suites that use clustered environments)
- Added cluster differentiation to the github workflow.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

N/A