### PR TITLE
fix(permissions) idp group info should be without notification wrapper in empty state

### DIFF
--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -198,7 +198,7 @@ const PermissionIdpGroups: FC = () => {
 
   const hasGroups = groups.length > 0;
   const idpGroupsInfo = (
-    <Notification severity="information">
+    <>
       <>
         Identity provider groups map authentication entities from your identity
         provider to groups within LXD.
@@ -221,12 +221,12 @@ const PermissionIdpGroups: FC = () => {
       >
         Learn more about IDP groups
       </a>
-    </Notification>
+    </>
   );
 
   const content = hasGroups ? (
     <>
-      {idpGroupsInfo}
+      <Notification severity="information">{idpGroupsInfo}</Notification>
       <ScrollableTable
         dependencies={[groups]}
         tableId="idp-groups-table"
@@ -265,7 +265,7 @@ const PermissionIdpGroups: FC = () => {
       image={<Icon name="user-group" className="empty-state-icon" />}
       title="No IDP group mappings"
     >
-      {idpGroupsInfo}
+      <p>{idpGroupsInfo}</p>
       <Button
         className="empty-state-button"
         appearance="positive"


### PR DESCRIPTION
## Done

- fix(permissions) idp group info should be without notification wrapper in empty state

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permissions > idp groups and ensure the empty state without any groups looks correct.

## Screenshots

<img width="1924" height="959" alt="image" src="https://github.com/user-attachments/assets/3302891a-4f6c-4c81-aecc-58d567d6eff0" />