### PR TITLE
refactor(YamlNotification): put documentation link in actions

### DIFF
--- a/src/components/forms/YamlNotification.tsx
+++ b/src/components/forms/YamlNotification.tsx
@@ -39,12 +39,13 @@ const YamlNotification: FC<Props> = ({ entity, docPath }) => {
       severity="information"
       title="YAML Configuration"
       onDismiss={handleClose}
+      actions={[
+        <DocLink docPath={docPath} key="learn-more-link">
+          Learn more about {pluralize(entity, 2)}
+        </DocLink>,
+      ]}
     >
       This is the YAML representation of the {entity}.
-      <br />
-      <DocLink docPath={docPath}>
-        Learn more about {pluralize(entity, 2)}
-      </DocLink>
     </Notification>
   );
 };


### PR DESCRIPTION
## Done

- Make YamlNotification consistent with SsoNotification

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to an instance configuration page (make sure you don't have yamlNotificationClosedinstance set up in your local storage): check that YamlNotification is displayed with link on the bottom right corner and that documentation link still works.

## Screenshots
<img width="1424" height="163" alt="image" src="https://github.com/user-attachments/assets/b620fc90-7c22-4017-9a09-a32be6e3c920" />


For reference, here is the SsoNotification:
<img width="1510" height="173" alt="image" src="https://github.com/user-attachments/assets/c1f86538-ebe7-4ef4-bcf3-682a7d165a27" />

