### PR TITLE
feat(instance) show notification on exporting instance with attached disks

### DIFF
--- a/src/pages/instances/forms/ExportInstanceModal.tsx
+++ b/src/pages/instances/forms/ExportInstanceModal.tsx
@@ -7,6 +7,7 @@ import {
   Form,
   Input,
   Modal,
+  Notification,
   Select,
   useToastNotification,
 } from "@canonical/react-components";
@@ -17,6 +18,8 @@ import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useSettings } from "context/useSettings";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
+import { isDiskDevice } from "util/devices";
+import { pluralize } from "util/instanceBulkActions";
 
 interface Props {
   instance: LxdInstance;
@@ -130,6 +133,11 @@ const ExportInstanceModal: FC<Props> = ({ instance, close }) => {
     },
   });
 
+  const customDiskDevices = Object.values(instance?.expanded_devices ?? {})
+    .filter(isDiskDevice)
+    .filter((device) => device.path !== "/"); // ignore root disk device
+  const hasCustomDisks = customDiskDevices.length > 0;
+
   return (
     <Modal
       close={close}
@@ -158,6 +166,16 @@ const ExportInstanceModal: FC<Props> = ({ instance, close }) => {
       }
     >
       <Form onSubmit={formik.handleSubmit}>
+        {hasCustomDisks && (
+          <Notification
+            severity="information"
+            title="Custom disks wil be ignored"
+          >
+            This instance has {customDiskDevices.length} custom{" "}
+            {pluralize("disk", customDiskDevices.length)}, which will be ignored
+            in the export.
+          </Notification>
+        )}
         <Select
           {...formik.getFieldProps("compression")}
           id="project"


### PR DESCRIPTION
## Done

- feat(instance) show notification on exporting instance with attached disks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Configure three instances, one without custom disks, one with a custom disk and one with more than one custom disks
    - Open the export modal for all three and ensure the notification does not show up or uses the right pluralization for each case.

## Screenshots

<img width="643" height="862" alt="image" src="https://github.com/user-attachments/assets/5e19a49c-1f10-4cb8-9b9e-9396971c052d" />

<img width="643" height="862" alt="image" src="https://github.com/user-attachments/assets/1a47453f-06b3-43f9-8c34-8c9ab9bde34f" />

<img width="647" height="721" alt="image" src="https://github.com/user-attachments/assets/0bc4ad64-eda1-4f63-b29d-30266e11234f" />
