### PR TITLE
fix(ImageSelector): set type to undefined instead of container when selecting any

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -418,7 +418,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
               onChange={(v) => {
                 setType(
                   v.target.value === ANY
-                    ? "container"
+                    ? undefined
                     : (v.target.value as LxdImageType),
                 );
               }}


### PR DESCRIPTION
## Done

- When creating an instance, in Select base image modal, the type can now beset to VM or container then back to Any.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Click on Create instance
    - Click on Browse images
    - Set Type to VM: make sure the filter is applied correctly
    - Set Type to Any: make sure the filter is applied correctly
    - Set Type to Container: make sure the filter is applied correctly

## Screenshots


https://github.com/user-attachments/assets/9ce552a4-ed5b-4d89-a62c-e5eb29e57953

