### PR TITLE
fix(instance) column responsiveness for a non-clustered environment for the instance list should not consider cluster member column

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -126,6 +126,13 @@ const InstanceList: FC = () => {
     return <>Missing project</>;
   }
 
+  useEffect(() => {
+    if (isClustered || !userHidden.includes(CLUSTER_MEMBER)) {
+      return;
+    }
+    setUserHidden(userHidden.filter((col) => col !== CLUSTER_MEMBER));
+  }, [isClustered]);
+
   const {
     data: instances = [],
     error,
@@ -587,6 +594,9 @@ const InstanceList: FC = () => {
     let gainedSpace = 0;
     const sizeHiddenNew: string[] = [];
     SIZE_HIDEABLE_COLUMNS.forEach((column) => {
+      if (column === CLUSTER_MEMBER && !isClustered) {
+        return;
+      }
       if (
         tableWidth - gainedSpace > wrapWidth &&
         !userHidden.includes(column)
@@ -597,6 +607,7 @@ const InstanceList: FC = () => {
     });
     if (JSON.stringify(sizeHiddenNew) !== JSON.stringify(sizeHidden)) {
       setSizeHidden(sizeHiddenNew);
+      console.log(sizeHiddenNew);
     }
   };
   useListener(window, figureSizeHidden, "resize", true);


### PR DESCRIPTION
## Done

- fix(instance) column responsiveness for a non-clustered environment for the instance list should not consider cluster member column

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance list on a non-clustered backend. Resize the window width and ensure the columns get hidden correctly.
    - test instance list with side panel open and resizing window from mobile to desktop and back.