### PR TITLE
feat: [WD-31107] Add profile copy button and modal

### DIFF
--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -52,7 +52,6 @@ import { ensureEditMode, getProfileEditValues } from "util/instanceEdit";
 import { slugify } from "util/slugify";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import FormFooterLayout from "components/forms/FormFooterLayout";
-import { getProfilePayload } from "util/profileEdit";
 import type { MigrationFormValues } from "components/forms/MigrationForm";
 import MigrationForm from "components/forms/MigrationForm";
 import GPUDeviceForm from "components/forms/GPUDeviceForm";
@@ -68,6 +67,7 @@ import { useProfileEntitlements } from "util/entitlements/profiles";
 import type { SshKeyFormValues } from "components/forms/SshKeyForm";
 import { useEventQueue } from "context/eventQueue";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { getProfilePayload } from "util/profiles";
 
 export type EditProfileFormValues = ProfileDetailsFormValues &
   FormDeviceValues &

--- a/src/pages/profiles/ProfileDetailHeader.tsx
+++ b/src/pages/profiles/ProfileDetailHeader.tsx
@@ -1,7 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import DeleteProfileBtn from "./actions/DeleteProfileBtn";
 import type { LxdProfile } from "types/profile";
 import type { RenameHeaderValues } from "components/RenameHeader";
 import RenameHeader from "components/RenameHeader";
@@ -12,6 +11,7 @@ import { checkDuplicateName } from "util/helpers";
 import { useNotify, useToastNotification } from "@canonical/react-components";
 import ResourceLink from "components/ResourceLink";
 import { useProfileEntitlements } from "util/entitlements/profiles";
+import ProfileDetailActions from "./actions/ProfileDetailActions";
 
 interface Props {
   name: string;
@@ -102,9 +102,7 @@ const ProfileDetailHeader: FC<Props> = ({ name, profile, project }) => {
       ]}
       renameDisabledReason={getRenameDisabledReason()}
       controls={
-        profile && (
-          <DeleteProfileBtn key="delete" profile={profile} project={project} />
-        )
+        profile && <ProfileDetailActions profile={profile} project={project} />
       }
       isLoaded={Boolean(profile)}
       formik={formik}

--- a/src/pages/profiles/ProfileDetailPanelContent.tsx
+++ b/src/pages/profiles/ProfileDetailPanelContent.tsx
@@ -29,9 +29,7 @@ const ProfileDetailPanelContent: FC<Props> = ({ profile, project }) => {
         <tr>
           <th className="u-text--muted">Name</th>
           <td>
-            <ProfileLink
-              profile={{ name: profile.name, project: project.name }}
-            />
+            <ProfileLink profile={profile} />
           </td>
         </tr>
         <tr>

--- a/src/pages/profiles/ProfileLink.tsx
+++ b/src/pages/profiles/ProfileLink.tsx
@@ -1,18 +1,16 @@
 import type { FC } from "react";
 import { Link } from "react-router-dom";
 import ItemName from "components/ItemName";
+import type { LxdProfile } from "types/profile";
 
 interface Props {
-  profile: {
-    name: string;
-    project: string;
-  };
+  profile: LxdProfile;
 }
 
 const ProfileLink: FC<Props> = ({ profile }) => {
   return (
     <Link
-      to={`/ui/project/${encodeURIComponent(profile.project)}/profile/${encodeURIComponent(profile.name)}`}
+      to={`/ui/project/${encodeURIComponent(profile?.project ?? "default")}/profile/${encodeURIComponent(profile.name)}`}
       onClick={(e) => {
         e.stopPropagation();
       }}

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -119,12 +119,7 @@ const ProfileList: FC = () => {
         {
           content: (
             <div className="u-truncate" title={`Profile ${profile.name}`}>
-              <ProfileLink
-                profile={{
-                  name: profile.name,
-                  project: profile.project ?? "default",
-                }}
-              />
+              <ProfileLink profile={profile} />
             </div>
           ),
           role: "rowheader",

--- a/src/pages/profiles/actions/CopyProfileBtn.tsx
+++ b/src/pages/profiles/actions/CopyProfileBtn.tsx
@@ -1,0 +1,39 @@
+import type { FC } from "react";
+import type { LxdProfile } from "types/profile";
+import { Button, Icon, usePortal } from "@canonical/react-components";
+import classnames from "classnames";
+import CopyProfileForm from "../forms/CopyProfileForm";
+
+interface Props {
+  profile: LxdProfile;
+  className?: string;
+}
+
+const CopyProfileBtn: FC<Props> = ({ profile, className }) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const handleClose = () => {
+    closePortal();
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <CopyProfileForm close={handleClose} profile={profile} />
+        </Portal>
+      )}
+      <Button
+        appearance="default"
+        aria-label="Copy profile"
+        className={classnames("u-no-margin--bottom has-icon", className)}
+        onClick={openPortal}
+        title={"Copy profile"}
+      >
+        <Icon name="canvas" />
+        <span>Copy</span>
+      </Button>
+    </>
+  );
+};
+
+export default CopyProfileBtn;

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -19,9 +19,10 @@ import { useProfileEntitlements } from "util/entitlements/profiles";
 interface Props {
   profile: LxdProfile;
   project: string;
+  className?: string;
 }
 
-const DeleteProfileBtn: FC<Props> = ({ profile, project }) => {
+const DeleteProfileBtn: FC<Props> = ({ profile, project, className }) => {
   const isSmallScreen = useIsScreenBelow();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -66,9 +67,7 @@ const DeleteProfileBtn: FC<Props> = ({ profile, project }) => {
   return (
     <ConfirmationButton
       onHoverText={getHoverText()}
-      className={classnames("u-no-margin--bottom", {
-        "has-icon": !isSmallScreen,
-      })}
+      className={classnames("u-no-margin--bottom has-icon", className)}
       disabled={!canDeleteProfile(profile) || isDefaultProfile || isLoading}
       loading={isLoading}
       confirmationModalProps={{

--- a/src/pages/profiles/actions/ProfileDetailActions.tsx
+++ b/src/pages/profiles/actions/ProfileDetailActions.tsx
@@ -1,0 +1,60 @@
+import type { FC } from "react";
+import { cloneElement } from "react";
+import DeleteProfileBtn from "./DeleteProfileBtn";
+import type { LxdProfile } from "types/profile";
+import CopyProfileBtn from "./CopyProfileBtn";
+import {
+  largeScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
+import { ContextualMenu } from "@canonical/react-components";
+
+interface Props {
+  profile: LxdProfile;
+  project: string;
+}
+
+const ProfileDetailActions: FC<Props> = ({ profile, project }) => {
+  const isSmallScreen = useIsScreenBelow(largeScreenBreakpoint);
+  const classname = isSmallScreen
+    ? "p-contextual-menu__link"
+    : "p-segmented-control__button";
+
+  const menuElements = [
+    <CopyProfileBtn key="copy" profile={profile} className={classname} />,
+    <DeleteProfileBtn
+      key="delete"
+      profile={profile}
+      project={project}
+      className={classname}
+    />,
+  ];
+
+  return (
+    <>
+      {isSmallScreen ? (
+        <ContextualMenu
+          closeOnOutsideClick={false}
+          toggleLabel="Actions"
+          position="left"
+          hasToggleIcon
+          title="actions"
+        >
+          {(close: () => void) => (
+            <span>
+              {[...menuElements].map((item) =>
+                cloneElement(item, { onClose: close }),
+              )}
+            </span>
+          )}
+        </ContextualMenu>
+      ) : (
+        <div className="p-segmented-control">
+          <div className="p-segmented-control__list">{menuElements}</div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ProfileDetailActions;

--- a/src/pages/profiles/forms/CopyProfileForm.tsx
+++ b/src/pages/profiles/forms/CopyProfileForm.tsx
@@ -1,0 +1,133 @@
+import { useState, type FC } from "react";
+import { useFormik } from "formik";
+import {
+  ActionButton,
+  Button,
+  Form,
+  Input,
+  Modal,
+  useToastNotification,
+} from "@canonical/react-components";
+import * as Yup from "yup";
+import { useNavigate } from "react-router-dom";
+import { getUniqueResourceName, truncateEntityName } from "util/helpers";
+import ResourceLink from "components/ResourceLink";
+import type { LxdProfile } from "types/profile";
+import { useProfiles } from "context/useProfiles";
+import ProfileLink from "../ProfileLink";
+import { createProfile } from "api/profiles";
+import { profileNameValidation } from "util/profiles";
+
+interface Props {
+  profile: LxdProfile;
+  close: () => void;
+}
+
+export interface LxdInstanceCopy {
+  profileName: string;
+}
+
+const CopyProfileForm: FC<Props> = ({ profile, close }) => {
+  const toastNotify = useToastNotification();
+  const navigate = useNavigate();
+  const controllerState = useState<AbortController | null>(null);
+  const { data: profiles = [] } = useProfiles(profile?.project ?? "");
+
+  const notifySuccess = (name: string, project: string) => {
+    const profileURL = `/ui/project/${encodeURIComponent(project)}/profile/${encodeURIComponent(name)}`;
+    const message = (
+      <>
+        Created profile{" "}
+        <ResourceLink type={"profile"} value={name} to={profileURL} />.
+      </>
+    );
+    const actions = [
+      {
+        label: "Configure",
+        onClick: async () => navigate(`${profileURL}/configuration`),
+      },
+    ];
+    toastNotify.success(message, actions);
+  };
+
+  const getCopiedProfileName = (oldProfileName: string): string => {
+    const newProfileName = truncateEntityName(oldProfileName, "-copy");
+    return getUniqueResourceName(newProfileName, profiles);
+  };
+
+  const formik = useFormik<LxdInstanceCopy>({
+    initialValues: {
+      profileName: getCopiedProfileName(profile.name),
+    },
+    enableReinitialize: true,
+    validationSchema: Yup.object().shape({
+      profileName: profileNameValidation(
+        profile.project ?? "default",
+        controllerState,
+      ).required(),
+    }),
+    onSubmit: (values) => {
+      const profileLink = <ProfileLink profile={profile} />;
+      createProfile(
+        JSON.stringify({
+          name: values.profileName,
+          description: profile.description,
+          config: profile.config,
+          devices: profile.devices,
+        }),
+        profile.project ?? "",
+      )
+        .then(() => {
+          notifySuccess(values.profileName, profile.project ?? "");
+        })
+        .catch((e) => {
+          toastNotify.failure("Profile copy failed.", e, profileLink);
+        })
+        .finally(() => {
+          close();
+        });
+    },
+  });
+
+  return (
+    <Modal
+      close={close}
+      className="copy-instances-modal"
+      title="Copy Profile"
+      buttonRow={
+        <>
+          <Button
+            appearance="base"
+            className="u-no-margin--bottom"
+            type="button"
+            onClick={close}
+          >
+            Cancel
+          </Button>
+          <ActionButton
+            appearance="positive"
+            className="u-no-margin--bottom"
+            loading={formik.isSubmitting}
+            disabled={!formik.isValid || formik.isSubmitting}
+            onClick={() => void formik.submitForm()}
+          >
+            Copy
+          </ActionButton>
+        </>
+      }
+    >
+      <Form onSubmit={formik.handleSubmit}>
+        <Input
+          {...formik.getFieldProps("profileName")}
+          type="text"
+          label="New profile name"
+          error={formik.touched.profileName ? formik.errors.profileName : null}
+        />
+        {/* hidden submit to enable enter key in inputs */}
+        <Input type="submit" hidden value="Hidden input" />
+      </Form>
+    </Modal>
+  );
+};
+
+export default CopyProfileForm;

--- a/src/util/profileEdit.spec.ts
+++ b/src/util/profileEdit.spec.ts
@@ -1,6 +1,6 @@
 import { getProfileEditValues } from "./instanceEdit";
-import { getProfilePayload } from "util/profileEdit";
 import type { LxdProfile } from "types/profile";
+import { getProfilePayload } from "./profiles";
 
 describe("conversion to form values and back with getProfileEditValues and getProfilePayload", () => {
   it("preserves custom top level profile setting field", () => {

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -187,3 +187,17 @@ test("'Other' tab is removed when config/creating Profiles, on LXD Version 5.0",
   await editProfile(page, profile);
   await expect(page.getByText("Other", { exact: true })).not.toBeVisible();
 });
+
+test("Profile copy", async ({ page }) => {
+  await visitProfile(page, profile);
+  await page.getByRole("button", { name: "Copy Profile" }).click();
+
+  const copiedProfileName = profile + "-copy";
+
+  await page.getByLabel("New profile name").fill(copiedProfileName);
+  await page.getByRole("button", { name: "Copy", exact: true }).click();
+
+  await page.waitForSelector(`text=Created profile ${copiedProfileName}.`);
+
+  await deleteProfile(page, copiedProfileName);
+});


### PR DESCRIPTION
## Done

- Added responsive profile copy button
- Added modal with name input.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a new profile with some configurations and copy (duplicate) it.
    - Verify all configurations have carried over.

## Screenshots

<img width="1085" height="380" alt="image" src="https://github.com/user-attachments/assets/70c7a12e-b51d-4b81-9efb-d780063f045e" />
<img width="1325" height="493" alt="image" src="https://github.com/user-attachments/assets/0619b233-2c34-4b36-9610-46bff890e940" />
