### PR TITLE
feat: [WD-17985] Add HPE Storage Driver

### DIFF
--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -16,6 +16,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { queryKeys } from "util/queryKeys";
 import { zfsDriver } from "util/storageOptions";
 import {
+  isAlletraIncomplete,
   isPowerflexIncomplete,
   isPureStorageIncomplete,
   testDuplicateStoragePoolName,
@@ -149,7 +150,8 @@ const CreateStoragePool: FC = () => {
             formik.isSubmitting ||
             !formik.values.name ||
             isPowerflexIncomplete(formik) ||
-            isPureStorageIncomplete(formik)
+            isPureStorageIncomplete(formik) ||
+            isAlletraIncomplete(formik)
           }
           onClick={() => void formik.submitForm()}
         >

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -12,6 +12,7 @@ import {
 import type { FormikProps } from "formik";
 import StoragePoolFormMain from "./StoragePoolFormMain";
 import StoragePoolFormMenu, {
+  ALLETRA_CONFIGURATION,
   CEPH_CONFIGURATION,
   CEPHFS_CONFIGURATION,
   CEPHOBJECT_CONFIGURATION,
@@ -24,6 +25,7 @@ import StoragePoolFormMenu, {
 import { updateMaxHeight } from "util/updateMaxHeight";
 import type { LxdStoragePool } from "types/storage";
 import {
+  alletraDriver,
   btrfsDriver,
   cephDriver,
   cephFSDriver,
@@ -48,6 +50,7 @@ import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 import StoragePoolFormPure from "pages/storage/forms/StoragePoolFormPure";
 import StoragePoolFormCephObject from "./StoragePoolFormCephObject";
 import { objectToYaml } from "util/yaml";
+import StoragePoolFormAlletra from "./StoragePoolFormAlletra";
 
 export interface StoragePoolFormValues {
   barePool?: LxdStoragePool;
@@ -96,6 +99,13 @@ export interface StoragePoolFormValues {
   zfs_export?: string;
   zfs_pool_name?: string;
   zfsPoolNamePerClusterMember?: ClusterSpecificValues;
+  alletra_target?: string;
+  alletra_wsapi?: string;
+  alletra_user_name?: string;
+  alletra_user_password?: string;
+  alletra_wsapi_verify?: string;
+  alletra_cpg?: string;
+  alletra_mode?: string;
   editRestriction?: string;
 }
 
@@ -115,6 +125,7 @@ export const toStoragePool = (
   const isPureDriver = values.driver === pureStorage;
   const isZFSDriver = values.driver === zfsDriver;
   const isCephObjectDriver = values.driver === cephObject;
+  const isAlletraDriver = values.driver === alletraDriver;
   const hasValidSize = values.size?.match(/^\d/);
 
   const getConfig = () => {
@@ -179,6 +190,17 @@ export const toStoragePool = (
         [getPoolKey("zfs_export")]: values.zfs_export ?? "",
         [getPoolKey("zfs_pool_name")]: values.zfs_pool_name,
         size: hasValidSize ? values.size : undefined,
+      };
+    }
+    if (isAlletraDriver) {
+      return {
+        [getPoolKey("alletra_target")]: values.alletra_target,
+        [getPoolKey("alletra_wsapi")]: values.alletra_wsapi,
+        [getPoolKey("alletra_user_name")]: values.alletra_user_name,
+        [getPoolKey("alletra_user_password")]: values.alletra_user_password,
+        [getPoolKey("alletra_wsapi_verify")]: values.alletra_wsapi_verify,
+        [getPoolKey("alletra_cpg")]: values.alletra_cpg,
+        [getPoolKey("alletra_mode")]: values.alletra_mode,
       };
     }
     return {
@@ -283,6 +305,9 @@ const StoragePoolForm: FC<Props> = ({
           )}
           {section === slugify(ZFS_CONFIGURATION) && (
             <StoragePoolFormZFS formik={formik} />
+          )}
+          {section === slugify(ALLETRA_CONFIGURATION) && (
+            <StoragePoolFormAlletra formik={formik} />
           )}
           {section === slugify(YAML_CONFIGURATION) && (
             <YamlForm

--- a/src/pages/storage/forms/StoragePoolFormAlletra.tsx
+++ b/src/pages/storage/forms/StoragePoolFormAlletra.tsx
@@ -1,0 +1,43 @@
+import type { FormikProps } from "formik";
+import type { FC } from "react";
+import type { StoragePoolFormValues } from "./StoragePoolForm";
+import { getConfigurationRow } from "components/ConfigurationRow";
+import { Input, Select } from "@canonical/react-components";
+import { optionIscsiNvme, optionTrueFalse } from "util/instanceOptions";
+import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+}
+
+const StoragePoolFormAlletra: FC<Props> = ({ formik }) => {
+  return (
+    <ScrollableConfigurationTable
+      rows={[
+        getConfigurationRow({
+          formik,
+          label: "Verify Certificate",
+          name: "alletra_wsapi_verify",
+          defaultValue: "",
+          children: <Select options={optionTrueFalse} />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Target",
+          name: "alletra_target",
+          defaultValue: "",
+          children: <Input type="text" />,
+        }),
+        getConfigurationRow({
+          formik,
+          label: "Mode",
+          name: "alletra_mode",
+          defaultValue: "",
+          children: <Select options={optionIscsiNvme} />,
+        }),
+      ]}
+    />
+  );
+};
+
+export default StoragePoolFormAlletra;

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -11,11 +11,13 @@ import {
   pureStorage,
   cephFSDriver,
   cephObject,
+  alletraDriver,
 } from "util/storageOptions";
 import type { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import {
+  getAlletraStoragePoolFormFields,
   getCephObjectPoolFormFields,
   getCephPoolFormFields,
   getPowerflexPoolFormFields,
@@ -57,9 +59,14 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const isCephObjectDriver = formik.values.driver === cephObject;
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
+  const isAlletraDriver = formik.values.driver === alletraDriver;
   const storageDriverOptions = getStorageDriverOptions(settings);
   const hasClusterWideSource = isCephDriver || isCephFSDriver;
-  const hasSource = !isPureDriver && !isPowerFlexDriver && !isCephObjectDriver;
+  const hasSource =
+    !isPureDriver &&
+    !isPowerFlexDriver &&
+    !isCephObjectDriver &&
+    !isAlletraDriver;
 
   const sourceHelpText = formik.values.isCreating
     ? getSourceHelpForDriver(formik.values.driver)
@@ -144,6 +151,12 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                   formik.setFieldValue(field, undefined);
                 }
                 formik.setFieldValue("zfsPoolNamePerClusterMember", "");
+              }
+              if (val !== alletraDriver) {
+                const alletraFields = getAlletraStoragePoolFormFields();
+                for (const field of alletraFields) {
+                  formik.setFieldValue(field, undefined);
+                }
               }
               if (!isStoragePoolWithSize(val)) {
                 formik.setFieldValue("size", undefined);
@@ -315,6 +328,58 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 label="API gateway"
                 placeholder="Enter Pure Storage API gateway"
                 help="URL for the Pure Storage API."
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
+                required
+              />
+            </>
+          )}
+          {isAlletraDriver && (
+            <>
+              <Input
+                {...formik.getFieldProps("alletra_wsapi")}
+                type="text"
+                label="Address"
+                placeholder="Enter Alletra WSAPI"
+                help="Address of the HPE Alletra Storage UI/WSAPI."
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
+                required
+              />
+              <Input
+                {...formik.getFieldProps("alletra_user_name")}
+                type="text"
+                label="User"
+                placeholder="Enter Alletra user"
+                help="HPE Alletra storage admin username"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
+                required
+              />
+              <Input
+                {...formik.getFieldProps("alletra_user_password")}
+                type="password"
+                label="Password"
+                placeholder="Enter Alletra password"
+                help="HPE Alletra storage admin password"
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.handleChange(e);
+                }}
+                required
+              />
+              <Input
+                {...formik.getFieldProps("alletra_cpg")}
+                type="text"
+                label="Common Provisioning Group"
+                placeholder="Enter Alletra CPG"
+                help="HPE Alletra Common Provisioning Group (CPG) name"
                 onChange={(e) => {
                   ensureEditMode(formik);
                   formik.handleChange(e);

--- a/src/pages/storage/forms/StoragePoolFormMenu.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMenu.tsx
@@ -6,6 +6,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import type { FormikProps } from "formik";
 import type { StoragePoolFormValues } from "./StoragePoolForm";
 import {
+  alletraDriver,
   cephDriver,
   cephFSDriver,
   cephObject,
@@ -14,6 +15,7 @@ import {
   zfsDriver,
 } from "util/storageOptions";
 import {
+  isAlletraIncomplete,
   isPowerflexIncomplete,
   isPureStorageIncomplete,
 } from "util/storagePool";
@@ -26,6 +28,7 @@ export const POWERFLEX = "Powerflex";
 export const ZFS_CONFIGURATION = "ZFS";
 export const YAML_CONFIGURATION = "YAML configuration";
 export const PURE_STORAGE = "Pure Storage";
+export const ALLETRA_CONFIGURATION = "HPE Alletra";
 
 interface Props {
   active: string;
@@ -52,6 +55,7 @@ const StoragePoolFormMenu: FC<Props> = ({
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
   const isZfsDriver = formik.values.driver === zfsDriver;
+  const isAlletraDriver = formik.values.driver === alletraDriver;
   const hasName = formik.values.name.length > 0;
   const getDisableReason = () => {
     if (!hasName) {
@@ -62,6 +66,9 @@ const StoragePoolFormMenu: FC<Props> = ({
     }
     if (isPureStorageIncomplete(formik)) {
       return "Please enter an API token and gateway to enable this section";
+    }
+    if (isAlletraIncomplete(formik)) {
+      return "Please enter an address, user, password and common provisioning group to enable this section";
     }
     return undefined;
   };
@@ -118,6 +125,13 @@ const StoragePoolFormMenu: FC<Props> = ({
           {isZfsDriver && (
             <MenuItem
               label={ZFS_CONFIGURATION}
+              {...menuItemProps}
+              disableReason={disableReason}
+            />
+          )}
+          {isAlletraDriver && (
+            <MenuItem
+              label={ALLETRA_CONFIGURATION}
               {...menuItemProps}
               disableReason={disableReason}
             />

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -55,6 +55,7 @@ export interface LxdMetadata {
     "storage-powerflex": LxcConfigOptionCategories;
     "storage-pure": LxcConfigOptionCategories;
     "storage-zfs": LxcConfigOptionCategories;
+    "storage-alletra": LxcConfigOptionCategories;
   };
   entities: LxdEntityEntitlements;
 }

--- a/src/util/permissions.spec.ts
+++ b/src/util/permissions.spec.ts
@@ -135,6 +135,7 @@ describe("General util functions for permissions feature", () => {
           "storage-powerflex": {},
           "storage-pure": {},
           "storage-zfs": {},
+          "storage-alletra": {},
         },
         entities: {
           server: {

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -10,6 +10,7 @@ export const cephFSDriver = "cephfs";
 export const cephObject = "cephobject";
 export const powerFlex = "powerflex";
 export const pureStorage = "pure";
+export const alletraDriver = "alletra";
 
 export const storageDriverLabels: { [key: string]: string } = {
   [dirDriver]: "Directory",
@@ -21,6 +22,7 @@ export const storageDriverLabels: { [key: string]: string } = {
   [powerFlex]: "Dell PowerFlex",
   [pureStorage]: "Pure Storage",
   [cephObject]: "Ceph Object",
+  [alletraDriver]: "HPE Alletra",
 };
 
 const bucketCompatibleDrivers = [cephObject];

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -5,6 +5,7 @@ import type { LxdConfigOptionsKeys } from "types/config";
 import type { FormikProps } from "formik";
 import type { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 import {
+  alletraDriver,
   btrfsDriver,
   dirDriver,
   lvmDriver,
@@ -47,6 +48,13 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   zfs_clone_copy: "zfs.clone_copy",
   zfs_export: "zfs.export",
   zfs_pool_name: "zfs.pool_name",
+  alletra_target: "alletra.target",
+  alletra_wsapi: "alletra.wsapi",
+  alletra_user_name: "alletra.user.name",
+  alletra_user_password: "alletra.user.password",
+  alletra_wsapi_verify: "alletra.wsapi.verify",
+  alletra_cpg: "alletra.cpg",
+  alletra_mode: "alletra.mode",
 };
 
 export const isClusterLocalDriver = (poolDriver: string) => {
@@ -93,6 +101,12 @@ export const getZfsStoragePoolFormFields = () => {
   );
 };
 
+export const getAlletraStoragePoolFormFields = () => {
+  return Object.keys(storagePoolFormFieldToPayloadName).filter((item) =>
+    item.startsWith("alletra_"),
+  );
+};
+
 const storagePoolDriverToOptionKey: Record<string, LxdConfigOptionsKeys> = {
   dir: "storage-dir",
   btrfs: "storage-btrfs",
@@ -103,6 +117,7 @@ const storagePoolDriverToOptionKey: Record<string, LxdConfigOptionsKeys> = {
   powerflex: "storage-powerflex",
   pure: "storage-pure",
   cephobject: "storage-cephobject",
+  alletra: "storage-alletra",
 };
 
 export const storagePoolFormDriverToOptionKey = (
@@ -149,5 +164,17 @@ export const isPureStorageIncomplete = (
   return (
     formik.values.driver === pureStorage &&
     (!formik.values.pure_gateway || !formik.values.pure_api_token)
+  );
+};
+
+export const isAlletraIncomplete = (
+  formik: FormikProps<StoragePoolFormValues>,
+): boolean => {
+  return (
+    formik.values.driver === alletraDriver &&
+    (!formik.values.alletra_wsapi ||
+      !formik.values.alletra_user_name ||
+      !formik.values.alletra_user_password ||
+      !formik.values.alletra_cpg)
   );
 };

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -94,6 +94,13 @@ export const toStoragePoolFormValues = (
     zfs_clone_copy: pool.config?.["zfs.clone_copy"],
     zfs_export: pool.config?.["zfs.export"],
     zfs_pool_name: pool.config?.["zfs.pool_name"],
+    alletra_target: pool.config?.["alletra.target"],
+    alletra_wsapi: pool.config?.["alletra.wsapi"],
+    alletra_user_name: pool.config?.["alletra.user.name"],
+    alletra_user_password: pool.config?.["alletra.user.password"],
+    alletra_wsapi_verify: pool.config?.["alletra.wsapi.verify"],
+    alletra_cpg: pool.config?.["alletra.cpg"],
+    alletra_mode: pool.config?.["alletra.mode"],
     zfsPoolNamePerClusterMember,
     editRestriction,
   };


### PR DESCRIPTION
## Done

- Adds HPE Driver integration to the UI.
- Create Operations :+1: 
- Read Operations :+1: 
- Update Operations :+1: 
- Delete Operations :+1: 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Within a HPE enabled backend, attempt CRUD Operations using a HPE Driver.
     
## Screenshots

<img width="1279" height="1020" alt="image" src="https://github.com/user-attachments/assets/1bfbb904-eafd-46c0-a8f0-583e5f024824" />
<img width="1279" height="1020" alt="image" src="https://github.com/user-attachments/assets/a6f9e0b5-7301-4f11-b26e-a1b2a8b5f630" />
<img width="1642" height="978" alt="image" src="https://github.com/user-attachments/assets/88f2b7c5-3f7f-4085-8cf1-a239b2f0185d" />
