### PR TITLE
feat: Amendments to local peering label casing

### DIFF
--- a/src/pages/networks/NetworkDetail.tsx
+++ b/src/pages/networks/NetworkDetail.tsx
@@ -94,7 +94,7 @@ const NetworkDetail: FC = () => {
     "Configuration",
     getTabLink("Forwards", hasForwards, "forwards"),
     getTabLink("Leases", hasLeases, "leases"),
-    getTabLink("Local Peerings", isPeeringSupported, "local-peerings"),
+    getTabLink("Local peerings", isPeeringSupported, "local-peerings"),
   ];
 
   return (

--- a/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
@@ -176,7 +176,7 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
     <>
       <SidePanel>
         <SidePanel.Header>
-          <SidePanel.HeaderTitle>Create Local peering</SidePanel.HeaderTitle>
+          <SidePanel.HeaderTitle>Create local peering</SidePanel.HeaderTitle>
         </SidePanel.Header>
         <NotificationRow className="u-no-padding" />
         <SidePanel.Content className="u-no-padding">


### PR DESCRIPTION
## Done

- Minor amendments to the casing of local peering labels.

Fixes inconsistent casing

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Review minor casing changes.
 
## Screenshots

N/A