### PR TITLE
fix(project creation): handle emoji in project name

### DIFF
--- a/src/components/ProjectNotFound.tsx
+++ b/src/components/ProjectNotFound.tsx
@@ -4,7 +4,9 @@ import { Row, Col, CustomLayout } from "@canonical/react-components";
 const ProjectNotFound: FC = () => {
   const url = location.pathname;
   const hasProjectInUrl = url.startsWith("/ui/project/");
-  const project = hasProjectInUrl ? url.split("/")[3] : "default";
+  const project = hasProjectInUrl
+    ? decodeURIComponent(url.split("/")[3])
+    : "default";
 
   return (
     <CustomLayout mainClassName="no-match">

--- a/src/context/useCurrentProject.tsx
+++ b/src/context/useCurrentProject.tsx
@@ -31,7 +31,9 @@ export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
   const { isLoading: isSettingsLoading } = useSettings();
   const location = useLocation();
   const url = location.pathname;
-  const project = url.startsWith("/ui/project/") ? url.split("/")[3] : "";
+  const project = url.startsWith("/ui/project/")
+    ? decodeURIComponent(url.split("/")[3])
+    : "";
   const isAllProjects = url.startsWith("/ui/all-projects/");
 
   const enabled = project.length > 0 && !isAllProjects;

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -50,7 +50,7 @@ export const isProjectEmpty = (project: LxdProject): boolean => {
     return true;
   }
 
-  const defaultProfile = `/1.0/profiles/default?project=${project.name}`;
+  const defaultProfile = `/1.0/profiles/default?project=${encodeURIComponent(project.name)}`;
   return !project.used_by.some((item) => item !== defaultProfile);
 };
 


### PR DESCRIPTION
## Done

- Decode project name in URL

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a project with an emoji in the name, for example 🐧-Penguin-Pen. Make sure that creation works and you can access the project
    - Create a project with no emoji in the name, for example boring-name. Make sure everything still works fine.
    - Access a URL with an emoji in the project name but the project doesn't exist, for example 🐧-Penguin-Peeeeen. Make sure the error message is displayed correctly.

## Screenshots

<img width="1394" height="1056" alt="project-list-and-url" src="https://github.com/user-attachments/assets/1d9c090c-14a0-480d-9e73-7bf881b04328" />
<img width="1853" height="1096" alt="project-not-found" src="https://github.com/user-attachments/assets/90069450-8b15-41e9-9355-58bd0e79b61d" />
