### PR TITLE
fix: NAT mode has a default value in proxy device form

### DIFF
--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -31,6 +31,7 @@ import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 import { optionEnabledDisabled } from "util/instanceOptions";
 import { getProxyAddress } from "util/proxyDevices";
 import { useProfiles } from "context/useProfiles";
+import type { CreateInstanceFormValues } from "pages/instances/CreateInstance";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -58,9 +59,13 @@ const ProxyDeviceForm: FC<Props> = ({ formik, project }) => {
 
   const addProxy = () => {
     const copy = [...formik.values.devices];
+    const isNATEnabled =
+      formik.values.entityType !== "profile" &&
+      (formik.values as CreateInstanceFormValues).instanceType !== "container";
     copy.push({
       type: "proxy",
       name: deduplicateName("proxy", 1, existingDeviceNames),
+      nat: String(isNATEnabled),
     });
     formik.setFieldValue("devices", copy);
   };


### PR DESCRIPTION
## Done

- fix: NAT mode has a default value in proxy device form

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    -  Start a creation or edit an instance or profile
    - Add a proxy device
    - Ensure NAT is enabled if the instance is a virtual machine and disabled if the instance is a container or we are in a profile
   
## Screenshots

The default value of NAT is disabled when instance is a container or we are in a profile

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/e992476d-2415-4bd1-9d79-69bb98a850e5" />

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/0771bcb1-8a9b-47ce-b2b3-67809d1c2360" />


The default value of NAT is enabled when instance is a VM 

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/956093d5-4544-48da-b280-2bf6c2d9f244" />
