### PR TITLE
fix(SnapshotForm): icon color in dark mode

### DIFF
--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -509,3 +509,13 @@
     margin-right: $sph--x-small;
   }
 }
+
+input[type="date"]::-webkit-calendar-picker-indicator,
+input[type="time"]::-webkit-calendar-picker-indicator {
+  filter: none;
+}
+
+.is-dark input[type="date"]::-webkit-calendar-picker-indicator,
+.is-dark input[type="time"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}


### PR DESCRIPTION
## Done

- In SnapshotForm (create / edit snapshot): change color of calendar and clock icons to white in dark mode. Unchanged for light mode

Note that this change will affect all calendar icons and all clock icons in LXD UI in the future. There is currently no other input with type="date" or type="time".

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In dark mode, create or edit snapshot. Make sure the calendar and clock icons are white.
    - In light mode, create or edit snapshot. Make sure the calendar and clock icons are black.

## Screenshots

Dark mode BEFORE
<img width="607" height="410" alt="edit-snapshot" src="https://github.com/user-attachments/assets/4f8cc395-4be3-41f1-bad7-fef98e639eb5" />

Dark mode AFTER
<img width="603" height="464" alt="Screenshot from 2025-11-19 13-18-33" src="https://github.com/user-attachments/assets/cd1103b4-dbf0-4b12-820d-50066686679a" />

Light mode unchanced
<img width="603" height="464" alt="Screenshot from 2025-11-19 13-18-21" src="https://github.com/user-attachments/assets/729e42cd-81fa-4864-8d71-898c57e4a710" />
