### PR TITLE
feat: [WD-31000] Migrate storage volume to another cluster

### DIFF
--- a/src/api/storage-volumes.tsx
+++ b/src/api/storage-volumes.tsx
@@ -271,12 +271,13 @@ export const deleteStorageVolumeBulk = async (
 
 export const migrateStorageVolume = async (
   volume: LxdStorageVolume,
-  targetPool: string,
-  targetProject: string,
+  project: string,
+  targetPool?: string,
   target?: string,
+  targetProject?: string,
 ): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
-  params.set("project", targetProject);
+  params.set("project", project);
   addTarget(params, target);
 
   return fetch(
@@ -287,8 +288,9 @@ export const migrateStorageVolume = async (
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
+        project: targetProject,
         name: volume.name,
-        pool: targetPool,
+        pool: targetPool ?? volume.pool,
       }),
     },
   )

--- a/src/pages/storage/MigrateVolumeBtn.tsx
+++ b/src/pages/storage/MigrateVolumeBtn.tsx
@@ -1,177 +1,51 @@
 import type { FC } from "react";
-import { useState } from "react";
-import {
-  ActionButton,
-  Icon,
-  usePortal,
-  useToastNotification,
-} from "@canonical/react-components";
-import { useQueryClient } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { useEventQueue } from "context/eventQueue";
+import { ActionButton, Icon, usePortal } from "@canonical/react-components";
 import type { LxdStorageVolume } from "types/storage";
 import MigrateVolumeModal from "./MigrateVolumeModal";
-import { useNavigate } from "react-router-dom";
-import ResourceLabel from "components/ResourceLabel";
-import ResourceLink from "components/ResourceLink";
-import { migrateStorageVolume } from "api/storage-volumes";
 import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
-import { hasLocation } from "util/storageVolume";
-import VolumeLinkChip from "pages/storage/VolumeLinkChip";
 import classNames from "classnames";
 
 interface Props {
   volume: LxdStorageVolume;
-  project: string;
   classname?: string;
   onClose?: () => void;
 }
 
-const MigrateVolumeBtn: FC<Props> = ({
-  volume,
-  project,
-  classname,
-  onClose,
-}) => {
-  const eventQueue = useEventQueue();
-  const toastNotify = useToastNotification();
+const MigrateVolumeBtn: FC<Props> = ({ volume, classname, onClose }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
-  const [isVolumeLoading, setVolumeLoading] = useState(false);
   const { canEditVolume } = useStorageVolumeEntitlements();
-
-  const handleSuccess = (
-    newTarget: string,
-    storageVolume: LxdStorageVolume,
-  ) => {
-    const memberPath = hasLocation(volume)
-      ? `/member/${encodeURIComponent(volume.location)}`
-      : "";
-    const oldVolumeUrl = `/ui/project/${encodeURIComponent(storageVolume.project)}/storage/pool/${encodeURIComponent(storageVolume.pool)}${memberPath}/volumes/${encodeURIComponent(storageVolume.type)}/${encodeURIComponent(storageVolume.name)}`;
-    const newVolumeUrl = `/ui/project/${encodeURIComponent(storageVolume.project)}/storage/pool/${encodeURIComponent(newTarget)}${memberPath}/volumes/${encodeURIComponent(storageVolume.type)}/${encodeURIComponent(storageVolume.name)}`;
-
-    const volumeLink = (
-      <ResourceLink
-        type="volume"
-        value={storageVolume.name}
-        to={newVolumeUrl}
-      />
-    );
-    const poolLink = (
-      <ResourceLink
-        type="pool"
-        value={newTarget}
-        to={`/ui/project/${encodeURIComponent(storageVolume.project)}/storage/pool/${encodeURIComponent(newTarget)}`}
-      />
-    );
-    toastNotify.success(
-      <>
-        Volume {volumeLink} successfully migrated to pool {poolLink}
-      </>,
-    );
-
-    if (window.location.pathname.startsWith(oldVolumeUrl)) {
-      navigate(newVolumeUrl);
-    }
-  };
-
-  const notifyFailure = (
-    e: unknown,
-    volumeName: string,
-    targetPool: string,
-  ) => {
-    setVolumeLoading(false);
-    toastNotify.failure(
-      `Migration failed for volume ${volumeName} to pool ${targetPool}`,
-      e,
-      <VolumeLinkChip volume={volume} />,
-    );
-  };
-
-  const handleFailure = (
-    msg: string,
-    storageVolume: string,
-    targetPool: string,
-  ) => {
-    notifyFailure(new Error(msg), storageVolume, targetPool);
-  };
-
-  const handleFinish = () => {
-    queryClient.invalidateQueries({
-      queryKey: [queryKeys.storage, volume.name],
-    });
-    setVolumeLoading(false);
-  };
-
-  const handleMigrate = (targetPool: string) => {
-    setVolumeLoading(true);
-    migrateStorageVolume(volume, targetPool, volume.project, volume.location)
-      .then((operation) => {
-        eventQueue.set(
-          operation.metadata.id,
-          () => {
-            handleSuccess(targetPool, volume);
-          },
-          (err) => {
-            handleFailure(err, volume.name, targetPool);
-          },
-          handleFinish,
-        );
-        const volumeLabel = (
-          <ResourceLabel bold type="volume" value={volume.name} />
-        );
-        const poolLink = (
-          <ResourceLink
-            type="pool"
-            value={targetPool}
-            to={`/ui/project/${encodeURIComponent(volume.project)}/storage/pool/${encodeURIComponent(targetPool)}`}
-          />
-        );
-        toastNotify.info(
-          <>
-            Migration started for volume {volumeLabel} to pool {poolLink}
-          </>,
-        );
-        queryClient.invalidateQueries({
-          queryKey: [queryKeys.storage, volume.name, project],
-        });
-      })
-      .catch((e) => {
-        notifyFailure(e, volume.name, targetPool);
-      })
-      .finally(() => {
-        handleClose();
-      });
-  };
+  const isEmpty = volume.used_by?.length === 0;
 
   const handleClose = () => {
     closePortal();
     onClose?.();
   };
 
+  const getTitle = () => {
+    if (!canEditVolume(volume)) {
+      return "You do not have permission to migrate this volume";
+    }
+
+    if (isEmpty) {
+      return "Migrate volume";
+    }
+
+    return "Volume is in use";
+  };
+
   return (
     <>
       {isOpen && (
         <Portal>
-          <MigrateVolumeModal
-            close={handleClose}
-            migrate={handleMigrate}
-            storageVolume={volume}
-          />
+          <MigrateVolumeModal close={handleClose} volume={volume} />
         </Portal>
       )}
       <ActionButton
         onClick={openPortal}
         type="button"
         className={classNames("u-no-margin--bottom has-icon", classname)}
-        loading={isVolumeLoading}
-        disabled={!canEditVolume(volume) || isVolumeLoading}
-        title={
-          canEditVolume(volume)
-            ? "Migrate volume"
-            : "You do not have permission to migrate this volume"
-        }
+        disabled={!canEditVolume(volume) || !isEmpty}
+        title={getTitle()}
       >
         <Icon name="machines" />
         <span>Migrate</span>

--- a/src/pages/storage/MigrateVolumeModal.tsx
+++ b/src/pages/storage/MigrateVolumeModal.tsx
@@ -1,17 +1,36 @@
-import type { FC, KeyboardEvent } from "react";
+import type { FC, KeyboardEvent, ReactNode } from "react";
 import { useState } from "react";
-import { ActionButton, Button, Modal } from "@canonical/react-components";
+import { Modal } from "@canonical/react-components";
 import type { LxdStorageVolume } from "types/storage";
-import StoragePoolSelectTable from "./StoragePoolSelectTable";
+import FormLink from "components/FormLink";
+import { useIsClustered } from "context/useIsClustered";
+import {
+  useStorageVolumeMigration,
+  type VolumeMigrationType,
+} from "util/storageVolumeMigration";
+import StorageVolumePoolMigration from "./StorageVolumePoolMigration";
+import BackLink from "components/BackLink";
+import StorageVolumeClusterMemberMigration from "./StorageVolumeClusterMemberMigration";
+import StorageVolumeProjectMigration from "./StorageVolumeProjectMigration";
+import { isClusterLocalDriver } from "util/storagePool";
+import { useStoragePool } from "context/useStoragePools";
 
 interface Props {
   close: () => void;
-  migrate: (target: string) => void;
-  storageVolume: LxdStorageVolume;
+  volume: LxdStorageVolume;
 }
 
-const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
-  const [selectedPool, setSelectedPool] = useState("");
+const MigrateVolumeModal: FC<Props> = ({ close, volume }) => {
+  const [type, setType] = useState<VolumeMigrationType>("");
+  const [target, setTarget] = useState("");
+  const isClustered = useIsClustered();
+  const { data: pool } = useStoragePool(volume.pool);
+  const { handleMigrate, handleMemberMigrate } = useStorageVolumeMigration({
+    close,
+    volume,
+    type,
+    target,
+  });
 
   const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
     if (e.key === "Escape") {
@@ -19,67 +38,121 @@ const MigrateVolumeModal: FC<Props> = ({ close, migrate, storageVolume }) => {
     }
   };
 
-  const handleCancel = () => {
-    if (selectedPool) {
-      setSelectedPool("");
+  const handleGoBack = () => {
+    // if target is set, we are on the confirmation stage
+    if (target) {
+      setTarget("");
       return;
     }
-
-    close();
+    // if type is set, we are on migration target selection stage
+    if (type) {
+      setType("");
+      return;
+    }
   };
 
-  const modalTitle = selectedPool
-    ? "Confirm migration"
-    : `Choose storage pool for volume ${storageVolume.name}`;
-
-  const summary = (
-    <div className="migrate-instance-summary">
-      <p>
-        This will migrate volume <strong>{storageVolume.name}</strong> to
-        storage pool <b>{selectedPool}</b>.
-      </p>
-    </div>
-  );
+  const renderTitle = (): ReactNode => {
+    if (!type) {
+      return "Choose migration method";
+    }
+    if (target) {
+      return (
+        <BackLink
+          title="Confirm migration"
+          linkText={`Choose ${type}`}
+          onClick={handleGoBack}
+        />
+      );
+    }
+    return (
+      <BackLink
+        title={
+          <>
+            Choose {type} for volume <strong>{volume.name}</strong>
+          </>
+        }
+        linkText="Choose migration method"
+        onClick={handleGoBack}
+      />
+    );
+  };
 
   return (
     <Modal
       close={close}
       className="migrate-instance-modal"
-      title={modalTitle}
-      buttonRow={
-        <div id="migrate-instance-actions">
-          <Button
-            className="u-no-margin--bottom"
-            type="button"
-            aria-label="cancel migrate"
-            appearance="base"
-            onClick={handleCancel}
-          >
-            Cancel
-          </Button>
-          <ActionButton
-            appearance="positive"
-            className="u-no-margin--bottom"
-            onClick={() => {
-              migrate(selectedPool);
-            }}
-            disabled={!selectedPool}
-          >
-            Migrate
-          </ActionButton>
-        </div>
-      }
       onKeyDown={handleEscKey}
     >
-      {selectedPool ? (
-        summary
-      ) : (
-        <StoragePoolSelectTable
-          onSelect={setSelectedPool}
-          disablePool={{
-            name: storageVolume.pool,
-            reason: "Volume is already in this pool",
-          }}
+      <header className="p-modal__header">
+        <h2
+          className="p-modal__title"
+          key={type ? (target ? "confirm" : "select") : "start"}
+          id="migrate-title"
+        >
+          {renderTitle()}
+        </h2>
+        <button
+          className="p-modal__close"
+          aria-label="Close active modal"
+          onClick={close}
+        >
+          Close
+        </button>
+      </header>
+      {!type && (
+        <div className="choose-migration-type">
+          {isClustered && isClusterLocalDriver(pool?.driver || "") && (
+            <FormLink
+              icon="cluster-host"
+              title="Migrate volume to a different cluster member"
+              onClick={() => {
+                setType("cluster member");
+              }}
+            />
+          )}
+          <FormLink
+            icon="switcher-dashboard"
+            title={`Move volume to a different storage pool`}
+            onClick={() => {
+              setType("pool");
+            }}
+          />
+          <FormLink
+            icon="folder"
+            title="Move volume to a different project"
+            onClick={() => {
+              setType("project");
+            }}
+          />
+        </div>
+      )}
+
+      {type === "cluster member" && (
+        <StorageVolumeClusterMemberMigration
+          volume={volume}
+          onSelect={setTarget}
+          targetMember={target}
+          onCancel={handleGoBack}
+          migrate={handleMemberMigrate}
+        />
+      )}
+
+      {type === "pool" && (
+        <StorageVolumePoolMigration
+          volume={volume}
+          onSelect={setTarget}
+          onCancel={handleGoBack}
+          migrate={handleMigrate}
+        />
+      )}
+
+      {type === "project" && (
+        <StorageVolumeProjectMigration
+          volume={volume}
+          onSelect={setTarget}
+          targetProject={target}
+          onCancel={handleGoBack}
+          migrate={handleMigrate}
         />
       )}
     </Modal>

--- a/src/pages/storage/StorageVolumeClusterMemberMigration.tsx
+++ b/src/pages/storage/StorageVolumeClusterMemberMigration.tsx
@@ -1,0 +1,67 @@
+import type { FC } from "react";
+import { ActionButton, Button } from "@canonical/react-components";
+import ClusterMemberSelectTable from "../cluster/ClusterMemberSelectTable";
+import type { LxdStorageVolume } from "types/storage";
+
+interface Props {
+  volume: LxdStorageVolume;
+  onSelect: (member: string) => void;
+  targetMember: string;
+  onCancel: () => void;
+  migrate: (member: string) => void;
+}
+
+const StorageVolumeClusterMemberMigration: FC<Props> = ({
+  volume,
+  onSelect,
+  targetMember,
+  onCancel,
+  migrate,
+}) => {
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate volume <strong>{volume.name}</strong> to cluster
+        member <b>{targetMember}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      {targetMember && summary}
+      {!targetMember && (
+        <ClusterMemberSelectTable
+          onSelect={onSelect}
+          disableMember={{
+            name: volume.location,
+            reason: "Volume already on this member",
+          }}
+        />
+      )}
+      <footer id="migrate-volume-actions" className="p-modal__footer">
+        <Button
+          className="u-no-margin--bottom"
+          type="button"
+          aria-label="cancel migrate"
+          appearance="base"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="positive"
+          className="u-no-margin--bottom"
+          onClick={() => {
+            migrate(targetMember);
+          }}
+          disabled={!targetMember}
+        >
+          Migrate
+        </ActionButton>
+      </footer>
+    </>
+  );
+};
+
+export default StorageVolumeClusterMemberMigration;

--- a/src/pages/storage/StorageVolumeDetailActions.tsx
+++ b/src/pages/storage/StorageVolumeDetailActions.tsx
@@ -33,12 +33,7 @@ const StorageVolumeDetailActions: FC<Props> = ({ volume, project }) => {
     : "p-segmented-control__button";
 
   const menuElements = [
-    <MigrateVolumeBtn
-      key="migrate"
-      volume={volume}
-      project={project}
-      classname={classname}
-    />,
+    <MigrateVolumeBtn key="migrate" volume={volume} classname={classname} />,
     ...(hasClusterInternalCustomVolumeCopy
       ? [<CopyVolumeBtn key="copy" volume={volume} classname={classname} />]
       : []),

--- a/src/pages/storage/StorageVolumePoolMigration.tsx
+++ b/src/pages/storage/StorageVolumePoolMigration.tsx
@@ -1,0 +1,74 @@
+import { useState, type FC } from "react";
+import { ActionButton, Button } from "@canonical/react-components";
+import type { LxdStorageVolume } from "types/storage";
+import StoragePoolSelectTable from "./StoragePoolSelectTable";
+
+interface Props {
+  volume: LxdStorageVolume;
+  onSelect: (pool: string) => void;
+  onCancel: () => void;
+  migrate: (pool: string) => void;
+}
+
+const StorageVolumePoolMigration: FC<Props> = ({
+  volume,
+  onSelect,
+  onCancel,
+  migrate,
+}) => {
+  const [selectedPool, setSelectedPool] = useState("");
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate volume <strong>{volume.name}</strong> to storage pool{" "}
+        <b>{selectedPool}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      {selectedPool ? (
+        summary
+      ) : (
+        <StoragePoolSelectTable
+          onSelect={(selectedPool) => {
+            setSelectedPool(selectedPool);
+            onSelect(selectedPool);
+          }}
+          disablePool={{
+            name: volume.pool,
+            reason: "Volume is already in this pool",
+          }}
+        />
+      )}
+
+      <footer id="migrate-volume-actions" className="p-modal__footer">
+        <Button
+          className="u-no-margin--bottom"
+          type="button"
+          aria-label="cancel migrate"
+          appearance="base"
+          onClick={() => {
+            onCancel();
+            setSelectedPool("");
+          }}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="positive"
+          className="u-no-margin--bottom"
+          onClick={() => {
+            migrate(selectedPool);
+          }}
+          disabled={!selectedPool}
+        >
+          Migrate
+        </ActionButton>
+      </footer>
+    </>
+  );
+};
+
+export default StorageVolumePoolMigration;

--- a/src/pages/storage/StorageVolumeProjectMigration.tsx
+++ b/src/pages/storage/StorageVolumeProjectMigration.tsx
@@ -1,0 +1,67 @@
+import type { FC } from "react";
+import { ActionButton, Button } from "@canonical/react-components";
+import ProjectSelectTable from "pages/projects/ProjectSelectTable";
+import type { LxdStorageVolume } from "types/storage";
+
+interface Props {
+  volume: LxdStorageVolume;
+  onSelect: (pool: string) => void;
+  targetProject: string;
+  onCancel: () => void;
+  migrate: (pool: string) => void;
+}
+
+const StorageVolumeProjectMigration: FC<Props> = ({
+  volume,
+  onSelect,
+  targetProject,
+  onCancel,
+  migrate,
+}) => {
+  const summary = (
+    <div className="migrate-instance-summary">
+      <p>
+        This will migrate the volume <strong>{volume.name}</strong> to the
+        project <b>{targetProject}</b>.
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      {targetProject && summary}
+      {!targetProject && (
+        <ProjectSelectTable
+          onSelect={onSelect}
+          disableProject={{
+            name: volume.project,
+            reason: "Volume already in this project",
+          }}
+        />
+      )}
+      <footer id="migrate-volume-actions" className="p-modal__footer">
+        <Button
+          className="u-no-margin--bottom"
+          type="button"
+          aria-label="cancel migrate"
+          appearance="base"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          appearance="positive"
+          className="u-no-margin--bottom"
+          onClick={() => {
+            migrate(targetProject);
+          }}
+          disabled={!targetProject}
+        >
+          Migrate
+        </ActionButton>
+      </footer>
+    </>
+  );
+};
+
+export default StorageVolumeProjectMigration;

--- a/src/util/storageVolumeMigration.tsx
+++ b/src/util/storageVolumeMigration.tsx
@@ -1,0 +1,272 @@
+import { useToastNotification } from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  copyStorageVolume,
+  deleteStorageVolume,
+  migrateStorageVolume,
+} from "api/storage-volumes";
+import ResourceLink from "components/ResourceLink";
+import { useEventQueue } from "context/eventQueue";
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import type { LxdStorageVolume } from "types/storage";
+import { capitalizeFirstLetter } from "./helpers";
+import { queryKeys } from "./queryKeys";
+import { linkForVolumeDetail } from "./storageVolume";
+import VolumeLinkChip from "pages/storage/VolumeLinkChip";
+
+export type VolumeMigrationType = "cluster member" | "pool" | "project" | "";
+
+interface Props {
+  volume: LxdStorageVolume;
+  type: VolumeMigrationType;
+  target: string;
+  close: () => void;
+}
+
+export const useStorageVolumeMigration = ({
+  volume,
+  close,
+  type,
+  target,
+}: Props) => {
+  const toastNotify = useToastNotification();
+  const eventQueue = useEventQueue();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const handleSuccess = () => {
+    let successMessage: ReactNode = "";
+
+    const oldVolumeDetailPage = linkForVolumeDetail(volume);
+    const newVolumeDetailPage = linkForVolumeDetail({
+      ...volume,
+      project: type === "project" ? target : volume.project,
+      pool: type === "pool" ? target : volume.pool,
+      location: type === "cluster member" ? target : volume.location,
+    } as LxdStorageVolume);
+
+    const poolLink = (
+      <ResourceLink
+        type="pool"
+        value={target}
+        to={`/ui/project/${encodeURIComponent(volume.project)}/storage/pool/${encodeURIComponent(target)}`}
+      />
+    );
+
+    if (type === "cluster member") {
+      successMessage = (
+        <>
+          Volume <VolumeLinkChip volume={{ ...volume, location: target }} />{" "}
+          successfully migrated to cluster member{" "}
+          <ResourceLink
+            type="cluster-member"
+            value={target}
+            to={`/ui/cluster/member/${encodeURIComponent(target)}`}
+          />
+        </>
+      );
+
+      if (oldVolumeDetailPage !== newVolumeDetailPage) {
+        navigate(newVolumeDetailPage);
+      }
+    }
+
+    if (type === "pool") {
+      successMessage = (
+        <>
+          Volume <VolumeLinkChip volume={{ ...volume, pool: target }} />
+          successfully migrated to pool {poolLink}
+        </>
+      );
+      if (oldVolumeDetailPage !== newVolumeDetailPage) {
+        navigate(newVolumeDetailPage);
+      }
+    }
+
+    if (type === "project") {
+      successMessage = (
+        <>
+          Volume <VolumeLinkChip volume={{ ...volume, project: target }} />
+          successfully moved to project{" "}
+          <ResourceLink
+            type="project"
+            value={target}
+            to={`/ui/project/${encodeURIComponent(target)}`}
+          />
+        </>
+      );
+
+      if (oldVolumeDetailPage !== newVolumeDetailPage) {
+        navigate(newVolumeDetailPage);
+      }
+    }
+
+    toastNotify.success(successMessage);
+  };
+
+  const notifyFailure = (e: unknown) => {
+    let failureMessage = "";
+    if (type === "cluster member") {
+      failureMessage = `Cluster member migration failed for volume ${volume.name}`;
+    }
+
+    if (type === "pool") {
+      failureMessage = `Migration failed for volume ${volume.name} to pool ${target}`;
+    }
+
+    if (type === "project") {
+      failureMessage = `Project move failed for volume ${volume.name}`;
+    }
+
+    toastNotify.failure(failureMessage, e, <VolumeLinkChip volume={volume} />);
+  };
+
+  const handleFailure = (msg: string) => {
+    notifyFailure(new Error(msg));
+  };
+
+  const handleFinish = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.volumes, volume.name, volume.project],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.volumes, volume.project],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.operations, volume.project],
+    });
+  };
+
+  const handleMigrate = () => {
+    const targetPool = type === "pool" ? target : undefined;
+    const targetProject = type === "project" ? target : undefined;
+
+    migrateStorageVolume(
+      volume,
+      volume.project,
+      targetPool,
+      volume.location,
+      targetProject,
+    )
+      .then((operation) => {
+        eventQueue.set(
+          operation.metadata.id,
+          () => {
+            handleSuccess();
+          },
+          (err) => {
+            handleFailure(err);
+          },
+          handleFinish,
+        );
+        toastNotify.info(
+          <>
+            {capitalizeFirstLetter(type)} migration started for{" "}
+            <VolumeLinkChip volume={volume} />.
+          </>,
+        );
+        queryClient.invalidateQueries({
+          queryKey: [queryKeys.volumes, volume.name, volume.project],
+        });
+      })
+      .catch((e) => {
+        notifyFailure(e);
+      })
+      .finally(() => {
+        close();
+      });
+  };
+
+  const handleMemberMigrate = () => {
+    // Copies volume to a new cluster member and deletes the old volume.
+    const targetMember = type === "cluster member" ? target : undefined;
+    const oldMember = volume.location;
+
+    const payload: Partial<LxdStorageVolume> = {
+      name: volume.name,
+      type: "custom",
+      config: volume.config,
+      description: volume.description,
+      content_type: volume.content_type,
+      source: {
+        name: volume.name,
+        type: "copy",
+        pool: volume.pool,
+        volume_only: false,
+        project: volume.project,
+        location: volume.location,
+      },
+    };
+
+    copyStorageVolume(payload, volume.pool, volume.project, targetMember)
+      .then((operation) => {
+        toastNotify.info(
+          <>
+            {capitalizeFirstLetter(type)} migration started for{" "}
+            <VolumeLinkChip volume={volume} />.
+          </>,
+        );
+        eventQueue.set(
+          operation.metadata.id,
+          () => {
+            queryClient.invalidateQueries({
+              queryKey: [queryKeys.volumes, volume.name, volume.project],
+            });
+
+            deleteStorageVolume(
+              volume.name,
+              volume.pool,
+              volume.project,
+              oldMember,
+            ).then((operation) => {
+              eventQueue.set(
+                operation.metadata.id,
+                () => {
+                  handleSuccess();
+                },
+                (err) => {
+                  handleFailure(err);
+                },
+                handleFinish,
+              );
+
+              queryClient.invalidateQueries({
+                queryKey: [queryKeys.isoVolumes],
+              });
+              queryClient.invalidateQueries({
+                queryKey: [queryKeys.projects, volume.project],
+              });
+              queryClient.invalidateQueries({
+                queryKey: [
+                  queryKeys.storage,
+                  volume.pool,
+                  queryKeys.volumes,
+                  volume.project,
+                  volume.location,
+                ],
+              });
+              queryClient.invalidateQueries({
+                predicate: (query) => query.queryKey[0] === queryKeys.volumes,
+              });
+            });
+          },
+          (err) => {
+            handleFailure(err);
+          },
+          handleFinish,
+        );
+      })
+      .catch((e) => {
+        notifyFailure(e);
+      })
+      .finally(() => {
+        close();
+      });
+  };
+
+  return {
+    handleMigrate,
+    handleMemberMigrate,
+  };
+};

--- a/tests/helpers/storageVolume.ts
+++ b/tests/helpers/storageVolume.ts
@@ -73,7 +73,7 @@ export const saveVolume = async (page: Page, volume: string) => {
   await page.waitForSelector(`text=Storage volume ${volume} updated.`);
 };
 
-export const migrateVolume = async (
+export const migrateVolumePool = async (
   page: Page,
   volume: string,
   targetPool: string,
@@ -82,13 +82,16 @@ export const migrateVolume = async (
   await visitVolume(page, volume);
   await page.getByRole("button", { name: "Migrate", exact: true }).click();
   await page
-    .getByRole("dialog", { name: `Choose storage pool for volume ${volume}` })
+    .getByRole("button", { name: "Move volume to a different storage pool" })
+    .click();
+  await page
+    .getByRole("dialog")
     .locator("tr")
     .filter({ hasText: targetPool })
     .getByRole("button")
     .click();
   await page
-    .getByLabel("Confirm migration")
+    .locator("#migrate-volume-actions")
     .getByRole("button", { name: "Migrate", exact: true })
     .click();
 

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -11,10 +11,10 @@ import {
   deleteVolume,
   copyStorageVolume,
   editVolume,
-  migrateVolume,
   randomVolumeName,
   saveVolume,
   visitVolume,
+  migrateVolumePool,
 } from "./helpers/storageVolume";
 import { activateOverride, setInput } from "./helpers/configuration";
 import { randomSnapshotName } from "./helpers/snapshots";
@@ -69,15 +69,15 @@ test("storage volume create, edit and remove", async ({ page }) => {
   await assertTextVisible(page, "size2GiB");
 });
 
-test("storage volume migrate", async ({ page }) => {
+test("storage volume migrate pool", async ({ page }) => {
   const pool2 = randomPoolName();
   await createPool(page, pool2);
 
-  await migrateVolume(page, volume, pool2);
+  await migrateVolumePool(page, volume, pool2);
   await expect(page.getByRole("cell", { name: pool2 })).toBeVisible();
 
   //Migrate back to default so that the Pool can be deleted
-  await migrateVolume(page, volume, "default");
+  await migrateVolumePool(page, volume, "default");
   await deletePool(page, pool2);
 });
 


### PR DESCRIPTION
## Done

- [x] Restructure files for the new nested modal system
- [x] Recreate old Pool migration flow
- [x] Create new cluster member migration flow
- [x] Fix any tests
- [x] Migrate storage volumes across projects

Outstanding questions / issues
- ~~Upon successful migration, the cluster member page does not update the pool shown. Query key issue? Should the UI navigate to the new storage volume link, as the old link is now ineffective. Refreshing the page at this stage show an error (expected).~~ [FIXED]
- ~~Cluster member migration at the API level doesn't seem to be working. Is there a specific way the API should be structured?~~ [FIXED]


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to Storage Volume > Any Custom Storage Volume > Ensure that the two migration flows, work.
    - A clustered environment is required.

## Screenshots (may be outdated)

<img width="852" height="410" alt="image" src="https://github.com/user-attachments/assets/4a78b574-3fa6-43bf-89de-e3963fec8c37" />
<img width="1503" height="976" alt="image" src="https://github.com/user-attachments/assets/28185ad3-6568-4ed7-9e5f-bacebc59fb22" />
<img width="908" height="642" alt="image" src="https://github.com/user-attachments/assets/46b221f8-4c45-43f7-a2e8-e011d06a204d" />
