### PR TITLE
fix(forms) debounce validation of names when validating forms

### DIFF
--- a/src/util/debounce.tsx
+++ b/src/util/debounce.tsx
@@ -6,3 +6,33 @@ export const debounce = (method: () => void, delay: number) => {
   clearTimeout(debouncedMethod._timeoutId);
   debouncedMethod._timeoutId = setTimeout(method, delay);
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounceAsync<F extends (...args: any[]) => Promise<any>>(
+  fn: F,
+  delay: number,
+  defaultValue: ReturnType<F> = true as ReturnType<F>,
+): (...args: Parameters<F>) => Promise<ReturnType<F>> {
+  let timeoutId: NodeJS.Timeout;
+  let pendingResolve: ((value: ReturnType<F>) => void) | null = null;
+
+  return async (...args: Parameters<F>) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (pendingResolve) {
+      pendingResolve(defaultValue);
+    }
+
+    return new Promise<ReturnType<F>>((resolve, reject) => {
+      pendingResolve = resolve;
+      timeoutId = setTimeout(() => {
+        try {
+          fn(...args).then(resolve);
+        } catch (err) {
+          reject(err as Error);
+        } finally {
+          pendingResolve = null;
+        }
+      }, delay);
+    });
+  };
+}

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -11,6 +11,7 @@ import { isRootDisk } from "./instanceValidation";
 import type { FormDevice } from "./formDevices";
 import type { LxdIdentity } from "types/permissions";
 import { addTarget } from "util/target";
+import { debounceAsync } from "util/debounce";
 
 export const UNDEFINED_DATE = "0001-01-01T00:00:00Z";
 
@@ -174,7 +175,10 @@ export type AbortControllerState = [
   Dispatch<SetStateAction<AbortController | null>>,
 ];
 
-export const checkDuplicateName = async (
+const validNameCache: Record<string, string[]> = {};
+const invalidNameCache: Record<string, string[]> = {};
+
+const _checkDuplicateName = async (
   candidate: string | undefined,
   project: string,
   controllerState: AbortControllerState,
@@ -193,13 +197,37 @@ export const checkDuplicateName = async (
   params.set("project", project);
   addTarget(params, target);
 
+  const cacheKey = `${basePath}-${params.toString()}`;
+  if (!validNameCache[cacheKey]) {
+    validNameCache[cacheKey] = [];
+  }
+  if (validNameCache[cacheKey].includes(candidate)) {
+    return true;
+  }
+  if (!invalidNameCache[cacheKey]) {
+    invalidNameCache[cacheKey] = [];
+  }
+  if (invalidNameCache[cacheKey].includes(candidate)) {
+    return false;
+  }
+
   return fetch(
     `/1.0/${basePath}/${encodeURIComponent(candidate)}?${params.toString()}`,
     {
       signal,
     },
-  ).then((response) => response.status === 404);
+  ).then((response) => {
+    if (response.status === 404) {
+      validNameCache[cacheKey].push(candidate);
+      return true;
+    } else {
+      invalidNameCache[cacheKey].push(candidate);
+      return false;
+    }
+  });
 };
+
+export const checkDuplicateName = debounceAsync(_checkDuplicateName, 500);
 
 export const getUrlParam = (paramName: string, url?: string): string | null => {
   const targetUrl = url ?? location.href;

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -34,8 +34,9 @@ export const createNetwork = async (
   if (type === "ovn") {
     await page.getByLabel("Uplink").selectOption({ index: 1 });
   }
-
+  await page.waitForTimeout(750);
   await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForTimeout(2500);
   const networkLink = await getNetworkLink(page, network);
   await expect(networkLink).toBeVisible();
 };


### PR DESCRIPTION
## Done

- fix(forms) debounce validation of names when validating them in forms

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start a new instance creation
    - quickly type the name and ensure there is only one request sent to validate the name in network debug tools
    - ensure the deduplication still catches conflicting names when reusing existing instance names.

FYI @tomponline and @markylaing