### PR TITLE
feat(instance) loading status for instances consistency update

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -32,9 +32,9 @@ const Root: FC = () => {
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
             <ProjectProvider>
-              <InstanceLoadingProvider>
-                <MemberLoadingProvider>
-                  <OperationsProvider>
+              <OperationsProvider>
+                <InstanceLoadingProvider>
+                  <MemberLoadingProvider>
                     <EventQueueProvider>
                       <MetricHistoryProvider>
                         <Application id="l-application">
@@ -48,9 +48,9 @@ const Root: FC = () => {
                         </Application>
                       </MetricHistoryProvider>
                     </EventQueueProvider>
-                  </OperationsProvider>
-                </MemberLoadingProvider>
-              </InstanceLoadingProvider>
+                  </MemberLoadingProvider>
+                </InstanceLoadingProvider>
+              </OperationsProvider>
             </ProjectProvider>
           </AuthProvider>
         </QueryClientProvider>

--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -1,7 +1,12 @@
 import type { FC, ReactNode } from "react";
+import { useEffect } from "react";
 import { createContext, useContext, useState } from "react";
 import type { LxdInstance } from "types/instance";
 import { getInstanceKey } from "util/instances";
+import { useOperations } from "context/operationsProvider";
+import { getInstanceName, getProjectName } from "util/operations";
+import type { LxdOperation } from "types/operation";
+import { mapsAreEqual } from "util/mapsAreEqual";
 
 type LoadingTypes =
   | "Starting"
@@ -26,12 +31,60 @@ interface Props {
   children: ReactNode;
 }
 
+const getLoadingType = (operation: LxdOperation): LoadingTypes | null => {
+  switch (operation.description) {
+    case "Starting instance":
+      return "Starting";
+    case "Stopping instance":
+      return "Stopping";
+    case "Freezing instance":
+      return "Freezing";
+    case "Unfreezing instance":
+      return "Starting";
+    case "Restarting instance":
+      return "Restarting";
+    default:
+      return null;
+  }
+};
+
+const getStatesFromOperations = (
+  operations: LxdOperation[],
+): Map<string, LoadingTypes> => {
+  const newMap = new Map<string, LoadingTypes>();
+  for (const operation of operations) {
+    const loadingType = getLoadingType(operation);
+    const name = getInstanceName(operation);
+    const project = getProjectName(operation);
+
+    if (loadingType && name && project && operation.status === "Running") {
+      const instance = { name, project } as LxdInstance;
+      newMap.set(getInstanceKey(instance), loadingType);
+    }
+  }
+  return newMap;
+};
+
 export const InstanceLoadingProvider: FC<Props> = ({ children }) => {
+  const { runningOperations } = useOperations();
   const [instanceStates, setInstanceStates] = useState(
     new Map<string, LoadingTypes>(),
   );
 
+  useEffect(() => {
+    // Update instance loading states based on running operations.
+    // This pulls in updates triggered on cli or from other users.
+    // This initializes the states on first load.
+    const newStates = getStatesFromOperations(runningOperations);
+    if (!mapsAreEqual(newStates, instanceStates)) {
+      setInstanceStates(newStates);
+    }
+  }, [runningOperations]);
+
   const setLoading = (instance: LxdInstance, loadingType: LoadingTypes) => {
+    if (instanceStates.get(getInstanceKey(instance)) === loadingType) {
+      return; // skip if state already matches
+    }
     setInstanceStates((oldMap) => {
       const newMap = new Map(oldMap);
       newMap.set(getInstanceKey(instance), loadingType);

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -532,9 +532,6 @@ const InstanceList: FC = () => {
                 className={classnames(
                   "instance-actions",
                   "u-no-margin--bottom",
-                  {
-                    "u-hide": Boolean(instanceLoading.getType(instance)),
-                  },
                 )}
                 instance={instance}
               />

--- a/src/pages/instances/actions/InstanceBulkAction.tsx
+++ b/src/pages/instances/actions/InstanceBulkAction.tsx
@@ -126,10 +126,15 @@ const InstanceBulkAction: FC<Props> = ({
     );
   };
 
+  // allow stop action when loading to allow to trigger force stop
+  const isLoadingNotStop = isLoading && action !== "stop";
+
   return (
     <ConfirmationButton
       appearance="base"
-      disabled={isDisabled || !hasChangedStates || allRestricted || isLoading}
+      disabled={
+        isDisabled || !hasChangedStates || allRestricted || isLoadingNotStop
+      }
       loading={isLoading}
       className="u-no-margin--right u-no-margin--bottom bulk-action has-icon"
       confirmationModalProps={{

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -73,16 +73,18 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
   };
 
   const disabledStatuses = ["Stopped", "Migrating"];
+
+  // Keep button disabled while instance is stopping to allow force stop
   const isDisabled =
-    isLoading ||
     disabledStatuses.includes(instance.status) ||
-    instanceLoading.getType(instance) === "Migrating";
+    instanceLoading.getType(instance) === "Migrating" ||
+    !canUpdateInstanceState(instance);
 
   return (
     <ConfirmationButton
       appearance="base"
       loading={isLoading}
-      disabled={isDisabled || !canUpdateInstanceState(instance) || isLoading}
+      disabled={isDisabled}
       confirmationModalProps={{
         title: "Confirm stop",
         children: (

--- a/src/util/mapsAreEqual.tsx
+++ b/src/util/mapsAreEqual.tsx
@@ -1,0 +1,11 @@
+export const mapsAreEqual = <K, V>(a: Map<K, V>, b: Map<K, V>): boolean => {
+  if (a.size !== b.size) return false;
+
+  for (const [key, valA] of a) {
+    if (!b.has(key)) return false;
+    const valB = b.get(key);
+    if (valA !== valB) return false;
+  }
+
+  return true;
+};

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -35,13 +35,17 @@ export const getVolumeSnapshotName = (operation?: LxdOperation): string => {
   return "";
 };
 
-export const getProjectName = (operation: LxdOperation): string => {
+export const getProjectName = (operation?: LxdOperation): string => {
   // the url can be
   // /1.0/images/<image_fingerprint>?project=<project_name>
   // /1.0/instances/<instance_name>?project=<project_name>
   // /1.0/instances/<instance_name>?other=params&project=<project_name>
   // /1.0/instances/<instance_name>?other=params&project=<project_name>&other=params
   // when no project parameter is present, the project will be "default"
+
+  if (!operation) {
+    return "default";
+  }
 
   const images = operation.resources?.images ?? [];
   if (images.length > 0) {


### PR DESCRIPTION
## Done

- feat(instance) loading status for instances consistency update
- Instance loading triggers from cli or other updates to instance state outside the currently open ui tab.
- Allow resubmit of stop instance action for triggering force-stop while an instance is stopping.
- Bootstrap instance loading states on initial load based on running operations

Fixes WD-26638

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open UI and stop/start also bulk stop/start instance, ensure the loading state is consistent
    - Stop a VM and then force stop it to stop it faster. Ensure loading state is consistent.
    - Open UI and start / stop an instance from CLI. Ensure the loading status for that instance updates in the UI without giving it focus.