### PR TITLE
feature:[WD-31497] revamp nic static ip

### DIFF
--- a/src/components/PrefixedInput.tsx
+++ b/src/components/PrefixedInput.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react";
+import { useLayoutEffect, useRef } from "react";
+
+import type { InputProps } from "@canonical/react-components";
+import { Input } from "@canonical/react-components";
+import classNames from "classnames";
+
+export type PrefixedInputProps = Omit<InputProps, "type"> & {
+  immutableText: string;
+};
+
+const PrefixedInput = ({
+  immutableText,
+  ...props
+}: PrefixedInputProps): ReactElement => {
+  const prefixTextRef = useRef<HTMLDivElement>(null);
+  const inputWrapperRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const prefixElement = prefixTextRef.current;
+    const inputElement = inputWrapperRef.current?.querySelector("input");
+
+    if (prefixElement && inputElement) {
+      // Adjust the left padding of the input to be the same width as the immutable text.
+      // This displays the user input and the unchangeable text together as one combined string.
+      const prefixWidth = prefixElement.getBoundingClientRect().width;
+      inputElement.style.paddingLeft = `${prefixWidth}px`;
+    }
+  }, [immutableText, props.label]);
+  return (
+    <div
+      className={classNames("prefixed-input", {
+        "prefixed-input--with-label": !!props.label,
+      })}
+    >
+      <div className="prefixed-input__text" ref={prefixTextRef}>
+        {immutableText}
+      </div>
+      <div ref={inputWrapperRef}>
+        <Input
+          className={classNames("prefixed-input__input", props.className)}
+          type="text"
+          wrapperClassName={classNames(
+            "prefixed-input__wrapper",
+            props.wrapperClassName,
+          )}
+          {...props}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PrefixedInput;

--- a/src/components/PrefixedIpInput.tsx
+++ b/src/components/PrefixedIpInput.tsx
@@ -1,0 +1,105 @@
+import { type ClipboardEvent, type ReactElement } from "react";
+import PrefixedInput from "./PrefixedInput";
+import type { PrefixedInputProps } from "./PrefixedInput";
+import { getImmutableAndEditable, isIPv4 } from "util/subnetIpRange";
+
+type Props = Omit<
+  PrefixedInputProps,
+  "immutableText" | "maxLength" | "placeholder" | "name"
+> & {
+  cidr: string;
+  ip: string;
+  name: string;
+  onIpChange: (ip: string) => void;
+};
+
+const PrefixedIpInput = ({
+  cidr,
+  help,
+  onIpChange,
+  ip,
+  name,
+  ...props
+}: Props): ReactElement => {
+  const [networkAddress] = cidr.split("/");
+  const isIPV4 = isIPv4(networkAddress);
+
+  const [immutable, editable] = getImmutableAndEditable(cidr);
+
+  const inputValue = isIPV4
+    ? ip.split(".").slice(immutable.split(".").length).join(".")
+    : ip.replace(immutable, "");
+
+  const getIPv4MaxLength = () => {
+    const immutableOctetsLength = immutable.split(".").length;
+    const lengths = [15, 11, 7, 3]; // Corresponding to 0-3 immutable octets
+    return lengths[immutableOctetsLength];
+  };
+
+  const maxLength = isIPV4 ? getIPv4MaxLength() : editable.length;
+  const placeholder = props.disabled ? "" : editable;
+
+  const setIp = (editableValue: string) => {
+    const fullIp = editableValue
+      ? isIPV4
+        ? `${immutable}.${editableValue}`
+        : `${immutable}${editableValue}`
+      : "";
+    onIpChange(fullIp);
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pastedText = e.clipboardData.getData("text");
+    if (isIPV4) {
+      const octets = pastedText.split(".");
+      const trimmed = octets.slice(0 - editable.split(".").length);
+      const ip = trimmed.join(".");
+      setIp(ip);
+    } else {
+      const ip = pastedText.replace(immutable, "");
+      setIp(ip);
+    }
+  };
+  return (
+    <PrefixedInput
+      help={
+        help ? (
+          help
+        ) : (
+          <>
+            {isIPV4 ? (
+              <>
+                The available range in this subnet is{" "}
+                <code>
+                  {immutable}.{editable}
+                </code>
+              </>
+            ) : (
+              <>
+                The available IPV6 address range is{" "}
+                <code>
+                  {immutable}
+                  {editable}
+                </code>
+              </>
+            )}
+            . If left empty, the address will be dynamically assigned.
+          </>
+        )
+      }
+      immutableText={isIPV4 ? `${immutable}.` : immutable}
+      maxLength={maxLength}
+      name={name}
+      onPaste={handlePaste}
+      value={inputValue}
+      onChange={(e) => {
+        setIp(e.target.value);
+      }}
+      placeholder={placeholder}
+      {...props}
+    />
+  );
+};
+
+export default PrefixedIpInput;

--- a/src/components/forms/NetworkDevicesForm/edit/NetworkDeviceIPAddressEdit.tsx
+++ b/src/components/forms/NetworkDevicesForm/edit/NetworkDeviceIPAddressEdit.tsx
@@ -1,9 +1,9 @@
 import { type FC } from "react";
-import { Input } from "@canonical/react-components";
 import { type LxdNetwork } from "types/network";
 import { typesWithNicStaticIPSupport } from "util/networks";
 import type { NetworkDeviceFormValues } from "components/forms/NetworkDevicesForm/edit/NetworkDevicePanel";
 import type { FormikProps } from "formik";
+import PrefixedIpInput from "components/PrefixedIpInput";
 
 interface Props {
   formik: FormikProps<NetworkDeviceFormValues>;
@@ -23,28 +23,23 @@ const NetworkDeviceIPAddressEdit: FC<Props> = ({ formik, network, family }) => {
   const isEnabled =
     network?.managed &&
     typesWithNicStaticIPSupport.includes(network.type) &&
-    ipAddressConfigValue !== "none";
-
+    ipAddressConfigValue !== "none" &&
+    ipAddressConfigValue !== undefined;
   return (
-    <Input
+    <PrefixedIpInput
       id={formikFieldName}
       name={formikFieldName}
-      type="text"
+      cidr={ipAddressConfigValue || ""}
+      ip={formik.values[formikFieldName] || ""}
       label={`${family} address reservation`}
-      placeholder={`Enter ${family} address`}
-      value={formik.values[formikFieldName] || ""}
-      onChange={(e) => {
-        void formik.setFieldValue(formikFieldName, e.target.value);
+      onIpChange={(ip: string) => {
+        formik.setFieldValue(formikFieldName, ip);
       }}
       onBlur={() => {
         void formik.setFieldTouched(formikFieldName, true);
       }}
       disabled={!isEnabled}
-      help={
-        isEnabled
-          ? `Choose an ${family} address within the subnet range ${ipAddressConfigValue || ""}, or leave empty for dynamic assignment`
-          : `Static ${family} is not available for this network`
-      }
+      help={!isEnabled && `Static ${family} is not available for this network`}
     />
   );
 };

--- a/src/sass/_prefixed_ip_input.scss
+++ b/src/sass/_prefixed_ip_input.scss
@@ -1,0 +1,16 @@
+.prefixed-input {
+  position: relative;
+
+  .prefixed-input__text {
+    padding-left: $spv--small;
+    padding-top: 0.25rem;
+    pointer-events: none;
+    position: absolute;
+  }
+
+  &--with-label {
+    .prefixed-input__text {
+      top: 2.5rem;
+    }
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -127,6 +127,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "permission_idp_groups";
 @import "permission_group_selection";
 @import "permission_groups";
+@import "prefixed_ip_input";
 @import "profile_detail_overview";
 @import "profile_detail_panel";
 @import "profile_list";

--- a/src/util/subnetIpRange.spec.ts
+++ b/src/util/subnetIpRange.spec.ts
@@ -1,0 +1,130 @@
+import {
+  getImmutableAndEditable,
+  getImmutableAndEditableOctets,
+  getIpRangeFromCidr,
+  isIpInSubnet,
+  isIPv4,
+} from "./subnetIpRange";
+
+describe("isIPv4", () => {
+  it("returns true for valid IPv4 addresses", () => {
+    expect(isIPv4("192.168.1.1")).toBe(true);
+    expect(isIPv4("255.255.255.255")).toBe(true);
+    expect(isIPv4("0.0.0.0")).toBe(true);
+  });
+  it("returns false for invalid IPv4 addresses", () => {
+    expect(isIPv4("256.256.256.256")).toBe(false);
+    expect(isIPv4("192.168.1")).toBe(false);
+    expect(isIPv4("abc.def.ghi.jkl")).toBe(false);
+    expect(isIPv4("1234.123.123.123")).toBe(false);
+  });
+});
+
+describe("getIpRangeFromCidr", () => {
+  it("returns the start and end IP of a subnet", () => {
+    expect(getIpRangeFromCidr("10.0.0.0/26")).toEqual([
+      "10.0.0.1",
+      "10.0.0.62",
+    ]);
+
+    expect(getIpRangeFromCidr("10.0.0.0/25")).toEqual([
+      "10.0.0.1",
+      "10.0.0.126",
+    ]);
+
+    expect(getIpRangeFromCidr("10.0.0.0/24")).toEqual([
+      "10.0.0.1",
+      "10.0.0.254",
+    ]);
+
+    expect(getIpRangeFromCidr("10.0.0.0/23")).toEqual([
+      "10.0.0.1",
+      "10.0.1.254",
+    ]);
+
+    expect(getIpRangeFromCidr("10.0.0.0/22")).toEqual([
+      "10.0.0.1",
+      "10.0.3.254",
+    ]);
+  });
+});
+
+describe("isIpInSubnet", () => {
+  it("returns true if an IP is in a subnet", () => {
+    expect(isIpInSubnet("10.0.0.1", "10.0.0.0/24")).toBe(true);
+    expect(isIpInSubnet("10.0.0.254", "10.0.0.0/24")).toBe(true);
+    expect(isIpInSubnet("192.168.0.1", "192.168.0.0/24")).toBe(true);
+    expect(isIpInSubnet("192.168.0.254", "192.168.0.0/24")).toBe(true);
+    expect(isIpInSubnet("192.168.1.1", "192.168.0.0/23")).toBe(true);
+  });
+
+  it("returns false if an IP is not in a subnet", () => {
+    expect(isIpInSubnet("10.0.1.0", "10.0.0.0/24")).toBe(false);
+    expect(isIpInSubnet("10.1.0.0", "10.0.0.0/24")).toBe(false);
+    expect(isIpInSubnet("11.0.0.0", "10.0.0.0/24")).toBe(false);
+    expect(isIpInSubnet("192.168.1.255", "192.168.0.0/23")).toBe(false);
+    expect(isIpInSubnet("10.0.0.1", "192.168.0.0/24")).toBe(false);
+    expect(isIpInSubnet("192.168.2.1", "192.168.0.0/24")).toBe(false);
+    expect(isIpInSubnet("172.16.0.1", "192.168.0.0/24")).toBe(false);
+  });
+
+  it("returns false for the network and broadcast addresses", () => {
+    expect(isIpInSubnet("10.0.0.0", "10.0.0.0/24")).toBe(false);
+    expect(isIpInSubnet("10.0.0.255", "10.0.0.0/24")).toBe(false);
+  });
+});
+
+describe("getImmutableAndEditableOctets", () => {
+  it("returns the immutable and editable octets for a given subnet range", () => {
+    expect(getImmutableAndEditableOctets("10.0.0.1", "10.0.0.254")).toEqual([
+      "10.0.0",
+      "[1-254]",
+    ]);
+    expect(getImmutableAndEditableOctets("10.0.0.1", "10.0.255.254")).toEqual([
+      "10.0",
+      "[0-255].[1-254]",
+    ]);
+    expect(getImmutableAndEditableOctets("10.0.0.1", "10.255.255.254")).toEqual(
+      ["10", "[0-255].[0-255].[1-254]"],
+    );
+    expect(getImmutableAndEditableOctets("10.0.0.1", "20.255.255.254")).toEqual(
+      ["", "[10-20].[0-255].[0-255].[1-254]"],
+    );
+  });
+});
+
+describe("getImmutableAndEditable", () => {
+  it("returns the immutable and editable parts of an IPv4 subnet", () => {
+    expect(getImmutableAndEditable("10.0.0.0/24")).toEqual([
+      "10.0.0",
+      "[1-254]",
+    ]);
+    expect(getImmutableAndEditable("192.168.1.0/24")).toEqual([
+      "192.168.1",
+      "[1-254]",
+    ]);
+    expect(getImmutableAndEditable("192.168.0.0/23")).toEqual([
+      "192.168",
+      "[0-1].[1-254]",
+    ]);
+    expect(getImmutableAndEditable("172.16.0.0/12")).toEqual([
+      "172",
+      "[16-31].[0-255].[1-254]",
+    ]);
+  });
+
+  it("returns the immutable and editable parts of an IPv6 subnet", () => {
+    expect(getImmutableAndEditable("2001:0db8:85a3::/64")).toEqual([
+      "2001:0db8:85a3:",
+      "0000:0000:0000:0000:0000",
+    ]);
+    expect(getImmutableAndEditable("fd00:1234:5678::/48")).toEqual([
+      "fd00:1234:5678:",
+      "0000:0000:0000:0000:0000",
+    ]);
+    expect(getImmutableAndEditable("fe80::/10")).toEqual([
+      "fe80:",
+      "0000:0000:0000:0000:0000:0000:0000",
+    ]);
+  });
+});

--- a/src/util/subnetIpRange.tsx
+++ b/src/util/subnetIpRange.tsx
@@ -1,0 +1,134 @@
+/**
+ * Checks if a given IP address is a valid IPv4 address.
+ * @param ip The IP address to check
+ * @returns True if the IP is a valid IPv4 address, false otherwise
+ */
+export const isIPv4 = (ip: string) => {
+  const ipv4Regex =
+    /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/;
+
+  return ipv4Regex.test(ip);
+};
+
+/**
+ * Takes a subnet CIDR notation (IPv4) and returns the first and last IP of the subnet.
+ * The network and host addresses are excluded.
+ *
+ * @param cidr The CIDR notation of the subnet
+ * @returns The first and last valid IP addresses as two strings in a list.
+ */
+export const getIpRangeFromCidr = (cidr: string): string[] => {
+  // https://gist.github.com/binarymax/6114792
+
+  // Get start IP and number of valid addresses
+  const [startIp, mask] = cidr.split("/");
+  const numberOfAddresses = (1 << (32 - parseInt(mask))) - 1;
+
+  // IPv4 can be represented by an unsigned 32-bit integer, so we can use a Uint32Array to store the IP
+  const buffer = new ArrayBuffer(4); //4 octets
+  const int32 = new Uint32Array(buffer);
+
+  // Convert starting IP to Uint32 and add the number of addresses to get the end IP.
+  // Subtract 1 from the number of addresses to exclude the broadcast address.
+  int32[0] = convertIpToUint32(startIp) + numberOfAddresses - 1;
+
+  // Convert the buffer to a Uint8Array to get the octets, then convert it to an array
+  const arrayApplyBuffer = Array.from(new Uint8Array(buffer));
+
+  // Reverse the octets and join them with "." to get the end IP
+  const endIp = arrayApplyBuffer.reverse().join(".");
+
+  const firstValidIp = getFirstValidIp(startIp);
+
+  return [firstValidIp, endIp];
+};
+
+const getFirstValidIp = (ip: string) => {
+  const buffer = new ArrayBuffer(4); //4 octets
+  const int32 = new Uint32Array(buffer);
+
+  // add 1 because the first IP is the network address
+  int32[0] = convertIpToUint32(ip) + 1;
+
+  const arrayApplyBuffer = Array.from(new Uint8Array(buffer));
+
+  return arrayApplyBuffer.reverse().join(".");
+};
+
+const convertIpToUint32 = (ip: string) => {
+  const octets = ip.split(".").map((a) => parseInt(a));
+  const buffer = new ArrayBuffer(4);
+  const int32 = new Uint32Array(buffer);
+  int32[0] =
+    (octets[0] << 24) + (octets[1] << 16) + (octets[2] << 8) + octets[3];
+  return int32[0];
+};
+
+/**
+ * Checks if an IPv4 address is valid for the given subnet.
+ *
+ * @param ip The IPv4 address to check, as a string
+ * @param cidr The subnet's CIDR notation e.g. 192.168.0.0/24
+ * @returns True if the IP is in the subnet, false otherwise
+ */
+export const isIpInSubnet = (ip: string, cidr: string): boolean => {
+  const [startIP, endIP] = getIpRangeFromCidr(cidr);
+
+  const ipUint32 = convertIpToUint32(ip);
+  const startIPUint32 = convertIpToUint32(startIP);
+  const endIPUint32 = convertIpToUint32(endIP);
+
+  return ipUint32 >= startIPUint32 && ipUint32 <= endIPUint32;
+};
+
+/**
+ * Separates the immutable and editable octets of an IPv4 subnet range.
+ *
+ * @param startIp The start IP of the subnet
+ * @param endIp The end IP of the subnet
+ * @returns The immutable and editable octects as two strings in a list
+ */
+export const getImmutableAndEditableOctets = (
+  startIp: string,
+  endIp: string,
+): string[] => {
+  const startIpOctetList = startIp.split(".");
+  const endIpOctetList = endIp.split(".");
+
+  const immutable: string[] = [];
+  const editable: string[] = [];
+
+  startIpOctetList.forEach((octet, index) => {
+    if (octet === endIpOctetList[index]) {
+      immutable.push(octet);
+    } else {
+      editable.push(`[${octet}-${endIpOctetList[index]}]`);
+    }
+  });
+
+  return [immutable.join("."), editable.join(".")];
+};
+
+/**
+ * Get the immutable and editable parts of an IPv4 or IPv6 subnet.
+ *
+ * @param cidr The CIDR notation of the subnet
+ * @returns The immutable and editable  as two strings in a list
+ */
+export const getImmutableAndEditable = (cidr: string) => {
+  const isIPV4 = isIPv4(cidr.split("/")[0]);
+  if (isIPV4) {
+    const [startIp, endIp] = getIpRangeFromCidr(cidr);
+    return getImmutableAndEditableOctets(startIp, endIp);
+  }
+
+  const [networkAddress] = cidr.split("/");
+  const immutableIPV6 = networkAddress.substring(
+    0,
+    networkAddress.lastIndexOf(":"),
+  );
+  const ipv6PlaceholderColons = 7 - (immutableIPV6.match(/:/g) || []).length; // 7 is the maximum number of colons in an IPv6 address
+  const editableIPV6 = `${"0000:".repeat(ipv6PlaceholderColons)}0000`;
+
+  return [immutableIPV6, editableIPV6];
+};


### PR DESCRIPTION
## Done

- Uses a prefixed input for nic static ip inputs.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to an instance (or create a new one)-> Configuration -> Network
    - Edit an existing network or attach a new one
    - Add static ipv4 and/or ipv6
    - Click Apply changes, then click Save

## Screenshots

<img width="1912" height="1128" alt="image" src="https://github.com/user-attachments/assets/6bd6d216-9e99-42d7-adb0-4e8540695847" />