### PR TITLE
feat: [WD-31912] Local Peering No-ACL warning

### DIFF
--- a/src/pages/networks/LocalPeeringWarning.tsx
+++ b/src/pages/networks/LocalPeeringWarning.tsx
@@ -1,0 +1,24 @@
+import { Notification } from "@canonical/react-components";
+import type { FC } from "react";
+import type { LxdNetwork } from "types/network";
+
+interface Props {
+  network: LxdNetwork;
+}
+
+const LocalPeeringWarning: FC<Props> = ({ network }) => {
+  const networkACLs = network.config["security.acls"];
+  return (
+    (!networkACLs || networkACLs?.length == 0) && (
+      <Notification
+        severity="caution"
+        title="No ACLs configured for this network."
+      >
+        Local peerings have unrestricted ingress and egress on this network. To
+        enforce filtering, add ACLs to the network configuration.
+      </Notification>
+    )
+  );
+};
+
+export default LocalPeeringWarning;

--- a/src/pages/networks/NetworkPeers.tsx
+++ b/src/pages/networks/NetworkPeers.tsx
@@ -18,6 +18,7 @@ import CreateNetworkPeeringBtn from "./actions/CreateNetworkPeeringBtn";
 import LocalPeeringActions from "./actions/LocalPeeringActions";
 import EditLocalPeeringPanel from "./panels/EditLocalPeeringPanel";
 import LocalPeeringStatusIcon from "./LocalPeeringStatusIcon";
+import LocalPeeringWarning from "./LocalPeeringWarning";
 
 interface Props {
   network: LxdNetwork;
@@ -125,6 +126,7 @@ const NetworkPeers: FC<Props> = ({ network, project }) => {
 
   return (
     <>
+      <LocalPeeringWarning network={network} />
       {hasNetworkPeers && (
         <CreateNetworkPeeringBtn network={network} className=" u-float-right" />
       )}


### PR DESCRIPTION
## Done

- Display warning when attempting to configure local peerings for a network with no ACLs.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to an OVN network and access the Peerings tab.
    - Observe whether the warning displays for a network with no ACLs vs a network with ACLs.

## Screenshots

<img width="1643" height="467" alt="image" src="https://github.com/user-attachments/assets/be1f538f-461f-419e-9924-80a55b248d16" />