### PR TITLE
feat(instance) save terminal connection defaults as instance user key

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -60,6 +60,17 @@ const defaultPayload: TerminalConnectPayload = {
   group: 0,
 };
 
+export const UI_TERMINAL_DEFAULT_PAYLOAD = "user.ui_terminal_default_payload";
+
+const getDefaultPayload = (instance: LxdInstance) => {
+  const userPayload = instance.config[UI_TERMINAL_DEFAULT_PAYLOAD];
+  if (userPayload) {
+    return JSON.parse(userPayload) as TerminalConnectPayload;
+  }
+
+  return defaultPayload;
+};
+
 interface Props {
   instance: LxdInstance;
   refreshInstance: () => Promise<unknown>;
@@ -75,7 +86,7 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
   const [isLoading, setLoading] = useState(false);
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
-  const [payload, setPayload] = useState(defaultPayload);
+  const [payload, setPayload] = useState(getDefaultPayload(instance));
   const [fitAddon] = useState<FitAddon>(new FitAddon());
   const [userInteracted, setUserInteracted] = useState(false);
   const xtermRef = useRef<Terminal>(null);
@@ -283,7 +294,11 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
             >
               Fullscreen
             </Button>
-            <ReconnectTerminalBtn reconnect={setPayload} payload={payload} />
+            <ReconnectTerminalBtn
+              reconnect={setPayload}
+              payload={payload}
+              instance={instance}
+            />
           </div>
           <NotificationRow />
           {isLoading && (

--- a/src/pages/instances/actions/ReconnectTerminalBtn.tsx
+++ b/src/pages/instances/actions/ReconnectTerminalBtn.tsx
@@ -3,13 +3,15 @@ import { useState } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import type { TerminalConnectPayload } from "types/terminal";
 import TerminalPayloadForm from "../TerminalPayloadForm";
+import type { LxdInstance } from "types/instance";
 
 interface Props {
   payload: TerminalConnectPayload;
   reconnect: (data: TerminalConnectPayload) => void;
+  instance: LxdInstance;
 }
 
-const ReconnectTerminalBtn: FC<Props> = ({ payload, reconnect }) => {
+const ReconnectTerminalBtn: FC<Props> = ({ payload, reconnect, instance }) => {
   const [isModal, setModal] = useState(false);
 
   const closeModal = () => {
@@ -31,6 +33,7 @@ const ReconnectTerminalBtn: FC<Props> = ({ payload, reconnect }) => {
         <TerminalPayloadForm
           close={closeModal}
           reconnect={handleReconnect}
+          instance={instance}
           payload={payload}
         />
       )}


### PR DESCRIPTION
## Done

- feat(instance) save terminal connection defaults as instnace user key

Fixes #1582

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance terminal and modify the reconnect settings, save them as default, ensure on reload the settings are restored

## Screenshots

<img width="1917" height="1044" alt="image" src="https://github.com/user-attachments/assets/546326c9-38d3-4663-90be-d43e982de446" />
