### PR TITLE
fix(instance) avoid graphic console to surface connection close error when leaving the tab

### DIFF
--- a/src/context/useMounted.tsx
+++ b/src/context/useMounted.tsx
@@ -1,0 +1,14 @@
+import type { RefObject } from "react";
+import { useEffect, useRef } from "react";
+
+export const useMounted = (): RefObject<boolean> => {
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -8,6 +8,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import type { LxdInstance } from "types/instance";
 import { useListener, useNotify, Spinner } from "@canonical/react-components";
 import { isInstanceRunning } from "util/instanceStatus";
+import { useMounted } from "context/useMounted";
 
 declare global {
   interface Window {
@@ -39,11 +40,14 @@ const InstanceGraphicConsole: FC<Props> = ({
   const notify = useNotify();
   const spiceRef = useRef<HTMLDivElement>(null);
   const [isVgaLoading, setVgaLoading] = useState<boolean>(false);
+  const isMounted = useMounted();
 
   const isRunning = isInstanceRunning(instance);
 
-  const handleError = (e: object) => {
-    onFailure("Console error", e);
+  const handleError = (e: object, message?: string) => {
+    if (isMounted.current) {
+      onFailure("Console error", e, message);
+    }
   };
 
   const handleResize = () => {
@@ -82,7 +86,7 @@ const InstanceGraphicConsole: FC<Props> = ({
     control.onerror = handleError;
 
     control.onclose = (event) => {
-      if (1005 !== event.code) {
+      if (1005 !== event.code && isMounted.current) {
         onFailure("Console error", event.reason, getWsErrorMsg(event.code));
       }
     };

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -14,6 +14,7 @@ import Xterm from "components/Xterm";
 import type { Terminal } from "@xterm/xterm";
 import { useListener, useNotify, Spinner } from "@canonical/react-components";
 import { isInstanceRunning } from "util/instanceStatus";
+import { useMounted } from "context/useMounted";
 
 interface Props {
   instance: LxdInstance;
@@ -38,6 +39,7 @@ const InstanceTextConsole: FC<Props> = ({
   const [userInteracted, setUserInteracted] = useState(false);
   const xtermRef = useRef<Terminal>(null);
   const notify = useNotify();
+  const isMounted = useMounted();
 
   usePrompt({
     when: userInteracted,
@@ -54,7 +56,9 @@ const InstanceTextConsole: FC<Props> = ({
   const isRunning = isInstanceRunning(instance);
 
   const handleError = (e: object) => {
-    onFailure("Error", e);
+    if (isMounted.current) {
+      onFailure("Error", e);
+    }
   };
 
   const openWebsockets = async () => {
@@ -98,7 +102,7 @@ const InstanceTextConsole: FC<Props> = ({
     control.onerror = handleError;
 
     control.onclose = (event) => {
-      if (1005 !== event.code) {
+      if (1005 !== event.code && isMounted.current) {
         onFailure("Error", event.reason, getWsErrorMsg(event.code));
       }
     };
@@ -110,7 +114,7 @@ const InstanceTextConsole: FC<Props> = ({
     data.onerror = handleError;
 
     data.onclose = (event) => {
-      if (1005 !== event.code) {
+      if (1005 !== event.code && isMounted.current) {
         onFailure("Error", event.reason, getWsErrorMsg(event.code));
       }
       setDataWs(null);


### PR DESCRIPTION
## Done

- fix(instance) avoid graphic console to surface connection close error when leaving the tab

Fixes #1658

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a VM graphic console
    - switch to any other tab (or to the text console)
    - ensure no error surfaces.