### PR TITLE
feat(instance) expose bulk instance delete details with view details link

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -17,6 +17,7 @@ import StatusBar from "components/StatusBar";
 import OperationsProvider from "context/operationsProvider";
 import { MetricHistoryProvider } from "context/metricHistory";
 import { MemberLoadingProvider } from "context/memberLoading";
+import { ModalProvider } from "context/useModal";
 
 const queryClient = new QueryClient();
 
@@ -37,15 +38,17 @@ const Root: FC = () => {
                   <MemberLoadingProvider>
                     <EventQueueProvider>
                       <MetricHistoryProvider>
-                        <Application id="l-application">
-                          <SkipLink mainId="main-content" />
-                          <Navigation />
-                          <ErrorBoundary fallback={ErrorPage}>
-                            <App />
-                            <Events />
-                            <StatusBar />
-                          </ErrorBoundary>
-                        </Application>
+                        <ModalProvider>
+                          <Application id="l-application">
+                            <SkipLink mainId="main-content" />
+                            <Navigation />
+                            <ErrorBoundary fallback={ErrorPage}>
+                              <App />
+                              <Events />
+                              <StatusBar />
+                            </ErrorBoundary>
+                          </Application>
+                        </ModalProvider>
                       </MetricHistoryProvider>
                     </EventQueueProvider>
                   </MemberLoadingProvider>

--- a/src/context/useBulkDetails.tsx
+++ b/src/context/useBulkDetails.tsx
@@ -1,0 +1,61 @@
+import type { BulkOperationResult } from "util/promises";
+import type { NotificationAction } from "@canonical/react-components";
+import { Icon, MainTable, Modal } from "@canonical/react-components";
+import { useModal } from "context/useModal";
+import ResourceLink from "components/ResourceLink";
+
+export function useBulkDetails() {
+  const { showModal, hideModal } = useModal();
+
+  return (results: BulkOperationResult[]): NotificationAction[] => {
+    const modal = (
+      <Modal close={hideModal} title="Bulk operation details">
+        <MainTable
+          style={{ width: "auto" }}
+          headers={[
+            {
+              content: "Item",
+            },
+            {
+              content: "Details",
+            },
+          ]}
+          rows={results.map((result) => {
+            const isSuccess = result.status === "fulfilled";
+
+            return {
+              columns: [
+                {
+                  content: (
+                    <ResourceLink
+                      value={result.item.name}
+                      type={result.item.type}
+                      to={result.item.href}
+                    />
+                  ),
+                },
+                {
+                  content: (
+                    <>
+                      <Icon name={isSuccess ? "success" : "error"} />{" "}
+                      {isSuccess ? "Success" : "Error: " + result.reason}
+                    </>
+                  ),
+                },
+              ],
+            };
+          })}
+        />
+      </Modal>
+    );
+
+    return [
+      {
+        label: "View details",
+        onClick: () => {
+          showModal(modal);
+        },
+      },
+    ];
+  };
+}

--- a/src/context/useModal.tsx
+++ b/src/context/useModal.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
+import { usePortal } from "@canonical/react-components";
+
+export interface ModalType {
+  showModal: (content: ReactNode) => void;
+  hideModal: () => void;
+}
+
+const ModalContext = createContext<ModalType>({
+  showModal: () => {},
+  hideModal: () => {},
+});
+
+export const ModalProvider = ({ children }: { children: ReactNode }) => {
+  const [content, setContent] = useState<ReactNode | null>(null);
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
+  const showModal = useCallback((content: ReactNode) => {
+    setContent(content);
+    openPortal();
+  }, []);
+
+  const hideModal = useCallback(() => {
+    closePortal();
+  }, []);
+
+  return (
+    <ModalContext.Provider value={{ showModal, hideModal }}>
+      {children}
+      {isOpen && <Portal>{content}</Portal>}
+    </ModalContext.Provider>
+  );
+};
+
+export const useModal = () => useContext(ModalContext);

--- a/src/pages/images/actions/BulkDeleteImageBtn.tsx
+++ b/src/pages/images/actions/BulkDeleteImageBtn.tsx
@@ -10,6 +10,7 @@ import BulkDeleteButton from "components/BulkDeleteButton";
 import { useImageEntitlements } from "util/entitlements/images";
 import type { LxdImage } from "types/image";
 import { useToastNotification } from "@canonical/react-components";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   images: LxdImage[];
@@ -29,6 +30,7 @@ const BulkDeleteImageBtn: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
   const { canDeleteImage } = useImageEntitlements();
+  const viewBulkDetails = useBulkDetails();
 
   const totalCount = images.length;
   const deletableImages = images.filter((image) => canDeleteImage(image));
@@ -48,6 +50,7 @@ const BulkDeleteImageBtn: FC<Props> = ({
               <b>{fingerprints.length}</b>{" "}
               {pluralize("image", fingerprints.length)} deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else if (rejectedCount === deleteCount) {
           toastNotify.failure(
@@ -57,6 +60,7 @@ const BulkDeleteImageBtn: FC<Props> = ({
               <b>{deleteCount}</b> {pluralize("image", deleteCount)} could not
               be deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -69,6 +73,7 @@ const BulkDeleteImageBtn: FC<Props> = ({
               <b>{rejectedCount}</b> {pluralize("image", rejectedCount)} could
               not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
         queryClient.invalidateQueries({

--- a/src/pages/instances/InstanceLinkChip.tsx
+++ b/src/pages/instances/InstanceLinkChip.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import type { LxdInstance } from "types/instance";
 import ResourceLink from "components/ResourceLink";
 import type { InstanceIconType } from "components/ResourceIcon";
+import { linkForInstanceDetail } from "util/instances";
 
 interface Props {
   instance: Partial<Omit<LxdInstance, "type">> & {
@@ -15,7 +16,7 @@ const InstanceLinkChip: FC<Props> = ({ instance }) => {
     <ResourceLink
       type={instance.type}
       value={instance.name}
-      to={`/ui/project/${encodeURIComponent(instance.project ?? "")}/instance/${encodeURIComponent(instance.name)}`}
+      to={linkForInstanceDetail(instance.name, instance.project)}
     />
   );
 };

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import type { NotificationAction } from "@canonical/react-components";
 import {
   EmptyState,
   Icon,
@@ -46,12 +47,17 @@ const InstanceSnapshots = (props: Props) => {
   const { project } = useCurrentProject();
   const snapshotsDisabled = isSnapshotsDisabled(project);
 
-  const onSuccess = (message: ReactNode) => {
-    toastNotify.success(message);
+  const onSuccess = (message: ReactNode, actions?: NotificationAction[]) => {
+    toastNotify.success(message, actions);
   };
 
-  const onFailure = (title: string, e: unknown, message?: ReactNode) => {
-    notify.failure(title, e, message);
+  const onFailure = (
+    title: string,
+    e: unknown,
+    message?: ReactNode,
+    actions?: NotificationAction[],
+  ) => {
+    notify.failure(title, e, message, actions);
   };
 
   useEffect(() => {

--- a/src/pages/instances/actions/InstanceBulkActions.tsx
+++ b/src/pages/instances/actions/InstanceBulkActions.tsx
@@ -16,6 +16,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { getInstanceKey } from "util/instances";
 import { useToastNotification } from "@canonical/react-components";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   instances: LxdInstance[];
@@ -32,6 +33,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
   );
   const [isForce, setForce] = useState(false);
   const { canUpdateInstanceState } = useInstanceEntitlements();
+  const viewBulkDetails = useBulkDetails();
 
   const clearCache = () => {
     queryClient.invalidateQueries({
@@ -63,6 +65,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
             <>
               <b>{count}</b> {pluralize("instance", count)} {action}.
             </>,
+            viewBulkDetails(results),
           );
           clearCache();
         } else if (rejectedCount === count) {
@@ -73,6 +76,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
               <b>{count}</b> {pluralize("instance", count)} could not be{" "}
               {action}.
             </>,
+            viewBulkDetails(results),
           );
           delayedClearCache();
         } else {
@@ -86,6 +90,7 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
               <b>{rejectedCount}</b> {pluralize("instance", rejectedCount)}{" "}
               could not be {action}.
             </>,
+            viewBulkDetails(results),
           );
           delayedClearCache();
         }

--- a/src/pages/instances/actions/InstanceBulkDelete.tsx
+++ b/src/pages/instances/actions/InstanceBulkDelete.tsx
@@ -11,6 +11,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import BulkDeleteButton from "components/BulkDeleteButton";
 import { useToastNotification } from "@canonical/react-components";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   instances: LxdInstance[];
@@ -36,6 +37,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
   const deleteCount = deletableInstances.length;
   const restrictedCount = restrictedInstances.length;
   const ignoredCount = totalCount - deleteCount - restrictedCount;
+  const viewBulkDetails = useBulkDetails();
 
   const handleDelete = () => {
     setLoading(true);
@@ -47,6 +49,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
         if (fulfilledCount === deleteCount) {
           toastNotify.success(
             `${deleteCount} ${pluralize("instance", deleteCount)} deleted`,
+            viewBulkDetails(results),
           );
         } else if (rejectedCount === deleteCount) {
           toastNotify.failure(
@@ -56,6 +59,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
               <b>{deleteCount}</b> {pluralize("instance", deleteCount)} could
               not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -68,6 +72,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
               <b>{rejectedCount}</b> {pluralize("instance", rejectedCount)}{" "}
               could not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
         queryClient.invalidateQueries({

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
@@ -9,14 +9,21 @@ import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/promises";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import BulkDeleteButton from "components/BulkDeleteButton";
+import { useBulkDetails } from "context/useBulkDetails";
+import type { NotificationAction } from "@canonical/react-components";
 
 interface Props {
   instance: LxdInstance;
   snapshotNames: string[];
   onStart: () => void;
   onFinish: () => void;
-  onSuccess: (message: ReactNode) => void;
-  onFailure: (title: string, e: unknown, message?: ReactNode) => void;
+  onSuccess: (message: ReactNode, actions?: NotificationAction[]) => void;
+  onFailure: (
+    title: string,
+    e: unknown,
+    message?: ReactNode,
+    actions?: NotificationAction[],
+  ) => void;
 }
 
 const InstanceSnapshotBulkDelete: FC<Props> = ({
@@ -31,6 +38,7 @@ const InstanceSnapshotBulkDelete: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
   const { canManageInstanceSnapshots } = useInstanceEntitlements();
+  const viewBulkDetails = useBulkDetails();
 
   const count = snapshotNames.length;
 
@@ -47,6 +55,7 @@ const InstanceSnapshotBulkDelete: FC<Props> = ({
               <b>{snapshotNames.length}</b>{" "}
               {pluralize("snapshot", snapshotNames.length)} deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else if (rejectedCount === count) {
           onFailure(
@@ -56,6 +65,7 @@ const InstanceSnapshotBulkDelete: FC<Props> = ({
               <b>{count}</b> {pluralize("snapshot", count)} could not be
               deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           onFailure(
@@ -68,6 +78,7 @@ const InstanceSnapshotBulkDelete: FC<Props> = ({
               <b>{rejectedCount}</b> {pluralize("snapshot", rejectedCount)}{" "}
               could not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
         queryClient.invalidateQueries({

--- a/src/pages/storage/actions/StorageBucketBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketBulkDelete.tsx
@@ -10,6 +10,7 @@ import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets"
 import { deleteStorageBucketBulk } from "api/storage-buckets";
 import { getPromiseSettledCounts } from "util/promises";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   buckets: LxdStorageBucket[];
@@ -22,6 +23,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
   const { canDeleteBucket } = useStorageBucketEntitlements();
+  const viewBulkDetails = useBulkDetails();
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
 
@@ -42,7 +44,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
           getPromiseSettledCounts(results);
 
         if (fulfilledCount === deleteCount) {
-          toastNotify.success(successMessage);
+          toastNotify.success(successMessage, viewBulkDetails(results));
         } else if (rejectedCount === deleteCount) {
           toastNotify.failure(
             "Bucket bulk deletion failed",
@@ -51,6 +53,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
               <b>{deleteCount}</b> {pluralize("bucket", deleteCount)} could not
               be deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -63,6 +66,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
               <b>{rejectedCount}</b> {pluralize("bucket", rejectedCount)} could
               not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
 

--- a/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
@@ -11,6 +11,7 @@ import { getPromiseSettledCounts } from "util/promises";
 import { useCurrentProject } from "context/useCurrentProject";
 import ResourceLink from "components/ResourceLink";
 import { getStorageBucketURL } from "util/storageBucket";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   keys: LxdStorageBucketKey[];
@@ -28,6 +29,7 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
+  const viewBulkDetails = useBulkDetails();
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
   const totalCount = keys.length;
@@ -59,7 +61,7 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
           getPromiseSettledCounts(results);
 
         if (fulfilledCount === totalCount) {
-          toastNotify.success(successMessage);
+          toastNotify.success(successMessage, viewBulkDetails(results));
         } else if (rejectedCount === totalCount) {
           toastNotify.failure(
             "Key bulk deletion failed",
@@ -68,6 +70,7 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
               <b>{totalCount}</b> {pluralize("key", totalCount)} could not be
               deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -80,6 +83,7 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
               <b>{rejectedCount}</b> {pluralize("key", rejectedCount)} could not
               be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
 

--- a/src/pages/storage/actions/StorageVolumeBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageVolumeBulkDelete.tsx
@@ -10,6 +10,7 @@ import { getPromiseSettledCounts } from "util/promises";
 import { useCurrentProject } from "context/useCurrentProject";
 import { deleteStorageVolumeBulk } from "api/storage-volumes";
 import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   volumes: LxdStorageVolume[];
@@ -22,6 +23,7 @@ const StorageVolumeBulkDelete: FC<Props> = ({ volumes, onStart, onFinish }) => {
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
   const { canDeleteVolume } = useStorageVolumeEntitlements();
+  const viewBulkDetails = useBulkDetails();
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
 
@@ -42,7 +44,7 @@ const StorageVolumeBulkDelete: FC<Props> = ({ volumes, onStart, onFinish }) => {
           getPromiseSettledCounts(results);
 
         if (fulfilledCount === deleteCount) {
-          toastNotify.success(successMessage);
+          toastNotify.success(successMessage, viewBulkDetails(results));
         } else if (rejectedCount === deleteCount) {
           toastNotify.failure(
             "Volume bulk deletion failed",
@@ -51,6 +53,7 @@ const StorageVolumeBulkDelete: FC<Props> = ({ volumes, onStart, onFinish }) => {
               <b>{deleteCount}</b> {pluralize("volume", deleteCount)} could not
               be deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -63,6 +66,7 @@ const StorageVolumeBulkDelete: FC<Props> = ({ volumes, onStart, onFinish }) => {
               <b>{rejectedCount}</b> {pluralize("volume", rejectedCount)} could
               not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
 

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
@@ -10,6 +10,7 @@ import type { LxdStorageVolume } from "types/storage";
 import BulkDeleteButton from "components/BulkDeleteButton";
 import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
 import { useToastNotification } from "@canonical/react-components";
+import { useBulkDetails } from "context/useBulkDetails";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -29,6 +30,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
   const { canManageStorageVolumeSnapshots } = useStorageVolumeEntitlements();
+  const viewBulkDetails = useBulkDetails();
 
   const count = snapshotNames.length;
 
@@ -45,6 +47,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
               "snapshot",
               snapshotNames.length,
             )} deleted`,
+            viewBulkDetails(results),
           );
         } else if (rejectedCount === count) {
           toastNotify.failure(
@@ -54,6 +57,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
               <b>{count}</b> {pluralize("snapshot", count)} could not be
               deleted.
             </>,
+            viewBulkDetails(results),
           );
         } else {
           toastNotify.failure(
@@ -66,6 +70,7 @@ const VolumeSnapshotBulkDelete: FC<Props> = ({
               <b>{rejectedCount}</b> {pluralize("snapshot", rejectedCount)}{" "}
               could not be deleted.
             </>,
+            viewBulkDetails(results),
           );
         }
         queryClient.invalidateQueries({

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -32,6 +32,10 @@ export const instanceLinkFromOperation = (args: {
   );
 };
 
+export const linkForInstanceDetail = (name: string, project?: string) => {
+  return `/ui/project/${encodeURIComponent(project ?? "default")}/instance/${encodeURIComponent(name)}`;
+};
+
 export const instanceNameValidation = (
   project: string,
   controllerState: AbortControllerState,

--- a/src/util/promises.ts
+++ b/src/util/promises.ts
@@ -1,5 +1,7 @@
+import type { ResourceIconType } from "components/ResourceIcon";
+
 export const getPromiseSettledCounts = (
-  results: PromiseSettledResult<void>[],
+  results: BulkOperationResult[],
 ): { fulfilledCount: number; rejectedCount: number } => {
   const settledCounts = { fulfilledCount: 0, rejectedCount: 0 };
   results.forEach((result) => {
@@ -12,27 +14,53 @@ export const getPromiseSettledCounts = (
   return settledCounts;
 };
 
-export const pushSuccess = (results: PromiseSettledResult<void>[]): void => {
+interface BulkOperationFulfilled {
+  status: "fulfilled";
+  item: BulkOperationItem;
+}
+
+interface BulkOperationRejected {
+  status: "rejected";
+  item: BulkOperationItem;
+  reason: string;
+}
+
+export interface BulkOperationItem {
+  name: string;
+  type: ResourceIconType;
+  href: string;
+}
+
+export type BulkOperationResult =
+  | BulkOperationFulfilled
+  | BulkOperationRejected;
+
+export const pushSuccess = (
+  results: BulkOperationResult[],
+  item: BulkOperationItem,
+): void => {
   results.push({
     status: "fulfilled",
-    value: undefined,
+    item,
   });
 };
 
 export const pushFailure = (
-  results: PromiseSettledResult<void>[],
+  results: BulkOperationResult[],
   msg: string,
+  item: BulkOperationItem,
 ): void => {
   results.push({
     status: "rejected",
     reason: msg,
+    item,
   });
 };
 
 export const continueOrFinish = (
-  results: PromiseSettledResult<void>[],
+  results: BulkOperationResult[],
   totalLength: number,
-  resolve: (value: PromiseSettledResult<void>[]) => void,
+  resolve: (value: BulkOperationResult[]) => void,
 ): void => {
   if (totalLength === results.length) {
     resolve(results);


### PR DESCRIPTION
## Done

- feat(instance) expose bulk instance delete details with view details link

Fixes #1545

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - set several instances as configuration > security policies > Protect deletion > true.
    - bulk delete the instances from the instance list
    - ensure the view more link reveals which instances were deleted and which succeeded with details

## Screenshots

<img width="1914" height="957" alt="image" src="https://github.com/user-attachments/assets/f5cfa6c6-659c-4b84-b33e-720bbb5a9e3d" />

<img width="1914" height="957" alt="image" src="https://github.com/user-attachments/assets/f30452a1-000e-4031-8911-e7b2282cc1ec" />

<img width="1914" height="957" alt="image" src="https://github.com/user-attachments/assets/00f26974-5dc0-4b7c-9222-d44d3d3d3c3c" />