### PR TITLE
fix(server) show memory information for unclustered server

### DIFF
--- a/src/pages/cluster/ClusterMemberDetailMemory.tsx
+++ b/src/pages/cluster/ClusterMemberDetailMemory.tsx
@@ -8,7 +8,7 @@ import ClusterMemberMemoryUsage from "pages/cluster/ClusterMemberMemoryUsage";
 interface Props {
   resources: LxdResources;
   state?: LxdClusterMemberState;
-  member: LxdClusterMember;
+  member?: LxdClusterMember;
 }
 
 const ClusterMemberDetailMemory: FC<Props> = ({ resources, state, member }) => {
@@ -18,12 +18,14 @@ const ClusterMemberDetailMemory: FC<Props> = ({ resources, state, member }) => {
   return (
     <table>
       <tbody>
-        <tr>
-          <th className="u-text--muted">Overview</th>
-          <td>
-            <ClusterMemberMemoryUsage member={member} />
-          </td>
-        </tr>
+        {member && (
+          <tr>
+            <th className="u-text--muted">Overview</th>
+            <td>
+              <ClusterMemberMemoryUsage member={member} />
+            </td>
+          </tr>
+        )}
         <tr>
           <th className="u-text--muted">Total</th>
           <td>{humanFileSize(resources?.memory?.total ?? 0)}</td>

--- a/src/pages/cluster/ClusterMemberHardware.tsx
+++ b/src/pages/cluster/ClusterMemberHardware.tsx
@@ -106,7 +106,7 @@ const ClusterMemberHardware: FC<Props> = ({ member }) => {
                 {sectionName === "CPU" && (
                   <ClusterMemberDetailCPU resources={resources} state={state} />
                 )}
-                {sectionName === "Memory" && member && (
+                {sectionName === "Memory" && (
                   <ClusterMemberDetailMemory
                     resources={resources}
                     state={state}


### PR DESCRIPTION
## Done

- fix(server) show memory information for unclustered server

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In an unclustered environment (such as the demo server)
    - Go to "server" > "memory" and ensure memory information is displayed

## Screenshots

Before:

<img width="1923" height="821" alt="image" src="https://github.com/user-attachments/assets/1d8e0e53-1db7-4f0f-9daf-a1f2fab7bcb6" />
