### PR TITLE
fix: Skip if not clustered fix

### DIFF
--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -12,7 +12,7 @@ export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
 };
 
 export const skipIfNotClustered = (projectName: string) => {
-  test.skip(!projectName.includes("-clustered"));
+  test.skip(!projectName.includes(":clustered"));
 };
 
 export const isServerClustered = async (page: Page) => {

--- a/tests/projects-clustered.spec.ts
+++ b/tests/projects-clustered.spec.ts
@@ -29,7 +29,7 @@ test("project edit configuration", async ({ page, lxdVersion }, testInfo) => {
   await setMultiselectOption(page, "Cluster groups", "default");
   await setOption(page, "Direct cluster targeting", "allow");
 
-  await page.getByRole("button", { name: "Save 3 changes" }).click();
+  await page.getByRole("button", { name: "Save 4 changes" }).click();
   await page.waitForSelector(`text=Project ${project} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();
 


### PR DESCRIPTION
## Done

A fix to allow all clustered test suites to run.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

N/A