### PR TITLE
Wd 26612 fix label lts

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -278,17 +278,20 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             onClick: selectImage,
           },
           {
-            content: (
-              <>
-                {getSource()}
-                {item.cached && <span className="u-text--muted"> cached</span>}
-              </>
-            ),
+            content: getSource(),
             role: "cell",
             "aria-label": "Source",
             onClick: selectImage,
           },
           {
+            className: "u-hide--small u-hide--medium",
+            content: item.cached ? "Cached" : "Remote",
+            role: "cell",
+            "aria-label": "Cached",
+            onClick: selectImage,
+          },
+          {
+            className: "u-hide--small u-hide--medium",
             content: (
               <Button
                 onClick={selectImage}
@@ -333,6 +336,11 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       content: "Source",
     },
     {
+      className: "u-hide--small u-hide--medium",
+      content: "Cached",
+    },
+    {
+      className: "u-hide--small u-hide--medium",
       content: "",
       "aria-label": "Actions",
     },

--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -89,12 +89,17 @@ const InstanceCreateDetailsForm: FC<Props> = ({
 }) => {
   const { hasCustomVolumeIso } = useSupportedFeatures();
 
-  function figureBaseImageName() {
+  const figureBaseImageName = () => {
     const image = formik.values.image;
-    return image
-      ? `${image.os} ${image.release} ${image.aliases.split(",")[0]}`
-      : "";
-  }
+
+    if (!image) return "";
+
+    if (image.variant?.toLocaleLowerCase().includes("desktop")) {
+      return `${image.os} ${image.release} ${image.aliases.split(",")[0]}`;
+    }
+
+    return `${image.os} ${image.release} ${image.release_title}`;
+  };
 
   return (
     <ScrollableForm>

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -353,8 +353,16 @@
       }
 
       &:nth-child(7) {
+        width: 5rem;
+      }
+
+      &:nth-child(8) {
         width: 6rem;
       }
+    }
+
+    @include mobile-and-tablet {
+      width: unset;
     }
   }
 

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -43,6 +43,11 @@ export const isoToRemoteImage = (volume: LxdStorageVolume): RemoteImage => {
 export const LOCAL_IMAGE = "local-image";
 
 export const localLxdToRemoteImage = (image: LxdImage): RemoteImage => {
+  const isLTS = image.properties?.description
+    .toLocaleLowerCase()
+    .includes("lts");
+  const releaseTitle = `${image.properties?.version ?? ""}${isLTS ? " LTS" : ""}`;
+
   return {
     aliases: image.update_source?.alias ?? image.aliases?.[0]?.name ?? "",
     fingerprint: image.fingerprint,
@@ -50,7 +55,7 @@ export const localLxdToRemoteImage = (image: LxdImage): RemoteImage => {
     os: capitalizeFirstLetter(image.properties?.os ?? ""),
     created_at: new Date(image.uploaded_at).getTime(),
     release: image.properties?.release ?? "",
-    release_title: image.properties?.version ?? "",
+    release_title: releaseTitle,
     type: image.type,
     cached: image.cached,
     server: image.cached ? image.update_source?.server : LOCAL_IMAGE,


### PR DESCRIPTION
## Done

- On create instance after selecting an image, add LTS label in instance name 
- On browsing images, add "Download &" to Select button for images that are not cached
- Update localLxdToRemoteImage to include LTS information in release title and aliases

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

<img width="1197" height="497" alt="image" src="https://github.com/user-attachments/assets/c07265e8-c748-416d-b37f-99d23ac7a939" />
<img width="1468" height="871" alt="image" src="https://github.com/user-attachments/assets/9a77fc52-5b96-4bcf-9788-a006dbf07747" />
