### PR TITLE
fix(scroll) active section on scroll

### DIFF
--- a/src/util/scroll.tsx
+++ b/src/util/scroll.tsx
@@ -15,7 +15,7 @@ export const getFirstVisibleSection = (
   for (const candidate of sections) {
     const element = document.getElementById(candidate.toLowerCase());
     const elementOffset = element?.offsetTop ?? 0;
-    if (elementOffset > scrollTop + offsetTop) {
+    if (elementOffset > scrollTop + offsetTop + 25) {
       return previousCandidate;
     }
     previousCandidate = candidate;


### PR DESCRIPTION
## Done

- fix(scroll) active section on scroll in hardware and network sections
- give a bit slack to consider the next element active a bit early to avoid activating the previous section on subpixel edge cases

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to server > hardware (or clustering > any member > hardware) and ensure on scroll the right section activates. test with chrome and firefox
    - test active section again on networking > networks > any network