### PR TITLE
fix(instance) yaml editor to always show lxd details from metadata api

### DIFF
--- a/src/components/forms/CloudInitForm.tsx
+++ b/src/components/forms/CloudInitForm.tsx
@@ -48,7 +48,7 @@ const CloudInitForm: FC<Props> = ({ formik }) => {
           <div className="mono-font">
             <b>
               <CloudInitConfig
-                key={`cloud-init-${name}`}
+                key={`cloud-init-${name}-${metadata.value}`}
                 config={metadata.value as string}
               />
             </b>


### PR DESCRIPTION
## Done

- fix(instance) yaml editor to always show lxd details from metadata api
- fixing race condition 

Fixes #1630

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance detail page > configuration > cloud init
    - hard reload on that page, ensure the inherited yaml editors show correctly each time.

<img width="1441" height="963" alt="image" src="https://github.com/user-attachments/assets/fadfea48-ddd5-4fbb-9ae7-182ce4706dea" />
