### PR TITLE
feat: [WD-31265] Adjust Screenshot directory in automation

### DIFF
--- a/.github/workflows/screenshot_automation.yaml
+++ b/.github/workflows/screenshot_automation.yaml
@@ -78,6 +78,17 @@ jobs:
         run: |
           npx playwright test --project screenshots
           npx playwright test --project screenshots-clustered
+      
+      - name: List screenshots
+        run: ls -R tests/screenshots || echo "No screenshots found"
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: lxd-ui-doc-screenshots
+          path: tests/screenshots/doc/images
+          retention-days: 7
 
       - name: Upload screenshot-automation-report
         if: always()

--- a/tests/docs-screenshots-clustered.spec.ts
+++ b/tests/docs-screenshots-clustered.spec.ts
@@ -72,7 +72,7 @@ test("LXD - UI Folder - Clustered", async ({ page }) => {
   await page.getByLabel("Cluster member").selectOption(clusterMemberName);
   await page.getByLabel("Cluster member").dblclick();
   await page.screenshot({
-    path: "tests/screenshots/doc/images/ui/create_instance_ex4.png",
+    path: "tests/screenshots/doc/images/UI/create_instance_ex4.png",
     clip: getClipPosition(240, 0, 1440, 760),
   });
 });


### PR DESCRIPTION
## Done

- Screenshot directory should be uploaded as an artefact, or a message should be displayed if it cannot be found.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run the workflow on Kxiru's fork and verify the screenshots folder is generated.

## Screenshots

N/A