### PR TITLE
feat(CloudInitForm): allow editor in full screen

### DIFF
--- a/src/components/forms/CloudInitConfig.tsx
+++ b/src/components/forms/CloudInitConfig.tsx
@@ -14,6 +14,7 @@ const CloudInitConfig: FC<Props> = ({ config, setConfig }) => {
         setYaml={setConfig}
         autoResize={true}
         readOnly={!setConfig}
+        readOnlyMessage="Read only editor for inherited value. Create an override to modify."
       />
     </div>
   );

--- a/src/components/forms/CloudInitExpandButton.tsx
+++ b/src/components/forms/CloudInitExpandButton.tsx
@@ -1,0 +1,141 @@
+import type { FC, MouseEvent, ReactNode } from "react";
+import { Button, Icon } from "@canonical/react-components";
+import { useModal } from "context/useModal";
+import ResourceLink from "components/ResourceLink";
+import type { CloudInitKey } from "components/forms/CloudInitForm";
+import YamlModal from "components/forms/YamlModal";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { ensureEditMode } from "util/instanceEdit";
+import classnames from "classnames";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
+import { useLocation } from "react-router-dom";
+import ResourceLabel from "components/ResourceLabel";
+
+const LABELS: Record<CloudInitKey, string> = {
+  cloud_init_network_config: "cloud-init network config",
+  cloud_init_user_data: "cloud-init user data",
+  cloud_init_vendor_data: "cloud-init vendor data",
+};
+
+interface Props {
+  formik: InstanceAndProfileFormikProps;
+  project: string;
+  name: CloudInitKey;
+  initialValue: string;
+  source?: ReactNode;
+  onApplyChanges?: () => void;
+  isReadOnly?: boolean;
+  className?: string;
+}
+
+const CloudInitExpandButton: FC<Props> = ({
+  formik,
+  project,
+  name,
+  initialValue,
+  source,
+  onApplyChanges,
+  isReadOnly,
+  className,
+}) => {
+  const { showModal, hideModal } = useModal();
+  const isSmallScreen = useIsScreenBelow();
+  const location = useLocation();
+
+  const getModalTitle = () => {
+    const label = LABELS[name];
+    const entityName = formik.values.name || "";
+    const entityType = formik.values.entityType;
+
+    const isCreating = location.pathname.includes("/create");
+    const isNew = isCreating || !entityName;
+    const isInherited = source && source !== entityName;
+
+    let entityIdentifier = null;
+
+    if (!isNew && entityName) {
+      entityIdentifier = (
+        <ResourceLink
+          type={entityType}
+          value={entityName}
+          to={`/ui/project/${encodeURIComponent(project)}/${entityType}/${encodeURIComponent(entityName)}`}
+        />
+      );
+    } else if (isNew && entityName) {
+      entityIdentifier = <ResourceLabel type={entityType} value={entityName} />;
+    }
+
+    return (
+      <div
+        className="u-no-margin"
+        onClick={(event) => {
+          const target = event.target as HTMLElement;
+          const link = target.closest("a");
+
+          if (link) {
+            const openInNewTab =
+              event.ctrlKey || event.metaKey || event.shiftKey;
+
+            if (!openInNewTab) {
+              hideModal();
+            }
+          }
+        }}
+      >
+        <h4 className="p-heading--4 u-no-margin--bottom">
+          {isReadOnly ? "View" : "Edit"} {label}
+        </h4>
+        <p className="p-heading--6 u-text--muted u-no-margin--top u-no-margin--bottom font-weight-normal">
+          For {isNew && "new "}
+          {entityType} {entityIdentifier}
+          {isSmallScreen && <br />}
+          {isInherited && (
+            <>
+              {" inherited from "}
+              {source}
+            </>
+          )}
+        </p>
+      </div>
+    );
+  };
+
+  const handleApply = (newValue: string) => {
+    ensureEditMode(formik);
+    formik.setFieldValue(name, newValue);
+    onApplyChanges?.();
+  };
+
+  const handleClick = (e: MouseEvent<HTMLElement>) => {
+    showModal(
+      <YamlModal
+        title={getModalTitle()}
+        onClose={hideModal}
+        applyChanges={handleApply}
+        readOnly={isReadOnly || !!formik.values.editRestriction}
+        readOnlyMessage={
+          isReadOnly
+            ? "Read only editor for inherited value. Create an override to modify."
+            : formik.values.editRestriction
+        }
+        initialValue={formik.values[name] || initialValue}
+      />,
+      e,
+    );
+  };
+
+  return (
+    <Button
+      onClick={handleClick}
+      type="button"
+      appearance="base"
+      title={isReadOnly ? "Expand view" : "Expand editor"}
+      hasIcon
+      className={classnames("u-no-margin--bottom", className)}
+    >
+      <Icon name="fullscreen" className="full-screen-icon" />
+    </Button>
+  );
+};
+
+export default CloudInitExpandButton;

--- a/src/components/forms/YamlForm.tsx
+++ b/src/components/forms/YamlForm.tsx
@@ -6,6 +6,7 @@ import { editor } from "monaco-editor/esm/vs/editor/editor.api";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import classnames from "classnames";
 import { useListener } from "@canonical/react-components";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
 
 export interface YamlFormValues {
   yaml?: string;
@@ -30,6 +31,7 @@ const YamlForm: FC<Props> = ({
 }) => {
   const [editor, setEditor] = useState<IStandaloneCodeEditor | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const isSmallScreen = useIsScreenBelow();
 
   loader.config({ paths: { vs: "/ui/monaco-editor/min/vs" } });
 
@@ -70,12 +72,15 @@ const YamlForm: FC<Props> = ({
             scrollBeyondLastLine: false,
             wordWrap: "on",
             wrappingStrategy: "advanced",
-            minimap: {
-              enabled: false,
-            },
+            minimap: { enabled: false },
             overviewRulerLanes: 0,
             readOnly: readOnly,
+            scrollbar: {
+              vertical: "auto",
+              alwaysConsumeMouseWheel: false,
+            },
             readOnlyMessage: { value: readOnlyMessage ?? "" },
+            lineNumbersMinChars: isSmallScreen ? 2 : 5,
           }}
           onMount={(editor: IStandaloneCodeEditor) => {
             setEditor(editor);

--- a/src/components/forms/YamlModal.tsx
+++ b/src/components/forms/YamlModal.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import { useState, useEffect, type FC } from "react";
+import { Modal } from "@canonical/react-components";
+import YamlForm from "components/forms/YamlForm";
+
+interface Props {
+  title: ReactNode;
+  onClose: () => void;
+  applyChanges: (newValue: string) => void;
+  readOnly?: boolean;
+  readOnlyMessage?: string;
+  initialValue: string;
+}
+
+const YamlModal: FC<Props> = ({
+  title,
+  onClose,
+  applyChanges,
+  readOnly,
+  readOnlyMessage,
+  initialValue,
+}) => {
+  const [value, setValue] = useState<string>(initialValue ?? "");
+
+  useEffect(() => {
+    setValue(initialValue ?? "");
+  }, [initialValue]);
+
+  const handleClose = () => {
+    if (!readOnly) {
+      applyChanges(value);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal
+      close={handleClose}
+      title={title}
+      className="cloud-init-full-editor-modal"
+      closeOnOutsideClick={false}
+    >
+      <div className="cloud-init-modal-content">
+        <YamlForm
+          yaml={value}
+          setYaml={setValue}
+          readOnly={readOnly}
+          readOnlyMessage={readOnlyMessage}
+          autoResize
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default YamlModal;

--- a/src/context/useModal.tsx
+++ b/src/context/useModal.tsx
@@ -1,9 +1,9 @@
-import type { ReactNode } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
 import { createContext, useContext, useState, useCallback } from "react";
 import { usePortal } from "@canonical/react-components";
 
 export interface ModalType {
-  showModal: (content: ReactNode) => void;
+  showModal: (content: ReactNode, event?: SyntheticEvent<HTMLElement>) => void;
   hideModal: () => void;
 }
 
@@ -14,7 +14,9 @@ const ModalContext = createContext<ModalType>({
 
 export const ModalProvider = ({ children }: { children: ReactNode }) => {
   const [content, setContent] = useState<ReactNode | null>(null);
-  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { openPortal, closePortal, isOpen, Portal } = usePortal({
+    programmaticallyOpen: true,
+  });
 
   const showModal = useCallback((content: ReactNode) => {
     setContent(content);

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -521,7 +521,9 @@ const CreateInstance: FC = () => {
 
             {section === BOOT && <BootForm formik={formik} />}
 
-            {section === CLOUD_INIT && <CloudInitForm formik={formik} />}
+            {section === CLOUD_INIT && (
+              <CloudInitForm formik={formik} project={project} />
+            )}
 
             {section === YAML_CONFIGURATION && (
               <YamlForm

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -271,7 +271,11 @@ const EditInstance: FC<Props> = ({ instance }) => {
             {section === slugify(BOOT) && <BootForm formik={formik} />}
 
             {section === slugify(CLOUD_INIT) && (
-              <CloudInitForm key={`yaml-form-${version}`} formik={formik} />
+              <CloudInitForm
+                key={`yaml-form-${version}`}
+                formik={formik}
+                project={project}
+              />
             )}
 
             {section === slugify(YAML_CONFIGURATION) && (

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -253,7 +253,9 @@ const CreateProfile: FC = () => {
 
             {section === BOOT && <BootForm formik={formik} />}
 
-            {section === CLOUD_INIT && <CloudInitForm formik={formik} />}
+            {section === CLOUD_INIT && (
+              <CloudInitForm formik={formik} project={project} />
+            )}
 
             {section === YAML_CONFIGURATION && (
               <YamlForm

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -264,7 +264,11 @@ const EditProfile: FC<Props> = ({ profile }) => {
             {section === slugify(BOOT) && <BootForm formik={formik} />}
 
             {section === slugify(CLOUD_INIT) && (
-              <CloudInitForm key={`yaml-form-${version}`} formik={formik} />
+              <CloudInitForm
+                key={`yaml-form-${version}`}
+                formik={formik}
+                project={project}
+              />
             )}
 
             {section === slugify(YAML_CONFIGURATION) && (

--- a/src/sass/_cloud_init_form.scss
+++ b/src/sass/_cloud_init_form.scss
@@ -1,0 +1,58 @@
+.cloud-init {
+  .configuration-table {
+    .configuration {
+      width: 9rem;
+    }
+
+    .inherited {
+      width: auto;
+    }
+
+    .override {
+      width: auto;
+    }
+
+    .override-form {
+      align-items: flex-end;
+      flex-direction: column;
+
+      > :first-child {
+        width: 100%;
+      }
+    }
+  }
+
+  .cloud-init-config {
+    .code-editor-wrapper {
+      max-height: 35dvh;
+      min-height: 7.5rem;
+    }
+  }
+}
+
+.cloud-init-full-editor-modal {
+  .p-modal__dialog {
+    display: flex;
+    flex-direction: column;
+    height: 80dvh;
+
+    @include large {
+      width: 80dvw;
+    }
+
+    .p-modal__header + div {
+      flex: 1;
+
+      .cloud-init-modal-content {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        padding-right: 2px;
+
+        .code-editor-wrapper {
+          min-height: 100%;
+        }
+      }
+    }
+  }
+}

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -209,13 +209,6 @@
     }
   }
 
-  .cloud-init-config {
-    .code-editor-wrapper {
-      max-height: 35dvh;
-      min-height: 7.5rem;
-    }
-  }
-
   .checkbox-label-tooltip {
     > span {
       display: inherit !important;
@@ -235,29 +228,6 @@
 
   .configuration-table {
     margin-bottom: $spv--x-large;
-  }
-
-  .cloud-init {
-    .configuration {
-      width: 9rem;
-    }
-
-    .inherited {
-      width: auto;
-    }
-
-    .override {
-      width: auto;
-    }
-
-    .override-form {
-      align-items: flex-end;
-      flex-direction: column;
-
-      > :first-child {
-        width: 100%;
-      }
-    }
   }
 
   .device-form {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -73,6 +73,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 
 @import "certificate_add";
 @import "certificates";
+@import "cloud_init_form";
 @import "cluster_group_form";
 @import "cluster_list";
 @import "cluster_specific_input";


### PR DESCRIPTION
## Done

- In instance/profile configuration > cloud init, add an expand icon for each editor
- When click on the expand icon, a big modal opens.
- The user can edit in the modal,and the changes are reflected in the editor when the modal gets closed. The changes are however not saved.
- The user can view inherited config in the modal, but not edit it there.
- When click on the chips in the modal title, the modal closes and the url changes to the one provided by the chip.
- In both inline editor and the modal, a read only message was added.

Fixes #1641 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a profile or instance > Configuration > Cloud Init
    - There should be expand icon for each editor
    - Make sure you can't edit an inherited config
    - Make sure you can edit when onverriding a config

## Screenshots

Read only
<img width="1484" height="847" alt="image" src="https://github.com/user-attachments/assets/0f3f1f7f-bc2e-45ba-a184-f2765800c664" />


Edit
<img width="1484" height="847" alt="image" src="https://github.com/user-attachments/assets/446a0772-ebbd-4d99-b879-3ca2ee40e2cf" />

