### PR TITLE
fix(volume) display correct snapshot count in volume list

### DIFF
--- a/src/util/storageVolume.spec.ts
+++ b/src/util/storageVolume.spec.ts
@@ -1,7 +1,17 @@
 import type { LxdStorageVolume } from "types/storage";
-import { getSnapshotsPerVolume } from "./storageVolume";
+import {
+  getSnapshotsPerVolume,
+  splitVolumeSnapshotName,
+} from "./storageVolume";
 
 describe("getSnapshotsPerVolume", () => {
+  it("splits volume and snapshot name correctly", () => {
+    const rawName = "instance-1/snapshot-1";
+    const { parentName, snapshotName } = splitVolumeSnapshotName(rawName);
+    expect(parentName).toBe("instance-1");
+    expect(snapshotName).toBe("snapshot-1");
+  });
+
   it("no snapshot volumes", () => {
     const volumes: LxdStorageVolume[] = [
       {
@@ -201,13 +211,13 @@ describe("getSnapshotsPerVolume", () => {
 
     const actual = getSnapshotsPerVolume(volumes);
     const expected = {
-      "instance-1-none": [
+      "instance-1-default-none": [
         "instance-1-snapshot-1",
         "instance-1-snapshot-2",
         "instance-1-snapshot-3",
       ],
-      "instance-2-none": ["snapshot-1", "snapshot-2"],
-      "vm-1-none": ["snapshot-1"],
+      "instance-2-default-none": ["snapshot-1", "snapshot-2"],
+      "vm-1-default-none": ["snapshot-1"],
     };
 
     expect(actual).toEqual(expected);

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -112,15 +112,11 @@ test("storage volume edit snapshot configuration", async ({
 test("custom storage volume add snapshot from CTA", async ({ page }) => {
   const volume = randomVolumeName();
   await createVolume(page, volume);
-  await page
+  const row = page
     .getByRole("row", { name: "Name" })
-    .filter({ hasText: volume })
-    .hover();
-  await page
-    .getByRole("row", { name: "Name" })
-    .filter({ hasText: volume })
-    .getByRole("button", { name: "Add Snapshot" })
-    .click();
+    .filter({ hasText: volume });
+  await row.hover();
+  await row.getByRole("button", { name: "Add Snapshot" }).click();
 
   const snapshot = randomSnapshotName();
   await page.getByLabel("Snapshot name").click();
@@ -131,6 +127,8 @@ test("custom storage volume add snapshot from CTA", async ({ page }) => {
   await page.waitForSelector(
     `text=Snapshot ${snapshot} created for volume ${volume}.`,
   );
+
+  expect(row.getByLabel("Snapshots")).toContainText("1");
 
   await deleteVolume(page, volume);
 });


### PR DESCRIPTION
## Done

- fix(volume) display correct snapshot count in volume list

Fixes #1490

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to storage > volumes
    - create a custom volume
    - create a snapshot for the volume
    - ensure the snapshot count n the volume list for that volume is increasing

## Screenshots

<img width="1916" height="954" alt="image" src="https://github.com/user-attachments/assets/b0f04f45-9fe0-4454-8a94-1eed198d5d2b" />
