### PR TITLE
fix(instance) disable console and terminal empty state start instance button if instance is booting

### DIFF
--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -143,7 +143,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
             loading={isLoading}
             aria-disabled={isLoading}
             onClick={handleStart}
-            disabled={!canUpdateInstanceState(instance)}
+            disabled={!canUpdateInstanceState(instance) || isLoading}
             title={
               canUpdateInstanceState(instance)
                 ? ""

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -255,6 +255,9 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
     );
   }
 
+  const isDisabled =
+    !canUpdateInstanceState(instance) || isBooting || isStartLoading;
+
   return (
     <div className="instance-terminal-tab">
       {canConnect && (
@@ -296,7 +299,7 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
             appearance="positive"
             loading={isStartLoading || isBooting}
             onClick={handleStart}
-            disabled={!canUpdateInstanceState(instance)}
+            disabled={isDisabled}
             title={
               canUpdateInstanceState(instance)
                 ? ""


### PR DESCRIPTION
## Done

- fix(instance) disable console and terminal empty state start instance button if instance is booting

Fixes #1543

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start an instance while on the terminal tab or graphical console tab.
    - ensure the big green button is disabled after stating the instance, and we can't issue a 2nd instance start.