### PR TITLE
feat(DeleteInstanceBtn): force stop and delete running or frozen instance

### DIFF
--- a/src/pages/instances/actions/InstanceBulkDelete.tsx
+++ b/src/pages/instances/actions/InstanceBulkDelete.tsx
@@ -5,7 +5,7 @@ import type { LxdInstance } from "types/instance";
 import { pluralize } from "util/instanceBulkActions";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
-import { deletableStatuses } from "util/instanceDelete";
+import { bulkDeletableStatuses } from "util/instanceDelete";
 import { getPromiseSettledCounts } from "util/promises";
 import { useEventQueue } from "context/eventQueue";
 import { useInstanceEntitlements } from "util/entitlements/instances";
@@ -30,7 +30,7 @@ const InstanceBulkDelete: FC<Props> = ({ instances, onStart, onFinish }) => {
   );
   const deletableInstances = instances.filter(
     (instance) =>
-      deletableStatuses.includes(instance.status) &&
+      bulkDeletableStatuses.includes(instance.status) &&
       canDeleteInstance(instance),
   );
   const totalCount = instances.length;

--- a/src/util/instanceDelete.tsx
+++ b/src/util/instanceDelete.tsx
@@ -1,3 +1,10 @@
 import type { LxdInstanceStatus } from "types/instance";
 
-export const deletableStatuses: LxdInstanceStatus[] = ["Error", "Stopped"];
+export const deletableStatuses: LxdInstanceStatus[] = [
+  "Error",
+  "Stopped",
+  "Running",
+  "Frozen",
+];
+
+export const bulkDeletableStatuses: LxdInstanceStatus[] = ["Error", "Stopped"];

--- a/src/util/instanceStatus.tsx
+++ b/src/util/instanceStatus.tsx
@@ -3,3 +3,7 @@ import type { LxdInstance } from "types/instance";
 export const isInstanceRunning = (instance: LxdInstance) => {
   return ["Ready", "Running"].includes(instance.status);
 };
+
+export const isInstanceFrozen = (instance: LxdInstance) => {
+  return instance.status === "Frozen";
+};


### PR DESCRIPTION
## Done

- Delete a running instance
- Delete a frozen instance

Note: bulk delete has been left untouched, meaning that you cannot select a running instance and delete it from the instance list screen. Is it acceptable ?

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Delete a running instance: 
        - go to a running instance page
        - make sure the delete button is enabled
        - click on delete button, a confirmation modal will open 
        - in the modal, make sure the delete button is disabled
        - tick the checkbox, it should enable the delete button
        - click on delete
        - delete should work and the it should navigate to the instance list screen
    - Delete a frozen instance: to freeze an instance, run `lxc pause {instanceName}`. Repeat above steps, the modal should display "The instance is currently frozen" instead of "The instance is currently running"

## Screenshots

<img width="547" height="398" alt="image" src="https://github.com/user-attachments/assets/a55a5c6b-0946-4eb1-9f52-c674a33e117b" />

