### PR TITLE
feat(active project): Add active project in user settings, store in localStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import { setFavicon } from "util/favicon";
+import { ALL_PROJECTS } from "util/loginProject";
 
 const CertificateAdd = lazy(async () => import("pages/login/CertificateAdd"));
 const CertificateGenerate = lazy(
@@ -172,7 +173,7 @@ const App: FC = () => {
             element={
               <Navigate
                 to={
-                  hasNoProjects
+                  hasNoProjects || defaultProject === ALL_PROJECTS
                     ? "/ui/all-projects/instances"
                     : `/ui/project/${encodeURIComponent(defaultProject)}/instances`
                 }

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -6,6 +6,7 @@ import { fetchCertificates } from "api/certificates";
 import { fetchProjects } from "api/projects";
 import { fetchCurrentIdentity } from "api/auth-identities";
 import { useSupportedFeatures } from "./useSupportedFeatures";
+import { getLoginProject } from "util/loginProject";
 
 interface ContextProps {
   isAuthenticated: boolean;
@@ -81,10 +82,7 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
     enabled: settings?.auth === "trusted" && isFineGrained() !== null,
   });
 
-  const defaultProject =
-    projects.length < 1 || projects.find((p) => p.name === "default")
-      ? "default"
-      : projects[0].name;
+  const defaultProject = getLoginProject(projects);
 
   const isTls = settings?.auth_user_method === "tls";
 

--- a/src/pages/settings/LoginProjectSelect.tsx
+++ b/src/pages/settings/LoginProjectSelect.tsx
@@ -1,0 +1,129 @@
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Form,
+  Icon,
+  Select,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useProjects } from "context/useProjects";
+import {
+  ALL_PROJECTS,
+  getDefaultProject,
+  getLoginProject,
+  loadLoginProject,
+  saveLoginProject,
+} from "util/loginProject";
+import ResourceLabel from "components/ResourceLabel";
+import type { ConfigField } from "types/config";
+
+interface Props {
+  configField: ConfigField;
+}
+
+const LoginProjectSelect: FC<Props> = ({ configField }) => {
+  const [isEditMode, setEditMode] = useState(false);
+  const { data: projects = [] } = useProjects();
+  const [value, setValue] = useState<string>(loadLoginProject() || "");
+  const toastNotify = useToastNotification();
+
+  const projectOptions = [
+    {
+      label: "All projects",
+      value: ALL_PROJECTS,
+    },
+    ...projects.map((project) => ({
+      label: project.name,
+      value: project.name,
+    })),
+  ];
+
+  const canBeReset = String(configField.default) !== String(value);
+
+  const handleSave = () => {
+    saveLoginProject(value);
+
+    const settingLabel = (
+      <ResourceLabel bold type="setting" value={configField.key} />
+    );
+    toastNotify.success(<>Setting {settingLabel} updated.</>);
+    setEditMode(false);
+  };
+
+  const resetToDefault = () => {
+    setValue(configField.default || "");
+  };
+
+  const onCancel = () => {
+    setValue(loadLoginProject() || "");
+    setEditMode(false);
+  };
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setValue(loadLoginProject() || "");
+      return;
+    }
+    setValue(getLoginProject(projects));
+  }, [isEditMode, projects]);
+
+  return (
+    <>
+      {isEditMode && (
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+        >
+          <Select
+            name={`${configField.key}-select`}
+            aria-label={configField.key}
+            options={projectOptions}
+            value={value}
+            onChange={(e) => {
+              setValue((e.target as HTMLSelectElement).value);
+            }}
+          />
+          <Button appearance="base" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button appearance="positive" type="submit">
+            Save
+          </Button>
+          {canBeReset && (
+            <Button
+              className="reset-button"
+              appearance="base"
+              onClick={resetToDefault}
+              hasIcon
+            >
+              <Icon name="restart" className="flip-horizontally" />
+              <span>Reset to default</span>
+            </Button>
+          )}
+        </Form>
+      )}
+      {!isEditMode && (
+        <Button
+          appearance="base"
+          className="readmode-button u-no-margin"
+          onClick={() => {
+            setEditMode(true);
+          }}
+          hasIcon
+        >
+          <div className="readmode-value u-truncate">
+            {value === ALL_PROJECTS
+              ? "All projects"
+              : value || getDefaultProject(projects)}
+          </div>
+          <Icon name="edit" className="edit-icon" />
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default LoginProjectSelect;

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -15,6 +15,7 @@ import { useAuth } from "context/auth";
 import SettingFormCheckbox from "./SettingFormCheckbox";
 import SettingFormInput from "./SettingFormInput";
 import SettingFormPassword from "./SettingFormPassword";
+import LoginProjectSelect from "./LoginProjectSelect";
 import ResourceLabel from "components/ResourceLabel";
 import { useServerEntitlements } from "util/entitlements/server";
 import ClusteredSettingFormInput from "./ClusteredSettingFormInput";
@@ -54,6 +55,7 @@ const SettingForm: FC<Props> = ({
   const isSecret = isTrustPassword || isLokiAuthPassword;
   const isClusteredInput = isClustered && configField.scope === "local";
   const isThemeSelector = configField.key === "user.ui_theme";
+  const isLoginProjectSelector = configField.key === "user.ui_login_project";
 
   const settingLabel = (
     <ResourceLabel bold type="setting" value={configField.key} />
@@ -134,6 +136,14 @@ const SettingForm: FC<Props> = ({
 
   if (isThemeSelector) {
     return <ThemeSwitcher />;
+  }
+
+  if (isLoginProjectSelector) {
+    return (
+      <div ref={editRef}>
+        <LoginProjectSelect configField={configField} />
+      </div>
+    );
   }
 
   return (

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -26,6 +26,8 @@ import { useServerEntitlements } from "util/entitlements/server";
 import type { ClusterSpecificValues } from "components/ClusterSpecificSelect";
 import { useClusteredSettings } from "context/useSettings";
 import type { LXDSettingOnClusterMember } from "types/server";
+import { useProjects } from "context/useProjects";
+import { getDefaultProject } from "util/loginProject";
 
 const Settings: FC = () => {
   const docBaseLink = useDocs();
@@ -45,6 +47,8 @@ const Settings: FC = () => {
   });
   const { data: clusteredSettings = [], error: clusterError } =
     useClusteredSettings();
+
+  const { data: projects = [] } = useProjects();
 
   if (clusterError) {
     notify.failure("Loading clustered settings failed", clusterError);
@@ -96,14 +100,6 @@ const Settings: FC = () => {
   const configFields = toConfigFields(configOptions?.configs?.server ?? {});
 
   configFields.push({
-    key: "user.ui_title",
-    category: "user",
-    default: "",
-    shortdesc: "Title for the LXD-UI web page. Shows the hostname when unset.",
-    type: "string",
-  });
-
-  configFields.push({
     key: "user.ui_grafana_base_url",
     category: "user",
     default: "",
@@ -115,11 +111,27 @@ const Settings: FC = () => {
   });
 
   configFields.push({
+    key: "user.ui_login_project",
+    category: "user",
+    default: getDefaultProject(projects),
+    shortdesc: "Project to display on login.",
+    type: "string",
+  });
+
+  configFields.push({
     key: "user.ui_theme",
     category: "user",
     default: "",
     shortdesc:
       "Set UI to dark theme, light theme, or to match the system theme.",
+    type: "string",
+  });
+
+  configFields.push({
+    key: "user.ui_title",
+    category: "user",
+    default: "",
+    shortdesc: "Title for the LXD-UI web page. Shows the hostname when unset.",
     type: "string",
   });
 

--- a/src/util/loginProject.ts
+++ b/src/util/loginProject.ts
@@ -1,0 +1,34 @@
+import type { LxdProject } from "types/project";
+
+export const ALL_PROJECTS = "__all_projects__";
+const LOCAL_STORAGE_KEY = "lxdLoginProject";
+
+export const loadLoginProject = (): string | undefined => {
+  const saved = localStorage.getItem(LOCAL_STORAGE_KEY);
+  return saved || undefined;
+};
+
+export const saveLoginProject = (project: string): void => {
+  localStorage.setItem(LOCAL_STORAGE_KEY, project);
+};
+
+export const getDefaultProject = (projects: LxdProject[]) => {
+  const project =
+    projects.length < 1 || projects.find((p) => p.name === "default")
+      ? "default"
+      : projects[0].name;
+
+  return project;
+};
+
+export const getLoginProject = (projects: LxdProject[]) => {
+  const savedProject = loadLoginProject();
+  if (savedProject === ALL_PROJECTS) {
+    return ALL_PROJECTS;
+  }
+  if (savedProject && projects.find((p) => p.name === savedProject)) {
+    return savedProject;
+  }
+
+  return getDefaultProject(projects);
+};

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -56,5 +56,7 @@ test("only user server setting available for lxd v5.0/edge", async ({
   await visitServerSettings(page);
   await page.waitForSelector(`text=Get more server settings`);
   const allSettingRows = await page.locator("#settings-table tbody tr").all();
-  expect(allSettingRows.length).toEqual(3);
+
+  // only 4 user settings available (user.ui_title, user.ui_grafana_base_url, user.ui_theme, user.ui_current_project)
+  expect(allSettingRows.length).toEqual(4);
 });


### PR DESCRIPTION
## Done

- Add a new user setting `user.ui_current_project`. Edit field is a dropdown list of projects, including All projects.
- Save `user.ui_current_project` in local storage.
- On login, if `user.ui_current_project` is correctly set, the current project is automatically selected.

Collateral improvements:
- On CertificateAdd page, add a Copy command button and display command on several lines.
- In LoggedInUserNotification, fix console error (p cannot be a descendant of p)

Fixes #1564

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots


<img width="1344" height="135" alt="Screenshot from 2025-11-10 11-12-22" src="https://github.com/user-attachments/assets/c958baa8-82e1-4480-b206-6c80729aeff3" />

<img width="1344" height="150" alt="Screenshot from 2025-11-10 11-12-34" src="https://github.com/user-attachments/assets/63efafd1-6a90-4bd0-b0dd-f9f980eec572" />

<img width="1344" height="195" alt="Screenshot from 2025-11-10 11-12-41" src="https://github.com/user-attachments/assets/b3ad0bd3-8d22-4f4b-b3f5-0ea151546f0c" />

