### PR TITLE
fix(microcloud) set page title to microcloud if it applies

### DIFF
--- a/src/util/title.tsx
+++ b/src/util/title.tsx
@@ -1,11 +1,14 @@
 import { useEffect } from "react";
 import { useSettings } from "context/useSettings";
+import { hasMicroCloudFlag } from "util/settings";
 
 export const setTitle = (): void => {
   const { data: settings } = useSettings();
+  const isMicroCloud = hasMicroCloudFlag(settings);
+  const suffix = isMicroCloud ? "MicroCloud" : "LXD UI";
 
   useEffect(() => {
     const host = settings?.config?.["user.ui_title"] ?? location.hostname;
-    document.title = `${host} | LXD UI`;
+    document.title = `${host} | ${suffix}`;
   }, [settings?.config]);
 };


### PR DESCRIPTION
## Done

- fix(microcloud) set page title to microcloud if it applies

Fixes #1461

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run ui against a normal lxd backend and ensure the page title ends with "LXD-UI".
    - run ui against a normal microcloud backend and ensure the page title ends with "MicroCloud".

## Screenshots

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/475ac7de-7cda-44f6-9b84-826b294c8b1e" />