### PR TITLE
fix(instance) default disk size limit of vm is 10GiB and only containers are unlimited

### DIFF
--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -31,6 +31,10 @@ const DiskDeviceFormRoot: FC<Props> = ({ formik, pools, profiles }) => {
   ] as LxdDiskDevice | null;
   const isEditingInstance =
     formik.values.entityType === "instance" && !formik.values.isCreating;
+  const isVirtualMachine =
+    formik.values.entityType === "instance" &&
+    formik.values.instanceType === "virtual-machine";
+  const defaultSize = isVirtualMachine ? "10GiB" : "unlimited";
 
   const [inheritValue, inheritSource] = getInheritedRootStorage(
     formik.values,
@@ -149,7 +153,7 @@ const DiskDeviceFormRoot: FC<Props> = ({ formik, pools, profiles }) => {
             id: "limits_disk",
             className: "override-with-form",
             inheritValue:
-              inheritValue?.size ?? (inheritValue ? "unlimited" : ""),
+              inheritValue?.size ?? (inheritValue ? defaultSize : ""),
             inheritSource,
             readOnly: readOnly,
             disabledReason: formik.values.editRestriction,
@@ -181,8 +185,8 @@ const DiskDeviceFormRoot: FC<Props> = ({ formik, pools, profiles }) => {
                   }
                 />
                 <p className="p-form-help-text">
-                  Size of root storage. If empty, root storage will not have a
-                  size limit.
+                  Size of root storage. If empty, root storage will{" "}
+                  {isVirtualMachine ? "be 10GiB." : "not have a size limit."}
                 </p>
               </>
             ),


### PR DESCRIPTION
## Done

- fix(instance) default disk size limit of vm is 10GiB and only containers are unlimited

Fixes #1464

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a container, ensure the disk size default is unlimited. Also take note of the help text for an override root disk.
    - create a vm, ensure the disk size default is mentioned as "10GiB". Also take note of the help text for an override root disk.

## Screenshots

Creating a VM

<img width="1928" height="959" alt="image" src="https://github.com/user-attachments/assets/bb6cf729-97ff-45e1-a7b0-1cacdd3c826b" />

Creating a container

<img width="1928" height="959" alt="image" src="https://github.com/user-attachments/assets/16317877-9b92-4746-81d4-1bf724055ac3" />
