### PR TITLE
feat(operations) handle async operation response on volume and profile api requests

### DIFF
--- a/src/api/profiles.tsx
+++ b/src/api/profiles.tsx
@@ -2,6 +2,7 @@ import { handleEtagResponse, handleResponse } from "util/helpers";
 import type { LxdProfile } from "types/profile";
 import type { LxdApiResponse } from "types/apiResponse";
 import { addEntitlements } from "util/entitlements/api";
+import type { LxdOperationResponse } from "types/operation";
 
 const profileEntitlements = ["can_delete", "can_edit"];
 
@@ -57,11 +58,11 @@ export const createProfile = async (
 export const updateProfile = async (
   profile: LxdProfile,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `/1.0/profiles/${encodeURIComponent(profile.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -71,7 +72,11 @@ export const updateProfile = async (
         "If-Match": profile.etag ?? "invalid-etag",
       },
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const renameProfile = async (

--- a/src/api/storage-volumes.tsx
+++ b/src/api/storage-volumes.tsx
@@ -105,12 +105,12 @@ export const renameStorageVolume = async (
   volume: LxdStorageVolume,
   newName: string,
   target: string | null = null,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `/1.0/storage-pools/${encodeURIComponent(volume.pool)}/volumes/${encodeURIComponent(volume.type)}/${encodeURIComponent(volume.name)}?${params.toString()}`,
     {
       method: "POST",
@@ -121,7 +121,11 @@ export const renameStorageVolume = async (
         name: newName,
       }),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const createIsoStorageVolume = async (
@@ -163,12 +167,12 @@ export const createStorageVolume = async (
   project: string,
   volume: Partial<LxdStorageVolume>,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `/1.0/storage-pools/${encodeURIComponent(pool)}/volumes?${params.toString()}`,
     {
       method: "POST",
@@ -177,7 +181,11 @@ export const createStorageVolume = async (
       },
       body: JSON.stringify(volume),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const updateStorageVolume = async (
@@ -185,12 +193,12 @@ export const updateStorageVolume = async (
   project: string,
   volume: LxdStorageVolume,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `/1.0/storage-pools/${encodeURIComponent(pool)}/volumes/${encodeURIComponent(volume.type)}/${encodeURIComponent(volume.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -200,7 +208,11 @@ export const updateStorageVolume = async (
         "If-Match": volume.etag ?? "invalid-etag",
       },
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageVolume = async (
@@ -208,17 +220,21 @@ export const deleteStorageVolume = async (
   pool: string,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `/1.0/storage-pools/${encodeURIComponent(pool)}/volumes/custom/${encodeURIComponent(volume)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageVolumeBulk = async (

--- a/src/api/volume-snapshots.tsx
+++ b/src/api/volume-snapshots.tsx
@@ -152,12 +152,12 @@ export const updateVolumeSnapshot = async (
   volume: LxdStorageVolume,
   snapshot: LxdVolumeSnapshot,
   expiresAt: string | null,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", volume.project);
   addTarget(params, volume.location);
 
-  await fetch(
+  return fetch(
     `/1.0/storage-pools/${encodeURIComponent(volume.pool)}/volumes/${encodeURIComponent(volume.type)}/${encodeURIComponent(volume.name)}/snapshots/${encodeURIComponent(snapshot.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -168,7 +168,11 @@ export const updateVolumeSnapshot = async (
         expires_at: expiresAt,
       }),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const fetchStorageVolumeSnapshots = async (

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -41,5 +41,8 @@ export const useSupportedFeatures = () => {
     ),
     hasCloudInitSshKeys: apiExtensions.has("cloud_init_ssh_keys"),
     hasBackupMetadataVersion: apiExtensions.has("backup_metadata_version"),
+    hasStorageAndProfileOperations: apiExtensions.has(
+      "storage_and_profile_operations",
+    ),
   };
 };


### PR DESCRIPTION
## Done

- feat(operations) handle async operation response on volume and profile api requests

Follow up to changes from https://github.com/canonical/lxd/issues/12637


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check create / edit / rename / delete storage volume
    - check update / rename storage volume snapshot
    - check edit profile 