### PR TITLE
fix(network) preserve network config on a cluster in a special case

### DIFF
--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -265,12 +265,13 @@ export const updateClusterNetwork = async (
   clusterMembers: LxdClusterMember[],
   parentsPerClusterMember: ClusterSpecificValues,
   bridgeExternalInterfacesPerClusterMember?: ClusterSpecificValues,
+  oldConfig?: LxdNetworkConfig,
 ): Promise<void> => {
   return new Promise((resolve, reject) => {
     Promise.allSettled(
       clusterMembers.map(async (member) => {
         const memberName = member.server_name;
-        const config: LxdNetworkConfig = {};
+        const config: LxdNetworkConfig = { ...oldConfig };
         if (parentsPerClusterMember?.[memberName]) {
           config.parent = parentsPerClusterMember[memberName];
         }

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -116,6 +116,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
             clusterMembers,
             values.parentPerClusterMember,
             values.bridge_external_interfaces_per_member,
+            network.config,
           );
         } else {
           return updateNetwork(saveNetwork, project);


### PR DESCRIPTION
## Done

- fix(network) preserve network config on a cluster in a special case when bgp.peers are changed and leading to an error in the final update of the network. instead include the old config details of the network in the cluster member specific updates.

Fixes https://github.com/canonical/lxd/issues/16652

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in a microcloud create a physical network
    - open the yaml editor for the network, enter following config: 
```
  bgp.peers.mx1.address: 2001:db8:3cc4:3::1
  bgp.peers.mx1.asn: '65512'
  volatile.last_state.created: 'false'
  ipv4.ovn.ranges: 192.168.3.30-192.168.3.45
  ipv4.gateway: 192.168.3.1/24
  ipv4.routes: 172.16.0.0/20
  ipv6.ovn.ranges: 2001:db8:3cc4:3::30-2001:db8:3cc4:3::45
  ipv6.gateway: 2001:db8:3cc4:3::1/64
  ipv6.routes: 2001:db8:3cc4:1ab0::/60
```
   - change the bgp.peers.mx1.asn, by incrementing it quickly and saving. Ensure no error occurs.