### PR TITLE
fix(instance) avoid both instance and operations query reporting error to the user at the same time

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -171,13 +171,13 @@ const InstanceList: FC = () => {
     saveHidden(columns);
   };
 
-  const { data: operationList } = useQuery({
+  const { data: operationList, error: operationError } = useQuery({
     queryKey: [queryKeys.operations, project?.name],
     queryFn: async () => fetchOperations(project?.name ?? null),
   });
 
-  if (error) {
-    notify.failure("Loading operations failed", error);
+  if (operationError && !error) {
+    notify.failure("Loading operations failed", operationError);
   }
 
   const creationNames: string[] = [];


### PR DESCRIPTION
## Done

- fix(instance) avoid both instance and operations query reporting error to the user at the same time
- This would cause ininite updates to the error reported to the user as notification, ultimately hogging memory as the state updates would pile up and not be executed on. fixes 

Fixes #1650

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open the instance list
    - open network tab in browser tools
    - block the domain serving the ui and api
    - switch to another tab and back, see the failing network requests and an error in the ui
    - unblock the domain
    - switch to another tab and back, see the ui recover
    - previously on the last steps the ui would not recover, but crash the tab.