### PR TITLE
fix(cluster) permission checks for cluster groups and members

### DIFF
--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -194,7 +194,7 @@ const SelectableMainTable: FC<Props> = ({
             indeterminate={isRowIndeterminate && !isRowSelected}
           />
         ),
-        role: "rowheader",
+        role: "cell",
         className: "select",
       },
       ...(row.columns ?? []),

--- a/src/pages/cluster/ClusterGroupList.tsx
+++ b/src/pages/cluster/ClusterGroupList.tsx
@@ -20,12 +20,14 @@ import CreateClusterGroupBtn from "pages/cluster/actions/CreateClusterGroupBtn";
 import ResourceLink from "components/ResourceLink";
 import { useClusterGroups } from "context/useClusterGroups";
 import usePanelParams from "util/usePanelParams";
+import { useServerEntitlements } from "util/entitlements/server";
 
 const ClusterGroupList: FC = () => {
   const docBaseLink = useDocs();
   const notify = useNotify();
   const panelParams = usePanelParams();
   const { data: groups = [], error, isLoading } = useClusterGroups();
+  const { canEditServerConfiguration } = useServerEntitlements();
 
   if (error) {
     notify.failure("Loading cluster groups failed", error);
@@ -94,10 +96,12 @@ const ClusterGroupList: FC = () => {
               : "-",
         },
         {
-          content: (
+          content: canEditServerConfiguration() ? (
             <Button appearance="link" dense onClick={openGroupEdit}>
               {group.members.length}
             </Button>
+          ) : (
+            group.members.length
           ),
           className: "members u-align--right",
         },

--- a/src/pages/cluster/ClusterMemberList.tsx
+++ b/src/pages/cluster/ClusterMemberList.tsx
@@ -19,6 +19,7 @@ import { useClusterMembers } from "context/useClusterMembers";
 import usePanelParams from "util/usePanelParams";
 import ClusterMemberStatus from "pages/cluster/ClusterMemberStatus";
 import { useMemberLoading } from "context/memberLoading";
+import { useServerEntitlements } from "util/entitlements/server";
 
 const ClusterMemberList: FC = () => {
   const docBaseLink = useDocs();
@@ -26,6 +27,7 @@ const ClusterMemberList: FC = () => {
   const panelParams = usePanelParams();
   const { data: members = [], error, isLoading } = useClusterMembers();
   const memberLoading = useMemberLoading();
+  const { canEditServerConfiguration } = useServerEntitlements();
 
   if (error) {
     notify.failure("Loading cluster members failed", error);
@@ -123,10 +125,12 @@ const ClusterMemberList: FC = () => {
           className: "description",
         },
         {
-          content: (
+          content: canEditServerConfiguration() ? (
             <Button appearance="link" dense onClick={openMemberEdit}>
               {groupCount}
             </Button>
+          ) : (
+            groupCount
           ),
           role: "cell",
           className: "groups u-align--right",

--- a/src/pages/cluster/actions/CreateClusterGroupBtn.tsx
+++ b/src/pages/cluster/actions/CreateClusterGroupBtn.tsx
@@ -2,15 +2,25 @@ import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import usePanelParams, { panels } from "util/usePanelParams";
 import CreateClusterGroupPanel from "pages/cluster/panels/CreateClusterGroupPanel";
+import { useServerEntitlements } from "util/entitlements/server";
 
 const CreateClusterGroupBtn: FC = () => {
   const panelParams = usePanelParams();
+  const { canEditServerConfiguration } = useServerEntitlements();
+
+  const hasPermission = canEditServerConfiguration();
 
   return (
     <>
       <Button
         appearance="positive"
         className="u-no-margin--bottom"
+        disabled={!hasPermission}
+        title={
+          hasPermission
+            ? undefined
+            : "You do not have permission to create cluster groups"
+        }
         hasIcon
         onClick={panelParams.openCreateClusterGroup}
       >

--- a/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterGroupBtn.tsx
@@ -10,6 +10,7 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import ResourceLabel from "components/ResourceLabel";
+import { useServerEntitlements } from "util/entitlements/server";
 
 interface Props {
   group: string;
@@ -20,6 +21,9 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
   const [isLoading, setLoading] = useState(false);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { canEditServerConfiguration } = useServerEntitlements();
+
+  const hasPermission = canEditServerConfiguration();
 
   const handleDelete = () => {
     setLoading(true);
@@ -49,6 +53,9 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
     if (isDefaultGroup) {
       return "The default cluster group cannot be deleted";
     }
+    if (!hasPermission) {
+      return "You do not have permission to delete cluster groups";
+    }
     return "Delete group";
   };
 
@@ -68,7 +75,7 @@ const DeleteClusterGroupBtn: FC<Props> = ({ group }) => {
         confirmButtonLabel: "Delete",
         onConfirm: handleDelete,
       }}
-      disabled={isDefaultGroup || isLoading}
+      disabled={isDefaultGroup || isLoading || !hasPermission}
       shiftClickEnabled
       showShiftClickHint
       title="Delete group"

--- a/src/pages/cluster/actions/EditClusterGroupBtn.tsx
+++ b/src/pages/cluster/actions/EditClusterGroupBtn.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import usePanelParams, { panels } from "util/usePanelParams";
 import EditClusterGroupPanel from "pages/cluster/panels/EditClusterGroupPanel";
+import { useServerEntitlements } from "util/entitlements/server";
 
 interface Props {
   group: string;
@@ -9,16 +10,23 @@ interface Props {
 
 const EditClusterGroupBtn: FC<Props> = ({ group }) => {
   const panelParams = usePanelParams();
+  const { canEditServerConfiguration } = useServerEntitlements();
+  const hasPermission = canEditServerConfiguration();
 
   return (
     <>
       <Button
         appearance="base"
         className="u-no-margin--bottom"
+        disabled={!hasPermission}
         onClick={() => {
           panelParams.openEditClusterGroup(group);
         }}
-        title="Edit group"
+        title={
+          hasPermission
+            ? "Edit group"
+            : "You do not have permission to edit cluster groups"
+        }
         hasIcon
       >
         <Icon name="edit" />

--- a/src/pages/cluster/actions/EditClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/EditClusterMemberBtn.tsx
@@ -3,6 +3,7 @@ import { Button, Icon } from "@canonical/react-components";
 import usePanelParams, { panels } from "util/usePanelParams";
 import classnames from "classnames";
 import EditClusterMemberPanel from "pages/cluster/panels/EditClusterMemberPanel";
+import { useServerEntitlements } from "util/entitlements/server";
 
 interface Props {
   member: string;
@@ -18,16 +19,24 @@ const EditClusterMemberBtn: FC<Props> = ({
   onClose,
 }) => {
   const panelParams = usePanelParams();
+  const { canEditServerConfiguration } = useServerEntitlements();
+
+  const hasPermission = canEditServerConfiguration();
 
   return (
     <>
       <Button
         appearance={hasLabel ? "" : "base"}
         className={classnames(className, "u-no-margin--bottom")}
+        disabled={!hasPermission}
         onClick={() => {
           panelParams.openEditMember(member);
         }}
-        title="Edit cluster member"
+        title={
+          hasPermission
+            ? "Edit cluster member"
+            : "You do not have permission to edit cluster members"
+        }
         hasIcon
       >
         <Icon name="edit" />

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
 import { randomNameSuffix } from "./name";
 import type { LxdVersions } from "../fixtures/lxd-test";
-import { test } from "../fixtures/lxd-test";
+import { expect, test } from "../fixtures/lxd-test";
 
 export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
@@ -80,6 +80,7 @@ export const getFirstClusterMember = async (page: Page): Promise<string> => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Clustering" }).click();
   await page.getByRole("link", { name: "Members" }).click();
+  await expect(page.getByText("Cluster members")).toBeVisible();
   const firstCellContent = await page
     .getByRole("rowheader")
     .first()

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -68,7 +68,7 @@ export const toggleClusterGroupMember = async (
     .getByRole("button", { name: "Edit group" })
     .click();
   await page
-    .getByRole("rowheader", { name: `Select ${member}` })
+    .getByRole("cell", { name: `Select ${member}` })
     .locator("span")
     .click();
   await page.getByRole("button", { name: "Save changes" }).click();

--- a/tests/helpers/permission-groups.ts
+++ b/tests/helpers/permission-groups.ts
@@ -107,7 +107,7 @@ export const toggleIdentitiesForGroups = async (
 ) => {
   for (const identity of identities) {
     await page
-      .getByRole("rowheader", { name: `Select ${identity}` })
+      .getByRole("cell", { name: `Select ${identity}` })
       .locator("label")
       .click();
     const rowModifiedIcon = page
@@ -120,7 +120,7 @@ export const toggleIdentitiesForGroups = async (
 export const selectGroupsToModify = async (page: Page, groups: string[]) => {
   for (const group of groups) {
     await page
-      .getByRole("rowheader", { name: `Select ${group}` })
+      .getByRole("cell", { name: `Select ${group}` })
       .locator("span")
       .click();
   }

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -26,7 +26,7 @@ export const toggleGroupsForIdentities = async (
 ) => {
   for (const group of groups) {
     await page
-      .getByRole("rowheader", { name: `Select ${group}` })
+      .getByRole("cell", { name: `Select ${group}` })
       .locator("label")
       .click();
     const rowModifiedIcon = page
@@ -42,7 +42,7 @@ export const selectIdentitiesToModify = async (
 ) => {
   for (const identity of identities) {
     await page
-      .getByRole("rowheader", { name: `Select ${identity}` })
+      .getByRole("cell", { name: `Select ${identity}` })
       .locator("span")
       .click();
   }

--- a/tests/helpers/permission-idp-groups.ts
+++ b/tests/helpers/permission-idp-groups.ts
@@ -26,7 +26,7 @@ export const createIdpGroup = async (
   await page.getByPlaceholder("Enter name").fill(idpGroup);
   for (const group of groups) {
     await page
-      .getByRole("rowheader", { name: `Select ${group}` })
+      .getByRole("cell", { name: `Select ${group}` })
       .locator("span")
       .click();
   }
@@ -60,7 +60,7 @@ export const editIdpGroup = async (
   await page.getByPlaceholder("Enter name").fill(newIdpGroupName);
   for (const group of groups) {
     await page
-      .getByRole("rowheader", { name: `Select ${group}` })
+      .getByRole("cell", { name: `Select ${group}` })
       .locator("span")
       .click();
   }

--- a/tests/members-clustered.spec.ts
+++ b/tests/members-clustered.spec.ts
@@ -23,19 +23,19 @@ test("cluster member evacuate and restore", async ({
   const restoreBtn = memberRow.getByRole("button", { name: "Restore" });
   if (await restoreBtn.isEnabled()) {
     await restoreBtn.click();
-    await page.getByRole("button", { name: "Restore member" }).click();
+    await page.getByText("Restore cluster member", { exact: true }).click();
     await page.waitForSelector(`text=Member ${member} restore completed.`);
   }
 
   await memberRow.hover();
   await memberRow.getByRole("button", { name: "Evacuate" }).click();
-  await page.getByText("Evacuate member").click();
+  await page.getByText("Evacuate cluster member", { exact: true }).click();
 
   await page.waitForSelector(`text=Member ${member} evacuation completed.`);
 
   await memberRow.hover();
   await memberRow.getByRole("button", { name: "Restore" }).click();
-  await page.getByText("Restore member").click();
+  await page.getByText("Restore cluster member", { exact: true }).click();
 
   await page.waitForSelector(`text=Member ${member} restore completed.`);
 });

--- a/tests/members-clustered.spec.ts
+++ b/tests/members-clustered.spec.ts
@@ -1,5 +1,4 @@
 import { test } from "./fixtures/lxd-test";
-import { gotoURL } from "./helpers/navigate";
 import {
   getFirstClusterMember,
   skipIfNotClustered,
@@ -13,10 +12,6 @@ test("cluster member evacuate and restore", async ({
   skipIfNotSupported(lxdVersion);
   skipIfNotClustered(testInfo.project.name);
   const member = await getFirstClusterMember(page);
-
-  await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Clustering" }).click();
-  await page.getByRole("link", { name: "Members" }).click();
   const memberRow = page.getByRole("row").filter({ hasText: member });
 
   await memberRow.hover();

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -155,7 +155,7 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     await page.keyboard.press("Escape");
     await page
       .locator("#instances-table")
-      .getByRole("rowheader", { name: `Select ${instanceName1}` })
+      .getByRole("cell", { name: `Select ${instanceName1}` })
       .hover();
     await expect(
       page


### PR DESCRIPTION
## Done

- fix(cluster) permission checks for cluster groups and members
- disable buttons if user has no permissions

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - use a user with limited permissions, as in only having project viewer on the default project
    - go to clustering > members and clustering > groups and ensure the interactive elements are disabled (like edit and delete or evacuate)