### PR TITLE
feat(auth): permissions are not fine-grained with unix authentication

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -704,6 +704,11 @@ const Navigation: FC = () => {
                             className="p-side-navigation__icon is-dark"
                             name="profile"
                           />
+                        ) : authMethod == "unix" ? (
+                          <Icon
+                            className="p-side-navigation__icon is-dark"
+                            name="profile"
+                          />
                         ) : (
                           <></>
                         )}

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -57,6 +57,7 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
       !isSettingsLoading &&
       settings &&
       settings.auth !== "untrusted" &&
+      settings.auth_user_method !== "unix" &&
       !settingsError &&
       settings.api_extensions?.includes("access_management_tls"),
   });
@@ -64,6 +65,9 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
   const isFineGrained = () => {
     if (isSettingsLoading) {
       return null;
+    }
+    if (settings?.auth_user_method === "unix") {
+      return false;
     }
     if (hasEntitiesWithEntitlements) {
       return currentIdentity?.fine_grained ?? null;

--- a/src/context/useLoggedInUser.tsx
+++ b/src/context/useLoggedInUser.tsx
@@ -8,11 +8,11 @@ export const useLoggedInUser = () => {
   const id = settings?.auth_user_name || "";
   const authMethod = settings?.auth_user_method || "";
 
-  const identityQueryEnabled = !!id && !!authMethod;
+  const identityQueryEnabled = !!id && !!authMethod && authMethod !== "unix";
   const { data: identity } = useIdentity(id, authMethod, identityQueryEnabled);
 
   return {
-    loggedInUserName: getIdentityName(identity),
+    loggedInUserName: authMethod === "unix" ? id : getIdentityName(identity),
     loggedInUserID: id,
     authMethod,
   };

--- a/src/pages/instances/Events.tsx
+++ b/src/pages/instances/Events.tsx
@@ -122,7 +122,8 @@ const Events: FC = () => {
 
   const connectEventWs = (retryCount = 0) => {
     try {
-      const wsUrl = `wss://${location.host}/1.0/events?type=operation,lifecycle&all-projects=true`;
+      const protocol = location.protocol === "https:" ? "wss" : "ws";
+      const wsUrl = `${protocol}://${location.host}/1.0/events?type=operation,lifecycle&all-projects=true`;
       const ws = new WebSocket(wsUrl);
       ws.onopen = () => {
         setEventWs(ws);

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -73,8 +73,9 @@ const InstanceGraphicConsole: FC<Props> = ({
     }
 
     const operationUrl = result.operation.split("?")[0];
-    const dataUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
-    const controlUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
+    const protocol = location.protocol === "https:" ? "wss" : "ws";
+    const dataUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
+    const controlUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
 
     const control = new WebSocket(controlUrl);
 

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -116,8 +116,9 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
     }
 
     const operationUrl = result.operation.split("?")[0];
-    const dataUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
-    const controlUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
+    const protocol = location.protocol === "https:" ? "wss" : "ws";
+    const dataUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
+    const controlUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
 
     const data = new WebSocket(dataUrl);
     const control = new WebSocket(controlUrl);

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -84,8 +84,9 @@ const InstanceTextConsole: FC<Props> = ({
     }
 
     const operationUrl = result.operation.split("?")[0];
-    const dataUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
-    const controlUrl = `wss://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
+    const protocol = location.protocol === "https:" ? "wss" : "ws";
+    const dataUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds["0"]}`;
+    const controlUrl = `${protocol}://${location.host}${operationUrl}/websocket?secret=${result.metadata.metadata.fds.control}`;
 
     const data = new WebSocket(dataUrl);
     const control = new WebSocket(controlUrl);

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -149,7 +149,8 @@ const UploadExternalFormatFileForm: FC<Props> = ({
         const instanceName = getInstanceName(operation.metadata);
 
         // establish websocket connection based on the instance creation operation
-        const wsUrl = `wss://${location.host}/1.0/operations/${encodeURIComponent(operationId)}/websocket?secret=${encodeURIComponent(operationSecret)}`;
+        const protocol = location.protocol === "https:" ? "wss" : "ws";
+        const wsUrl = `${protocol}://${location.host}/1.0/operations/${encodeURIComponent(operationId)}/websocket?secret=${encodeURIComponent(operationSecret)}`;
 
         const ws = sendFileByWebSocket(
           wsUrl,


### PR DESCRIPTION
## Done

- feat(auth): permissions are not fine grained with unix authentication using the new lxc ui command
- feat(auth) support unix auth through lxc ui socket, this should disable loading current user object via api
- feat(auth) allow websockets to be opened as ws if we call the ui via http like with lxc ui command running on localhost

This relates to https://github.com/canonical/lxd/pull/16267