### PR TITLE
fix(instance) inherited devices with same name from different profiles override each other

### DIFF
--- a/src/util/configInheritance.spec.ts
+++ b/src/util/configInheritance.spec.ts
@@ -1,6 +1,11 @@
-import { getConfigRowMetadata } from "util/configInheritance";
+import {
+  getConfigRowMetadata,
+  getInheritedNetworks,
+} from "util/configInheritance";
 import type { StoragePoolFormValues } from "pages/storage/forms/StoragePoolForm";
 import type { StorageVolumeFormValues } from "pages/storage/forms/StorageVolumeForm";
+import type { InstanceAndProfileFormValues } from "components/forms/instanceAndProfileFormValues";
+import type { LxdProfile } from "types/profile";
 
 beforeEach(() => {
   vi.mock("@tanstack/react-query", () => ({
@@ -84,5 +89,41 @@ describe("getConfigRowMetadata", () => {
       "Valid options are: `btrfs`, `ext4`, `xfs`\n" +
         "If not set, `ext4` is assumed.",
     );
+  });
+
+  it("devices with same name in inherited profiles override each other", () => {
+    const values = {
+      entityType: "instance",
+      profiles: ["foo", "bar"],
+    } as InstanceAndProfileFormValues;
+    const profiles = [
+      {
+        name: "foo",
+        description: "",
+        config: {},
+        devices: {
+          abc: {
+            network: "foo profile network",
+            type: "nic",
+          },
+        },
+      },
+      {
+        name: "bar",
+        description: "",
+        config: {},
+        devices: {
+          abc: {
+            network: "bar profile network",
+            type: "nic",
+          },
+        },
+      },
+    ] as LxdProfile[];
+
+    const result = getInheritedNetworks(values, profiles);
+
+    expect(result.length).toBe(1);
+    expect(result[0].source).toBe("bar profile");
   });
 });

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -243,6 +243,11 @@ const getInheritedDevices = (
     const appliedProfiles = getAppliedProfiles(values, profiles);
     for (const profile of appliedProfiles) {
       Object.entries(profile.devices).map(([key, device]) => {
+        const id = result.findIndex((item) => item.key === key);
+        // device already exists, skip it
+        if (id !== -1) {
+          return;
+        }
         result.push({ key, device, source: `${profile.name} profile` });
       });
     }


### PR DESCRIPTION
## Done

- fix(instance) inherited devices with same name from different profiles override each other

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create two profiles that both define a network or disk device with the same name.
    - apply both profiles to an instance. Ensure the instance only shows the device from the later profile.
    - change the profile order in the instance main configuration section
    - ensure the applied device changed to the other profile now