### PR TITLE
fix(modal) ensure modals on mobile are respecting the total available height reduced by open url bar

### DIFF
--- a/src/components/forms/YamlSwitch.tsx
+++ b/src/components/forms/YamlSwitch.tsx
@@ -8,6 +8,7 @@ import {
 } from "pages/instances/forms/InstanceFormMenu";
 import type { FormikProps } from "formik/dist/types";
 import classnames from "classnames";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
 
 interface Props {
   section?: string;
@@ -24,6 +25,7 @@ const YamlSwitch: FC<Props> = ({
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const yamlFormik = formik as FormikProps<{ yaml: string }>;
+  const isSmallScreen = useIsScreenBelow();
 
   const isChecked = slugify(section ?? "") === slugify(YAML_CONFIGURATION);
 
@@ -54,7 +56,7 @@ const YamlSwitch: FC<Props> = ({
         </Portal>
       )}
       <Switch
-        label="YAML Configuration"
+        label={isSmallScreen ? "YAML" : "YAML Configuration"}
         checked={isChecked}
         onChange={handleSwitch}
         disabled={disableReason !== undefined}

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -68,8 +68,8 @@ const TerminalPayloadForm: FC<Props> = ({ payload, close, reconnect }) => {
   useEffect(() => {
     ref.current?.scrollIntoView({
       behavior: "smooth",
-      block: "end",
-      inline: "start",
+      block: "nearest",
+      inline: "nearest",
     });
     window.dispatchEvent(new Event("resize"));
   }, [formik.values.environment]);

--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -52,7 +52,10 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
                   const aclSelector =
                     document.getElementById(networlAclSelectorId);
                   // open multi select dropdown
-                  aclSelector?.scrollIntoView({ block: "nearest" });
+                  aclSelector?.scrollIntoView({
+                    block: "nearest",
+                    inline: "nearest",
+                  });
                   aclSelector?.click();
                 }, 100);
               }}

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -103,7 +103,11 @@ const SettingForm: FC<Props> = ({
 
   useEffect(() => {
     if (isEditMode && isLast) {
-      editRef.current?.scrollIntoView({ behavior: "smooth" });
+      editRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "nearest",
+      });
     }
   }, [isEditMode]);
 

--- a/src/util/scroll.tsx
+++ b/src/util/scroll.tsx
@@ -1,5 +1,8 @@
 export const scrollToElement = (id: string) => {
-  document.getElementById(id)?.scrollIntoView();
+  document.getElementById(id)?.scrollIntoView({
+    inline: "nearest",
+    block: "nearest",
+  });
 };
 
 /**


### PR DESCRIPTION
## Done

- fix(modal) ensure modals on mobile are respecting the total available height reduced by open url bar (this comes in with vanilla update)
- fix(mobile) navigation bar should not hide on mobile when browsing to the network detail page. Calling scrollToElement without argument will scroll the body down, which hides the mobile navigation bar on top of the screen

Fixes #1496

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open network > acl > create acl > add ingress modal and ensure the buttons in the modal are accessible on mobile browsers.
    - open networks > detail page of any network on a phone and ensure the top navigation bar stays visible.