### PR TITLE
feat: added LXD UI context to report a bug navigation button

### DIFF
--- a/src/components/ErrorPage.tsx
+++ b/src/components/ErrorPage.tsx
@@ -8,32 +8,14 @@ import {
   useListener,
 } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
-import { UI_VERSION } from "util/version";
+import { getReportBugURL } from "util/reportBug";
 
 interface Props {
   error?: Error;
 }
 
 const ErrorPage: FC<Props> = ({ error }) => {
-  const body = encodeURIComponent(
-    `# Description
-
-A brief description of the problem. Should include what you were
-attempting to do, what you did, what happened and what you expected to
-see happen.
-
-# Metadata
-
-UI Version: ${UI_VERSION}
-Path: ${location.pathname}${location.search}
-
-# Stacktrace
-
-\`\`\`
-${error?.stack ?? "No stack trace"}
-\`\`\``,
-  );
-  const url = `https://github.com/canonical/lxd-ui/issues/new?labels=bug&title=Error%20report&body=${body}`;
+  const url = getReportBugURL(error);
 
   const updateHeight = () => {
     updateMaxHeight("error-info", undefined, 0, "max-height");

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -33,6 +33,7 @@ import { useSettings } from "context/useSettings";
 import type { LxdProject } from "types/project";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import { useIsClustered } from "context/useIsClustered";
+import { getReportBugURL } from "util/reportBug";
 
 const initialiseOpenNavMenus = (location: Location) => {
   const openPermissions = location.pathname.includes("/permissions/");
@@ -752,7 +753,7 @@ const Navigation: FC = () => {
                   <SideNavigationItem>
                     <a
                       className="p-side-navigation__link"
-                      href="https://github.com/canonical/lxd-ui/issues/new"
+                      href={getReportBugURL()}
                       target="_blank"
                       rel="noopener noreferrer"
                       title="Report a bug"

--- a/src/util/reportBug.spec.ts
+++ b/src/util/reportBug.spec.ts
@@ -1,0 +1,41 @@
+import { getReportBugBodyTemplate } from "./reportBug";
+
+describe("report bug body template", () => {
+  it("should contain all required sections and subsections", () => {
+    const body = getReportBugBodyTemplate();
+    expect(body).toContain("# Description");
+    expect(body).toContain("# Metadata");
+    expect(body).toContain("UI Version");
+    expect(body).toContain("Path");
+  });
+
+  it("should handle undefined error", () => {
+    const body = getReportBugBodyTemplate();
+    expect(body).not.toContain("# Stacktrace");
+  });
+
+  it("should display error stack when provided", () => {
+    const error = new Error("Something bad happened");
+    error.stack = "Something went terribly wrong";
+    const body = getReportBugBodyTemplate(error);
+    expect(body).toContain("Something went terribly wrong");
+  });
+
+  it("should handle undefined stack", () => {
+    const error = new Error();
+    error.stack = undefined;
+    const body = getReportBugBodyTemplate(error);
+    expect(body).not.toContain("# Stacktrace");
+  });
+
+  it("should have consistent layout regardless of the error", () => {
+    const error = new Error("Something bad happened");
+    error.stack = "Something went terribly wrong";
+    const body1 = getReportBugBodyTemplate(error);
+    const body2 = getReportBugBodyTemplate();
+    const nonErrorSections = (body: string) => {
+      return body.split("# Stacktrace")[0].trim();
+    };
+    expect(nonErrorSections(body1)).toBe(nonErrorSections(body2));
+  });
+});

--- a/src/util/reportBug.tsx
+++ b/src/util/reportBug.tsx
@@ -1,0 +1,26 @@
+import { UI_VERSION } from "./version";
+
+export const getReportBugBodyTemplate = (error?: Error) => {
+  return `\
+  # Description
+
+  A brief description of the problem. Should include what you were attempting to do, what you did, what happened and what you expected to 
+  see happen.
+    
+  # Metadata
+    
+  UI Version: ${UI_VERSION}
+  Path: ${location.toString()}
+    
+  ${
+    error && error.stack
+      ? `# Stacktrace
+    
+    ${error.stack}`
+      : ""
+  } `;
+};
+
+export const getReportBugURL = (error?: Error) => {
+  return `https://github.com/canonical/lxd-ui/issues/new?labels=Bug&title=Bug%20report&body=${encodeURIComponent(getReportBugBodyTemplate(error))}`;
+};


### PR DESCRIPTION
## Done

- feat: enhanced report a bug feature by adding UI context to the navigated to github issue

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Click on "report a bug" button in the side navigation bar
    - Ensure the issue body is filled with a template containing the LXD UI context and that Bug label is assigned.

## Screenshots

<img width="1435" height="643" alt="image" src="https://github.com/user-attachments/assets/caed973c-fae6-4282-bd4b-627fc62dbaf8" />