### PR TITLE
fix: [WD-31443] total memory in cluster

### DIFF
--- a/src/api/server.tsx
+++ b/src/api/server.tsx
@@ -110,6 +110,24 @@ export const fetchResources = async (
     });
 };
 
+export const fetchClusterMembersResources = async (
+  clusterMembers: LxdClusterMember[],
+): Promise<LxdResources[]> => {
+  const results = await Promise.allSettled(
+    clusterMembers.map(async (member) => fetchResources(member.server_name)),
+  );
+  const data: LxdResources[] = [];
+  for (let i = 0; i < clusterMembers.length; i++) {
+    const member = clusterMembers[i];
+    const result = results[i];
+    if (result.status === "rejected") {
+      throw constructMemberError(result, member.server_name);
+    }
+    data.push(result.value);
+  }
+  return data;
+};
+
 export const fetchConfigOptions = async (
   hasMetadataConfiguration: boolean,
 ): Promise<LxdMetadata | null> => {

--- a/src/components/forms/DiskSizeSelector.tsx
+++ b/src/components/forms/DiskSizeSelector.tsx
@@ -76,12 +76,11 @@ const DiskSizeSelector: FC<Props> = ({
           title={disabledReason}
         />
       </div>
-      {(help || helpTotal) && (
-        <p className="p-form-help-text">
-          {help}
-          {helpTotal}
-        </p>
-      )}
+      <p className="p-form-help-text">
+        {help}
+        {help && helpTotal && <br />}
+        {helpTotal}
+      </p>
     </div>
   );
 };

--- a/src/components/forms/MemoryLimitAvailable.tsx
+++ b/src/components/forms/MemoryLimitAvailable.tsx
@@ -1,59 +1,138 @@
 import type { FC } from "react";
 import { useNotify, Spinner } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { fetchResources } from "api/server";
-import { queryKeys } from "util/queryKeys";
 import { humanFileSize } from "util/helpers";
 import { limitToBytes } from "util/limits";
 import type { LxdProject } from "types/project";
-import { useServerEntitlements } from "util/entitlements/server";
+import { Icon } from "@canonical/react-components";
+import type { InstanceAndProfileFormikProps } from "./instanceAndProfileFormValues";
+import type { CreateInstanceFormValues } from "pages/instances/CreateInstance";
+import type { EditInstanceFormValues } from "pages/instances/EditInstance";
+import { CLUSTER_GROUP_PREFIX } from "util/instances";
+import ResourceLink from "components/ResourceLink";
+import { useIsClustered } from "context/useIsClustered";
+import { useResources } from "context/useResources";
 
+interface MemoryLimit {
+  min: number;
+  max: number;
+  source: "project" | "cluster-member" | "";
+}
 interface Props {
+  formik?: InstanceAndProfileFormikProps;
   project?: LxdProject;
 }
 
-const MemoryLimitAvailable: FC<Props> = ({ project }) => {
+const MemoryLimitAvailable: FC<Props> = ({ formik, project }) => {
   const notify = useNotify();
-  const { canViewResources } = useServerEntitlements();
+  const isClustered = useIsClustered();
+  const values = formik?.values;
+  const projectResourceMemory = project?.config["limits.memory"]
+    ? limitToBytes(project?.config["limits.memory"])
+    : undefined;
+  const { target } = values as CreateInstanceFormValues;
+  const { location } = values as EditInstanceFormValues;
+  const isClusterGroupTarget = target?.startsWith(CLUSTER_GROUP_PREFIX);
+  const validTarget = target && !isClusterGroupTarget ? target : undefined;
+  const clusterMember = isClustered ? (validTarget ?? location) : undefined;
 
-  const {
-    data: resources,
-    error,
-    isLoading,
-  } = useQuery({
-    queryKey: [queryKeys.resources],
-    queryFn: async () => fetchResources(),
-    enabled: canViewResources(),
-  });
+  const { data: resources, error, isLoading } = useResources(clusterMember);
 
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading resources..." />;
   }
-
   if (error) {
     notify.failure("Loading resources failed", error);
+    return null;
+  }
+  if (!resources) {
+    return null;
   }
 
-  const getAvailableMemory = () => {
-    if (!project?.config["limits.memory"]) {
-      return resources?.memory.total;
+  const getSourceQualifier = (source: string) => {
+    if (source === "project") {
+      return (
+        <>
+          {"in project "}
+          <ResourceLink
+            type="project"
+            value={project?.name || "default"}
+            to={`/ui/projects/${encodeURIComponent(project?.name || "default")}`}
+          />
+        </>
+      );
     }
-    if (!resources?.memory.total) {
-      return limitToBytes(project.config["limits.memory"]);
+
+    if (source === "cluster-member") {
+      return (
+        <>
+          {"on cluster member "}
+          <ResourceLink
+            type="cluster-member"
+            value={clusterMember ?? ""}
+            to={`/ui/cluster/member/${encodeURIComponent(clusterMember ?? "")}`}
+          />
+        </>
+      );
     }
-    return Math.min(
-      resources.memory.total,
-      Number(limitToBytes(project.config["limits.memory"])),
-    );
+    return null;
   };
 
-  const maxMemory = getAvailableMemory();
+  const getAvailableMemory = (): MemoryLimit => {
+    const resourceArray = Array.isArray(resources) ? resources : [resources];
+    const projectLimit = Number(projectResourceMemory);
+    const resourcesMemories = resourceArray.map((r) => r.memory.total);
+    const minResourceMemory = Math.min(...resourcesMemories);
+    const maxResourceMemory = Math.max(...resourcesMemories);
 
-  return maxMemory ? (
+    if (resourceArray.length === 0 || projectLimit < minResourceMemory) {
+      return {
+        min: projectLimit,
+        max: projectLimit,
+        source: projectLimit ? "project" : "",
+      };
+    }
+
+    if (!projectResourceMemory || maxResourceMemory < projectLimit) {
+      return {
+        min: minResourceMemory,
+        max: maxResourceMemory,
+        source: clusterMember ? "cluster-member" : "",
+      };
+    }
+
+    return {
+      min: minResourceMemory,
+      max: projectLimit,
+      source: "",
+    };
+  };
+
+  const { min: minMemory, max: maxMemory, source } = getAvailableMemory();
+  const showHelpIcon = minMemory !== maxMemory;
+  const helpIconText = `The available memory depends on the cluster member that the instance will be created on.\
+  To determine the available memory exactly, go to the "Main configuration" section, and from\
+  the "Target" dropdown, select the "Cluster Member" option, then choose a member.`;
+
+  return (
     <>
-      Total memory: <b>{humanFileSize(maxMemory)}</b>
+      Total memory:{" "}
+      <b>
+        {humanFileSize(minMemory)}
+        {minMemory !== maxMemory && ` - ${humanFileSize(maxMemory)}`}
+        {showHelpIcon && (
+          <>
+            {" "}
+            <Icon
+              name="information"
+              className="help-link-icon"
+              title={helpIconText}
+            />
+          </>
+        )}
+      </b>
+      <br />
+      {getSourceQualifier(source)}
     </>
-  ) : null;
+  );
 };
-
 export default MemoryLimitAvailable;

--- a/src/components/forms/MemoryLimitSelector.tsx
+++ b/src/components/forms/MemoryLimitSelector.tsx
@@ -4,13 +4,19 @@ import type { MemoryLimit } from "types/limits";
 import { BYTES_UNITS, MEM_LIMIT_TYPE } from "types/limits";
 import MemoryLimitAvailable from "components/forms/MemoryLimitAvailable";
 import { useCurrentProject } from "context/useCurrentProject";
+import type { InstanceAndProfileFormikProps } from "./instanceAndProfileFormValues";
 
 interface Props {
+  formik: InstanceAndProfileFormikProps;
   memoryLimit?: MemoryLimit;
   setMemoryLimit: (memoryLimit: MemoryLimit) => void;
 }
 
-const MemoryLimitSelector: FC<Props> = ({ memoryLimit, setMemoryLimit }) => {
+const MemoryLimitSelector: FC<Props> = ({
+  formik,
+  memoryLimit,
+  setMemoryLimit,
+}) => {
   const { project } = useCurrentProject();
 
   if (!memoryLimit) {
@@ -58,7 +64,7 @@ const MemoryLimitSelector: FC<Props> = ({ memoryLimit, setMemoryLimit }) => {
             setMemoryLimit({ ...memoryLimit, value: +e.target.value });
           }}
           value={`${memoryLimit.value ? memoryLimit.value : ""}`}
-          help={<MemoryLimitAvailable project={project} />}
+          help={<MemoryLimitAvailable project={project} formik={formik} />}
         />
       )}
       {memoryLimit.selectedType === MEM_LIMIT_TYPE.FIXED && (
@@ -74,7 +80,7 @@ const MemoryLimitSelector: FC<Props> = ({ memoryLimit, setMemoryLimit }) => {
               setMemoryLimit({ ...memoryLimit, value: +e.target.value });
             }}
             value={`${memoryLimit.value ? memoryLimit.value : ""}`}
-            help={<MemoryLimitAvailable project={project} />}
+            help={<MemoryLimitAvailable project={project} formik={formik} />}
           />
           <Select
             id="memUnitSelect"

--- a/src/components/forms/ResourceLimitsForm.tsx
+++ b/src/components/forms/ResourceLimitsForm.tsx
@@ -76,6 +76,7 @@ const ResourceLimitsForm: FC<Props> = ({ formik }) => {
             memoryLimitToPayload(val as MemoryLimit | undefined) ?? "",
           children: (
             <MemoryLimitSelector
+              formik={formik}
               memoryLimit={formik.values.limits_memory}
               setMemoryLimit={(memoryLimit) =>
                 void formik.setFieldValue("limits_memory", memoryLimit)

--- a/src/context/useResources.tsx
+++ b/src/context/useResources.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useServerEntitlements } from "util/entitlements/server";
+import { useIsClustered } from "./useIsClustered";
+import { fetchResources, fetchClusterMembersResources } from "api/server";
+import { useClusterMembers } from "./useClusterMembers";
+
+export const useResources = (currentServerInCluster?: string) => {
+  const isClustered = useIsClustered();
+  const { data: clusterMembers = [] } = useClusterMembers();
+  const { canViewResources } = useServerEntitlements();
+  const singleNodeQuery = useQuery({
+    queryKey: [queryKeys.resources],
+    queryFn: async () => fetchResources(),
+    enabled: canViewResources() && !isClustered,
+  });
+  const filteredClusterMembers = clusterMembers.filter(
+    (member) =>
+      !currentServerInCluster || member.server_name === currentServerInCluster,
+  );
+  const clusterQuery = useQuery({
+    queryKey: [queryKeys.resources, filteredClusterMembers],
+    queryFn: async () => fetchClusterMembersResources(filteredClusterMembers),
+    enabled: canViewResources() && isClustered,
+  });
+
+  return isClustered ? clusterQuery : singleNodeQuery;
+};

--- a/src/pages/instances/forms/InstanceTargetSelect.tsx
+++ b/src/pages/instances/forms/InstanceTargetSelect.tsx
@@ -20,6 +20,7 @@ import { useClusterMembers } from "context/useClusterMembers";
 import type { SelectRef } from "@canonical/react-components/dist/components/CustomSelect/CustomSelect";
 import PlacementGroupSelect from "pages/instances/forms/PlacementGroupSelect";
 import { PLACEMENT_GROUP_POLICY_COMPACT } from "pages/placement-groups/PlacementGroupForm";
+import { CLUSTER_GROUP_PREFIX } from "util/instances";
 
 export const TARGET = {
   AUTO: "auto",
@@ -27,8 +28,6 @@ export const TARGET = {
   CLUSTER_MEMBER: "clusterMember",
   PLACEMENT_GROUP: "placementGroup",
 };
-
-export const CLUSTER_GROUP_PREFIX = "@";
 
 interface Props {
   formik: FormikProps<CreateInstanceFormValues>;

--- a/src/pages/projects/ProjectMemoryLimit.tsx
+++ b/src/pages/projects/ProjectMemoryLimit.tsx
@@ -1,0 +1,30 @@
+import { useResources } from "context/useResources";
+import type { FC } from "react";
+import { humanFileSize } from "util/helpers";
+import { useNotify } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
+
+export const ProjectMemoryLimit: FC = () => {
+  const notify = useNotify();
+
+  const { data: resources = [], error, isLoading } = useResources();
+  if (isLoading) {
+    return <Spinner className="u-loader" text="Loading resources..." />;
+  }
+  if (error) {
+    notify.failure("Loading resources failed", error);
+    return null;
+  }
+  const resourceArray = Array.isArray(resources) ? resources : [resources];
+
+  const sumMemoryLimit = resourceArray.reduce(
+    (sum, resource) => sum + resource.memory.total,
+    0,
+  );
+
+  return (
+    <>
+      Total memory: <b>{humanFileSize(sumMemoryLimit)}</b>
+    </>
+  );
+};

--- a/src/pages/projects/forms/ProjectResourceLimitsForm.tsx
+++ b/src/pages/projects/forms/ProjectResourceLimitsForm.tsx
@@ -8,7 +8,7 @@ import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import { getProjectKey } from "util/projectConfigFields";
 import type { LxdConfigPair } from "types/config";
 import CpuLimitInput from "components/forms/CpuLimitInput";
-import MemoryLimitAvailable from "components/forms/MemoryLimitAvailable";
+import { ProjectMemoryLimit } from "../ProjectMemoryLimit";
 
 export interface ProjectResourceLimitsFormValues {
   limits_instances?: number;
@@ -109,7 +109,7 @@ const ProjectResourceLimitsForm: FC<Props> = ({ formik }) => {
               setMemoryLimit={(val?: string) =>
                 void formik.setFieldValue("limits_memory", val)
               }
-              helpTotal={<MemoryLimitAvailable />}
+              helpTotal={<ProjectMemoryLimit />}
             />
           ),
         }),

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -11,6 +11,8 @@ import { useImagesInProject } from "context/useImages";
 import ResourceLabel from "components/ResourceLabel";
 import ResourceLink from "components/ResourceLink";
 
+export const CLUSTER_GROUP_PREFIX = "@";
+
 export const instanceLinkFromOperation = (args: {
   operation?: LxdOperationResponse;
   project?: string;


### PR DESCRIPTION
## Done

- Fixes available memory in cluster

Fixes #1625 
## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Create an instance page and then to Resource Limits tab
    - Create an override for Memory Limit
    - Ensure available memory is reported correctly as:
           (i) a value if you selected a cluster member as target
           (ii) a value if you have not selected a cluster member as target and all the cluster members have equal limits
           (iii) a range if you have not selected a cluster member as target and the cluster members do not have equal limits
     - Go to one instance -> Configuration -> Resource Limits
      - Create an override for Memory Limit
      - Ensure available memory is reported correctly as a value


## Screenshots

<img width="1984" height="963" alt="image" src="https://github.com/user-attachments/assets/cf869821-f5cb-41c4-b8e3-f0b3aa9f372d" />

<img width="1984" height="963" alt="image" src="https://github.com/user-attachments/assets/79bc64fb-0213-40a0-8edd-53fc735c3ec1" />
