### PR TITLE
fix(console) surface nested websocket errors

### DIFF
--- a/src/lib/spice/src/spiceconn.js
+++ b/src/lib/spice/src/spiceconn.js
@@ -120,6 +120,10 @@ function SpiceConn(o)
 
             this.parent.onerror(e);
             this.parent.log_err(e.toString());
+        } else {
+          if (this.parent?.parent?.onerror !== undefined) {
+            this.parent.parent.onerror(new Error("Connection closed"));
+          }
         }
     });
 


### PR DESCRIPTION
## Done

- fix(console) surface nested websocket errors
- this is dependent on lxd pr https://github.com/canonical/lxd/pull/16273
- with both prs the linked issue is resolved

fixes #1390

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a graphic console for an instance (must be a VM with a desktop)
    - open a second tab with the graphic console for the instance
    - check first console to show an error that the connection was closed
