### PR TITLE
feat(InstanceList, InstanceIps): sort IPv6 addresses in InstanceIps and display 2 IPv6 addresses in InstanceList (+n more if necessary)

### DIFF
--- a/src/pages/instances/InstanceIps.tsx
+++ b/src/pages/instances/InstanceIps.tsx
@@ -1,18 +1,20 @@
 import type { FC } from "react";
-import { getIpAddresses } from "util/networks";
-import type { LxdInstance } from "types/instance";
+import { getIpAddresses, sortIpv6Addresses } from "util/networks";
+import type { IpFamily, LxdInstance } from "types/instance";
 import ExpandableList from "components/ExpandableList";
 
 interface Props {
   instance: LxdInstance;
-  family: "inet" | "inet6";
+  family: IpFamily;
 }
 
 const InstanceIps: FC<Props> = ({ instance, family }) => {
   const addresses = getIpAddresses(instance, family);
+  const sortedAddresses =
+    family === "inet6" ? sortIpv6Addresses(addresses) : addresses;
   return addresses.length ? (
     <ExpandableList
-      items={addresses.map((item) => (
+      items={sortedAddresses.map((item) => (
         <div
           key={item.address}
           className="ip u-truncate"

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -61,6 +61,7 @@ import type { LxdInstanceStatus } from "types/instance";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
 import InstanceDetailPanel from "./InstanceDetailPanel";
+import InstanceListIps from "./InstanceListIps";
 import {
   mediumScreenBreakpoint,
   useIsScreenBelow,
@@ -492,7 +493,7 @@ const InstanceList: FC = () => {
           },
           {
             key: `ipv4-${ipv4.length}`,
-            content: ipv4.length > 1 ? `${ipv4.length} addresses` : ipv4,
+            content: <InstanceListIps ips={ipv4} />,
             role: "cell",
             className: "u-align--right clickable-cell",
             "aria-label": IPV4,
@@ -501,7 +502,7 @@ const InstanceList: FC = () => {
           },
           {
             key: `ipv6-${ipv6.length}`,
-            content: ipv6.length > 1 ? `${ipv6.length} addresses` : ipv6,
+            content: <InstanceListIps ips={ipv6} />,
             role: "cell",
             "aria-label": IPV6,
             onClick: openSummary,

--- a/src/pages/instances/InstanceListIps.tsx
+++ b/src/pages/instances/InstanceListIps.tsx
@@ -1,0 +1,23 @@
+import type { FC } from "react";
+
+interface Props {
+  ips: string[];
+}
+
+const InstanceListIps: FC<Props> = ({ ips }) => {
+  if (ips.length < 3) {
+    return ips.map((ip) => <div key={ip}>{ip}</div>);
+  }
+
+  return (
+    <>
+      <div>{ips[0]}</div>
+      <div>{ips[1]}</div>
+      <div className="p-text--x-small u-text--muted">
+        + {ips.length - 2} more
+      </div>
+    </>
+  );
+};
+
+export default InstanceListIps;

--- a/src/types/instance.d.ts
+++ b/src/types/instance.d.ts
@@ -12,12 +12,18 @@ interface LxdInstanceMemory {
   usage_peak: number;
 }
 
+export type IpFamily = "inet" | "inet6";
+
 interface LxdInstanceNetworkAddress {
   address: string;
-  family: string;
+  family: IpFamily;
   netmask: string;
   scope: string;
 }
+
+export type IpAddress = LxdInstanceNetworkAddress & {
+  iface: string;
+};
 
 interface LxdInstanceNetworkCounters {
   bytes_received: number;

--- a/src/util/networks.spec.ts
+++ b/src/util/networks.spec.ts
@@ -1,4 +1,11 @@
-import { areNetworksEqual, testValidIp, testValidPort } from "./networks";
+import type { IpAddress, IpFamily } from "types/instance";
+import {
+  areNetworksEqual,
+  isLocalIPv6,
+  sortIpv6Addresses,
+  testValidIp,
+  testValidPort,
+} from "./networks";
 import type { LxdNetwork } from "types/network";
 
 describe("areNetworksEqual", () => {
@@ -111,5 +118,129 @@ describe("testValidPort", () => {
   it("rejects invalid range", () => {
     const result = testValidPort("23-");
     expect(result).toBe(false);
+  });
+});
+
+describe("isLocalIPv6", () => {
+  it("accepts link local ipv6", () => {
+    const result = isLocalIPv6("fe80::1234:5678:90ab:cdef");
+    expect(result).toBe(true);
+  });
+
+  it("rejects unique local ipv6", () => {
+    const result = isLocalIPv6("fd00::a123:4567:8901:2345");
+    expect(result).toBe(false);
+  });
+
+  it("accepts ::1", () => {
+    const result = isLocalIPv6("::1");
+    expect(result).toBe(true);
+  });
+
+  it("rejects global ipv6", () => {
+    const result = isLocalIPv6("2a02:c01:0:2::1");
+    expect(result).toBe(false);
+  });
+});
+
+describe("sortIpv6Addresses", () => {
+  const defaultFieldsV6 = {
+    iface: "",
+    family: "inet6" as IpFamily,
+    netmask: "",
+    scope: "",
+  };
+  const ipv6Addresses: IpAddress[] = [
+    {
+      ...defaultFieldsV6,
+      address: "::1", // local
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:0db8:1111:2222:3333:4444:5555:6666", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:470:1f06:21c3::1", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2a00:1450:4000:a12::c4", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2600:1f18:1234:5678::1", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "fe80::208:74ff:feda:625c", // link - local
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2a03:2880:f000:3000:4::2b", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2a01:4f9:c010:278::8", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2607:f8b0:4003:c07::2b", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:c0a8:0101::1", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "fd00::a123:4567:8901:2345", // unique local
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:2222:3333:4444:5555: 6666:7777", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2a02:26f0:e000:421::1", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2a02:c01:0:2::1", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:3333:4444:5555:6666:7777:8888", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:1234:5678:9abc:def0:1234:5678", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:5555:6666:7777:8888:9999:aaaa", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "2001:db8:bbbb:cccc:dddd:eeee:ffff:1111", // global
+    },
+    {
+      ...defaultFieldsV6,
+      address: "fe80::1234:5678:90ab:cdef", // link - local
+    },
+  ];
+
+  it("should set IPv6 local addresses at the end", () => {
+    const result = sortIpv6Addresses(ipv6Addresses);
+
+    for (let i = 0; i < 17; i++) {
+      expect(isLocalIPv6(result[i].address)).toBe(false);
+    }
+    for (let i = 17; i < result.length; i++) {
+      expect(isLocalIPv6(result[i].address)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Done

- in InstanceIps (used in InstanceOverview and InstanceDetailPanelContent), sort IPv6 addresses so that local addresses are at the end
- in InstanceList, display 2 addresses and "+ n more" if necessary


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

<img width="1536" height="374" alt="Screenshot from 2025-09-09 09-40-04" src="https://github.com/user-attachments/assets/a9320506-8a72-4ed5-9a7d-c8c535b8839b" />
<img width="1536" height="374" alt="Screenshot from 2025-09-09 09-41-06" src="https://github.com/user-attachments/assets/90b78d54-5a31-48f8-a1d7-a8efbf211fe1" />
<img width="1188" height="522" alt="Screenshot from 2025-09-09 14-40-51" src="https://github.com/user-attachments/assets/6fca3db0-52ff-4539-891c-f6235cb9c6de" />
<img width="474" height="602" alt="Screenshot from 2025-09-09 14-41-32" src="https://github.com/user-attachments/assets/f470c777-8595-49c6-84d3-18928b8f5c5c" />
