### PR TITLE
fix: Profile copy button responsivity fixes

### DIFF
--- a/src/pages/profiles/actions/CopyProfileBtn.tsx
+++ b/src/pages/profiles/actions/CopyProfileBtn.tsx
@@ -7,12 +7,15 @@ import CopyProfileForm from "../forms/CopyProfileForm";
 interface Props {
   profile: LxdProfile;
   className?: string;
+  onClose?: () => void;
 }
 
-const CopyProfileBtn: FC<Props> = ({ profile, className }) => {
+const CopyProfileBtn: FC<Props> = ({ profile, className, onClose }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
+
   const handleClose = () => {
     closePortal();
+    onClose?.();
   };
 
   return (

--- a/src/pages/profiles/actions/DeleteProfileBtn.tsx
+++ b/src/pages/profiles/actions/DeleteProfileBtn.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { deleteProfile } from "api/profiles";
 import { useNavigate } from "react-router-dom";
 import type { LxdProfile } from "types/profile";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
 import {
   ConfirmationButton,
   Icon,
@@ -20,10 +19,15 @@ interface Props {
   profile: LxdProfile;
   project: string;
   className?: string;
+  onClose?: () => void;
 }
 
-const DeleteProfileBtn: FC<Props> = ({ profile, project, className }) => {
-  const isSmallScreen = useIsScreenBelow();
+const DeleteProfileBtn: FC<Props> = ({
+  profile,
+  project,
+  className,
+  onClose,
+}) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
@@ -71,6 +75,7 @@ const DeleteProfileBtn: FC<Props> = ({ profile, project, className }) => {
       disabled={!canDeleteProfile(profile) || isDefaultProfile || isLoading}
       loading={isLoading}
       confirmationModalProps={{
+        close: onClose,
         title: "Confirm delete",
         confirmButtonLabel: "Delete",
         onConfirm: handleDelete,
@@ -85,7 +90,7 @@ const DeleteProfileBtn: FC<Props> = ({ profile, project, className }) => {
       shiftClickEnabled
       showShiftClickHint
     >
-      {!isSmallScreen && <Icon name="delete" />}
+      <Icon name="delete" />
       <span>Delete</span>
     </ConfirmationButton>
   );


### PR DESCRIPTION
## Done

- Delete icon no longer disappears on resize
- Contextual menu closes as expected when modal closes.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Please verify above (done section)

## Screenshots

N/A