### PR TITLE
fix(test) ensure network test is picking first available network

### DIFF
--- a/tests/devices.spec.ts
+++ b/tests/devices.spec.ts
@@ -131,7 +131,8 @@ test("profile edit networks", async ({ page }) => {
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.getByPlaceholder("Enter name").fill("eth0");
   await page.getByRole("button", { name: "Network", exact: true }).click();
-  await page.getByText("lxdbr0 (bridge)").click();
+  await expect(page.getByText("NameTypeACLs")).toBeVisible();
+  await page.keyboard.press("Enter");
   await finishProfileCreation(page, profile);
 
   await visitProfile(page, profile);
@@ -141,10 +142,8 @@ test("profile edit networks", async ({ page }) => {
 
   await page.getByRole("button", { name: "Attach network" }).click();
   await page.locator("[id='devices.1.network']").click();
-  await page
-    .locator("[id='devices.1.network']")
-    .getByText("lxdbr0 (bridge)")
-    .click();
+  await expect(page.getByText("NameTypeACLs")).toBeVisible();
+  await page.keyboard.press("Enter");
   await page.locator("[id='devices.1.name']").fill("eth1");
   await saveProfile(page, profile, 1);
 


### PR DESCRIPTION
## Done

- fix(test) ensure network test is picking first available network without assuming existance of lxdbr0

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - not needed

## Screenshots

[if relevant, include a screenshot or screen capture]