### PR TITLE
fix(DetachDiskDeviceBtn): remove confirmation modal on instance creation

### DIFF
--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -19,7 +19,7 @@ import {
   isDiskDeviceMountPointMissing,
   isRootDisk,
 } from "util/instanceValidation";
-import { ensureEditMode } from "util/instanceEdit";
+import { ensureEditMode, isInstanceCreation } from "util/instanceEdit";
 import { getExistingDeviceNames, isVolumeDevice } from "util/devices";
 import type { LxdProfile } from "types/profile";
 import { focusField } from "util/formFields";
@@ -119,6 +119,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
               removeDevice(index, formik);
             }}
             disabledReason={formik.values.editRestriction}
+            isInstanceCreation={isInstanceCreation(formik)}
           />
         ),
       }),

--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -14,7 +14,7 @@ import {
 } from "util/formDevices";
 import DetachDiskDeviceBtn from "pages/instances/actions/DetachDiskDeviceBtn";
 import { getInheritedDeviceRow } from "components/forms/InheritedDeviceRow";
-import { ensureEditMode } from "util/instanceEdit";
+import { ensureEditMode, isInstanceCreation } from "util/instanceEdit";
 import { isHostDiskDevice } from "util/devices";
 
 interface Props {
@@ -72,6 +72,7 @@ const DiskDeviceFormInherited: FC<Props> = ({
               addNoneDevice(item.key, formik);
             }}
             disabledReason={formik.values.editRestriction}
+            isInstanceCreation={isInstanceCreation(formik)}
           />
         ),
       }),

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -13,7 +13,7 @@ import type { LxdStoragePool } from "types/storage";
 import type { LxdProfile } from "types/profile";
 import { removeDevice } from "util/formDevices";
 import { hasNoRootDisk, isRootDisk } from "util/instanceValidation";
-import { ensureEditMode } from "util/instanceEdit";
+import { ensureEditMode, isInstanceCreation } from "util/instanceEdit";
 import { focusField } from "util/formFields";
 import DiskSizeQuotaLimitation from "components/forms/DiskSizeQuotaLimitation";
 
@@ -31,7 +31,7 @@ const DiskDeviceFormRoot: FC<Props> = ({ formik, pools, profiles }) => {
     rootIndex
   ] as LxdDiskDevice | null;
   const isEditingInstance =
-    formik.values.entityType === "instance" && !formik.values.isCreating;
+    formik.values.entityType === "instance" && !isInstanceCreation(formik);
   const isVirtualMachine =
     formik.values.entityType === "instance" &&
     formik.values.instanceType === "virtual-machine";

--- a/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
+++ b/src/pages/instances/actions/DetachDiskDeviceBtn.tsx
@@ -1,12 +1,33 @@
 import type { FC } from "react";
-import { ConfirmationButton, Icon } from "@canonical/react-components";
+import { ConfirmationButton, Icon, Button } from "@canonical/react-components";
 
 interface Props {
   onDetach: () => void;
   disabledReason?: string;
+  isInstanceCreation?: boolean;
 }
 
-const DetachDiskDeviceBtn: FC<Props> = ({ onDetach, disabledReason }) => {
+const DetachDiskDeviceBtn: FC<Props> = ({
+  onDetach,
+  disabledReason,
+  isInstanceCreation,
+}) => {
+  if (isInstanceCreation) {
+    return (
+      <Button
+        appearance="base"
+        type="button"
+        title={disabledReason ?? "Detach disk"}
+        className="has-icon u-no-margin--bottom is-dense"
+        onClick={onDetach}
+        disabled={!!disabledReason}
+      >
+        <Icon name="disconnect" />
+        <span>Detach</span>
+      </Button>
+    );
+  }
+
   return (
     <ConfirmationButton
       appearance="base"

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -14,6 +14,7 @@ import * as Yup from "yup";
 import type { EditProfileFormValues } from "pages/profiles/EditProfile";
 import { migrationPayload } from "components/forms/MigrationForm";
 import type { ConfigurationRowFormikProps } from "components/ConfigurationRow";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import { bootPayload } from "components/forms/BootForm";
 import type { SshKey } from "components/forms/SshKeyForm";
 import { sshKeyPayload } from "components/forms/SshKeyForm";
@@ -160,4 +161,14 @@ export const ensureEditMode = (formik: ConfigurationRowFormikProps) => {
   if (formik.values.readOnly) {
     formik.setFieldValue("readOnly", false);
   }
+};
+
+export const isInstanceCreation = (
+  formik: InstanceAndProfileFormikProps,
+): boolean => {
+  return (
+    formik.values.entityType === "instance" &&
+    "isCreating" in formik.values &&
+    formik.values.isCreating
+  );
 };


### PR DESCRIPTION
## Done

- When detaching an inherited disk device, remove confirmation modal on instance creation

Fixes #1626

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Test instance creation:
        - Create a storage volume
        - Go to a profile > configuration > devices > disk. Click on Attach disk device, then attach custom volume, select newly created volume
        - Create instance, select an image, select profile, go to devices disk, you should see a section called `Inherited disk devices`, detach inherited device: you should not see a confirmation modal, the device should be detached.
    - Test instance edit:
        - Create an instance with inherited device.
        - Once the instance is created, go to configuration > Devices > Disk
        - Detach inherited device: you should see a confirmation modal

## Screenshots

Instance creation
<img width="1756" height="984" alt="image" src="https://github.com/user-attachments/assets/b7ce9c5b-1acc-424d-afea-1439b726a089" />

Instance edit
<img width="1756" height="984" alt="image" src="https://github.com/user-attachments/assets/b9c848ac-a9c7-4589-9519-e7250ecfef17" />
