### PR TITLE
fix(instance) ensure stable ordering of images on instance creation

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -19,6 +19,7 @@ import { queryKeys } from "util/queryKeys";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import {
   byLtsFirst,
+  byOSRelease,
   localLxdToRemoteImage,
   isContainerOnlyImage,
   isVmOnlyImage,
@@ -117,7 +118,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     ? []
     : localImages
         .map(localLxdToRemoteImage)
-        .sort((a, b) => Number(b.cached) - Number(a.cached))
+        .sort(byOSRelease)
         .concat([...canonicalImages].reverse().sort(byLtsFirst))
         .concat([...minimalImages].reverse().sort(byLtsFirst))
         .concat([...imagesLxdImages])
@@ -139,14 +140,14 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     mapper,
     filter = () => true,
   ) => {
-    const options = [...new Set(images.filter(filter).map(mapper))].map(
-      (item: string) => {
+    const options = [...new Set(images.filter(filter).map(mapper))]
+      .sort()
+      .map((item: string) => {
         return {
           label: item,
           value: item,
         };
-      },
-    );
+      });
     options.unshift({
       label: "Any",
       value: "",

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -72,3 +72,16 @@ export const byLtsFirst = (a: RemoteImage, b: RemoteImage): number => {
   }
   return 0;
 };
+
+export const byOSRelease = (a: RemoteImage, b: RemoteImage): number => {
+  const aTitle = a.os + a.release_title + a.release + a.type + a.server;
+  const bTitle = b.os + b.release_title + b.release + b.type + b.server;
+
+  if (aTitle < bTitle) {
+    return -1;
+  }
+  if (aTitle > bTitle) {
+    return 1;
+  }
+  return 0;
+};


### PR DESCRIPTION
## Done

- fix(instance) ensure stable ordering of images on instance creation

fixes #1570

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure you multiple cached images (start instances with various base images to have them download and cached)
    - create a new instance, with the image selector open switch tabs to another one a back, wait some seconds so the image cache updates. Ensure the image order in the selector does not change