### PR TITLE
fix(project) exclude default profile from blocking project deletion

### DIFF
--- a/src/pages/projects/actions/DeleteProjectBtn.tsx
+++ b/src/pages/projects/actions/DeleteProjectBtn.tsx
@@ -50,7 +50,10 @@ const generateProjectUsedByTooltip = (project: LxdProject) => {
   for (const resourceType of resourceTypes) {
     const usedBy = filterUsedByType(
       resourceType as ResourceType,
-      project.used_by,
+      project.used_by?.filter(
+        // the default profile is not blocking project deletion and can't be removed itself
+        (item) => !item.startsWith("/1.0/profiles/default"),
+      ),
     );
 
     if (usedBy.length > 0) {


### PR DESCRIPTION
## Done

- fix(project) exclude default profile from blocking project deletion

Fixes #1466

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a project with profiles and/or instances in it.
    - ensure the project can't be deleted and mentions on hover of the project delete button the entities with counts that are blocking the deletion. The counts should be matching up and excluding the default profile.

## Screenshots

<img width="1922" height="956" alt="image" src="https://github.com/user-attachments/assets/50f92803-9846-4950-9bd7-4e31ba643be4" />

<img width="1922" height="956" alt="image" src="https://github.com/user-attachments/assets/ff256709-87d3-40ad-a089-1fd204e88f12" />
