### PR TITLE
fix(images) ensure local images in instance image selector have a unique key

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -244,7 +244,13 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       };
 
       return {
-        key: itemType + item.os + displayRelease + displayVariant + item.server,
+        key:
+          itemType +
+          item.os +
+          displayRelease +
+          displayVariant +
+          item.server +
+          item.fingerprint,
         className: "u-row",
         columns: [
           {


### PR DESCRIPTION
## Done

- fix(images) ensure local images in instance image selector have a unique key, could have multiple versions of the same image in cache.

Fixes #1576

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start image creation, open image selector. search for a locally cached image that has two different versions. Ensure selector behaves normally.