### PR TITLE
feat(ClusterMemberList): add Memory, remove failure domain

### DIFF
--- a/src/pages/cluster/ClusterMemberDetailMemory.tsx
+++ b/src/pages/cluster/ClusterMemberDetailMemory.tsx
@@ -2,20 +2,28 @@ import type { FC } from "react";
 import type { LxdResources } from "types/resources";
 import { humanFileSize } from "util/helpers";
 import Meter from "components/Meter";
-import type { LxdClusterMemberState } from "types/cluster";
+import type { LxdClusterMemberState, LxdClusterMember } from "types/cluster";
+import ClusterMemberMemoryUsage from "pages/cluster/ClusterMemberMemoryUsage";
 
 interface Props {
   resources: LxdResources;
   state?: LxdClusterMemberState;
+  member: LxdClusterMember;
 }
 
-const ClusterMemberDetailMemory: FC<Props> = ({ resources, state }) => {
+const ClusterMemberDetailMemory: FC<Props> = ({ resources, state, member }) => {
   const totalSwap = state?.sysinfo.free_swap ?? 0;
   const freeSwap = state?.sysinfo.free_swap ?? 0;
 
   return (
     <table>
       <tbody>
+        <tr>
+          <th className="u-text--muted">Overview</th>
+          <td>
+            <ClusterMemberMemoryUsage member={member} />
+          </td>
+        </tr>
         <tr>
           <th className="u-text--muted">Total</th>
           <td>{humanFileSize(resources?.memory?.total ?? 0)}</td>

--- a/src/pages/cluster/ClusterMemberHardware.tsx
+++ b/src/pages/cluster/ClusterMemberHardware.tsx
@@ -106,10 +106,11 @@ const ClusterMemberHardware: FC<Props> = ({ member }) => {
                 {sectionName === "CPU" && (
                   <ClusterMemberDetailCPU resources={resources} state={state} />
                 )}
-                {sectionName === "Memory" && (
+                {sectionName === "Memory" && member && (
                   <ClusterMemberDetailMemory
                     resources={resources}
                     state={state}
+                    member={member}
                   />
                 )}
                 {sectionName === "GPU" && (

--- a/src/pages/cluster/ClusterMemberList.tsx
+++ b/src/pages/cluster/ClusterMemberList.tsx
@@ -17,6 +17,7 @@ import ClusterMemberActions from "pages/cluster/ClusterMemberActions";
 import { useClusterMembers } from "context/useClusterMembers";
 import usePanelParams from "util/usePanelParams";
 import ClusterMemberStatus from "pages/cluster/ClusterMemberStatus";
+import ClusterMemberMemoryUsage from "pages/cluster/ClusterMemberMemoryUsage";
 import { useMemberLoading } from "context/memberLoading";
 import { useServerEntitlements } from "util/entitlements/server";
 
@@ -44,9 +45,8 @@ const ClusterMemberList: FC = () => {
     },
     { content: "Roles", sortKey: "roles", className: "roles" },
     {
-      content: "Failure domain",
-      className: "failure-domain",
-      sortKey: "failureDomain",
+      content: "Memory",
+      className: "memory",
     },
     {
       content: "Description",
@@ -111,10 +111,10 @@ const ClusterMemberList: FC = () => {
           className: "roles",
         },
         {
-          content: member.failure_domain,
+          content: <ClusterMemberMemoryUsage member={member} />,
           role: "cell",
-          "aria-label": "Failure domain",
-          className: "failure-domain",
+          "aria-label": "Memory",
+          className: "memory",
         },
         {
           content: member.description,
@@ -144,7 +144,6 @@ const ClusterMemberList: FC = () => {
       sortData: {
         name: member.server_name.toLowerCase(),
         status: member.status.toLowerCase(),
-        failureDomain: member.failure_domain.toLowerCase(),
         roles: member.roles,
         description: member.description?.toLowerCase(),
         groups: groupCount,

--- a/src/pages/cluster/ClusterMemberMemoryUsage.tsx
+++ b/src/pages/cluster/ClusterMemberMemoryUsage.tsx
@@ -1,0 +1,55 @@
+import type { FC } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Meter from "components/Meter";
+import { fetchClusterMemberState } from "api/cluster-members";
+import { queryKeys } from "util/queryKeys";
+import { humanFileSize } from "util/helpers";
+import type { LxdClusterMember } from "types/cluster";
+
+interface Props {
+  member: LxdClusterMember;
+}
+
+const ClusterMemberMemoryUsage: FC<Props> = ({ member }) => {
+  const { data: state } = useQuery({
+    queryKey: [
+      queryKeys.cluster,
+      queryKeys.members,
+      member.server_name,
+      queryKeys.state,
+    ],
+    queryFn: async () => fetchClusterMemberState(member.server_name),
+  });
+
+  const totalMemory = state?.sysinfo?.total_ram ?? 0;
+
+  if (!state?.sysinfo || totalMemory === 0) {
+    return <span className="u-text--muted">-</span>;
+  }
+
+  const freeMemory = state?.sysinfo.free_ram ?? 0;
+  const sharedMemory = state?.sysinfo.shared_ram ?? 0;
+  const bufferedMemory = state?.sysinfo.buffered_ram ?? 0;
+
+  const usedMemory = totalMemory - freeMemory;
+  const memoryPercentage = (usedMemory / totalMemory) * 100;
+  const secondaryMemory = sharedMemory + bufferedMemory;
+  const secondaryPercentage = (secondaryMemory / totalMemory) * 100;
+
+  const memoryText = `${humanFileSize(usedMemory)} of ${humanFileSize(totalMemory)}`;
+
+  let hoverText = `free: ${humanFileSize(freeMemory)}\n`;
+  hoverText += `used: ${humanFileSize(usedMemory)}\n`;
+  hoverText += `cached: ${humanFileSize(bufferedMemory + sharedMemory)}\n`;
+
+  return (
+    <Meter
+      percentage={memoryPercentage}
+      secondaryPercentage={secondaryPercentage}
+      text={memoryText}
+      hoverText={hoverText}
+    />
+  );
+};
+
+export default ClusterMemberMemoryUsage;

--- a/src/sass/_cluster_list.scss
+++ b/src/sass/_cluster_list.scss
@@ -30,7 +30,8 @@
   }
 
   @media screen and (width <= 1300px) {
-    .failure-domain {
+    .memory,
+    .description {
       display: none;
     }
   }


### PR DESCRIPTION
## Done

- Remove failure domain from cluster member list
- Add memory column with a Meter in cluster member list
- Add Meter in cluster member detail hardware page


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - See cluster member list

## Screenshots

<img width="1540" height="299" alt="image" src="https://github.com/user-attachments/assets/01b8ce9a-5038-4474-9266-c2b0ddba04c4" />
</br></br>
ClusterMemberDetailMemory
<img width="917" height="581" alt="image" src="https://github.com/user-attachments/assets/5a154c4d-7cb3-4c84-8963-8b453164b1bb" />


