### PR TITLE
fix(volume) preserve config keys in updating snapshot configuration for a storage volume

### DIFF
--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
@@ -30,7 +30,7 @@ const VolumeConfigureSnapshotModal: FC<Props> = ({ volume, close }) => {
   const formik = useFormik<StorageVolumeFormValues>({
     initialValues: getStorageVolumeEditValues(volume),
     onSubmit: (values) => {
-      const saveVolume = volumeFormToPayload(values, volume.project);
+      const saveVolume = volumeFormToPayload(values, volume.project, volume);
       updateStorageVolume(
         volume.pool,
         volume.project,


### PR DESCRIPTION
## Done

- fix(volume) preserve config keys in updating snapshot configuration for a storage volume

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - with lxd latest/edge backend: create a storage volume, then update storage volume snapshot configuration from volume detail page > snapshots > see configuration > change config (add or remove) and save the modal.