### PR TITLE
fix(network) chip placement on unmanaged member networks in cluster

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -118,9 +118,7 @@ const RenameHeader: FC<Props> = ({
               </li>
             )}
           </ol>
-          {relatedChip && (
-            <span style={{ marginLeft: "-1rem" }}>{relatedChip}</span>
-          )}
+          {relatedChip}
         </nav>
         {!formik?.values.isRenaming && centerControls}
       </div>

--- a/src/pages/networks/forms/NetworkFormMain.tsx
+++ b/src/pages/networks/forms/NetworkFormMain.tsx
@@ -27,7 +27,7 @@ import NetworkAddresses from "pages/networks/forms/NetworkAddresses";
 import NetworkAcls from "pages/networks/forms/NetworkAcls";
 import NetworkVlanField from "pages/networks/forms/NetworkVlanField";
 import NetworkMTUField from "pages/networks/forms/NetworkMTUField";
-import NetworkGVRPField from "pages/networks/forms/NetworkGVRPField";
+import NetworkGARPField from "pages/networks/forms/NetworkGARPField";
 import NetworkTypeSelector from "pages/networks/forms/NetworkTypeSelector";
 
 interface Props {
@@ -69,20 +69,15 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
             {formik.values.isCreating ? (
               <NetworkTypeSelector formik={formik} />
             ) : (
-              renderNetworkType(formik.values.networkType)
+              <>
+                {renderNetworkType(formik.values.networkType)}
+                {!isManagedNetwork && (
+                  <span className="u-text--muted">, not managed</span>
+                )}
+              </>
             )}
           </div>
         </div>
-        {!isManagedNetwork && (
-          <>
-            <div className="general-field">
-              <div className="general-field-label">
-                <Label forId="networkType">Managed</Label>
-              </div>
-              <div className="general-field-content">No</div>
-            </div>
-          </>
-        )}
         {formik.values.isCreating && (
           <div className="general-field">
             <div className="general-field-label">
@@ -115,20 +110,20 @@ const NetworkFormMain: FC<Props> = ({ formik, project, isClustered }) => {
             isClustered={isClustered}
           />
         )}
-        {formik.values.networkType === physicalType && (
+        {formik.values.networkType === physicalType && isManagedNetwork && (
           <>
             <NetworkMTUField formik={formik} />
             <NetworkVlanField formik={formik} />
           </>
         )}
-        {formik.values.networkType === macvlanType && (
+        {formik.values.networkType === macvlanType && isManagedNetwork && (
           <>
             <NetworkMTUField formik={formik} />
             <NetworkVlanField formik={formik} />
-            <NetworkGVRPField formik={formik} />
+            <NetworkGARPField formik={formik} />
           </>
         )}
-        {formik.values.networkType === sriovType && (
+        {formik.values.networkType === sriovType && isManagedNetwork && (
           <>
             <NetworkMTUField formik={formik} />
             <NetworkVlanField formik={formik} />

--- a/src/pages/networks/forms/NetworkGARPField.tsx
+++ b/src/pages/networks/forms/NetworkGARPField.tsx
@@ -9,7 +9,7 @@ interface Props {
   formik: FormikProps<NetworkFormValues>;
 }
 
-const NetworkGVRPField: FC<Props> = ({ formik }) => {
+const NetworkGARPField: FC<Props> = ({ formik }) => {
   return (
     <div className="general-field">
       <div className="general-field-label can-edit">
@@ -67,4 +67,4 @@ const NetworkGVRPField: FC<Props> = ({ formik }) => {
   );
 };
 
-export default NetworkGVRPField;
+export default NetworkGARPField;


### PR DESCRIPTION
## Done

- fix(network) chip placement on unmanaged member networks in cluster
- hide edit on unmanaged networks
- fix typo in component name

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check unmanaged networks detail page. the "managed no" is now merged with the type label to be easier to read and more consistent with instance detail page
    - check header for an unmanaged network in a cluster. the chip for the cluster member position was fixed
    - check an unmanaged physical network detail page, no edit buttons should be visible

## Screenshots


<img width="770" height="618" alt="image" src="https://github.com/user-attachments/assets/b8a3c60c-2951-4725-bc84-5f80920b3b4e" />
