### PR TITLE
feat support ssh key generation in UI

### DIFF
--- a/src/components/forms/SshKeyAddModal.tsx
+++ b/src/components/forms/SshKeyAddModal.tsx
@@ -2,6 +2,7 @@ import type { FC, FormEvent, ReactNode } from "react";
 import { useState } from "react";
 import { Button, Form, Input, Label, Modal } from "@canonical/react-components";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
+import SshKeyGenerateAndDownload from "./SshKeyGenerateAndDownload";
 
 interface Props {
   initialName: string;
@@ -9,7 +10,12 @@ interface Props {
   onClose: () => void;
 }
 
-type SourceType = "clipboard" | "fileUpload" | "github" | "launchpad";
+type SourceType =
+  | "clipboard"
+  | "fileUpload"
+  | "generate"
+  | "github"
+  | "launchpad";
 
 const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
   const [name, setName] = useState(initialName);
@@ -20,6 +26,7 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
     launchpad: "",
     fileUpload: "",
     clipboard: "",
+    generate: "",
   });
 
   const getFingerprint = () => {
@@ -32,6 +39,8 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
         return source.fileUpload;
       case "clipboard":
         return source.clipboard;
+      case "generate":
+        return source.generate;
     }
   };
 
@@ -79,6 +88,10 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
     document.getElementById("ssh-file-upload")?.click();
   };
 
+  const onSSHKeyGenerate = (key: string) => {
+    setSource({ ...source, generate: key });
+  };
+
   return (
     <Modal close={onClose} title="Add SSH key" className="ssh-key-add-modal">
       <Form onSubmit={handleAdd}>
@@ -112,6 +125,7 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
             aria-label="Source"
           >
             {segmentButton("clipboard", "Clipboard")}
+            {segmentButton("generate", "Generate key")}
             {segmentButton("fileUpload", "File upload")}
             {segmentButton("github", "Github")}
             {segmentButton("launchpad", "Launchpad")}
@@ -122,7 +136,7 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
           {segmentContent(
             "clipboard",
             <AutoExpandingTextArea
-              placeholder="ssh-rsa ..."
+              placeholder="ecdsa-sha2-nistp384 ..."
               help="Paste the contents of the public key file (.pub)"
               className="u-break-all"
               autoFocus
@@ -131,6 +145,14 @@ const SshKeyAddModal: FC<Props> = ({ initialName, onSelect, onClose }) => {
               onChange={(e) => {
                 setSource({ ...source, clipboard: e.target.value });
               }}
+            />,
+          )}
+
+          {segmentContent(
+            "generate",
+            <SshKeyGenerateAndDownload
+              keyName={name}
+              setSSHPublicKey={onSSHKeyGenerate}
             />,
           )}
 

--- a/src/components/forms/SshKeyGenerateAndDownload.tsx
+++ b/src/components/forms/SshKeyGenerateAndDownload.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState, type FC } from "react";
+import { Button } from "@canonical/react-components";
+
+interface Props {
+  keyName: string;
+  setSSHPublicKey: (value: string) => void;
+}
+
+const SshKeyGenerateAndDownload: FC<Props> = ({ keyName, setSSHPublicKey }) => {
+  const [privateKey, setPrivateKey] = useState<CryptoKey>();
+  const [publicKey, setPublicKey] = useState<CryptoKey>();
+  const [isDownloaded, setIsDownloaded] = useState(false);
+  const generateSSHKey = async () => {
+    setSSHPublicKey("");
+    const key = await window.crypto.subtle.generateKey(
+      {
+        name: "ECDSA",
+        namedCurve: "P-384",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    setPrivateKey(key.privateKey);
+    setPublicKey(key.publicKey);
+  };
+
+  useEffect(() => {
+    generateSSHKey();
+  }, []);
+
+  const exportEcdsaPublicKeyAsOpenSSH = (publicKey: ArrayBuffer) => {
+    const key = new Uint8Array(publicKey);
+    const curveName = "nistp384";
+    const sshAlgo = "ecdsa-sha2-nistp384";
+
+    const writeString = (input: string | Uint8Array): Uint8Array => {
+      const data =
+        typeof input === "string" ? new TextEncoder().encode(input) : input;
+      const len = new Uint8Array(4);
+      new DataView(len.buffer).setUint32(0, data.length, false); //big-endian
+      return new Uint8Array([...len, ...data]);
+    };
+
+    const combined = new Uint8Array([
+      ...writeString(sshAlgo),
+      ...writeString(curveName),
+      ...writeString(key),
+    ]);
+    const base64Key = btoa(String.fromCharCode(...combined));
+    return `${sshAlgo} ${base64Key}`;
+  };
+
+  const convertToPEMFormat = (keyData: ArrayBuffer, label: string) => {
+    const base64 = window.btoa(String.fromCharCode(...new Uint8Array(keyData)));
+    const lines = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+    return `-----BEGIN ${label}-----\n${lines}\n-----END ${label}-----`;
+  };
+
+  const downloadPEMFile = (pemString: string, filename: string) => {
+    const blob = new Blob([pemString], { type: "application/x-pem-file" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    setIsDownloaded(true);
+  };
+
+  const downloadPrivateKey = async () => {
+    if (!privateKey || !publicKey) return;
+    const privateKeyData = await window.crypto.subtle.exportKey(
+      "pkcs8",
+      privateKey,
+    );
+    const privateKeyPEM = convertToPEMFormat(privateKeyData, "EC PRIVATE KEY");
+    downloadPEMFile(privateKeyPEM, `lxd-${location.hostname}-${keyName}`);
+    const publicKeyDataRaw = await window.crypto.subtle.exportKey(
+      "raw",
+      publicKey,
+    );
+    const publicKeyOpenSsh = exportEcdsaPublicKeyAsOpenSSH(publicKeyDataRaw);
+    setSSHPublicKey(publicKeyOpenSsh);
+  };
+
+  return (
+    <>
+      <p className="u-text--muted">
+        {isDownloaded
+          ? "Your private key was downloaded successfully."
+          : "Your key pair was generated successfully."}
+      </p>
+      <Button disabled={!privateKey} type="button" onClick={downloadPrivateKey}>
+        Download private key
+      </Button>
+    </>
+  );
+};
+
+export default SshKeyGenerateAndDownload;


### PR DESCRIPTION
## Done

- Feat: Support SSH key pair generation and download in the UI. Addresses #1508 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to an instance Configuration tab.
    - Click on "+ New SSH key" button.
    - Click on "Generate key" option.
    - Click on "Download private key" button.
    - Click on "Add key" button.
    - Click on "Save 1 change" button.
    - Make sure your new public key is added to the instance and your private key is downloaded on your device.
    - SSH into your instance using your new key pair and ensure you can log in.

## Screenshots

<img width="1435" height="750" alt="image" src="https://github.com/user-attachments/assets/a1afc0f3-616f-4032-812e-9c04264bc70b" />
<img width="1435" height="750" alt="image" src="https://github.com/user-attachments/assets/5b35ff0c-8ce0-48c2-a013-1f6947c44d20" />
<img width="1435" height="680" alt="image" src="https://github.com/user-attachments/assets/0165e8c9-a91a-4e19-a2d3-0d2119700985" />
<img width="1435" height="750" alt="image" src="https://github.com/user-attachments/assets/05bc7c4c-a53f-48db-a31d-e0db93bc8c08" />
