### PR TITLE
fix(network) fix leases sort

### DIFF
--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -60,7 +60,7 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
 
   const rows = leases.map((lease) => {
     return {
-      key: lease.address,
+      key: lease.address + lease.hostname + lease.type,
       columns: [
         {
           content: lease.type,


### PR DESCRIPTION
## Done

- fix(network) fix leases sort
- the address of a network lease is not unique as an allocation address can be dynamic and static at the same time

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to a bridge network detail page > open leases tab, sort network leases by clicking in the header