### PR TITLE
fix(cluster) enable clustering permission handling should not always disable the button

### DIFF
--- a/src/pages/cluster/actions/EnableClusteringBtn.tsx
+++ b/src/pages/cluster/actions/EnableClusteringBtn.tsx
@@ -9,7 +9,8 @@ const EnableClusteringBtn: FC = () => {
     programmaticallyOpen: true,
   });
 
-  const editRestriction = canEditServerConfiguration()
+  const canEdit = canEditServerConfiguration();
+  const title = canEdit
     ? "Enable clustering"
     : "You do not have permission to edit the server";
 
@@ -19,8 +20,8 @@ const EnableClusteringBtn: FC = () => {
         appearance="positive"
         hasIcon
         onClick={openPortal}
-        disabled={!!editRestriction}
-        title={editRestriction}
+        disabled={!canEdit}
+        title={title}
       >
         <Icon name="plus" light />
         <span>Enable clustering</span>


### PR DESCRIPTION
## Done

- fix(cluster) enable clustering permission handling should not always disable the button

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Server > Clustering and ensure the "Enable Clustering" button is active if fine grained permission user has access.