### PR TITLE
feat(instance) use mounted confirmation button

### DIFF
--- a/src/components/MountedConfirmationButton.tsx
+++ b/src/components/MountedConfirmationButton.tsx
@@ -1,0 +1,134 @@
+import type {
+  ActionButtonProps,
+  ConfirmationModalProps,
+  PropsWithSpread,
+  SubComponentProps,
+} from "@canonical/react-components";
+import { ActionButton, ConfirmationModal } from "@canonical/react-components";
+import type { MouseEvent, ReactNode } from "react";
+import { useModal } from "context/useModal";
+
+const generateTitle = (title: ReactNode) => {
+  if (typeof title === "string") {
+    return title;
+  }
+  if (typeof title === "number") {
+    return title.toString();
+  }
+  return null;
+};
+
+export type Props = PropsWithSpread<
+  {
+    /**
+     * Additional props to pass to the confirmation modal.
+     */
+    confirmationModalProps: SubComponentProps<ConfirmationModalProps> & {
+      onConfirm: (event: MouseEvent) => void;
+    };
+    /**
+     * An optional text to be shown when hovering over the button.<br/>
+     * Defaults to the label of the confirm button in the modal.
+     */
+    onHoverText?: string;
+    /**
+     * Whether to enable the SHIFT+Click shortcut to skip the confirmation modal and perform the action.
+     */
+    shiftClickEnabled?: boolean;
+    /**
+     * Whether to show a hint about the SHIFT+Click shortcut to skip the confirmation modal.
+     */
+    showShiftClickHint?: boolean;
+    /**
+     * A handler that determines whether the confirmation modal should be shown.
+     * If it returns `true`, the modal is shown. If it returns `false`, the modal is not shown.
+     */
+    preModalOpenHook?: (event: MouseEvent) => boolean;
+  },
+  ActionButtonProps
+>;
+
+/**
+ * `ConfirmationButton` is a specialised version of the [ActionButton](?path=/docs/actionbutton--default-story) component that uses a [ConfirmationModal](?path=/docs/confirmationmodal--default-story) to prompt a confirmation from the user before executing an action.
+ */
+export const MountedConfirmationButton = ({
+  confirmationModalProps,
+  onHoverText,
+  shiftClickEnabled = false,
+  showShiftClickHint = false,
+  preModalOpenHook,
+  ...actionButtonProps
+}: Props): React.JSX.Element => {
+  const { showModal, hideModal } = useModal();
+
+  const openModal = () => {
+    showModal(
+      <ConfirmationModal
+        {...confirmationModalProps}
+        close={handleCancelModal}
+        confirmButtonLabel={confirmationModalProps.confirmButtonLabel}
+        onConfirm={handleConfirmModal}
+      >
+        {confirmationModalProps.children}
+        {showShiftClickHint && (
+          <p className="p-text--small u-text--muted u-hide--small">
+            Next time, you can skip this confirmation by holding{" "}
+            <code>SHIFT</code> and clicking the action.
+          </p>
+        )}
+      </ConfirmationModal>,
+    );
+  };
+
+  const handleCancelModal = () => {
+    hideModal();
+    if (confirmationModalProps.close) {
+      confirmationModalProps.close();
+    }
+  };
+
+  const handleConfirmModal = (e: MouseEvent) => {
+    hideModal();
+    confirmationModalProps.onConfirm(e);
+  };
+
+  const handleShiftClick = (e: MouseEvent) => {
+    if (e.shiftKey) {
+      confirmationModalProps.onConfirm(e);
+    } else {
+      openModal();
+    }
+  };
+
+  const handleClick = (e: MouseEvent) => {
+    if (preModalOpenHook) {
+      const result = preModalOpenHook(e);
+
+      if (!result) return;
+    }
+
+    if (shiftClickEnabled) {
+      handleShiftClick(e);
+    } else {
+      openModal();
+    }
+  };
+
+  return (
+    <>
+      <ActionButton
+        {...actionButtonProps}
+        onClick={handleClick}
+        title={
+          generateTitle(
+            onHoverText ?? confirmationModalProps.confirmButtonLabel,
+          ) ?? ""
+        }
+      >
+        {actionButtonProps.children}
+      </ActionButton>
+    </>
+  );
+};
+
+export default MountedConfirmationButton;

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -4,16 +4,13 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { freezeInstance } from "api/instances";
 import { useInstanceLoading } from "context/instanceLoading";
-import {
-  ConfirmationButton,
-  Icon,
-  useToastNotification,
-} from "@canonical/react-components";
+import { Icon, useToastNotification } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { isInstanceRunning } from "util/instanceStatus";
 import ResourceLabel from "components/ResourceLabel";
+import MountedConfirmationButton from "components/MountedConfirmationButton";
 
 interface Props {
   instance: LxdInstance;
@@ -76,7 +73,7 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
     instanceLoading.getType(instance) === "Migrating";
 
   return (
-    <ConfirmationButton
+    <MountedConfirmationButton
       appearance="base"
       loading={isLoading}
       confirmationModalProps={{
@@ -98,7 +95,7 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
       showShiftClickHint
     >
       <Icon name="pause" />
-    </ConfirmationButton>
+    </MountedConfirmationButton>
   );
 };
 

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -6,15 +6,12 @@ import { queryKeys } from "util/queryKeys";
 import { restartInstance } from "api/instances";
 import { useInstanceLoading } from "context/instanceLoading";
 import ConfirmationForce from "components/ConfirmationForce";
-import {
-  ConfirmationButton,
-  Icon,
-  useToastNotification,
-} from "@canonical/react-components";
+import { Icon, useToastNotification } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import ResourceLabel from "components/ResourceLabel";
+import MountedConfirmationButton from "components/MountedConfirmationButton";
 
 interface Props {
   instance: LxdInstance;
@@ -67,7 +64,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
     instanceLoading.getType(instance) === "Migrating";
 
   return (
-    <ConfirmationButton
+    <MountedConfirmationButton
       appearance="base"
       loading={isLoading}
       className="has-icon is-dense"
@@ -98,7 +95,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
       showShiftClickHint
     >
       <Icon name="restart" />
-    </ConfirmationButton>
+    </MountedConfirmationButton>
   );
 };
 

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -6,15 +6,12 @@ import { stopInstance } from "api/instances";
 import { queryKeys } from "util/queryKeys";
 import { useInstanceLoading } from "context/instanceLoading";
 import ConfirmationForce from "components/ConfirmationForce";
-import {
-  ConfirmationButton,
-  Icon,
-  useToastNotification,
-} from "@canonical/react-components";
+import { Icon, useToastNotification } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
 import InstanceLinkChip from "../InstanceLinkChip";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import ResourceLabel from "components/ResourceLabel";
+import MountedConfirmationButton from "components/MountedConfirmationButton";
 
 interface Props {
   instance: LxdInstance;
@@ -81,7 +78,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
     !canUpdateInstanceState(instance);
 
   return (
-    <ConfirmationButton
+    <MountedConfirmationButton
       appearance="base"
       loading={isLoading}
       disabled={isDisabled}
@@ -109,7 +106,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
       showShiftClickHint
     >
       <Icon name="stop" />
-    </ConfirmationButton>
+    </MountedConfirmationButton>
   );
 };
 


### PR DESCRIPTION

## Done

- feat(instance) use mounted confirmation button
- so instance states change buttons can be moved into tooltip

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - no changes expected.