### PR TITLE
feat: support user defined settings

### DIFF
--- a/src/pages/settings/ClusteredSettingFormInput.tsx
+++ b/src/pages/settings/ClusteredSettingFormInput.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Button, Form, Icon } from "@canonical/react-components";
 import type { ConfigField } from "types/config";
-import { getConfigId } from "./SettingForm";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 import ClusterSpecificInput from "components/forms/ClusterSpecificInput";
 import { useClusterMembers } from "context/useClusterMembers";
@@ -62,7 +61,7 @@ const ClusteredSettingFormInput: FC<Props> = ({
           aria-label={configField.key}
           classname={readonly ? "read-only" : ""}
           disableReason={disableReason}
-          id={getConfigId(configField.key)}
+          id={configField.key}
           values={value}
           isReadOnly={readonly}
           onChange={(value) => {
@@ -83,7 +82,7 @@ const ClusteredSettingFormInput: FC<Props> = ({
           aria-label={configField.key}
           classname={readonly ? "read-only" : ""}
           disableReason={disableReason}
-          id={getConfigId(configField.key)}
+          id={configField.key}
           values={value}
           isReadOnly={readonly}
           onChange={(value) => {

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -22,22 +22,18 @@ import ClusteredSettingFormInput from "./ClusteredSettingFormInput";
 import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 import { useIsClustered } from "context/useIsClustered";
 
-export const getConfigId = (key: string) => {
-  return key.replace(".", "___");
-};
-
 interface Props {
   configField: ConfigField;
+  onDelete: (key: string) => void;
   value?: string;
   clusteredValue?: ClusterSpecificValues;
-  isLast?: boolean;
 }
 
 const SettingForm: FC<Props> = ({
   configField,
+  onDelete,
   value,
   clusteredValue,
-  isLast,
 }) => {
   const { isRestricted } = useAuth();
   const [isEditMode, setEditMode] = useState(false);
@@ -104,7 +100,7 @@ const SettingForm: FC<Props> = ({
   };
 
   useEffect(() => {
-    if (isEditMode && isLast) {
+    if (isEditMode) {
       editRef.current?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
@@ -172,6 +168,7 @@ const SettingForm: FC<Props> = ({
                   initialValue={value ?? ""}
                   configField={configField}
                   onSubmit={onSubmit}
+                  onDelete={onDelete}
                   onCancel={onCancel}
                 />
               )}

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Input, Button, Icon } from "@canonical/react-components";
 import type { ConfigField } from "types/config";
-import { getConfigId } from "./SettingForm";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 
 interface Props {
@@ -37,7 +36,7 @@ const SettingFormCheckbox: FC<Props> = ({
     <>
       <Input
         label={label}
-        id={getConfigId(configField.key)}
+        id={configField.key}
         wrapperClassName="input-wrapper"
         type="checkbox"
         checked={checked}

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -2,13 +2,13 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Button, Form, Icon, Input } from "@canonical/react-components";
 import type { ConfigField } from "types/config";
-import { getConfigId } from "./SettingForm";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 
 interface Props {
   initialValue: string;
   configField: ConfigField;
   onSubmit: (newValue: string | boolean) => void;
+  onDelete: (key: string) => void;
   onCancel: () => void;
 }
 
@@ -16,6 +16,7 @@ const SettingFormInput: FC<Props> = ({
   initialValue,
   configField,
   onSubmit,
+  onDelete,
   onCancel,
 }) => {
   const [value, setValue] = useState(initialValue);
@@ -29,7 +30,8 @@ const SettingFormInput: FC<Props> = ({
     }
   };
 
-  const canBeReset = String(configField.default) !== String(value);
+  const canBeReset =
+    !configField.isUserDefined && String(configField.default) !== String(value);
 
   const resetToDefault = () => {
     setValue(configField.default);
@@ -46,7 +48,7 @@ const SettingFormInput: FC<Props> = ({
       <Input type="submit" hidden value="Hidden input" />
       <Input
         aria-label={configField.key}
-        id={getConfigId(configField.key)}
+        id={configField.key}
         wrapperClassName="input-wrapper"
         type={getInputType()}
         value={configField.type === "bool" ? undefined : String(value)}
@@ -61,6 +63,20 @@ const SettingFormInput: FC<Props> = ({
       <Button appearance="positive" type="submit">
         Save
       </Button>
+      {configField.isUserDefined && (
+        <Button
+          appearance="base"
+          hasIcon
+          className="delete-button"
+          type="button"
+          onClick={() => {
+            onDelete(configField.key);
+          }}
+        >
+          <Icon name="delete"></Icon>
+          <span>Delete</span>
+        </Button>
+      )}
       {canBeReset && (
         <Button
           className="reset-button"

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -2,7 +2,6 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Button, Form, Icon, Input } from "@canonical/react-components";
 import type { ConfigField } from "types/config";
-import { getConfigId } from "./SettingForm";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 
 interface Props {
@@ -36,7 +35,7 @@ const SettingFormPassword: FC<Props> = ({
           <div className="input-row">
             <Input
               aria-label={configField.key}
-              id={getConfigId(configField.key)}
+              id={configField.key}
               wrapperClassName="input-wrapper"
               type={showPassword ? "text" : "password"}
               value={password}

--- a/src/pages/settings/SettingsRow.tsx
+++ b/src/pages/settings/SettingsRow.tsx
@@ -1,0 +1,225 @@
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
+import SettingForm from "pages/settings/SettingForm";
+import type { ConfigField } from "types/config";
+import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
+import { Input, Button, Form } from "@canonical/react-components";
+import { generateUUID } from "util/helpers";
+import { getConfigFieldValue, type UserSetting } from "util/settings";
+import type { LxdSettings } from "types/server";
+
+type SetUserSettings = (prev: (prev: UserSetting[]) => UserSetting[]) => void;
+
+export const getSettingRow = (
+  configField: ConfigField,
+  isNewCategory: boolean,
+  clusteredValue: ClusterSpecificValues,
+  deleteUserSetting: (key: string) => void,
+  settings?: LxdSettings,
+): MainTableRow => {
+  const isDefault = !Object.keys(settings?.config ?? {}).some(
+    (key) => key === configField.key,
+  );
+  const value = getConfigFieldValue(configField, settings);
+  return {
+    key: configField.key,
+    columns: [
+      {
+        content: isNewCategory && (
+          <h2 className="p-heading--5">{configField.category}</h2>
+        ),
+        role: "cell",
+        className: "group",
+        "aria-label": "Group",
+      },
+      {
+        content: (
+          <div className="key-cell">
+            {isDefault ? configField.key : <strong>{configField.key}</strong>}
+            <p className="p-text--small u-text--muted u-no-margin--bottom">
+              <ConfigFieldDescription description={configField.shortdesc} />
+            </p>
+          </div>
+        ),
+        role: "rowheader",
+        className: "key",
+        "aria-label": "Key",
+      },
+      {
+        content: (
+          <SettingForm
+            configField={configField}
+            value={value}
+            clusteredValue={clusteredValue}
+            onDelete={deleteUserSetting}
+          />
+        ),
+        role: "cell",
+        "aria-label": "Value",
+        className: "u-vertical-align-middle",
+      },
+    ],
+  };
+};
+
+export const getUserSettingInputRow = (
+  userSettings: UserSetting[],
+  index: number,
+  setUserSettings: SetUserSettings,
+  saveUserSetting: (index: number) => void,
+): MainTableRow => {
+  const userSetting = userSettings[index];
+  const isKeyDuplicate = userSettings.some(
+    (setting) => `user.${userSetting.key}` === setting.key,
+  );
+  const isFormDisabled =
+    isKeyDuplicate || !userSetting.value || !userSetting.key;
+
+  return {
+    key: userSetting.id,
+    columns: [
+      {
+        content: false,
+        role: "cell",
+        className: "group",
+        "aria-label": "Group",
+      },
+      {
+        content: (
+          <>
+            <Input
+              aria-label="new user key"
+              id={`new-user-defined-key-${index}`}
+              placeholder="User key"
+              type="text"
+              value={userSetting.key}
+              autoFocus
+              error={
+                isKeyDuplicate && <>Setting with this name already exists</>
+              }
+              onChange={(e) => {
+                setUserSettings((prev) => {
+                  const copy = [...prev];
+                  copy[index] = {
+                    ...copy[index],
+                    key: e.target.value,
+                  };
+                  return copy;
+                });
+              }}
+              help={
+                <>
+                  Key will be saved as <code>{"user.{your-key}"}</code>. Enter
+                  only the part after user.
+                </>
+              }
+            />
+          </>
+        ),
+        role: "rowheader",
+        className: "key",
+        "aria-label": "key",
+      },
+      {
+        content: (
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              saveUserSetting(index);
+            }}
+          >
+            <Input
+              type="submit"
+              hidden
+              value="Hidden input"
+              disabled={isFormDisabled}
+            />
+            <Input
+              aria-label="new user value"
+              id={`new-user-defined-value-${index}`}
+              placeholder="Value"
+              type="text"
+              value={userSetting.value}
+              onChange={(e) => {
+                setUserSettings((prev) => {
+                  const copy = [...prev];
+                  copy[index] = {
+                    ...copy[index],
+                    value: e.target.value,
+                  };
+                  return copy;
+                });
+              }}
+            />
+            <Button
+              type="button"
+              appearance="base"
+              className="button"
+              onClick={() => {
+                setUserSettings((prev) => {
+                  const copy = [...prev];
+                  copy.splice(index, 1);
+                  return copy;
+                });
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isFormDisabled}
+              appearance="positive"
+            >
+              Save
+            </Button>
+          </Form>
+        ),
+        role: "cell",
+        className: "u-vertical-align-middle",
+        "aria-label": "Value",
+      },
+    ],
+  };
+};
+
+export const getAddSettingButton = (setNewUserSettings: SetUserSettings) => {
+  return {
+    key: "add-user-config-button",
+    columns: [
+      {
+        content: false,
+        role: "cell",
+        className: "group",
+        "aria-label": "Group",
+      },
+      {
+        content: (
+          <Button
+            type="button"
+            onClick={() => {
+              setNewUserSettings((prev) => {
+                return [
+                  ...prev,
+                  {
+                    key: "",
+                    value: "",
+                    default: "",
+                    category: "user",
+                    type: "string",
+                    isSaved: false,
+                    isUserDefined: true,
+                    id: generateUUID(),
+                  },
+                ];
+              });
+            }}
+          >
+            Add user setting
+          </Button>
+        ),
+        role: "rowheader",
+        className: "key",
+      },
+    ],
+  };
+};

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -38,9 +38,9 @@
     }
   }
 
-  .reset-button {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+  .reset-button,
+  .delete-button {
+    padding: 0 $sph--small;
   }
 
   .cluster-specific-input {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -13,6 +13,7 @@ export interface LxdConfigOption {
   scope?: "global" | "local";
   shortdesc?: string;
   type: "bool" | "string" | "integer";
+  isUserDefined?: boolean;
 }
 
 export interface LxcConfigOptionCategories {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -5,13 +5,13 @@ import type { LxdProfile } from "types/profile";
 import type { LxdNetwork, LxdNetworkAcl } from "types/network";
 import type { LxdStoragePool, LxdStorageVolume } from "types/storage";
 import type { Dispatch, SetStateAction } from "react";
-import crypto from "crypto";
 import { isDiskDevice, isNicDevice } from "./devices";
 import { isRootDisk } from "./instanceValidation";
 import type { FormDevice } from "./formDevices";
 import type { LxdIdentity } from "types/permissions";
 import { addTarget } from "util/target";
 import { debounceAsync } from "util/debounce";
+import crypto from "crypto";
 
 export const UNDEFINED_DATE = "0001-01-01T00:00:00Z";
 
@@ -316,7 +316,10 @@ export const getAbsoluteHeightBelowBySelector = (selector: string): number => {
 };
 
 export const generateUUID = (): string => {
-  return crypto.randomBytes(16).toString("hex");
+  if (typeof window !== "undefined") {
+    return self.crypto.randomUUID();
+  }
+  return crypto.randomUUID();
 };
 
 export const getClientOS = (userAgent: string) => {

--- a/src/util/settings.tsx
+++ b/src/util/settings.tsx
@@ -1,4 +1,16 @@
 import type { LxdSettings } from "types/server";
+import type { ConfigField, LxdConfigPair } from "types/config";
+import type { LXDSettingOnClusterMember } from "types/server";
+import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
+
+import { getDefaultProject } from "util/loginProject";
+import type { LxdProject } from "types/project";
+
+export type UserSetting = ConfigField & {
+  value?: string;
+  isSaved: boolean;
+  id?: string;
+};
 
 export const supportsOvnNetwork = (
   settings: LxdSettings | undefined,
@@ -16,4 +28,98 @@ export const isClusteredServer = (
 
 export const hasMicroCloudFlag = (settings?: LxdSettings): boolean => {
   return Boolean(settings?.config?.["user.microcloud"]);
+};
+
+export const getConfigFieldValue = (
+  configField: ConfigField,
+  settings?: LxdSettings,
+): string | undefined => {
+  for (const [key, value] of Object.entries(settings?.config ?? {})) {
+    if (key === configField.key) {
+      return value;
+    }
+  }
+  if (configField.type === "bool") {
+    return configField.default === "true" ? "true" : "false";
+  }
+  if (configField.default === "-") {
+    return undefined;
+  }
+  return configField.default;
+};
+
+export const getConfigFieldClusteredValue = (
+  clusteredSettings: LXDSettingOnClusterMember[],
+  configField: ConfigField,
+): ClusterSpecificValues => {
+  const settingPerClusterMember: ClusterSpecificValues = {};
+
+  clusteredSettings?.forEach((item) => {
+    settingPerClusterMember[item.memberName] =
+      item.config?.[configField.key] ?? configField.default ?? "";
+  });
+  return settingPerClusterMember;
+};
+
+export const getUserSettings = (
+  configPairs: LxdConfigPair,
+  projects: LxdProject[],
+): UserSetting[] => {
+  const settings: UserSetting[] = [
+    {
+      key: "user.ui_grafana_base_url",
+      category: "user",
+      default: "",
+      longdesc:
+        "e.g. https://example.org/dashboard?project={project}&name={instance}\n or https://192.0.2.1:3000/d/bGY-LSB7k/lxd?orgId=1",
+      shortdesc:
+        "LXD will replace `{instance}` and `{project}` with project and instance names for deep-linking to individual grafana pages.\nSee {ref}`grafana` for more information.",
+      type: "string",
+      isSaved: true,
+    },
+    {
+      key: "user.ui_login_project",
+      category: "user",
+      default: getDefaultProject(projects),
+      shortdesc: "Project to display on login.",
+      type: "string",
+      isSaved: true,
+    },
+    {
+      key: "user.ui_theme",
+      category: "user",
+      default: "",
+      shortdesc:
+        "Set UI to dark theme, light theme, or to match the system theme.",
+      type: "string",
+      isSaved: true,
+    },
+    {
+      key: "user.ui_title",
+      category: "user",
+      default: "",
+      shortdesc:
+        "Title for the LXD-UI web page. Shows the hostname when unset.",
+      type: "string",
+      isSaved: true,
+    },
+  ];
+
+  Object.entries(configPairs ?? {})
+    .filter(
+      ([key, _]) =>
+        key.startsWith("user.") && !settings.some((s) => s.key === key), //Do not duplicate ui user defined configs
+    )
+    .forEach(([key, _]) => {
+      settings.push({
+        key: key,
+        category: "user",
+        default: "",
+        type: "string",
+        isUserDefined: true,
+        isSaved: true,
+      });
+    });
+
+  return settings;
 };

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,8 +1,17 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 import { gotoURL } from "./navigate";
+import { randomNameSuffix } from "./name";
 
 export type ServerSettingType = "checkbox" | "text" | "number" | "password";
+
+export const randomSettingKey = (): string => {
+  return `playwright-setting-key-${randomNameSuffix()}`;
+};
+
+export const randomSettingValue = (): string => {
+  return `playwright-setting-value-${randomNameSuffix()}`;
+};
 
 export const visitServerSettings = async (page: Page) => {
   await gotoURL(page, "/ui/");
@@ -98,4 +107,27 @@ export const openServerSetting = async (page: Page, setting: string) => {
     .locator("css=tr", { hasText: setting })
     .getByRole("button")
     .click();
+};
+
+export const addUserSetting = async (
+  page: Page,
+  key: string,
+  value: string,
+) => {
+  await page
+    .getByRole("button", { name: "Add user setting", exact: true })
+    .click();
+  await page.getByPlaceholder("User key").fill(key);
+  await page.getByPlaceholder("Value").fill(value);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+};
+
+export const deleteUserSetting = async (page: Page, value: string) => {
+  const button = page.locator("button", {
+    has: page.locator("div", { hasText: value }),
+  });
+
+  await button.click();
+  await page.getByRole("button", { name: "Delete", exact: true }).click();
+  await expect(button).toHaveCount(0);
 };

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "./fixtures/lxd-test";
+import { dismissNotification } from "./helpers/notification";
 import type { ServerSettingType } from "./helpers/server";
 import {
+  addUserSetting,
+  deleteUserSetting,
+  randomSettingKey,
+  randomSettingValue,
   resetSetting,
   updateSetting,
   visitServerSettings,
@@ -57,6 +62,27 @@ test("only user server setting available for lxd v5.0/edge", async ({
   await page.waitForSelector(`text=Get more server settings`);
   const allSettingRows = await page.locator("#settings-table tbody tr").all();
 
-  // only 4 user settings available (user.ui_title, user.ui_grafana_base_url, user.ui_theme, user.ui_current_project)
-  expect(allSettingRows.length).toEqual(4);
+  // only 4 user settings available (user.ui_title, user.ui_grafana_base_url, user.ui_theme, user.ui_current_project) + 1 "Add key" button.
+  expect(allSettingRows.length).toEqual(5);
+});
+
+test("add and delete user defined setting", async ({ page }) => {
+  const key = randomSettingKey();
+  const value = randomSettingValue();
+
+  await visitServerSettings(page);
+  await addUserSetting(page, key, value);
+
+  await page.getByText(`Setting user.${key} added`).click();
+  await dismissNotification(page);
+
+  const keyElement = page.getByText(`user.${key}`);
+  await keyElement.click();
+
+  const valueElement = page.getByText(value);
+  await expect(valueElement).toHaveCount(1);
+
+  await deleteUserSetting(page, value);
+  await expect(keyElement).toHaveCount(0);
+  await expect(valueElement).toHaveCount(0);
 });


### PR DESCRIPTION
## Done

- feat: support adding, editing and deleting user defined settings
Addresses #1567 
 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Settings page.
    - At the bottom of the page, click on "Add key" button
    - Add a new key and value, and click the "Save" button.
    - Ensure the new key/value are added with the key being saved as user.{key}.
    - Click on the newly added value.
    - Change the value and click "Save".
    - Ensure the value is reflected.
    - Click on the newly added value.
    - Click the "Delete user setting" button.
    - Ensure that key/value are deleted.
    - Make sure the key input does not accept duplicate keys or empty values.

## Screenshots

<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/feae07ae-31f9-4833-8e4c-e44b0975114e" />
<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/0857a650-362d-4422-9d8a-7c1c0e9c080d" />
<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/64d7231a-e279-407b-b1a0-cdcc9a9eeb91" />
<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/c8b174fd-4a71-4bb9-b351-e99dbbdb74f1" />
<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/01ebb634-e68d-40b8-8a7b-3931a590128b" />



