### PR TITLE
fix(pool) ceph source to be sent as cluster member specific config

### DIFF
--- a/src/pages/storage/forms/ClusteredSourceSelector.tsx
+++ b/src/pages/storage/forms/ClusteredSourceSelector.tsx
@@ -8,12 +8,14 @@ import { useClusterMembers } from "context/useClusterMembers";
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
   helpText?: string;
+  canToggleMemberSpecific?: boolean;
   disabledReason?: string;
 }
 
 const ClusteredSourceSelector: FC<Props> = ({
   formik,
   helpText,
+  canToggleMemberSpecific = true,
   disabledReason,
 }) => {
   const { data: clusterMembers = [] } = useClusterMembers();
@@ -29,7 +31,7 @@ const ClusteredSourceSelector: FC<Props> = ({
         onChange={(value) => {
           formik.setFieldValue("sourcePerClusterMember", value);
         }}
-        canToggleSpecific={formik.values.isCreating}
+        canToggleSpecific={formik.values.isCreating && canToggleMemberSpecific}
         memberNames={memberNames}
         disabled={!formik.values.isCreating}
         helpText={helpText}

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -9,9 +9,9 @@ import {
   getStorageDriverOptions,
   powerFlex,
   pureStorage,
-  cephFSDriver,
   cephObject,
   alletraDriver,
+  isClusterWideSourceDriver,
 } from "util/storageOptions";
 import type { StoragePoolFormValues } from "./StoragePoolForm";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
@@ -54,14 +54,13 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
     };
   };
 
-  const isCephDriver = formik.values.driver === cephDriver;
-  const isCephFSDriver = formik.values.driver === cephFSDriver;
   const isCephObjectDriver = formik.values.driver === cephObject;
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
   const isAlletraDriver = formik.values.driver === alletraDriver;
   const storageDriverOptions = getStorageDriverOptions(settings);
-  const hasClusterWideSource = isCephDriver || isCephFSDriver;
+  const isClusterWideSource = isClusterWideSourceDriver(formik.values.driver);
+
   const hasSource =
     !isPureDriver &&
     !isPowerFlexDriver &&
@@ -207,7 +206,14 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
               />
             ))}
           {hasSource &&
-            (hasClusterWideSource || !isClusteredServer(settings) ? (
+            (isClusteredServer(settings) ? (
+              <ClusteredSourceSelector
+                formik={formik}
+                helpText={sourceHelpText}
+                disabledReason={formik.values.editRestriction}
+                canToggleMemberSpecific={!isClusterWideSource}
+              />
+            ) : (
               <Input
                 {...getFormProps("source")}
                 type="text"
@@ -217,12 +223,6 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
                 help={sourceHelpText}
                 label="Source"
                 title={formik.values.editRestriction}
-              />
-            ) : (
-              <ClusteredSourceSelector
-                formik={formik}
-                helpText={sourceHelpText}
-                disabledReason={formik.values.editRestriction}
               />
             ))}
           {isCephObjectDriver && (

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -26,9 +26,14 @@ export const storageDriverLabels: { [key: string]: string } = {
 };
 
 const bucketCompatibleDrivers = [cephObject];
+const driversWithClusterWideSource = [cephDriver, cephFSDriver];
 
 export const isBucketCompatibleDriver = (driver: string): boolean => {
   return bucketCompatibleDrivers.includes(driver);
+};
+
+export const isClusterWideSourceDriver = (driver: string): boolean => {
+  return driversWithClusterWideSource.includes(driver);
 };
 
 export const getStorageDriverOptions = (


### PR DESCRIPTION
## Done

- fix(pool) ceph source to be sent as cluster member specific config

Fixes #1526

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In a cluster with ceph configured
    - create a storage pool, specify a source
    - ensure the pool is created and on edit the source is displayed correctly on the pool configuration