### PR TITLE
fix(instance) ensure cpu limit input gets focus after creating override

### DIFF
--- a/src/components/forms/CpuLimitInput.tsx
+++ b/src/components/forms/CpuLimitInput.tsx
@@ -26,15 +26,14 @@ const CpuLimitInput: FC<Props> = ({ help, project, ...props }) => {
     enabled: canViewResources(),
   });
 
-  if (isLoading) {
-    return <Spinner className="u-loader" text="Loading resources..." />;
-  }
-
   if (error) {
     notify.failure("Loading resources failed", error);
   }
 
   const getNumberOfCores = () => {
+    if (isLoading) {
+      return <Spinner className="u-loader" text="Loading resources..." />;
+    }
     if (!project?.config["limits.cpu"]) {
       return resources?.cpu.total;
     }


### PR DESCRIPTION
## Done

- fix(instance) ensure cpu limit input gets focus after creating override
- previously would show loading for resources leading to no auto focus on a cold cache

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - edit an instance under configuration > Resource limits > Exposed CPU limit, ensure the override is not active
    - reload the page to force the cache to be stale on host resources
    - create cpu limit override, ensure the input is receiving focus
    - repeat same for memory limit, clear cpu limit first.

## Screenshots

<img width="1645" height="953" alt="image" src="https://github.com/user-attachments/assets/ca6a1b48-bf59-4413-9ec1-cd9956ea9295" />
