### PR TITLE
feat: [WD-30998] Update Network Tabs

### DIFF
--- a/src/api/network-peering.tsx
+++ b/src/api/network-peering.tsx
@@ -1,0 +1,20 @@
+import { handleResponse } from "util/helpers";
+import type { LxdNetworkPeer } from "types/network";
+import type { LxdApiResponse } from "types/apiResponse";
+
+export const fetchNetworkPeers = async (
+  network: string,
+  project: string,
+): Promise<LxdNetworkPeer[]> => {
+  const params = new URLSearchParams();
+  params.set("project", project);
+  params.set("recursion", "1");
+
+  return fetch(
+    `/1.0/networks/${encodeURIComponent(network)}/peers?${params.toString()}`,
+  )
+    .then(handleResponse)
+    .then((data: LxdApiResponse<LxdNetworkPeer[]>) => {
+      return data.metadata;
+    });
+};

--- a/src/pages/networks/NetworkPeers.tsx
+++ b/src/pages/networks/NetworkPeers.tsx
@@ -1,0 +1,148 @@
+import type { FC } from "react";
+import {
+  EmptyState,
+  Icon,
+  MainTable,
+  Row,
+  ScrollableTable,
+  useNotify,
+  Spinner,
+} from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import type { LxdNetwork } from "types/network";
+import { fetchNetworkPeers } from "api/network-peering";
+import ResourceLink from "components/ResourceLink";
+import DocLink from "components/DocLink";
+
+interface Props {
+  network: LxdNetwork;
+  project: string;
+}
+
+const NetworkPeers: FC<Props> = ({ network, project }) => {
+  const notify = useNotify();
+
+  const {
+    data: peers = [],
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [
+      queryKeys.projects,
+      project,
+      queryKeys.networks,
+      network.name,
+      queryKeys.peers,
+    ],
+    queryFn: async () => fetchNetworkPeers(network.name, project),
+  });
+
+  if (error) {
+    notify.failure("Loading local network peerings failed", error);
+  }
+
+  const hasNetworkPeers = peers.length > 0;
+
+  const headers = [
+    { content: "Name", sortKey: "name" },
+    { content: "Description", sortKey: "description" },
+    { content: "Peer project", sortKey: "project" },
+    { content: "Peer network", sortKey: "peerNetwork" },
+    { content: "Status", sortKey: "status" },
+  ];
+
+  const rows = peers.map((peer) => {
+    return {
+      key: peer.name,
+      columns: [
+        {
+          content: peer.name,
+          role: "rowheader",
+          "aria-label": "Name",
+        },
+        {
+          content: peer.description,
+          role: "cell",
+          "aria-label": "Description",
+        },
+        {
+          content: peer.target_project && (
+            <ResourceLink
+              type="project"
+              value={peer.target_project}
+              to={`/ui/project/${encodeURIComponent(peer.target_project)}`}
+            />
+          ),
+          role: "cell",
+          "aria-label": "Project",
+        },
+        {
+          content: (
+            <ResourceLink
+              type="network"
+              value={peer.target_network}
+              to={`/ui/project/${encodeURIComponent(peer.target_project ?? "")}/network/${encodeURIComponent(peer.target_network)}`}
+            />
+          ),
+          role: "cell",
+          "aria-label": "Target network",
+        },
+        {
+          content: peer.status,
+          role: "cell",
+          "aria-label": "Status",
+        },
+      ],
+      sortData: {
+        name: peer.name?.toLowerCase(),
+        description: peer.description?.toLowerCase(),
+        project: peer.target_project?.toLowerCase(),
+        peerNetwork: peer.target_network,
+        status: peer.status?.toLowerCase(),
+      },
+    };
+  });
+
+  if (isLoading) {
+    return <Spinner className="u-loader" text="Loading..." isMainComponent />;
+  }
+
+  return (
+    <Row>
+      {hasNetworkPeers && (
+        <ScrollableTable
+          dependencies={peers}
+          tableId="network-peer-table"
+          belowIds={["status-bar"]}
+        >
+          <MainTable
+            id="network-peer-table"
+            headers={headers}
+            expanding
+            rows={rows}
+            responsive
+            sortable
+            className="u-table-layout--auto"
+          />
+        </ScrollableTable>
+      )}
+      {!hasNetworkPeers && (
+        <EmptyState
+          className="empty-state"
+          image={<Icon className="empty-state-icon" name="exposed" />}
+          title="No local peerings found"
+        >
+          <p>There are no local peerings in this network and project.</p>
+          <p>
+            <DocLink docPath={`/howto/network_ovn_peers`}>
+              Learn more about local peering
+            </DocLink>
+          </p>
+        </EmptyState>
+      )}
+    </Row>
+  );
+};
+
+export default NetworkPeers;

--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -18,13 +18,9 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
 
   return (
     <div className="general-field">
-      {formik.values.readOnly ? (
-        <div className="general-field-label">ACLs</div>
-      ) : (
-        <Label className="general-field-label" forId={networlAclSelectorId}>
-          ACLs
-        </Label>
-      )}
+      <Label className="general-field-label" forId={networlAclSelectorId}>
+        ACLs
+      </Label>
       <div
         className="general-field-content"
         key={formik.values.readOnly ? "read" : "edit"}

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -164,6 +164,14 @@ export interface LxdNetworkLease {
   type: "string";
 }
 
+export interface LxdNetworkPeer {
+  name: "string";
+  target_network: "string";
+  description: "string";
+  target_project: "string";
+  status: "string";
+}
+
 export interface LxdNetworkAllocation {
   addresses: string;
   hwaddr: string;

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -20,9 +20,11 @@ export const typesForUplink = [bridgeType, physicalType];
 
 export const typesWithAcls = [bridgeType, ovnType];
 export const typesWithForwards = [bridgeType, ovnType];
+export const typesWithLeases = [bridgeType, ovnType];
 export const typesWithParent = [physicalType, sriovType, macvlanType];
 export const typesWithStatistics = [bridgeType, ovnType, physicalType];
 export const typesWithNicDeviceAcls = [ovnType];
+export const typesWithLocalPeerings = [ovnType];
 
 export const getIpAddresses = (
   instance: LxdInstance,

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -32,4 +32,5 @@ export const queryKeys = {
   idpGroups: "idpGroups",
   permissions: "permissions",
   currentIdentity: "currentIdentity",
+  peers: "peers",
 };

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -150,7 +150,7 @@ test("networks", async ({ page }) => {
     clip: getClipPosition(240, 0, 1130, 750),
   });
 
-  await page.getByTestId("tab-link-Leases").click();
+  await page.getByRole("link", { name: "Leases" }).click();
   await page.waitForSelector(`text=Hostname`);
   await page.screenshot({
     path: "tests/screenshots/doc/images/networks/network_view_leases.png",
@@ -663,7 +663,7 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
   let networkSubnet = await page.inputValue("input#ipv4_address");
   let listenAddress = networkSubnet.replace("1/24", "1");
   let targetAddress = networkSubnet.replace("1/24", "3");
-  await page.getByTestId("tab-link-Forwards").click();
+  await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByRole("link", { name: "Create forward" }).click();
   await page.getByLabel("Listen address").fill(listenAddress);
   await page.getByLabel("Default target address").fill(targetAddress);
@@ -687,7 +687,7 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
   networkSubnet = await page.inputValue("input#ipv4_address");
   listenAddress = networkSubnet.replace("1/24", "1");
   targetAddress = networkSubnet.replace("1/24", "3");
-  await page.getByTestId("tab-link-Forwards").click();
+  await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByRole("link", { name: "Create forward" }).click();
   await page.getByLabel("Listen address").fill(listenAddress);
   await page.getByLabel("Default target address").fill(targetAddress);

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -80,7 +80,9 @@ export const getFirstClusterMember = async (page: Page): Promise<string> => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Clustering" }).click();
   await page.getByRole("link", { name: "Members" }).click();
-  await expect(page.getByText("Cluster members")).toBeVisible();
+  await expect(
+    page.getByText("Cluster members", { exact: true }),
+  ).toBeVisible();
   const firstCellContent = await page
     .getByRole("rowheader")
     .first()

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -84,7 +84,7 @@ export const createNetworkForward = async (page: Page, network: string) => {
   const listenAddress = networkSubnet.replace("1/24", "1");
   const targetAddress = networkSubnet.replace("1/24", "3");
 
-  await page.getByTestId("tab-link-Forwards").click();
+  await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByRole("link", { name: "Create forward" }).click();
   await page.getByLabel("Listen address").fill(listenAddress);
 
@@ -125,14 +125,14 @@ export const createNetworkForward = async (page: Page, network: string) => {
   await page.getByText(`Network forward ${listenAddress} updated.`).click();
   await expect(page.getByText(`My forward description`)).toBeVisible();
 
-  await page.getByTestId("tab-link-Leases").click();
+  await page.getByRole("link", { name: "Leases" }).click();
   await expect(page.getByText(`${network}.gw`).first()).toBeVisible();
 
   await page.getByRole("link", { name: "IPAM", exact: true }).click();
   await expect(page.getByText(`network-forward`).first()).toBeVisible();
 
   await visitNetwork(page, network);
-  await page.getByTestId("tab-link-Forwards").click();
+  await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByRole("button", { name: "Delete network forward" }).click();
   await page
     .getByRole("dialog", { name: "Confirm delete" })

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -274,7 +274,7 @@ test.describe("Given a user with Viewer Server permissions...", () => {
       page.getByRole("button", { name: "Delete network" }),
     ).toBeDisabled();
 
-    await page.getByTestId("tab-link-Forwards").click();
+    await page.getByRole("link", { name: "Forwards" }).click();
     await expect(
       page.getByRole("button", { name: "Create forward" }),
     ).toBeDisabled();


### PR DESCRIPTION
## Done

- Updates network tabs to be responsive (enabled / disabled) to different networking features depending on their type.
- Introduces the Network Peering Tab for OVN networks, allowing current network Peers to be listed. For testing, please create a new Peer via the CLI.

To do:
- [x] Currently active tabs are not properly displayed. Investigating...
- [x] Add help text in empty state noting that peers can only be created between networks on the same cluster.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - View the network tabs on any backend and verify that Forwards and Leases are accessible and only applicable to managed networks or networks that are compatible.
    - View the network tabs on an OVN configured network and verify that the Peer empty state is visible, with appropriate Copy / Wording.
    - Clone locally, create a Peer via and CLI and verify that the table displays the Peer appropriately.

## Screenshots
Network tabs on an OVN network:
<img width="1917" height="816" alt="image" src="https://github.com/user-attachments/assets/86894a44-4dda-4d08-95f1-a54f009c2b61" />

Network tabs on a bridge network:
<img width="1917" height="816" alt="image" src="https://github.com/user-attachments/assets/e0169b10-9512-49ad-9f21-920a286362c5" />

Network tabs on a non-conforming network (disabled):
<img width="1917" height="816" alt="image" src="https://github.com/user-attachments/assets/a2008deb-060e-4add-9c88-1e86c95e77b7" />

CRUD Operations to be continued in a new PR.