### PR TITLE
feat(profile) add explainer on what a profile is on instance create and edit

### DIFF
--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -69,6 +69,24 @@ const ProfileSelector: FC<Props> = ({
     }
   };
 
+  const getHelp = (index: number) => {
+    const profileIntro =
+      "Profiles store a set of configuration options, such as instance and device options.";
+
+    if (index > 0 && index === selected.length - 1) {
+      return (
+        <>
+          {profileIntro}
+          <br />
+          Each profile overrides the settings specified in previous profiles.
+        </>
+      );
+    }
+    if (selected.length === 1) {
+      return profileIntro;
+    }
+  };
+
   return (
     <>
       <Label forId="profile-0">Profiles</Label>
@@ -78,11 +96,7 @@ const ProfileSelector: FC<Props> = ({
             <Select
               id={`profile-${index}`}
               aria-label="Select a profile"
-              help={
-                index > 0 &&
-                index === selected.length - 1 &&
-                "Each profile overrides the settings specified in previous profiles"
-              }
+              help={getHelp(index)}
               onChange={(e) => {
                 const newValues = [...selected];
                 newValues[index] = e.target.value;


### PR DESCRIPTION
## Done

- feat(profile) add explainer on what a profile is on instance create and edit

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create and edit an instance, check the help text for the profile selector. assign one or multiple profiles.

## Screenshots

<img width="1921" height="914" alt="image" src="https://github.com/user-attachments/assets/85bd0696-9cfb-4df2-8d3c-09fc7e5acccf" />
