### PR TITLE
feat(network) add network type help text to clarify network types

### DIFF
--- a/src/pages/networks/forms/NetworkTypeSelector.tsx
+++ b/src/pages/networks/forms/NetworkTypeSelector.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Select } from "@canonical/react-components";
+import { CustomSelect } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
 import type { NetworkFormValues } from "pages/networks/forms/NetworkForm";
 import { useDocs } from "context/useDocs";
@@ -19,7 +19,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
   const docBaseLink = useDocs();
 
   return (
-    <Select
+    <CustomSelect
       id="networkType"
       name="networkType"
       help={
@@ -34,30 +34,75 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
         ) : undefined
       }
       required
+      searchable="never"
       options={[
         {
-          label: "Bridge",
+          label: (
+            <div className="label network-type-label">
+              <span className="network-type-name">Bridge</span>
+              <span className="network-type-explanation u-text--muted">
+                Setup local virtual subnet providing NAT, DHCP and DNS to
+                instances.
+              </span>
+            </div>
+          ),
+          text: "Bridge",
           value: bridgeType,
         },
         {
-          label: "Macvlan",
+          label: (
+            <div className="label network-type-label">
+              <span className="network-type-name">Macvlan</span>
+              <span className="network-type-explanation u-text--muted">
+                Connect instances to an existing network interface without a
+                bridge.
+              </span>
+            </div>
+          ),
+          text: "Macvlan",
           value: macvlanType,
         },
         {
-          label: "OVN",
+          label: (
+            <div className="label network-type-label">
+              <div className="network-type-name">OVN</div>
+              <div className="network-type-explanation u-text--muted">
+                Setup cluster-wide virtual subnet providing NAT, DHCP and DNS to
+                instances.
+              </div>
+            </div>
+          ),
+          text: "OVN",
           value: ovnType,
         },
         {
-          label: "Physical",
+          label: (
+            <div className="label network-type-label">
+              <span className="network-type-name">Physical</span>
+              <span className="network-type-explanation u-text--muted">
+                Define OVN uplink or pass-through existing physical interface to
+                one instance.
+              </span>
+            </div>
+          ),
+          text: "Physical",
           value: physicalType,
         },
         {
-          label: "SR-IOV",
+          label: (
+            <div className="label network-type-label">
+              <span className="network-type-name">SR-IOV</span>
+              <span className="network-type-explanation u-text--muted">
+                Connect instances to an existing SR-IOV network interface.
+              </span>
+            </div>
+          ),
+          text: "SR-IOV",
           value: sriovType,
         },
       ]}
-      onChange={(e) => {
-        if (e.target.value === bridgeType) {
+      onChange={(value) => {
+        if (value === bridgeType) {
           formik.setFieldValue("networkType", bridgeType);
           formik.setFieldValue("network", undefined);
           formik.setFieldValue("parent", undefined);
@@ -77,7 +122,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           formik.setFieldValue("mtu", undefined);
           formik.setFieldValue("ovn_ingress_mode", undefined);
         }
-        if (e.target.value === macvlanType) {
+        if (value === macvlanType) {
           formik.setFieldValue("networkType", macvlanType);
           formik.setFieldValue("network", undefined);
           formik.setFieldValue("bridge_driver", undefined);
@@ -103,7 +148,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           formik.setFieldValue("ovn_ingress_mode", undefined);
           formik.setFieldValue("security_acls", []);
         }
-        if (e.target.value === ovnType) {
+        if (value === ovnType) {
           formik.setFieldValue("networkType", ovnType);
           formik.setFieldValue("bridge_driver", undefined);
           formik.setFieldValue("bridge_external_interfaces", undefined);
@@ -129,7 +174,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           formik.setFieldValue("mtu", undefined);
           formik.setFieldValue("ovn_ingress_mode", undefined);
         }
-        if (e.target.value === physicalType) {
+        if (value === physicalType) {
           formik.setFieldValue("networkType", physicalType);
           formik.setFieldValue("network", undefined);
           formik.setFieldValue("bridge_driver", undefined);
@@ -156,7 +201,7 @@ const NetworkTypeSelector: FC<Props> = ({ formik }) => {
           formik.setFieldValue("mtu", undefined);
           formik.setFieldValue("security_acls", []);
         }
-        if (e.target.value === sriovType) {
+        if (value === sriovType) {
           formik.setFieldValue("networkType", sriovType);
           formik.setFieldValue("network", undefined);
           formik.setFieldValue("bridge_driver", undefined);

--- a/src/sass/_network_form.scss
+++ b/src/sass/_network_form.scss
@@ -106,3 +106,24 @@
     }
   }
 }
+
+.network-type-label {
+  display: flex;
+
+  .network-type-name {
+    margin-left: $sph--small;
+    width: 5rem;
+  }
+
+  .network-type-explanation {
+    margin-left: $sph--small;
+  }
+
+  @media screen and (width <= 1200px) {
+    flex-direction: column;
+
+    .network-type-explanation {
+      white-space: break-spaces;
+    }
+  }
+}

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -130,7 +130,8 @@ test("networks", async ({ page }) => {
   await page.getByText("Networks").click();
   await page.getByText("Create network").click();
   await page.getByPlaceholder("Enter name").fill(network);
-  await page.getByLabel("Type").selectOption("bridge");
+  await page.getByRole("button", { name: "Type" }).click();
+  await page.getByLabel("submenu").getByText("bridge").first().click();
   await page.screenshot({
     path: "tests/screenshots/doc/images/networks/network_create.png",
     clip: getClipPosition(240, 0, 1420, 750),
@@ -671,7 +672,8 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
   await page.getByRole("link", { name: "Networks", exact: true }).click();
   await page.getByRole("button", { name: "Create network" }).click();
   await page.getByRole("heading", { name: "Create a network" }).click();
-  await page.getByLabel("Type").selectOption("bridge");
+  await page.getByRole("button", { name: "Type" }).click();
+  await page.getByLabel("submenu").getByText("bridge").first().click();
   await page.getByPlaceholder("Enter name").fill(network1);
   await page.getByRole("button", { name: "Create", exact: true }).click();
   await page.getByTestId("notification-close-button").click();

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -1,6 +1,5 @@
 import type { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
-import type { LxdNetworkType } from "types/network";
 import { activateAllTableOverrides } from "./configuration";
 import { gotoURL } from "./navigate";
 import { expect } from "../fixtures/lxd-test";
@@ -13,7 +12,7 @@ export const randomNetworkName = (): string => {
 export const createNetwork = async (
   page: Page,
   network: string,
-  type: LxdNetworkType = "bridge",
+  type = "bridge",
   hasMemberSpecificParents?: boolean,
 ) => {
   await gotoURL(page, "/ui/");
@@ -21,11 +20,12 @@ export const createNetwork = async (
   await page.getByRole("link", { name: "Networks", exact: true }).click();
   await page.getByRole("button", { name: "Create network" }).click();
   await page.getByRole("heading", { name: "Create a network" }).click();
-  await page.getByLabel("Type").selectOption(type);
+  await page.getByRole("button", { name: "Type" }).click();
+  await page.getByLabel("submenu").getByText(type).first().click();
   await page.getByLabel("Name", { exact: true }).click();
   await page.getByLabel("Name", { exact: true }).fill(network);
 
-  if (["physical", "sriov", "macvlan"].includes(type)) {
+  if (["physical", "sr-iov", "macvlan"].includes(type)) {
     if (hasMemberSpecificParents) {
       await page.getByText("Same for all cluster members").click();
     }

--- a/tests/networks.spec.ts
+++ b/tests/networks.spec.ts
@@ -241,7 +241,8 @@ test.describe("OVN type", () => {
     await page.getByRole("link", { name: "Networks", exact: true }).click();
     await page.getByRole("button", { name: "Create network" }).click();
     await page.getByRole("heading", { name: "Create a network" }).click();
-    await page.getByLabel("Type").selectOption("OVN");
+    await page.getByRole("button", { name: "Type" }).click();
+    await page.getByLabel("submenu").getByText("OVN").first().click();
     await page.getByLabel("Name").click();
     await page.getByLabel("Name").fill(network);
     await page.getByLabel("Uplink").selectOption({ index: 1 });
@@ -321,10 +322,10 @@ test("create network forward for specified network", async ({ page }) => {
   await deleteNetwork(page, network);
 });
 
-test.describe("SRIOV type", () => {
+test.describe("SR-IOV type", () => {
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
-    await createNetwork(page, network, "sriov");
+    await createNetwork(page, network, "sr-iov");
     await page.close();
   });
 
@@ -334,7 +335,7 @@ test.describe("SRIOV type", () => {
     await page.close();
   });
 
-  test("configure SRIOV network settings", async ({ page }) => {
+  test("configure SR-IOV network settings", async ({ page }) => {
     await visitNetwork(page, network);
 
     await page.getByRole("button", { name: "Edit" }).first().click();


### PR DESCRIPTION
## Done

- feat(network) add network type help text to clarify network types

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start network creation and explore the network type selector

## Screenshots

<img width="1276" height="383" alt="image" src="https://github.com/user-attachments/assets/72e86ca5-8ba9-4f1b-9209-3c630418c3f5" />