### PR TITLE
fix(instance) hide cursor of browser on canvas for graphic console of the instance

### DIFF
--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -16,6 +16,7 @@
   }
 
   .spice-wrapper {
+    cursor: none;
     overflow: auto;
   }
 


### PR DESCRIPTION
## Done

- hide cursor of browser on canvas for graphic console of the instance
- This is to avoid duplicate cursors when serving windows guests

## Screenshots

### before:

<img width="1645" height="953" alt="image" src="https://github.com/user-attachments/assets/397cea04-173b-4416-82aa-d03578494d78" />

### after:

<img width="1645" height="953" alt="image" src="https://github.com/user-attachments/assets/8be89112-8da6-4699-81c9-b89db86f5a98" />