### PR TITLE
feat: [WD-24082] Schedule doc screenshots

### DIFF
--- a/.github/workflows/screenshot_automation.yaml
+++ b/.github/workflows/screenshot_automation.yaml
@@ -1,0 +1,88 @@
+name: Screenshot automation
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sundays at midnight
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-e2e-test:
+    name: generate-screenshots
+    runs-on: ubuntu-latest
+    outputs:
+      job_status: ${{job.status}}
+    env:
+      LXD_OIDC_CLIENT_ID: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
+      LXD_OIDC_CLIENT_SECRET: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
+      LXD_OIDC_ISSUER: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
+      LXD_OIDC_AUDIENCE: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
+      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
+      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
+      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Dotrun
+        run: |
+          sudo pip3 install dotrun
+
+      - name: Install LXD-UI dependencies
+        run: |
+          set -x
+          sudo chmod 0777 ../lxd-ui
+          dotrun install
+
+      - name: Run LXD-UI
+        env:
+          ENVIRONMENT: devel
+          PORT: 8407
+          LXD_UI_BACKEND_IP: 172.17.0.1
+          VITE_PORT: 3000
+        run: |
+          dotrun &
+          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
+
+      - name: Install LXD
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          group: lxd
+
+      - name: Setup LXD
+        shell: bash
+        run: |
+          set -x
+          sudo lxc config set core.https_address "[::]:8443"
+          sudo lxc config trust add keys/lxd-ui.crt
+          sudo lxc config set cluster.https_address "127.0.0.1"
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Setup for tests
+        shell: bash
+        run: sudo -E ./tests/scripts/setup_test
+
+      - name: Run Playwright tests
+        env:
+          ENABLE_SCREENSHOTS: true
+        run: |
+          npx playwright test --project screenshots
+          npx playwright test --project screenshots-clustered
+
+      - name: Upload screenshot-automation-report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: blob-report
+          retention-days: 1

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -199,6 +199,23 @@ const config: PlaywrightTestConfig<TestOptions> = {
       dependencies: ["enable-clustering-chrome"],
       testMatch: "*-clustered.spec.ts",
     },
+    {
+      name: "screenshots",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+      },
+      testMatch: "docs-screenshots.spec.ts",
+    },
+    {
+      name: "screenshots-clustered",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+      },
+      dependencies: ["enable-clustering-chrome"],
+      testMatch: "docs-screenshots-clustered.spec.ts",
+    },
   ],
 };
 

--- a/tests/docs-screenshots-clustered.spec.ts
+++ b/tests/docs-screenshots-clustered.spec.ts
@@ -5,7 +5,7 @@ import { createPool, deletePool } from "./helpers/storagePool";
 
 test.beforeEach(() => {
   test.skip(
-    Boolean(process.env.CI),
+    !!process.env.CI && !process.env.ENABLE_SCREENSHOTS,
     "This suite is only run manually to create screenshots for the documentation",
   );
 });
@@ -56,17 +56,17 @@ test("Clustered storage volumes", async ({ page }) => {
 });
 
 test("LXD - UI Folder - Clustered", async ({ page }) => {
-  //This test assumes that there is a cluster member named micro2 within the environment. This is the value within the original screenshot, but it can also be changed to accomodate alternative names.
-  const clusterMemberName = "micro2";
+  //This test assumes that there is a cluster member named micro1 within the environment. This is the value within the original screenshot, but it can also be changed to accomodate alternative names.
+  const clusterMemberName = "micro1";
   page.setViewportSize({ width: 1440, height: 800 });
   await gotoURL(page, "/ui/");
   await page.getByRole("link", { name: "Instances", exact: true }).click();
-  await page.getByText("Create instance").click();
+  await page.getByRole("button", { name: "Create instance" }).click();
   await page.getByPlaceholder("Enter name").fill("Ubuntu-vm-server2");
   await page.getByRole("button", { name: "Browse images" }).click();
   await page
     .locator("tr")
-    .filter({ hasText: "Ubuntu24.04 LTSnoblealldefaultUbuntuSelect" })
+    .filter({ hasText: "Ubuntu24.04 LTSnoblealldefaultUbuntuRemoteSelect" })
     .getByRole("button")
     .click();
   await page.getByLabel("Cluster member").selectOption(clusterMemberName);

--- a/tests/enable-clustering.spec.ts
+++ b/tests/enable-clustering.spec.ts
@@ -11,7 +11,7 @@ test("check enabling clustering", async ({ page, lxdVersion }, testInfo) => {
   await page.getByTestId("tab-link-Clustering").click();
   await expect(page.getByText("This server is not clustered")).toBeVisible();
   await page.getByRole("button", { name: "Enable clustering" }).click();
-  await page.getByLabel("Server name").fill("test-cluster");
+  await page.getByLabel("Server name").fill("micro1");
   await page.getByLabel("Cluster address").fill("127.0.0.1");
   await page.getByRole("button", { name: "Enable clustering" }).nth(1).click();
   await page.waitForSelector(`text=Clustering enabled`);

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -34,11 +34,7 @@ export const createNetwork = async (
   if (type === "ovn") {
     await page.getByLabel("Uplink").selectOption({ index: 1 });
   }
-  await page.waitForTimeout(750);
-  await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForTimeout(2500);
-  const networkLink = await getNetworkLink(page, network);
-  await expect(networkLink).toBeVisible();
+  await submitCreateNetwork(page, network);
 };
 
 export const deleteNetwork = async (page: Page, network: string) => {
@@ -48,12 +44,14 @@ export const deleteNetwork = async (page: Page, network: string) => {
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })
     .click();
+  await page.waitForTimeout(2500);
   const networkLink = await getNetworkLink(page, network);
   await expect(networkLink).not.toBeVisible();
 };
 
 export const visitNetwork = async (page: Page, network: string) => {
   await gotoURL(page, "/ui/");
+  await page.waitForLoadState("networkidle");
   await page.getByRole("button", { name: "Networking" }).click();
   await page.getByRole("link", { name: "Networks", exact: true }).click();
   await page.getByRole("link", { name: network }).first().click();
@@ -113,10 +111,10 @@ export const createNetworkForward = async (page: Page, network: string) => {
   await page
     .getByText(`Network forward with listen address ${listenAddress} created.`)
     .click();
-  await page.getByText(`:80 → ${targetAddress}:80 (tcp)`).click();
-  await page
-    .getByText(`:23,443-455 → ${targetAddress}:23,443-455 (tcp)`)
-    .click();
+  await expect(page.getByText(`:80 → ${targetAddress}:80 (tcp)`)).toBeVisible();
+  await expect(
+    page.getByText(`:23,443-455 → ${targetAddress}:23,443-455 (tcp)`),
+  ).toBeVisible();
 
   await page.getByRole("link", { name: "Edit network forward" }).click();
   await expect(page.getByText("Edit a network forward")).toBeVisible();
@@ -152,7 +150,15 @@ export const getNetworkLink = async (page: Page, network: string) => {
   await page.waitForLoadState("networkidle");
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Networking" }).click();
-  await page.getByRole("link", { name: "Networks", exact: true }).click();
+  await page.getByTitle("Networks (default)").click();
   const networkLink = page.getByRole("link", { name: network, exact: true });
   return networkLink;
+};
+
+export const submitCreateNetwork = async (page: Page, network: string) => {
+  await page.waitForTimeout(750);
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.waitForTimeout(2500);
+  const networkLink = await getNetworkLink(page, network);
+  await expect(networkLink).toBeVisible();
 };


### PR DESCRIPTION
## Done

- Created screenshot_automation.yaml, a new workflow to automate documentation screenshots.

Fixes inability to generate documentation images.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Manually start the workflow from Github actions and verify that screenshots are generated as behaviour suggests.

## Screenshots

N/A