### PR TITLE
Link nic static IP page from network lease and IPAM pages

### DIFF
--- a/src/components/InstanceIpEdit.tsx
+++ b/src/components/InstanceIpEdit.tsx
@@ -1,0 +1,32 @@
+import type { FC } from "react";
+import { Icon } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+
+interface Props {
+  address: string;
+  instanceName: string;
+  projectName: string;
+}
+
+export const InstanceIpEdit: FC<Props> = ({
+  address,
+  instanceName,
+  projectName,
+}) => {
+  return (
+    <div className="instance-ip-edit-content">
+      <div className="u-truncate instance-ip-edit-address" title={address}>
+        {address}
+      </div>
+      <Link
+        to={`/ui/project/${encodeURIComponent(projectName)}/instance/${encodeURIComponent(instanceName)}/configuration/network`}
+        rel="noopener noreferrer"
+        className="p-button-base instance-ip-edit-link is-dense"
+        type="button"
+        title={`Edit network configuration for instance ${instanceName}`}
+      >
+        <Icon name="edit" />
+      </Link>
+    </div>
+  );
+};

--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -15,6 +15,8 @@ import { fetchNetworkLeases } from "api/network-leases";
 import ResourceLink from "components/ResourceLink";
 import { useIsClustered } from "context/useIsClustered";
 import DocLink from "components/DocLink";
+import { typesWithNicStaticIPSupport } from "util/networks";
+import { InstanceIpEdit } from "components/InstanceIpEdit";
 
 interface Props {
   network: LxdNetwork;
@@ -49,12 +51,12 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
   const headers = [
     { content: "Type", sortKey: "type" },
     { content: "Hostname", sortKey: "hostname" },
-    { content: "IP Address", sortKey: "address" },
     { content: "Project", sortKey: "project" },
     ...(isClustered
       ? [{ content: "Cluster member", sortKey: "clusterMember" }]
       : []),
     { content: "MAC address", sortKey: "macAddress" },
+    { content: "IP Address", sortKey: "address" },
   ];
 
   const rows = leases.map((lease) => {
@@ -70,11 +72,6 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
           content: lease.hostname,
           role: "rowheader",
           "aria-label": "Hostname",
-        },
-        {
-          content: lease.address,
-          role: "cell",
-          "aria-label": "MAC address",
         },
         {
           content: lease.project && (
@@ -105,16 +102,31 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
         {
           content: lease.hwaddr,
           role: "cell",
-          "aria-label": "Description",
+          "aria-label": "MAC address",
+        },
+        {
+          content:
+            typesWithNicStaticIPSupport.includes(network.type) &&
+            ["static", "dynamic"].includes(lease.type) ? (
+              <InstanceIpEdit
+                address={lease.address}
+                instanceName={lease.hostname}
+                projectName={lease.project}
+              />
+            ) : (
+              <>{lease.address}</>
+            ),
+          role: "cell",
+          "aria-label": "IP address",
         },
       ],
       sortData: {
         hostname: lease.hostname.toLowerCase(),
         macAddress: lease.hwaddr,
-        address: lease.address,
         type: lease.type,
         project: lease.project?.toLowerCase(),
         clusterMember: lease.location?.toLowerCase(),
+        address: lease.address,
       },
     };
   });

--- a/src/sass/_instance_ip_edit.scss
+++ b/src/sass/_instance_ip_edit.scss
@@ -1,0 +1,17 @@
+.instance-ip-edit-content {
+  align-items: center;
+  display: flex;
+}
+
+.instance-ip-edit-address {
+  flex: 1;
+  min-width: 0;
+}
+
+.instance-ip-edit-link {
+  padding: 0 $sph--small;
+}
+
+.instance-ip-edit-link:hover {
+  background-color: $colors--theme--background-hover;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -96,6 +96,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "instance_detail_page";
 @import "instance_detail_panel";
 @import "instance_detail_terminal";
+@import "instance_ip_edit";
 @import "instance_list";
 @import "ip_address";
 @import "login";


### PR DESCRIPTION
## Done

- Link nic static IP page from network lease and IPAM pages

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Networks page
    - Choose a network that supports static ip (bridge or OVN)
    - Go to Leases page
    - Click on the IP address for an instance
    - Ensure you are navigated to the  Configuration -> Networks tab of that instance.

## Screenshots

<img width="1421" height="749" alt="image" src="https://github.com/user-attachments/assets/90a1392a-ba57-4ba0-a612-96753cfdc79f" />
<img width="1421" height="749" alt="image" src="https://github.com/user-attachments/assets/d72d2be4-ceb1-4209-b1f1-2cc0e479aa20" />
<img width="1421" height="749" alt="image" src="https://github.com/user-attachments/assets/d6454ac4-8c70-47ef-a212-1e3540d86e0e" />
