### PR TITLE
feat(project) streamline project form: remove default features selector

### DIFF
--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -112,6 +112,12 @@ const CreateProject: FC = () => {
       default_project_network: defaultProjectDefaultProfile
         ? getDefaultNetwork(defaultProjectDefaultProfile)
         : "",
+      features_images: true,
+      features_profiles: true,
+      features_networks: false,
+      features_networks_zones: false,
+      features_storage_buckets: true,
+      features_storage_volumes: true,
     },
     enableReinitialize: true,
     validationSchema: ProjectSchema,

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -1,12 +1,10 @@
 import type { FC } from "react";
-import { useState } from "react";
 import {
   CheckboxInput,
   Col,
   Icon,
   Input,
   Row,
-  Select,
   Tooltip,
 } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
@@ -92,41 +90,12 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
 
   const { data: networks = [] } = useNetworks(project?.name || "default");
   const managedNetworks = networks.filter((network) => network.managed);
-
-  const figureFeatures = () => {
-    if (
-      formik.values.features_images === undefined &&
-      formik.values.features_profiles === undefined &&
-      formik.values.features_networks === undefined &&
-      formik.values.features_networks_zones === undefined &&
-      formik.values.features_storage_buckets === undefined &&
-      formik.values.features_storage_volumes === undefined
-    ) {
-      return "default";
-    }
-    if (
-      formik.values.features_images !== true ||
-      formik.values.features_profiles !== true ||
-      formik.values.features_networks !== false ||
-      formik.values.features_networks_zones !== false ||
-      formik.values.features_storage_buckets !== true ||
-      formik.values.features_storage_volumes !== true
-    ) {
-      return "customised";
-    }
-    return "default";
-  };
-  const [features, setFeatures] = useState(figureFeatures());
-
   const isDefaultProject = formik.values.name === "default";
   const isNonEmpty = project ? !isProjectEmpty(project) : false;
-  const hadFeaturesNetwork = project?.config["features.networks"] === "true";
   const hadFeaturesNetworkZones =
     project?.config["features.networks.zones"] === "true";
-  const hasNoProfiles =
-    features === "customised" && !formik.values.features_profiles;
-  const hasIsolatedNetworks =
-    features === "customised" && formik.values.features_networks;
+  const hasNoProfiles = !formik.values.features_profiles;
+  const hasIsolatedNetworks = formik.values.features_networks;
 
   return (
     <ScrollableForm>
@@ -171,10 +140,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             }
             selectProps={{
               label: "Default instance storage pool",
-              disabled:
-                (formik.values.features_profiles === false &&
-                  features === "customised") ||
-                isEdit,
+              disabled: formik.values.features_profiles === false || isEdit,
               help: isEdit ? (
                 <>
                   Edit the storage pool in the{" "}
@@ -196,7 +162,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
               void formik.setFieldValue("default_project_network", value)
             }
             hasNoneOption
-            label="Default profile network"
+            label="Default instance network"
             disabled={hasNoProfiles || hasIsolatedNetworks || isEdit}
             managedNetworks={managedNetworks}
             help={
@@ -223,170 +189,133 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 : "")
             }
           >
-            <Select
-              id="features"
-              name="features"
-              label="Features"
-              onChange={(e) => {
+            Isolate the following features:
+            {!isDefaultProject && (
+              <>
+                {" "}
+                <Tooltip message="Unselected features will be shared with the default project">
+                  <Icon name="information" />
+                </Tooltip>
+              </>
+            )}
+            <CheckboxInput
+              id="features_images"
+              name="features_images"
+              label="Images"
+              onChange={() => {
                 ensureEditMode(formik);
-                setFeatures(e.target.value);
-                formik.setFieldValue("features_images", true);
-                formik.setFieldValue("features_profiles", true);
-                formik.setFieldValue("features_networks", false);
-                formik.setFieldValue("features_networks_zones", false);
-                formik.setFieldValue("features_storage_buckets", true);
-                formik.setFieldValue("features_storage_volumes", true);
+                formik.setFieldValue(
+                  "features_images",
+                  !formik.values.features_images,
+                );
               }}
-              value={features}
-              options={[
-                {
-                  label: "Default LXD",
-                  value: "default",
-                },
-                {
-                  label: "Customised",
-                  value: "customised",
-                },
-              ]}
+              checked={formik.values.features_images}
               disabled={
                 !!formik.values.editRestriction ||
                 isDefaultProject ||
-                (isNonEmpty && hadFeaturesNetwork) ||
-                (isNonEmpty && hadFeaturesNetworkZones)
+                isNonEmpty
               }
             />
-
-            {features === "customised" && (
-              <>
-                Isolate the following features:
-                {!isDefaultProject && (
-                  <>
-                    {" "}
-                    <Tooltip message="Unselected features will be shared with the default project">
-                      <Icon name="information" />
-                    </Tooltip>
-                  </>
-                )}
-                <CheckboxInput
-                  id="features_images"
-                  name="features_images"
-                  label="Images"
-                  onChange={() => {
-                    ensureEditMode(formik);
-                    formik.setFieldValue(
-                      "features_images",
-                      !formik.values.features_images,
-                    );
-                  }}
-                  checked={formik.values.features_images}
-                  disabled={
-                    !!formik.values.editRestriction ||
-                    isDefaultProject ||
-                    isNonEmpty
-                  }
-                />
-                <CheckboxInput
-                  id="features_profiles"
-                  name="features_profiles"
-                  label="Profiles"
-                  onChange={() => {
-                    ensureEditMode(formik);
-                    const newValue = !formik.values.features_profiles;
-                    formik.setFieldValue("features_profiles", newValue);
-                    if (!newValue) {
-                      formik.setFieldValue("restricted", false);
-                    }
-                  }}
-                  checked={formik.values.features_profiles}
-                  disabled={
-                    !!formik.values.editRestriction ||
-                    isDefaultProject ||
-                    isNonEmpty
-                  }
-                />
-                <CheckboxInput
-                  id="features_networks"
-                  name="features_networks"
-                  label="Networks"
-                  onChange={() => {
-                    ensureEditMode(formik);
-                    formik.setFieldValue(
-                      "features_networks",
-                      !formik.values.features_networks,
-                    );
-                    const featuresNetworks = !formik.values.features_networks;
-                    formik.setFieldValue("features_networks", featuresNetworks);
-                    if (featuresNetworks && !isEdit) {
-                      formik.setFieldValue("default_project_network", "none");
-                    }
-                  }}
-                  checked={formik.values.features_networks}
-                  disabled={
-                    !!formik.values.editRestriction ||
-                    isDefaultProject ||
-                    isNonEmpty
-                  }
-                />
-                {hasProjectsNetworksZones && (
-                  <CheckboxInput
-                    id="features_networks_zones"
-                    name="features_networks_zones"
-                    label="Network zones"
-                    onChange={() => {
-                      ensureEditMode(formik);
-                      formik.setFieldValue(
-                        "features_networks_zones",
-                        !formik.values.features_networks_zones,
-                      );
-                    }}
-                    checked={formik.values.features_networks_zones}
-                    disabled={
-                      !!formik.values.editRestriction ||
-                      isDefaultProject ||
-                      (isNonEmpty && hadFeaturesNetworkZones)
-                    }
-                  />
-                )}
-                {hasStorageBuckets && (
-                  <CheckboxInput
-                    id="features_storage_buckets"
-                    name="features_storage_buckets"
-                    label="Storage buckets"
-                    onChange={() => {
-                      ensureEditMode(formik);
-                      formik.setFieldValue(
-                        "features_storage_buckets",
-                        !formik.values.features_storage_buckets,
-                      );
-                    }}
-                    checked={formik.values.features_storage_buckets}
-                    disabled={
-                      !!formik.values.editRestriction ||
-                      isDefaultProject ||
-                      isNonEmpty
-                    }
-                  />
-                )}
-                <CheckboxInput
-                  id="features_storage_volumes"
-                  name="features_storage_volumes"
-                  label="Storage volumes"
-                  onChange={() => {
-                    ensureEditMode(formik);
-                    formik.setFieldValue(
-                      "features_storage_volumes",
-                      !formik.values.features_storage_volumes,
-                    );
-                  }}
-                  checked={formik.values.features_storage_volumes}
-                  disabled={
-                    !!formik.values.editRestriction ||
-                    isDefaultProject ||
-                    isNonEmpty
-                  }
-                />
-              </>
+            <CheckboxInput
+              id="features_profiles"
+              name="features_profiles"
+              label="Profiles"
+              onChange={() => {
+                ensureEditMode(formik);
+                const newValue = !formik.values.features_profiles;
+                formik.setFieldValue("features_profiles", newValue);
+                if (!newValue) {
+                  formik.setFieldValue("restricted", false);
+                }
+              }}
+              checked={formik.values.features_profiles}
+              disabled={
+                !!formik.values.editRestriction ||
+                isDefaultProject ||
+                isNonEmpty
+              }
+            />
+            <CheckboxInput
+              id="features_networks"
+              name="features_networks"
+              label="Networks"
+              onChange={() => {
+                ensureEditMode(formik);
+                formik.setFieldValue(
+                  "features_networks",
+                  !formik.values.features_networks,
+                );
+                const featuresNetworks = !formik.values.features_networks;
+                formik.setFieldValue("features_networks", featuresNetworks);
+                if (featuresNetworks && !isEdit) {
+                  formik.setFieldValue("default_project_network", "none");
+                }
+              }}
+              checked={formik.values.features_networks}
+              disabled={
+                !!formik.values.editRestriction ||
+                isDefaultProject ||
+                isNonEmpty
+              }
+            />
+            {hasProjectsNetworksZones && (
+              <CheckboxInput
+                id="features_networks_zones"
+                name="features_networks_zones"
+                label="Network zones"
+                onChange={() => {
+                  ensureEditMode(formik);
+                  formik.setFieldValue(
+                    "features_networks_zones",
+                    !formik.values.features_networks_zones,
+                  );
+                }}
+                checked={formik.values.features_networks_zones}
+                disabled={
+                  !!formik.values.editRestriction ||
+                  isDefaultProject ||
+                  (isNonEmpty && hadFeaturesNetworkZones)
+                }
+              />
             )}
+            {hasStorageBuckets && (
+              <CheckboxInput
+                id="features_storage_buckets"
+                name="features_storage_buckets"
+                label="Storage buckets"
+                onChange={() => {
+                  ensureEditMode(formik);
+                  formik.setFieldValue(
+                    "features_storage_buckets",
+                    !formik.values.features_storage_buckets,
+                  );
+                }}
+                checked={formik.values.features_storage_buckets}
+                disabled={
+                  !!formik.values.editRestriction ||
+                  isDefaultProject ||
+                  isNonEmpty
+                }
+              />
+            )}
+            <CheckboxInput
+              id="features_storage_volumes"
+              name="features_storage_volumes"
+              label="Storage volumes"
+              onChange={() => {
+                ensureEditMode(formik);
+                formik.setFieldValue(
+                  "features_storage_volumes",
+                  !formik.values.features_storage_volumes,
+                );
+              }}
+              checked={formik.values.features_storage_volumes}
+              disabled={
+                !!formik.values.editRestriction ||
+                isDefaultProject ||
+                isNonEmpty
+              }
+            />
           </div>
 
           <hr />
@@ -399,7 +328,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                   Allow custom restrictions on a project level
                   <Tooltip
                     className="checkbox-label-tooltip"
-                    message={`Custom restrictions are only available${"\n"}to projects with enabled profiles`}
+                    message={`Custom restrictions are only available${"\n"}to projects with isolated profiles`}
                   >
                     <Icon name="information" />
                   </Tooltip>
@@ -412,8 +341,7 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
               checked={formik.values.restricted}
               disabled={
                 !!formik.values.editRestriction ||
-                (formik.values.features_profiles === false &&
-                  features === "customised")
+                formik.values.features_profiles === false
               }
             />
           </div>

--- a/src/pages/storage/StoragePoolSelector.tsx
+++ b/src/pages/storage/StoragePoolSelector.tsx
@@ -51,6 +51,12 @@ const StoragePoolSelector: FC<Props> = ({
           value: pool.name,
           disabled: false,
           text: `${pool.name} (${pool.driver})`,
+          selectedLabel: (
+            <span>
+              {pool.name}&nbsp;
+              <span className="u-text--muted">&#40;{pool.driver}&#41;</span>
+            </span>
+          ),
         });
       });
       if (poolsToUse.length === 0) {

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -529,10 +529,6 @@ test("LXD - UI Folder - Project", async ({ page }) => {
   await page.getByRole("button", { name: "Create project" }).click();
   await page.waitForLoadState("networkidle");
   await page.getByPlaceholder("Enter name").fill("my-project");
-  await page
-    .getByRole("combobox", { name: "Features" })
-    .selectOption("customised");
-  await page.getByRole("combobox", { name: "Features" }).focus();
   await page.screenshot({
     path: "tests/screenshots/doc/images/UI/create_project.png",
     clip: getClipPosition(240, 0, 1440, 960),
@@ -540,9 +536,6 @@ test("LXD - UI Folder - Project", async ({ page }) => {
 
   await page.getByPlaceholder("Enter name").fill("my-restricted-project");
   await page.getByText("Allow custom restrictions on").click();
-  await page
-    .getByRole("combobox", { name: "Features" })
-    .selectOption("default");
   await page.screenshot({
     path: "tests/screenshots/doc/images/UI/create_restr_project1.png",
     clip: getClipPosition(240, 0, 1440, 760),

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -16,7 +16,7 @@ const openProjectCreationForm = async (page: Page) => {
   await expect(page.getByText("Project name")).toBeVisible();
   await expect(page.getByText("Loading storage pools")).not.toBeVisible();
 
-  await page.getByLabel("Default profile network", { exact: true }).click();
+  await page.getByLabel("Default instance network", { exact: true }).click();
   await page.getByText("No network", { exact: true }).click();
 };
 
@@ -34,7 +34,6 @@ export const createProject = async (page: Page, project: string) => {
 
 export const createCustomProject = async (page: Page, project: string) => {
   await openProjectCreationForm(page);
-  await page.getByLabel("Features").selectOption("customised");
   await submitProjectCreationForm(page, project);
 };
 

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -44,9 +44,6 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await page.waitForLoadState("networkidle");
   await page.waitForTimeout(2000); // Wait for the form state to be fully loaded
   await page.getByPlaceholder("Enter description").fill("A-new-description");
-  await page
-    .getByRole("combobox", { name: "Features" })
-    .selectOption("customised");
   await page.locator("span").filter({ hasText: "Networks" }).click();
   if (lxdVersion === "5.0-edge") {
     await expect(
@@ -103,7 +100,12 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setTextarea(page, "Network uplinks", "lxdbr0");
   await setTextarea(page, "Network zones", "foo,bar");
 
-  await page.getByRole("button", { name: "Save 34 changes" }).click();
+  if (lxdVersion === "5.0-edge") {
+    // network zones option is not available in 5.0-edge, so total changes are one less
+    await page.getByRole("button", { name: "Save 33 changes" }).click();
+  } else {
+    await page.getByRole("button", { name: "Save 34 changes" }).click();
+  }
 
   await page.waitForSelector(`text=Project ${project} updated.`);
   await page.getByRole("button", { name: "Close notification" }).click();


### PR DESCRIPTION
## Done

- feat(project) streamline project form: remove default features selector
- align network and storage selector selected labels

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a project and check the feature isolation
    - edit a project and check the feature isolation

## Screenshots

<img width="1285" height="900" alt="image" src="https://github.com/user-attachments/assets/23f3e7e5-e513-4914-a272-8410ecaacb6a" />
