### PR TITLE
fix(instance) stable instance sorting when migrating instances

### DIFF
--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -43,6 +43,8 @@ const getLoadingType = (operation: LxdOperation): LoadingTypes | null => {
       return "Starting";
     case "Restarting instance":
       return "Restarting";
+    case "Migrating instance":
+      return "Migrating";
     default:
       return null;
   }

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -19,6 +19,7 @@ import InstanceLinkChip from "./InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { useCurrentProject } from "context/useCurrentProject";
 import { useToastNotification } from "@canonical/react-components";
+import { useInstanceLoading } from "context/instanceLoading";
 
 interface Props {
   name: string;
@@ -39,6 +40,9 @@ const InstanceDetailHeader: FC<Props> = ({
   const { canEditInstance } = useInstanceEntitlements();
   const controllerState = useState<AbortController | null>(null);
   const { canViewProject } = useCurrentProject();
+  const instanceLoading = useInstanceLoading();
+
+  const loadingType = instance ? instanceLoading.getType(instance) : undefined;
 
   const RenameSchema = Yup.object().shape({
     name: instanceNameValidation(project, controllerState, name).required(
@@ -147,7 +151,9 @@ const InstanceDetailHeader: FC<Props> = ({
         centerControls={
           instance ? (
             <div className="instance-header-state-controls">
-              <i className="status u-text--muted">{instance.status}</i>
+              <i className="status u-text--muted">
+                {loadingType ?? instance.status}
+              </i>
               <InstanceStateActions key="state" instance={instance} />
             </div>
           ) : null

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -180,6 +180,10 @@ const InstanceList: FC = () => {
     notify.failure("Loading operations failed", operationError);
   }
 
+  const migrationNames = (operationList?.running ?? [])
+    .filter((operation) => "Migrating instance" === operation.description)
+    .map(getInstanceName);
+
   const creationNames: string[] = [];
   const creationOperations = (operationList?.running ?? [])
     .concat(operationList?.success ?? [])
@@ -187,7 +191,8 @@ const InstanceList: FC = () => {
       const name = getInstanceName(operation);
       const isCreating = operation.description === "Creating instance";
       const isProcessing = processingNames.includes(name);
-      if (!isCreating || isProcessing) {
+      const isMigrating = migrationNames.includes(name);
+      if (!isCreating || isProcessing || isMigrating) {
         return false;
       }
       const isInInstanceList = instances.some((item) => item.name === name);

--- a/src/util/instanceMigration.tsx
+++ b/src/util/instanceMigration.tsx
@@ -123,6 +123,12 @@ export const useInstanceMigration = ({
     queryClient.invalidateQueries({
       queryKey: [queryKeys.instances, instance.name, instance.project],
     });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.instances, instance.project],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.operations, instance.project],
+    });
     instanceLoading.setFinish(instance);
   };
 


### PR DESCRIPTION
## Done

- fix(instance) stable instance sorting when migrating instances or evacuating cluster members.
- Show migration status in instance list and instance detail page

Fixes canonical/lxd#17139 canonical/lxd-ui#1514

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in cluster migrate instances between cluster members (instance detail > migrate > to a different cluster member)
    - while migration is in progress check instance detail page header and instance list, both should show status "Migrating"
    - instance list sorting should be stable for the migrating instance. before it would jump to the top of the list, that should not happen any more.
