### PR TITLE
feat(force delete project): list content

### DIFF
--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -85,8 +85,17 @@ export const renameProject = async (
     });
 };
 
-export const deleteProject = async (project: LxdProject): Promise<void> => {
-  await fetch(`/1.0/projects/${encodeURIComponent(project.name)}`, {
+export const deleteProject = async (
+  project: LxdProject,
+  force?: boolean,
+): Promise<void> => {
+  const params = new URLSearchParams();
+  if (force) {
+    params.set("force", "1");
+  }
+  const url = `/1.0/projects/${encodeURIComponent(project.name)}?${params.toString()}`;
+
+  await fetch(url, {
     method: "DELETE",
   }).then(handleResponse);
 };

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -44,5 +44,6 @@ export const useSupportedFeatures = () => {
     hasStorageAndProfileOperations: apiExtensions.has(
       "storage_and_profile_operations",
     ),
+    hasProjectForceDelete: apiExtensions.has("projects_force_delete"),
   };
 };

--- a/src/pages/images/actions/BulkDeleteImageBtn.tsx
+++ b/src/pages/images/actions/BulkDeleteImageBtn.tsx
@@ -77,7 +77,14 @@ const BulkDeleteImageBtn: FC<Props> = ({
           );
         }
         queryClient.invalidateQueries({
-          predicate: (query) => query.queryKey[0] === queryKeys.images,
+          predicate: (query) => {
+            const firstKey = query.queryKey[0];
+            return (
+              firstKey === queryKeys.images ||
+              // Invalidate projects to update used_by field
+              firstKey === queryKeys.projects
+            );
+          },
         });
         setLoading(false);
         onFinish();

--- a/src/pages/projects/actions/DeleteProjectModal.tsx
+++ b/src/pages/projects/actions/DeleteProjectModal.tsx
@@ -1,0 +1,86 @@
+import ResourceLabel from "components/ResourceLabel";
+import type { ChangeEvent, FC, KeyboardEvent } from "react";
+import { useState } from "react";
+import type { LxdProject } from "types/project";
+import { isProjectEmpty } from "util/projects";
+import ProjectUsedBy from "pages/projects/actions/ProjectUsedBy";
+import {
+  ActionButton,
+  Input,
+  Modal,
+  NotificationConsumer,
+} from "@canonical/react-components";
+
+interface Props {
+  project: LxdProject;
+  handleDelete: () => void;
+  isLoading: boolean;
+  closePortal: () => void;
+}
+
+const DeleteProjectModal: FC<Props> = ({
+  project,
+  handleDelete,
+  isLoading,
+  closePortal,
+}) => {
+  const [disableConfirm, setDisableConfirm] = useState(true);
+
+  const isEmpty = isProjectEmpty(project);
+
+  const handleConfirmInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDisableConfirm(e.target.value !== project.name);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !disableConfirm && !isLoading) {
+      handleDelete();
+    }
+  };
+
+  return (
+    <Modal
+      title="Confirm delete"
+      className="delete-project-dialog"
+      close={closePortal}
+      buttonRow={[
+        <span className="u-float-left confirm-input" key="confirm-input">
+          <Input
+            name="confirm-delete-project-input"
+            type="text"
+            onChange={handleConfirmInputChange}
+            onKeyDown={handleKeyDown}
+            placeholder={project.name}
+            className="u-no-margin--bottom"
+          />
+        </span>,
+        <ActionButton
+          key="confirm-action-button"
+          appearance="negative"
+          className="u-no-margin--bottom"
+          onClick={handleDelete}
+          loading={isLoading}
+          disabled={disableConfirm}
+        >
+          Permanently delete {project.name}
+        </ActionButton>,
+      ]}
+    >
+      <NotificationConsumer />
+      <p>
+        This will permanently delete project{" "}
+        <ResourceLabel type="project" value={project.name} bold />.<br />
+        This action cannot be undone, and can result in data loss.
+      </p>
+      {!isEmpty && (
+        <>
+          The following items will also be deleted:
+          <ProjectUsedBy project={project} />
+        </>
+      )}
+      <p>To continue, please type the project name below.</p>
+    </Modal>
+  );
+};
+
+export default DeleteProjectModal;

--- a/src/pages/projects/actions/ProjectUsedBy.tsx
+++ b/src/pages/projects/actions/ProjectUsedBy.tsx
@@ -1,0 +1,138 @@
+import { type FC } from "react";
+import type { LxdProject } from "types/project";
+import type { LxdUsedBy } from "util/usedBy";
+import { filterUsedByType } from "util/usedBy";
+import { Icon } from "@canonical/react-components";
+import { useImagesInProject } from "context/useImages";
+import ExpandableList from "components/ExpandableList";
+import UsedByItem from "components/UsedByItem";
+
+const INSTANCES = "Instances";
+const PROFILES = "Profiles";
+const IMAGES = "Images";
+const CUSTOM_VOLUMES = "Custom volumes";
+
+interface Props {
+  project: LxdProject;
+}
+
+const ProjectUsedBy: FC<Props> = ({ project }) => {
+  const { data: imagesFromProject = [] } = useImagesInProject(project.name);
+  const data: Record<string, LxdUsedBy[]> = {
+    [INSTANCES]: filterUsedByType("instance", project.used_by),
+    [PROFILES]: filterUsedByType(
+      "profile",
+      project.used_by?.filter(
+        // the default profile is not blocking project deletion and can't be removed itself
+        (item) => !item.startsWith("/1.0/profiles/default"),
+      ),
+    ),
+    [IMAGES]: filterUsedByType("image", project.used_by),
+    [CUSTOM_VOLUMES]: filterUsedByType("volume", project.used_by),
+  };
+
+  return (
+    <table className="p-main-table delete-project-table">
+      <tbody>
+        {data[INSTANCES].length > 0 && (
+          <tr>
+            <th>
+              <Icon name="pods" className="icon" />
+              Instances ({data[INSTANCES].length})
+            </th>
+            <td>
+              <ExpandableList
+                items={data[INSTANCES].map((item) => (
+                  <UsedByItem
+                    key={`${item.name}-${item.project}`}
+                    item={item}
+                    activeProject={project.name}
+                    type="instance"
+                    to={`/ui/project/${encodeURIComponent(item.project)}/instance/${encodeURIComponent(item.name)}`}
+                  />
+                ))}
+              />
+            </td>
+          </tr>
+        )}
+
+        {data[PROFILES].length > 0 && (
+          <tr>
+            <th>
+              <Icon name="repository" className="icon" />
+              Profiles ({data[PROFILES].length})
+            </th>
+            <td>
+              <ExpandableList
+                items={data[PROFILES].map((item) => (
+                  <UsedByItem
+                    key={`${item.name}-${item.project}`}
+                    item={item}
+                    activeProject={project.name}
+                    type="profile"
+                    to={`/ui/project/${encodeURIComponent(item.project)}/profile/${encodeURIComponent(item.name)}`}
+                  />
+                ))}
+              />
+            </td>
+          </tr>
+        )}
+
+        {data[IMAGES].length > 0 && (
+          <tr>
+            <th>
+              <Icon name="image" className="icon" />
+              Images ({data[IMAGES].length})
+            </th>
+            <td>
+              <ExpandableList
+                items={data[IMAGES].map((image) => {
+                  const imageFromProject = imagesFromProject.find(
+                    (img) => img.fingerprint === image.name,
+                  );
+                  return {
+                    ...image,
+                    name:
+                      imageFromProject?.properties?.description || image.name,
+                  };
+                }).map((item) => (
+                  <UsedByItem
+                    key={`${item.name}-${item.project}`}
+                    item={item}
+                    activeProject={project.name}
+                    type="image"
+                    to={`/ui/project/${encodeURIComponent(item.project)}/images`}
+                  />
+                ))}
+              />
+            </td>
+          </tr>
+        )}
+
+        {data[CUSTOM_VOLUMES].length > 0 && (
+          <tr>
+            <th>
+              <Icon name="switcher-dashboard" className="icon" />
+              Volumes ({data[CUSTOM_VOLUMES].length})
+            </th>
+            <td>
+              <ExpandableList
+                items={data[CUSTOM_VOLUMES].map((item) => (
+                  <UsedByItem
+                    key={`${item.name}-${item.project}-${item.target}`}
+                    item={item}
+                    activeProject={project.name}
+                    type="volume"
+                    to={`/ui/project/${encodeURIComponent(item.project)}/storage/volumes`}
+                  />
+                ))}
+              />
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default ProjectUsedBy;

--- a/src/sass/_project_configuration.scss
+++ b/src/sass/_project_configuration.scss
@@ -1,0 +1,39 @@
+.delete-project-dialog {
+  .p-modal__dialog {
+    @include large {
+      width: 40rem;
+    }
+
+    .delete-project-table {
+      tbody {
+        tr {
+          th:first-child {
+            width: 14rem;
+
+            @include mobile-and-tablet {
+              width: 9rem;
+            }
+          }
+        }
+      }
+
+      .icon {
+        margin-right: $sph--large;
+      }
+    }
+
+    .p-modal__footer {
+      align-items: center;
+      display: flex;
+      gap: $sph--large;
+
+      .confirm-input {
+        flex: 1;
+      }
+
+      .p-action-button {
+        flex: 1;
+      }
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -123,6 +123,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "profile_list";
 @import "profile_used_by_default_project";
 @import "progress_bar";
+@import "project_configuration";
 @import "project_select";
 @import "rename_device";
 @import "rename_header";

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -19,6 +19,7 @@ export interface LxdUsedBy {
  * "/1.0/profiles/default?project=foo"
  * "/1.0/storage-pools/pool-dir/volumes/custom/test/snapshots/snap1?project=bar"
  * "/1.0/storage-pools/local/volumes/custom/abb?project=robots&target=micro2"
+ * "/1.0/images/b5509ae406f49e84faa1fe8e2d78d156b8a79efe00a4d9ea563e865253375db2?project=Penguin-Pen"
  */
 export const filterUsedByType = (
   type: ResourceType,

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -59,9 +59,11 @@ export const deleteProject = async (page: Page, project: string) => {
   await page.waitForLoadState("networkidle");
   await page.getByRole("link", { name: "Configuration" }).click();
   await page.getByRole("button", { name: "Delete" }).click();
+  await page.getByRole("dialog", { name: "Confirm delete" }).waitFor();
+  await page.getByPlaceholder(project).fill(project);
   await page
     .getByRole("dialog", { name: "Confirm delete" })
-    .getByRole("button", { name: "Delete" })
+    .getByRole("button", { name: `Permanently delete ${project}` })
     .click();
   await page.waitForSelector(`text=Project ${project} deleted.`);
 };


### PR DESCRIPTION
## Done

- Enable `Delete project` button for non empty projects
- List content in the confirmation modal
- Make the user type project name to confirm deletion both for empty and non empty projects
- Keep behavior the same on LXD versions that don't support force deletion (force delete project was introduced in 6.6)
- Add tests for old and new process


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Running against latest edge, delete empty project: you should have to type the project name
    - Running against latest edge, delete non empty project: force delete should work
    - Repeat those steps while running against an version that doesn't support force delete (5.21 for example). You should be able to delete an empty project. The delete project button should be disabled for non empty project, with a tooltip listing its content.

## Screenshots

<img width="964" height="927" alt="modal-wip" src="https://github.com/user-attachments/assets/423aaa6b-6829-4cc4-91f9-5ea9556f6a6c" />
<img width="964" height="927" alt="modal-wip-2" src="https://github.com/user-attachments/assets/e02ed3e8-94c3-46f3-be41-f1e027d599ef" />
</br></br>

When deleting an empty project:
<img width="966" height="338" alt="empty" src="https://github.com/user-attachments/assets/abf4a2b6-6204-4899-a44f-f2194f38fd76" />
