### PR TITLE
feat(storage) refine storage documentation link targets and text

### DIFF
--- a/src/pages/storage/CustomIsoList.tsx
+++ b/src/pages/storage/CustomIsoList.tsx
@@ -163,11 +163,11 @@ const CustomIsoList: FC = () => {
       <p>Custom ISOs will appear here</p>
       <p>
         <a
-          href={`${docBaseLink}/explanation/storage/`}
+          href={`${docBaseLink}/howto/instances_create/#instances-create-iso`}
           target="_blank"
           rel="noopener noreferrer"
         >
-          Learn more about storage
+          Learn how to create a VM that boots from an ISO
           <Icon className="external-link-icon" name="external-link" />
         </a>
       </p>
@@ -211,8 +211,8 @@ const CustomIsoList: FC = () => {
           <PageHeader.Left>
             <PageHeader.Title>
               <HelpLink
-                href={`${docBaseLink}/explanation/storage/`}
-                title="Learn more about storage pools, volumes and buckets"
+                href={`${docBaseLink}/howto/instances_create/#instances-create-iso`}
+                title="Learn how to create a VM that boots from an ISO"
               >
                 Custom ISOs
               </HelpLink>

--- a/src/pages/storage/StorageBucketKeys.tsx
+++ b/src/pages/storage/StorageBucketKeys.tsx
@@ -245,11 +245,11 @@ const StorageBucketKeys: FC<Props> = ({ bucket }) => {
           <p>This bucket does not contain any keys.</p>
           <p>
             <a
-              href={`${docBaseLink}/explanation/storage/`}
+              href={`${docBaseLink}/howto/storage_buckets/#manage-storage-bucket-keys`}
               target="_blank"
               rel="noopener noreferrer"
             >
-              Learn more about storage
+              Learn how to manage storage bucket keys
               <Icon className="external-link-icon" name="external-link" />
             </a>
           </p>

--- a/src/pages/storage/StorageBuckets.tsx
+++ b/src/pages/storage/StorageBuckets.tsx
@@ -276,11 +276,11 @@ const StorageBuckets: FC = () => {
       <p>Storage buckets will appear here</p>
       <p>
         <a
-          href={`${docBaseLink}/explanation/storage/`}
+          href={`${docBaseLink}/explanation/storage/#storage-buckets`}
           target="_blank"
           rel="noopener noreferrer"
         >
-          Learn more about storage
+          Learn more about storage buckets
           <Icon className="external-link-icon" name="external-link" />
         </a>
       </p>
@@ -310,8 +310,8 @@ const StorageBuckets: FC = () => {
             <PageHeader.Left>
               <PageHeader.Title>
                 <HelpLink
-                  href={`${docBaseLink}/explanation/storage/`}
-                  title="Learn more about storage pools, volumes and buckets"
+                  href={`${docBaseLink}/explanation/storage/#storage-buckets`}
+                  title="Learn more about storage buckets"
                 >
                   Buckets
                 </HelpLink>

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -162,7 +162,7 @@ const StoragePools: FC = () => {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Learn more about storage
+            Learn more about storage pools, volumes and buckets
             <Icon className="external-link-icon" name="external-link" />
           </a>
         </p>

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -419,11 +419,11 @@ const StorageVolumes: FC = () => {
         <p>Storage volumes will appear here</p>
         <p>
           <a
-            href={`${docBaseLink}/explanation/storage/`}
+            href={`${docBaseLink}/explanation/storage/#storage-volumes`}
             target="_blank"
             rel="noopener noreferrer"
           >
-            Learn more about storage
+            Learn more about storage volumes
             <Icon className="external-link-icon" name="external-link" />
           </a>
         </p>
@@ -503,8 +503,8 @@ const StorageVolumes: FC = () => {
           <PageHeader.Left>
             <PageHeader.Title>
               <HelpLink
-                href={`${docBaseLink}/explanation/storage/`}
-                title="Learn more about storage pools, volumes and buckets"
+                href={`${docBaseLink}/explanation/storage/#storage-volumes`}
+                title="Learn more about storage volumes"
               >
                 Volumes
               </HelpLink>


### PR DESCRIPTION
## Done

- feat(storage) refine storage documentation link targets and text

Fixes #1579

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check doc links and link texts in:
    - storage bucket list
    - storage volume list
    - custom iso list