### PR TITLE
feat(project) add restricted.backups input for project configuration

### DIFF
--- a/src/pages/instances/actions/ExportInstanceBtn.tsx
+++ b/src/pages/instances/actions/ExportInstanceBtn.tsx
@@ -4,6 +4,8 @@ import { Button, Icon, usePortal } from "@canonical/react-components";
 import classNames from "classnames";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import ExportInstanceModal from "pages/instances/forms/ExportInstanceModal";
+import { useCurrentProject } from "context/useCurrentProject";
+import { isBackupDisabled } from "util/snapshots";
 
 interface Props {
   instance: LxdInstance;
@@ -14,10 +16,24 @@ interface Props {
 const ExportInstanceBtn: FC<Props> = ({ instance, classname, onClose }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const { canManageInstanceBackups } = useInstanceEntitlements();
+  const { project } = useCurrentProject();
+  const backupDisabled = isBackupDisabled(project);
 
   const handleClose = () => {
     closePortal();
     onClose?.();
+  };
+
+  const getTitle = () => {
+    if (!canManageInstanceBackups(instance)) {
+      return "You do not have permission to export this instance.";
+    }
+
+    if (backupDisabled) {
+      return `Project "${project?.name}" doesn't allow for backup creation.`;
+    }
+
+    return "Export instance";
   };
 
   return (
@@ -31,12 +47,8 @@ const ExportInstanceBtn: FC<Props> = ({ instance, classname, onClose }) => {
         appearance="default"
         className={classNames("u-no-margin--bottom has-icon", classname)}
         onClick={openPortal}
-        title={
-          canManageInstanceBackups(instance)
-            ? "Export instance"
-            : "You do not have permission to export this instance."
-        }
-        disabled={!canManageInstanceBackups(instance)}
+        title={getTitle()}
+        disabled={!canManageInstanceBackups(instance) || backupDisabled}
       >
         <Icon name="export" />
         <span>Export</span>

--- a/src/pages/projects/forms/InstanceRestrictionForm.tsx
+++ b/src/pages/projects/forms/InstanceRestrictionForm.tsx
@@ -18,6 +18,7 @@ export interface InstanceRestrictionFormValues {
   restricted_containers_nesting?: string;
   restricted_containers_privilege?: string;
   restricted_container_interception?: string;
+  restrict_backups?: string;
   restrict_snapshots?: string;
   restricted_idmap_uid?: string;
   restricted_idmap_gid?: string;
@@ -37,6 +38,7 @@ export const instanceRestrictionPayload = (
       values.restricted_containers_privilege,
     [getProjectKey("restricted_container_interception")]:
       values.restricted_container_interception,
+    [getProjectKey("restrict_backups")]: values.restrict_backups,
     [getProjectKey("restrict_snapshots")]: values.restrict_snapshots,
     [getProjectKey("restricted_idmap_uid")]: values.restricted_idmap_uid,
     [getProjectKey("restricted_idmap_gid")]: values.restricted_idmap_gid,
@@ -92,6 +94,15 @@ const InstanceRestrictionForm: FC<Props> = ({ formik }) => {
           formik,
           name: "restricted_container_interception",
           label: "Container interception",
+          defaultValue: "",
+          readOnlyRenderer: (val) => optionRenderer(val, optionAllowBlock),
+          children: <Select options={optionAllowBlock} />,
+        }),
+
+        getConfigurationRow({
+          formik,
+          name: "restrict_backups",
+          label: "Backup creation",
           defaultValue: "",
           readOnlyRenderer: (val) => optionRenderer(val, optionAllowBlock),
           children: <Select options={optionAllowBlock} />,

--- a/src/util/projectConfigFields.tsx
+++ b/src/util/projectConfigFields.tsx
@@ -16,6 +16,7 @@ const projectConfigFormFieldsToPayload: Record<string, string> = {
   restricted_containers_nesting: "restricted.containers.nesting",
   restricted_containers_privilege: "restricted.containers.privilege",
   restricted_container_interception: "restricted.containers.interception",
+  restrict_backups: "restricted.backups",
   restrict_snapshots: "restricted.snapshots",
   restricted_idmap_uid: "restricted.idmap.uid",
   restricted_idmap_gid: "restricted.idmap.gid",

--- a/src/util/projectEdit.tsx
+++ b/src/util/projectEdit.tsx
@@ -78,6 +78,7 @@ export const getProjectEditValues = (
       project.config["restricted.containers.privilege"],
     restricted_container_interception:
       project.config["restricted.containers.interception"],
+    restrict_backups: project.config["restricted.backups"],
     restrict_snapshots: project.config["restricted.snapshots"],
     restricted_idmap_uid: project.config["restricted.idmap.uid"],
     restricted_idmap_gid: project.config["restricted.idmap.gid"],

--- a/src/util/snapshots.tsx
+++ b/src/util/snapshots.tsx
@@ -72,18 +72,21 @@ export const testValidTime = (): [
 };
 
 export const isSnapshotsDisabled = (project?: LxdProject): boolean => {
+  return isProjectFeatureDisabled("restricted.snapshots", project);
+};
+
+export const isBackupDisabled = (project?: LxdProject): boolean => {
+  return isProjectFeatureDisabled("restricted.backups", project);
+};
+
+const isProjectFeatureDisabled = (feature: string, project?: LxdProject) => {
   if (!project) {
     return false;
   }
 
-  if (project.config["restricted"] === "true") {
-    if (
-      !project.config["restricted.snapshots"] ||
-      project.config["restricted.snapshots"] === "block"
-    ) {
-      return true;
-    }
+  if (project.config["restricted"] !== "true") {
+    return false;
   }
 
-  return false;
+  return !project.config[feature] || project.config[feature] === "block";
 };


### PR DESCRIPTION
## Done

- feat(project) add restricted.backups input for project configuration

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to project > configuration > enable "Allow custom restrictions on a project level" > restrictions > instances > Backup restriction and set it to allow or block.

## Screenshots

<img width="1920" height="957" alt="image" src="https://github.com/user-attachments/assets/54445d24-7b7f-4d2d-8f11-24e4c93b8e11" />