### PR TITLE
fix(idp-groups) use consistent notification style for idp groups information

### DIFF
--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -1,9 +1,9 @@
 import {
   Button,
-  Card,
   EmptyState,
   Icon,
   List,
+  Notification,
   Row,
   ScrollableTable,
   TablePagination,
@@ -197,40 +197,36 @@ const PermissionIdpGroups: FC = () => {
   };
 
   const hasGroups = groups.length > 0;
-  const infoStyle = hasGroups ? "u-text--muted u-no-max-width" : "";
   const idpGroupsInfo = (
-    <>
-      <p className={infoStyle}>
+    <Notification severity="information">
+      <>
         Identity provider groups map authentication entities from your identity
         provider to groups within LXD.
-      </p>
-      {!hasCustomClaim ? (
-        <p className={infoStyle}>
+      </>
+      {!hasCustomClaim && (
+        <>
+          <br />
           You need to set your server{" "}
           <Link to="/ui/settings">
             configuration (<code>oidc.groups.claim</code>)
           </Link>{" "}
           to the name of the custom claim that provides the IDP groups.
-        </p>
-      ) : (
-        ""
+        </>
       )}
-      <p className={infoStyle}>
-        <a
-          href={`${docBaseLink}/explanation/authorization/#use-groups-defined-by-the-identity-provider`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn more about IDP groups
-          <Icon className="external-link-icon" name="external-link" />
-        </a>
-      </p>
-    </>
+      <br />
+      <a
+        href={`${docBaseLink}/explanation/authorization/#use-groups-defined-by-the-identity-provider`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Learn more about IDP groups
+      </a>
+    </Notification>
   );
 
   const content = hasGroups ? (
     <>
-      <Card>{idpGroupsInfo}</Card>
+      {idpGroupsInfo}
       <ScrollableTable
         dependencies={[groups]}
         tableId="idp-groups-table"


### PR DESCRIPTION
## Done

- fix(idp-groups) use consistent notification style for idp groups information

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > IDP groups and ensure the notification on the top looks correct

## Screenshots

<img width="1923" height="958" alt="image" src="https://github.com/user-attachments/assets/05e5ee81-0ccf-40e9-bb4c-c2dca8211533" />