### PR TITLE
fix(InstanceTerminal): typo in message to user

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -289,7 +289,7 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
         >
           <p>
             {isBooting
-              ? "Terminal will be ready once the instance is finished booting."
+              ? "Terminal will be ready once the instance has finished booting."
               : "Start the instance to access the terminal."}
           </p>
           <ActionButton


### PR DESCRIPTION
## Done

- Fix typo: "Terminal will be ready once the instance is finished booting." -> "Terminal will be ready once the instance **has** finished booting."

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Start an instance, preferably one that takes forever to boot
    - Go to this instance terminal and check the message

## Screenshots

<img width="743" height="220" alt="Screenshot from 2025-09-19 14-45-02" src="https://github.com/user-attachments/assets/af133d84-c712-48ca-b222-8d389d897f75" />
