### PR TITLE
feat(NetworkDevicesForm): override inherited network

### DIFF
--- a/src/components/DeviceDetails.tsx
+++ b/src/components/DeviceDetails.tsx
@@ -17,7 +17,7 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
         <>
           Pool{" "}
           <ResourceLink
-            type={"pool"}
+            type="pool"
             value={device.pool || ""}
             to={`/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}`}
           />
@@ -33,13 +33,13 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
       <>
         Volume{" "}
         <ResourceLink
-          type={"volume"}
+          type="volume"
           value={device.source as string}
           to={`/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}/volumes/custom/${encodeURIComponent(device.source ?? "")}`}
         />{" "}
         on pool{" "}
         <ResourceLink
-          type={"pool"}
+          type="pool"
           value={device.pool || ""}
           to={`/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}`}
         />

--- a/src/components/UsedByItem.tsx
+++ b/src/components/UsedByItem.tsx
@@ -55,7 +55,7 @@ const UsedByItem: FC<Props> = ({
       {type === "snapshot" && item.volume && (
         <>
           <ResourceLink
-            type={"volume"}
+            type="volume"
             value={item.volume}
             to={linkForVolumeDetail({
               name: item.volume,

--- a/src/components/forms/NetworkDevicesForm/InheritedNetworkRow.tsx
+++ b/src/components/forms/NetworkDevicesForm/InheritedNetworkRow.tsx
@@ -1,0 +1,100 @@
+import ResourceLink from "components/ResourceLink";
+import { getConfigurationRowBase } from "components/ConfigurationRow";
+import ReadOnlyAclsList from "components/forms/NetworkDevicesForm/ReadOnlyAclsList";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import type { InheritedNetwork } from "util/configInheritance";
+import type { LxdNetwork } from "types/network";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import classnames from "classnames";
+import NetworkDevice from "./NetworkDevice";
+import type { LxdNicDevice, LxdNoneDevice } from "types/device";
+import { isNoneDevice } from "util/devices";
+
+interface Props {
+  device: InheritedNetwork;
+  project: string;
+  managedNetworks: LxdNetwork[];
+  formik: InstanceAndProfileFormikProps;
+}
+
+export const getInheritedNetworkRow = ({
+  device,
+  project,
+  managedNetworks,
+  formik,
+}: Props): MainTableRow => {
+  const overrideDevice = formik.values.devices.find(
+    (t) => t.name === device.key,
+  ) as LxdNicDevice | LxdNoneDevice | undefined;
+  const isOverridden = overrideDevice !== undefined;
+  const isDetached = overrideDevice && isNoneDevice(overrideDevice);
+
+  const overrideNetwork = managedNetworks.find(
+    (t) => t.name === (overrideDevice as LxdNicDevice)?.network,
+  );
+
+  return getConfigurationRowBase({
+    configuration: (
+      <b
+        className={classnames({
+          "u-text--muted": isDetached,
+          "u-text--line-through": isDetached,
+        })}
+      >
+        {device.key}
+      </b>
+    ),
+    inherited: (
+      <div>
+        <div
+          className={classnames("p-text--small", "u-text--muted", {
+            "u-text--line-through": isOverridden,
+          })}
+        >
+          From profile{" "}
+          <ResourceLink
+            type="profile"
+            value={device.sourceProfile}
+            to={`/ui/project/${encodeURIComponent(project)}/profile/${encodeURIComponent(device.sourceProfile)}`}
+            className={classnames({
+              "u-text--line-through": isOverridden,
+            })}
+          />
+        </div>
+        <div
+          className={classnames({
+            "u-text--muted": isOverridden,
+            "u-text--line-through": isOverridden,
+          })}
+        >
+          Network
+        </div>
+        <ResourceLink
+          type="network"
+          value={device.network?.network || ""}
+          to={`/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(device.network?.network || "")}`}
+          className={classnames({
+            "u-text--line-through": isOverridden,
+          })}
+        />
+        <ReadOnlyAclsList
+          project={project}
+          network={managedNetworks.find(
+            (t) => t.name === device.network?.network,
+          )}
+          device={device.network}
+          isOverridden={isOverridden}
+        />
+      </div>
+    ),
+    override: (
+      <NetworkDevice
+        formik={formik}
+        project={project}
+        device={overrideDevice}
+        network={overrideNetwork}
+        inheritedDevice={device}
+      />
+    ),
+  });
+};

--- a/src/components/forms/NetworkDevicesForm/NetworkDeviceAcls.tsx
+++ b/src/components/forms/NetworkDevicesForm/NetworkDeviceAcls.tsx
@@ -3,7 +3,7 @@ import type { LxdNicDevice } from "types/device";
 import type { LxdNetwork } from "types/network";
 import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import NetworkAclSelector from "pages/networks/forms/NetworkAclSelector";
-import { getDeviceAcls } from "util/devices";
+import { getDeviceAcls, getIndex } from "util/devices";
 import { getNetworkAcls } from "util/networks";
 import ReadOnlyAclsList from "./ReadOnlyAclsList";
 
@@ -13,7 +13,6 @@ interface Props {
   device: LxdNicDevice;
   readOnly?: boolean;
   formik?: InstanceAndProfileFormikProps;
-  index?: number;
   canSelectManualAcls?: boolean;
 }
 
@@ -23,7 +22,6 @@ const NetworkDeviceAcls: FC<Props> = ({
   device,
   readOnly,
   formik,
-  index,
   canSelectManualAcls,
 }) => {
   if (readOnly) {
@@ -62,7 +60,7 @@ const NetworkDeviceAcls: FC<Props> = ({
           selectedAcls={selectedAcls}
           setSelectedAcls={(selectedItems) => {
             formik.setFieldValue(
-              `devices.${index}["security.acls"]`,
+              `devices.${getIndex(device.name || "", formik)}["security.acls"]`,
               selectedItems.join(","),
             );
           }}

--- a/src/components/forms/NetworkDevicesForm/NetworkDeviceActionButtons.tsx
+++ b/src/components/forms/NetworkDevicesForm/NetworkDeviceActionButtons.tsx
@@ -1,0 +1,175 @@
+import { Button, Icon } from "@canonical/react-components";
+import type { FC } from "react";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { ensureEditMode } from "util/instanceEdit";
+import {
+  addNicDevice,
+  addNoneDevice,
+  focusNicDevice,
+  removeNicDevice,
+} from "util/formDevices";
+import type { LxdNicDevice, LxdNoneDevice } from "types/device";
+import { isNicDevice, isNoneDevice } from "util/devices";
+import type { InheritedNetwork } from "util/configInheritance";
+
+interface Props {
+  readOnly: boolean;
+  formik: InstanceAndProfileFormikProps;
+  index: number;
+  device?: LxdNicDevice | LxdNoneDevice;
+  inheritedDevice?: InheritedNetwork;
+}
+
+const NetworkDeviceActionButtons: FC<Props> = ({
+  readOnly,
+  formik,
+  index,
+  device,
+  inheritedDevice,
+}: Props) => {
+  const isPurelyInherited = inheritedDevice && !device;
+  const hasNicOverride = inheritedDevice && device && isNicDevice(device);
+  const hasNoneOverride = inheritedDevice && device && isNoneDevice(device);
+  const isLocal = !inheritedDevice && device;
+
+  const isDisabled = !!formik.values.editRestriction;
+
+  const getEditTitle = () => {
+    if (formik.values.editRestriction) return formik.values.editRestriction;
+    if (isPurelyInherited || hasNoneOverride) return "Create override";
+    if (hasNicOverride) return "Edit override";
+    return "Edit network";
+  };
+  const editTitle = getEditTitle();
+
+  const onEdit = () => {
+    ensureEditMode(formik);
+    if (isPurelyInherited || hasNoneOverride) {
+      const newDeviceIndex = formik.values.devices.length;
+      addNicDevice({
+        formik,
+        deviceName: inheritedDevice.key,
+        deviceNetworkName: inheritedDevice.network?.network ?? "",
+      });
+      focusNicDevice(newDeviceIndex);
+    } else {
+      focusNicDevice(index);
+    }
+  };
+
+  const clearOverride = () => {
+    ensureEditMode(formik);
+    removeNicDevice({ formik, deviceName: device?.name || "" });
+  };
+
+  const detachInherited = () => {
+    ensureEditMode(formik);
+    addNoneDevice(inheritedDevice?.key || "", formik);
+  };
+
+  const detachOverridden = () => {
+    ensureEditMode(formik);
+    addNoneDevice(device?.name || "", formik);
+  };
+
+  return (
+    <div className="network-device-actions">
+      {(readOnly || isPurelyInherited) && (
+        <Button
+          onClick={onEdit}
+          type="button"
+          appearance="base"
+          title={editTitle}
+          className="u-no-margin--top"
+          hasIcon
+          dense
+          disabled={isDisabled}
+        >
+          <Icon name="edit" />
+          <span>Edit</span>
+        </Button>
+      )}
+
+      {isPurelyInherited && (
+        <Button
+          className="u-no-margin--top"
+          onClick={detachInherited}
+          type="button"
+          appearance="base"
+          hasIcon
+          dense
+          title={formik.values.editRestriction || "Detach network"}
+          disabled={isDisabled}
+        >
+          <Icon name="disconnect" />
+          <span>Detach</span>
+        </Button>
+      )}
+
+      {hasNicOverride && (
+        <>
+          <Button
+            className="u-no-margin--top"
+            onClick={clearOverride}
+            type="button"
+            appearance="base"
+            hasIcon
+            dense
+            title={formik.values.editRestriction || "Clear override"}
+            disabled={isDisabled}
+          >
+            <Icon name="close" />
+            <span>Clear</span>
+          </Button>
+          <Button
+            className="u-no-margin--top"
+            onClick={detachInherited}
+            type="button"
+            appearance="base"
+            hasIcon
+            dense
+            title={formik.values.editRestriction || "Detach network"}
+            disabled={isDisabled}
+          >
+            <Icon name="disconnect" />
+            <span>Detach</span>
+          </Button>
+        </>
+      )}
+
+      {hasNoneOverride && (
+        <Button
+          className="u-no-margin--top"
+          onClick={clearOverride}
+          type="button"
+          appearance="base"
+          hasIcon
+          dense
+          title={formik.values.editRestriction || "Reattach inherited network"}
+          disabled={isDisabled}
+        >
+          <Icon name="connected" />
+          <span>Reattach</span>
+        </Button>
+      )}
+
+      {isLocal && (
+        <Button
+          className="u-no-margin--top"
+          onClick={detachOverridden}
+          type="button"
+          appearance="base"
+          hasIcon
+          dense
+          title={formik.values.editRestriction || "Detach network"}
+          disabled={isDisabled}
+        >
+          <Icon name="disconnect" />
+          <span>Detach</span>
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default NetworkDeviceActionButtons;

--- a/src/components/forms/NetworkDevicesForm/NetworkDeviceContent.tsx
+++ b/src/components/forms/NetworkDevicesForm/NetworkDeviceContent.tsx
@@ -1,0 +1,89 @@
+import ResourceLink from "components/ResourceLink";
+import type { FC } from "react";
+import type { LxdNicDevice, LxdNoneDevice } from "types/device";
+import NetworkDeviceAcls from "./NetworkDeviceAcls";
+import type { LxdNetwork } from "types/network";
+import NetworkSelector from "pages/projects/forms/NetworkSelector";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { supportsNicDeviceAcls } from "util/networks";
+import { isNoneDevice } from "util/devices";
+
+interface Props {
+  readOnly: boolean;
+  project: string;
+  formik: InstanceAndProfileFormikProps;
+  device: LxdNicDevice | LxdNoneDevice;
+  index: number;
+  managedNetworks: LxdNetwork[];
+  network?: LxdNetwork;
+}
+
+const NetworkDeviceContent: FC<Props> = ({
+  readOnly,
+  project,
+  formik,
+  device,
+  index,
+  managedNetworks,
+  network,
+}) => {
+  if (isNoneDevice(device)) {
+    return (
+      <span className="u-text--muted">
+        <i>detached</i>
+      </span>
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <>
+        <div>Network</div>
+        <ResourceLink
+          type="network"
+          value={device.network}
+          to={`/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(device.network)}`}
+        />
+        <NetworkDeviceAcls
+          project={project}
+          network={network}
+          device={device}
+          readOnly
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <NetworkSelector
+        value={device.network}
+        setValue={(value) => {
+          formik.setFieldValue(`devices.${index}.network`, value);
+
+          const selectedNetwork = managedNetworks.find((t) => t.name === value);
+
+          if (selectedNetwork && !supportsNicDeviceAcls(selectedNetwork)) {
+            formik.setFieldValue(
+              `devices.${index}["security.acls"]`,
+              undefined,
+            );
+          }
+        }}
+        id={`devices.${index}.network`}
+        name={`devices.${index}.network`}
+        managedNetworks={managedNetworks}
+      />
+      <NetworkDeviceAcls
+        project={project}
+        network={network}
+        device={device}
+        readOnly={readOnly}
+        formik={formik}
+        canSelectManualAcls={supportsNicDeviceAcls(network)}
+      />
+    </>
+  );
+};
+
+export default NetworkDeviceContent;

--- a/src/components/forms/NetworkDevicesForm/ReadOnlyAclsList.tsx
+++ b/src/components/forms/NetworkDevicesForm/ReadOnlyAclsList.tsx
@@ -5,14 +5,21 @@ import type { LxdNicDevice } from "types/device";
 import type { LxdNetwork } from "types/network";
 import { getDeviceAcls } from "util/devices";
 import { getNetworkAcls } from "util/networks";
+import classnames from "classnames";
 
 interface Props {
   project: string;
   network?: LxdNetwork;
   device: LxdNicDevice | null;
+  isOverridden?: boolean;
 }
 
-const ReadOnlyAclsList: FC<Props> = ({ project, network, device }) => {
+const ReadOnlyAclsList: FC<Props> = ({
+  project,
+  network,
+  device,
+  isOverridden,
+}) => {
   const networkAcls = getNetworkAcls(network);
   const deviceAcls = getDeviceAcls(device);
   const allAcls = Array.from(new Set(networkAcls.concat(deviceAcls)));
@@ -20,23 +27,29 @@ const ReadOnlyAclsList: FC<Props> = ({ project, network, device }) => {
   if (!allAcls.length) return null;
 
   return (
-    <div className="acls-from-network">
-      <div>ACLs</div>
-      <div>
-        <ExpandableList
-          items={allAcls.map((acl) => (
-            <div key={acl}>
-              <ResourceLink
-                type="network-acl"
-                value={acl}
-                to={`/ui/project/${encodeURIComponent(project || "default")}/network-acl/${encodeURIComponent(acl)}`}
-                className="acl-chip"
-              />
-            </div>
-          ))}
-        />
+    <>
+      <div
+        className={classnames("acl-label", {
+          "u-text--muted": isOverridden,
+          "u-text--line-through": isOverridden,
+        })}
+      >
+        ACLs
       </div>
-    </div>
+      <ExpandableList
+        items={allAcls.map((acl) => (
+          <ResourceLink
+            key={acl}
+            type="network-acl"
+            value={acl}
+            to={`/ui/project/${encodeURIComponent(project || "default")}/network-acl/${encodeURIComponent(acl)}`}
+            className={classnames("acl-chip", {
+              "u-text--line-through": isOverridden,
+            })}
+          />
+        ))}
+      />
+    </>
   );
 };
 

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -59,19 +59,37 @@
     .network-device {
       display: flex;
 
-      > :first-child {
+      @media screen and (width <= 1420px) {
+        flex-direction: column-reverse;
+
+        > .network-device-actions {
+          margin-bottom: $spv--medium;
+        }
+      }
+
+      .network-device-content {
+        display: flex;
+        flex-direction: column;
         flex-grow: 1;
         margin-right: $sph--large;
-        max-width: 19rem;
+        min-width: 19rem;
+      }
+
+      .network-device-actions {
+        align-items: flex-start;
+        display: flex;
+        flex-direction: column;
+        max-width: 8.5rem;
+        min-width: 8.5rem;
       }
     }
 
-    .acls-from-network {
-      margin-top: $spv--small;
+    .acl-chip {
+      margin-bottom: 0.25rem;
+    }
 
-      .acl-chip {
-        max-width: 15rem;
-      }
+    .acl-label {
+      margin-top: $spv--small;
     }
 
     .image-change-link {
@@ -108,10 +126,6 @@
 
     .profile-add-btn {
       display: block;
-    }
-
-    .delete-device {
-      margin-top: $spv--x-large;
     }
   }
 

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -232,6 +232,7 @@ interface InheritedDevice {
   key: string;
   device: LxdDeviceValue;
   source: string;
+  sourceProfile: string;
 }
 
 const getInheritedDevices = (
@@ -248,7 +249,12 @@ const getInheritedDevices = (
         if (id !== -1) {
           return;
         }
-        result.push({ key, device, source: `${profile.name} profile` });
+        result.push({
+          key,
+          device,
+          source: `${profile.name} profile`,
+          sourceProfile: profile.name,
+        });
       });
     }
   }
@@ -296,10 +302,11 @@ export const getInheritedDiskDevices = (
     }));
 };
 
-interface InheritedNetwork {
+export interface InheritedNetwork {
   key: string;
   network: LxdNicDevice | null;
   source: string;
+  sourceProfile: string;
 }
 
 export const getInheritedNetworks = (

--- a/src/util/devices.spec.ts
+++ b/src/util/devices.spec.ts
@@ -1,5 +1,31 @@
-import type { LxdNicDevice } from "types/device";
-import { getDeviceAcls } from "./devices";
+import type { LxdDeviceValue, LxdNicDevice } from "types/device";
+import { getDeviceAcls, getIndex, isNoneDevice } from "./devices";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import type { FormDevice } from "./formDevices";
+
+describe("isNoneDevice", () => {
+  it("should return true for a 'none' device", () => {
+    const noneDevice: LxdDeviceValue = {
+      type: "none",
+    };
+    expect(isNoneDevice(noneDevice)).toBe(true);
+  });
+
+  test.each([
+    { type: "proxy", listen: "tcp:0.0.0.0:80" },
+    { type: "other", someProp: "value" },
+    {
+      type: "nic",
+      network: "lxdbr0",
+    },
+    {
+      type: "disk",
+      path: "/dev/sda",
+    },
+  ])("should return false for device type $type", (device) => {
+    expect(isNoneDevice(device as LxdDeviceValue)).toBe(false);
+  });
+});
 
 describe("getDeviceAcls", () => {
   it("should return an empty array when device is undefined", () => {
@@ -72,5 +98,53 @@ describe("getDeviceAcls", () => {
       network: "network-name",
     };
     expect(getDeviceAcls(device)).toEqual(["acl1", "acl2", "acl3"]);
+  });
+});
+
+describe("getIndex", () => {
+  const mockDevice1: FormDevice = {
+    name: "eth0",
+    type: "nic",
+    network: "lxdbr0",
+  };
+  const mockDevice2: FormDevice = {
+    name: "eth1",
+    type: "nic",
+    network: "lxdbr1",
+  };
+  const mockDevice3: FormDevice = {
+    name: "eth2",
+    type: "nic",
+    network: "lxdbr2",
+  };
+
+  const createMockFormik = (devices: FormDevice[]) =>
+    ({
+      values: {
+        devices: devices,
+      },
+    }) as InstanceAndProfileFormikProps;
+
+  it("returns -1 if formik is not provided", () => {
+    expect(getIndex("eth0", undefined)).toBe(-1);
+  });
+
+  it("returns the correct index when the device exists in the array", () => {
+    const mockFormik = createMockFormik([
+      mockDevice1,
+      mockDevice2,
+      mockDevice3,
+    ]);
+    expect(getIndex(mockDevice2.name, mockFormik)).toBe(1);
+  });
+
+  it("returns -1 if the device does not exist in the array", () => {
+    const mockFormik = createMockFormik([mockDevice1, mockDevice3]);
+    expect(getIndex(mockDevice2.name, mockFormik)).toBe(-1);
+  });
+
+  it("returns -1 when the devices array is empty", () => {
+    const mockFormik = createMockFormik([]);
+    expect(getIndex(mockDevice1.name, mockFormik)).toBe(-1);
   });
 });

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -1,9 +1,13 @@
-import type { InstanceAndProfileFormValues } from "components/forms/instanceAndProfileFormValues";
+import type {
+  InstanceAndProfileFormikProps,
+  InstanceAndProfileFormValues,
+} from "components/forms/instanceAndProfileFormValues";
 import type {
   LxdDeviceValue,
   LxdDiskDevice,
   LxdGPUDevice,
   LxdNicDevice,
+  LxdNoneDevice,
   LxdOtherDevice,
   LxdProxyDevice,
 } from "types/device";
@@ -22,6 +26,9 @@ export const isHostDiskDevice = (device: LxdDiskDevice): boolean => {
     device.type === "disk" && device.pool === undefined && device.path !== "/"
   );
 };
+
+export const isNoneDevice = (device: LxdDeviceValue): device is LxdNoneDevice =>
+  device.type === "none";
 
 export const isVolumeDevice = (
   device: FormDiskDevice | LxdDiskDevice,
@@ -116,4 +123,13 @@ export const getDeviceAcls = (device?: LxdNicDevice | null) => {
     return device["security.acls"]?.split(",").filter((t) => t) || [];
   }
   return [];
+};
+
+export const getIndex = (
+  deviceName: string,
+  formik?: InstanceAndProfileFormikProps,
+) => {
+  if (!formik) return -1;
+
+  return formik?.values.devices.findIndex((t) => t.name === deviceName);
 };

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -9,6 +9,7 @@ import type {
 } from "types/device";
 import type { RemoteImage } from "types/image";
 import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { focusField } from "util/formFields";
 
 interface EmptyDevice {
   type: "";
@@ -194,7 +195,7 @@ export const addNoneDevice = (
   name: string,
   formik: InstanceAndProfileFormikProps,
 ) => {
-  const copy = [...formik.values.devices];
+  const copy = [...formik.values.devices].filter((t) => t.name !== name);
   copy.push({
     type: "none",
     name,
@@ -231,4 +232,38 @@ export const deduplicateName = (
     return deduplicateName(prefix, index + 1, existingNames);
   }
   return candidate;
+};
+
+export const addNicDevice = ({
+  formik,
+  deviceName,
+  deviceNetworkName,
+}: {
+  formik: InstanceAndProfileFormikProps;
+  deviceName: string;
+  deviceNetworkName: string;
+}) => {
+  const copy = [...formik.values.devices].filter((t) => t.name !== deviceName);
+  copy.push({
+    type: "nic",
+    name: deviceName,
+    network: deviceNetworkName,
+  });
+  formik.setFieldValue("devices", copy);
+  return copy.length;
+};
+
+export const focusNicDevice = (id: number) => {
+  focusField(`devices.${id}.network`);
+};
+
+export const removeNicDevice = ({
+  formik,
+  deviceName,
+}: {
+  formik: InstanceAndProfileFormikProps;
+  deviceName: string;
+}) => {
+  const copy = [...formik.values.devices].filter((t) => t.name !== deviceName);
+  formik.setFieldValue("devices", copy);
 };


### PR DESCRIPTION
## Done

- Handle overrides: if a device is overriden, display both on the same line.
- An inherited network can be overridden from the ui with one click.
- An inherited network, that is **not** overriden, can be removed from the ui with one click (a device with `type = none` and same name is created)
- An inherited network, that **is** overriden, can become not overriden from the ui with one click (the override device is removed)
- Profile chip in inherited network

Fixes #1547 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Step 0: Create or use an instance with an inherited network.
<img width="1591" height="743" alt="image" src="https://github.com/user-attachments/assets/65439c98-0f25-4a2d-80f0-27c35421ca51" />

- Step 1: In Instance > Configuration > Network > in the column override, make sure that `Edit` and `Detach` buttons exist.
    
- Step 2: Click on `Detach`. Everything in Inherited column should be striked through. Save.
<img width="1591" height="901" alt="image" src="https://github.com/user-attachments/assets/db513398-9aca-4e37-9187-c9ac2b4bd5e3" />

- Step 3: The inherited device is now removed. To put it back, remove the override by clicking `Clear` and save. You should see the original UI of Step 0.
- Step 4: Click on `Edit`. Select any network and save. The inherited network should be overriden.
<img width="1591" height="901" alt="image" src="https://github.com/user-attachments/assets/cfabcc66-981f-4e01-b9c2-1f96375bb01a" />

- Step 5: Click on `Clear` and save. You should see the original UI of Step 0.


## Screenshots

Before
<img width="1595" height="871" alt="before" src="https://github.com/user-attachments/assets/347aafb2-f240-438d-92ca-ef73610ea1c8" />

### Inherited
Not overridden, read mode
<img width="1100" height="184" alt="image" src="https://github.com/user-attachments/assets/f7b5bd0a-1f25-42a1-ac34-9f9da360da6b" />

Not overridden, edit mode after clicking on "Detach"
<img width="1100" height="184" alt="image" src="https://github.com/user-attachments/assets/4cc53daf-13ee-4298-86f1-2b0c365577d4" />

Overridden, read mode
<img width="1100" height="240" alt="image" src="https://github.com/user-attachments/assets/455f5b24-e326-48b4-bcc7-ea27c8e86b22" />

Overridden, edit mode
<img width="1100" height="272" alt="image" src="https://github.com/user-attachments/assets/8b482b6d-af68-4de9-b999-57b5d84b67e7" />
