### PR TITLE
feat: [WD-30458] ACL Default Action

### DIFF
--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -7,6 +7,8 @@ import FormEditButton from "components/FormEditButton";
 import { ensureEditMode } from "util/instanceEdit";
 import NetworkAclSelector from "pages/networks/forms/NetworkAclSelector";
 import { Label } from "@canonical/react-components";
+import NetworkDefaultACLSelector from "./NetworkDefaultACLSelector";
+import NetworkDefaultACLRead from "./NetworkDefaultACLRead";
 
 interface Props {
   project: string;
@@ -15,6 +17,10 @@ interface Props {
 
 const NetworkAcls: FC<Props> = ({ formik, project }) => {
   const networlAclSelectorId = useId();
+  const defaultEgressIngress = {
+    Egress: formik.values.security_acls_default_egress ?? "",
+    Ingress: formik.values.security_acls_default_ingress ?? "",
+  };
 
   return (
     <div className="general-field">
@@ -67,6 +73,19 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
               formik.setFieldValue("security_acls", selectedItems);
             }}
             id={networlAclSelectorId}
+          />
+        )}
+        {formik.values.readOnly ? (
+          formik.values.security_acls.length !== 0 && (
+            <NetworkDefaultACLRead values={defaultEgressIngress} />
+          )
+        ) : (
+          <NetworkDefaultACLSelector
+            onChange={(fieldValue, value) => {
+              formik.setFieldValue(fieldValue, value);
+            }}
+            values={defaultEgressIngress}
+            disabled={formik.values.security_acls.length === 0}
           />
         )}
       </div>

--- a/src/pages/networks/forms/NetworkDefaultACLRead.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLRead.tsx
@@ -1,0 +1,26 @@
+import type { FC } from "react";
+import { Icon } from "@canonical/react-components";
+import { conjugateACLAction } from "util/helpers";
+import type { Direction } from "./NetworkDefaultACLSelector";
+
+const NetworkDefaultACLRead: FC<{
+  values: Record<Direction, string>;
+}> = ({ values }) => {
+  const egressAction = values.Egress;
+  const ingressAction = values.Ingress;
+
+  return (
+    <div className="u-sv1">
+      When no ACL rule matches:
+      <br />
+      <Icon name="arrow-left" className="network-default-acl-icon" />
+      Egress traffic will be{" "}
+      <code>{conjugateACLAction(egressAction || "reject")}</code>
+      <br />
+      <Icon name="arrow-right" className="network-default-acl-icon" />
+      Ingress traffic will be{" "}
+      <code>{conjugateACLAction(ingressAction || "reject")}</code>
+    </div>
+  );
+};
+export default NetworkDefaultACLRead;

--- a/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
@@ -1,0 +1,67 @@
+import type { FC } from "react";
+import { Fragment } from "react";
+import { Icon, Select } from "@canonical/react-components";
+import { conjugateACLAction } from "util/helpers";
+
+export type Direction = "Ingress" | "Egress";
+
+interface Props {
+  onChange: (fieldValue: string, value: string) => void;
+  values?: Record<Direction, string>;
+  disabled?: boolean;
+}
+
+const NetworkDefaultACLSelector: FC<Props> = ({
+  values,
+  onChange,
+  disabled,
+}) => {
+  const DIRECTIONS: Direction[] = ["Egress", "Ingress"];
+  const ACTIONS = ["allow", "drop", "reject"];
+  const FIELD_BY_DIRECTION: Record<Direction, string> = {
+    Egress: "security_acls_default_egress",
+    Ingress: "security_acls_default_ingress",
+  };
+
+  const options = [
+    { label: "Select option", value: "" },
+    ...ACTIONS.map((value) => ({
+      label: conjugateACLAction(value),
+      value: value,
+    })),
+  ];
+
+  return (
+    <div>
+      <div className="u-sv2">When no ACL rule matches:</div>
+      <div className="network-default-acl-selector u-sv1">
+        {DIRECTIONS.map((direction) => {
+          return (
+            <Fragment key={direction}>
+              <div>
+                <Icon
+                  name={direction === "Egress" ? "arrow-left" : "arrow-right"}
+                  className="network-default-acl-icon"
+                />
+                {direction} traffic will be{" "}
+              </div>
+              <div>
+                <Select
+                  className="u-no-margin--bottom"
+                  options={options}
+                  onChange={(e) => {
+                    onChange(FIELD_BY_DIRECTION[direction], e.target.value);
+                  }}
+                  value={values?.[direction]}
+                  disabled={disabled}
+                />
+              </div>
+            </Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default NetworkDefaultACLSelector;

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -100,6 +100,8 @@ export interface NetworkFormValues {
   entityType: "network";
   bareNetwork?: LxdNetwork;
   editRestriction?: string;
+  security_acls_default_egress?: string;
+  security_acls_default_ingress?: string;
 }
 
 export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
@@ -178,6 +180,10 @@ export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
         values.security_acls.length > 0
           ? values.security_acls.join(",")
           : undefined,
+      [getNetworkKey("security_acls_default_egress")]:
+        values.security_acls_default_egress,
+      [getNetworkKey("security_acls_default_ingress")]:
+        values.security_acls_default_ingress,
       [getNetworkKey("vlan")]: values.vlan ? values.vlan.toString() : undefined,
     },
   };
@@ -234,7 +240,7 @@ const NetworkForm: FC<Props> = ({
     return filteredRows;
   };
 
-  const isManageed = formik.values.bareNetwork?.managed ?? true;
+  const isManaged = formik.values.bareNetwork?.managed ?? true;
 
   // see https://documentation.ubuntu.com/lxd/en/latest/reference/networks/
   // for details on available sections per type
@@ -246,19 +252,19 @@ const NetworkForm: FC<Props> = ({
   const isPhysical = formik.values.networkType === physicalType;
   const isSriov = formik.values.networkType === sriovType;
 
-  if (isManageed && !isPhysical && !isMacvlan && !isSriov) {
+  if (isManaged && !isPhysical && !isMacvlan && !isSriov) {
     availableSections.push(BRIDGE);
   }
-  if (isManageed && hasIpV4 && !isMacvlan && !isSriov) {
+  if (isManaged && hasIpV4 && !isMacvlan && !isSriov) {
     availableSections.push(IPV4);
   }
-  if (isManageed && hasIpV6 && !isMacvlan && !isSriov) {
+  if (isManaged && hasIpV6 && !isMacvlan && !isSriov) {
     availableSections.push(IPV6);
   }
-  if (isManageed && !isMacvlan && !isSriov) {
+  if (isManaged && !isMacvlan && !isSriov) {
     availableSections.push(DNS);
   }
-  if (isManageed && isPhysical) {
+  if (isManaged && isPhysical) {
     availableSections.push(OVN);
   }
 

--- a/src/sass/_network_default_acl_selector.scss
+++ b/src/sass/_network_default_acl_selector.scss
@@ -1,0 +1,15 @@
+.network-default-acl-selector {
+  align-items: center;
+  display: grid;
+  gap: $sp-medium;
+  grid-template-columns: fit-content(50%) 1fr;
+  margin-left: $sph--small;
+  margin-right: $sph--small;
+  padding-bottom: $spv--large;
+}
+
+.network-default-acl-icon {
+  margin-left: $sph--small;
+  margin-right: $sph--small;
+  opacity: 0.66;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -8,6 +8,8 @@
 @include vf-p-icon-add-canvas;
 @include vf-p-icon-add-logical-volume;
 @include vf-p-icon-applications;
+@include vf-p-icon-arrow-left;
+@include vf-p-icon-arrow-right;
 @include vf-p-icon-begin-downloading;
 @include vf-p-icon-book;
 @include vf-p-icon-canvas;
@@ -104,6 +106,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "meter";
 @import "migrate_instance";
 @import "modified_actions";
+@import "network_default_acl_selector";
 @import "network_form";
 @import "network_forwards_form";
 @import "network_ipam";

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -62,6 +62,8 @@ export interface LxdNetworkConfig {
   vlan?: string;
   [key: `user.${string}`]: string;
   [key: `volatile.${string}`]: string;
+  "security.acls.default.egress.action"?: string;
+  "security.acls.default.ingress.action"?: string;
 }
 
 export interface LxdNetwork {

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -435,3 +435,7 @@ export const fileToSanitisedName = (
   const newName = truncateEntityName(sanitisedFileName, suffix);
   return newName;
 };
+
+export const conjugateACLAction = (action: string) => {
+  return action === "drop" ? "dropped" : action + "ed";
+};

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -82,5 +82,9 @@ export const toNetworkFormValues = (
     entityType: "network",
     bareNetwork: network,
     editRestriction,
+    security_acls_default_egress:
+      network.config[getNetworkKey("security_acls_default_egress")],
+    security_acls_default_ingress:
+      network.config[getNetworkKey("security_acls_default_ingress")],
   };
 };

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -113,6 +113,8 @@ export const networkFormFieldToPayloadName: Record<
   parent: "parent",
   security_acls: "security.acls",
   vlan: "vlan",
+  security_acls_default_egress: "security.acls.default.egress.action",
+  security_acls_default_ingress: "security.acls.default.ingress.action",
 };
 
 export const getHandledNetworkConfigKeys = () => {


### PR DESCRIPTION
## Done

- Add Default ACL Actions to Network configuration
- Config values successfully update

- [x] Fix: Once updated, the config needs to show the values.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to Network > Any Bridge/OVN network > Click on edit ACL
    - Select an ACL if none is already selected.
    - View the defualt ACL action component enable,
    - Set default actions for both directions and then for single directions.
    - Ensure in the Inspector tools network tab that requests are being fulfilled successfully.

## Screenshots

<img width="869" height="139" alt="image" src="https://github.com/user-attachments/assets/0c185ea8-a63b-4986-9e8e-8fed1dcb5972" />
<img width="1025" height="233" alt="image" src="https://github.com/user-attachments/assets/6a893c0f-5572-4e06-bfa8-5e724279b37a" />
<img width="1025" height="442" alt="image" src="https://github.com/user-attachments/assets/97af1e98-b651-4a92-9759-31d426495061" />
