### PR TITLE
feat(CreateIdentityModal): improve identity creation flow

### DIFF
--- a/src/components/CodeSnippetWithCopyButton.tsx
+++ b/src/components/CodeSnippetWithCopyButton.tsx
@@ -1,29 +1,44 @@
 import type { FC } from "react";
-import {
-  CodeSnippet,
-  CodeSnippetBlockAppearance,
-} from "@canonical/react-components";
+import type { ValueOf } from "@canonical/react-components";
+import { CodeSnippetBlockAppearance } from "@canonical/react-components";
+import { CodeSnippet } from "@canonical/react-components";
 import CopyToClipboard from "components/CopyToClipboard";
 import classnames from "classnames";
 
 interface Props {
   code: string;
   className?: string;
+  appearance?: ValueOf<typeof CodeSnippetBlockAppearance>;
+  title?: string;
+  tooltipMessage?: string;
+  onCopyButtonClick?: () => void;
 }
 
-const CodeSnippetWithCopyButton: FC<Props> = ({ code, className }) => {
+const CodeSnippetWithCopyButton: FC<Props> = ({
+  code,
+  className,
+  appearance = CodeSnippetBlockAppearance.LINUX_PROMPT,
+  title,
+  tooltipMessage,
+  onCopyButtonClick,
+}) => {
   return (
     <CodeSnippet
       className={classnames("code-snippet-with-copy-button-wrapper", className)}
       blocks={[
         {
-          appearance: CodeSnippetBlockAppearance.LINUX_PROMPT,
+          appearance,
+          title,
           code: (
             <div className="command-wrapper">
               <span className="command u-truncate" title={code}>
                 {code}
               </span>
-              <CopyToClipboard value={code} />
+              <CopyToClipboard
+                value={code}
+                tooltipMessage={tooltipMessage}
+                onCopyButtonClick={onCopyButtonClick}
+              />
             </div>
           ),
         },

--- a/src/components/ConfirmationCheckbox.tsx
+++ b/src/components/ConfirmationCheckbox.tsx
@@ -3,11 +3,11 @@ import { CheckboxInput } from "@canonical/react-components";
 
 interface Props {
   label: string;
-  force: [boolean, Dispatch<SetStateAction<boolean>>];
+  confirmed: [boolean, Dispatch<SetStateAction<boolean>>];
 }
 
-const ConfirmationForce: FC<Props> = ({ label, force }) => {
-  const [isForce, setForce] = force;
+const ConfirmationCheckbox: FC<Props> = ({ label, confirmed }) => {
+  const [isConfirmed, setConfirmed] = confirmed;
 
   return (
     <span className="u-float-left">
@@ -15,13 +15,13 @@ const ConfirmationForce: FC<Props> = ({ label, force }) => {
         inline
         label={label}
         tabIndex={-1}
-        defaultChecked={isForce}
+        checked={isConfirmed}
         onClick={() => {
-          setForce((prev) => !prev);
+          setConfirmed((prev) => !prev);
         }}
       />
     </span>
   );
 };
 
-export default ConfirmationForce;
+export default ConfirmationCheckbox;

--- a/src/components/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard.tsx
@@ -5,15 +5,23 @@ import { Button, Icon, Tooltip } from "@canonical/react-components";
 interface Props {
   value: string;
   children?: ReactNode;
+  tooltipMessage?: string;
+  onCopyButtonClick?: () => void;
 }
 
-const CopyToClipboard: FC<Props> = ({ value, children }) => {
+const CopyToClipboard: FC<Props> = ({
+  value,
+  children,
+  tooltipMessage,
+  onCopyButtonClick,
+}) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(value);
       setCopied(true);
+      onCopyButtonClick?.();
 
       setTimeout(() => {
         setCopied(false);
@@ -46,7 +54,7 @@ const CopyToClipboard: FC<Props> = ({ value, children }) => {
           />
         ) : (
           <Tooltip
-            message="Copy"
+            message={tooltipMessage ?? "Copy"}
             position="top-center"
             className="copy-to-clipboard-button-wrapper"
             zIndex={999}

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -19,7 +19,7 @@ import { useInstanceEntitlements } from "util/entitlements/instances";
 import { isInstanceFrozen, isInstanceRunning } from "util/instanceStatus";
 import { Notification } from "@canonical/react-components";
 import { InstanceRichChip } from "../InstanceRichChip";
-import ConfirmationForce from "components/ConfirmationForce";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 
 interface Props {
   instance: LxdInstance;
@@ -180,7 +180,10 @@ const DeleteInstanceBtn: FC<Props> = ({
         onConfirm: handleDelete,
         confirmButtonLabel: "Delete",
         confirmExtra: isRunningOrFrozen ? (
-          <ConfirmationForce label="Force delete" force={[isForce, setForce]} />
+          <ConfirmationCheckbox
+            label="Force delete"
+            confirmed={[isForce, setForce]}
+          />
         ) : undefined,
         confirmButtonDisabled: isRunningOrFrozen && !isForce,
       }}

--- a/src/pages/instances/actions/InstanceBulkActions.tsx
+++ b/src/pages/instances/actions/InstanceBulkActions.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { updateInstanceBulkAction } from "api/instances";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import ConfirmationForce from "components/ConfirmationForce";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import type { LxdInstance, LxdInstanceAction } from "types/instance";
 import {
   instanceActionLabel,
@@ -135,9 +135,9 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
           instances={instances}
           confirmLabel="Restart"
           confirmExtra={
-            <ConfirmationForce
+            <ConfirmationCheckbox
               label="Force restart"
-              force={[isForce, setForce]}
+              confirmed={[isForce, setForce]}
             />
           }
           restrictedInstances={restrictedInstances}
@@ -165,7 +165,10 @@ const InstanceBulkActions: FC<Props> = ({ instances, onStart, onFinish }) => {
           instances={instances}
           confirmLabel="Stop"
           confirmExtra={
-            <ConfirmationForce label="Force stop" force={[isForce, setForce]} />
+            <ConfirmationCheckbox
+              label="Force stop"
+              confirmed={[isForce, setForce]}
+            />
           }
           restrictedInstances={restrictedInstances}
         />

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { restartInstance } from "api/instances";
 import { useInstanceLoading } from "context/instanceLoading";
-import ConfirmationForce from "components/ConfirmationForce";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { Icon, useToastNotification } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
 import { InstanceRichChip } from "../InstanceRichChip";
@@ -89,9 +89,9 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
           ? "Restart"
           : "You do not have permission to restart this instance",
         confirmExtra: (
-          <ConfirmationForce
+          <ConfirmationCheckbox
             label="Force restart"
-            force={[isForce, setForce]}
+            confirmed={[isForce, setForce]}
           />
         ),
       }}

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { stopInstance } from "api/instances";
 import { queryKeys } from "util/queryKeys";
 import { useInstanceLoading } from "context/instanceLoading";
-import ConfirmationForce from "components/ConfirmationForce";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { Icon, useToastNotification } from "@canonical/react-components";
 import { useEventQueue } from "context/eventQueue";
 import { useInstanceEntitlements } from "util/entitlements/instances";
@@ -96,7 +96,10 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
           </p>
         ),
         confirmExtra: (
-          <ConfirmationForce label="Force stop" force={[isForce, setForce]} />
+          <ConfirmationCheckbox
+            label="Force stop"
+            confirmed={[isForce, setForce]}
+          />
         ),
         onConfirm: handleStop,
         close: () => {

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotActions.tsx
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { ConfirmationButton, Icon, List } from "@canonical/react-components";
 import classnames from "classnames";
-import ConfirmationForce from "components/ConfirmationForce";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { useEventQueue } from "context/eventQueue";
 import InstanceEditSnapshotBtn from "./InstanceEditSnapshotBtn";
 import CreateImageFromInstanceSnapshotBtn from "pages/instances/actions/snapshots/CreateImageFromInstanceSnapshotBtn";
@@ -153,9 +153,9 @@ const InstanceSnapshotActions: FC<Props> = ({
                 </p>
               ),
               confirmExtra: snapshot.stateful ? (
-                <ConfirmationForce
+                <ConfirmationCheckbox
                   label="Restore the instance state"
-                  force={[restoreState, setRestoreState]}
+                  confirmed={[restoreState, setRestoreState]}
                 />
               ) : undefined,
               confirmButtonLabel: disabledReason ?? "Restore snapshot",

--- a/src/pages/permissions/CreateIdentityModal.tsx
+++ b/src/pages/permissions/CreateIdentityModal.tsx
@@ -1,7 +1,16 @@
 import type { FC } from "react";
+import { useState } from "react";
 import ResourceLabel from "components/ResourceLabel";
-import { Modal } from "@canonical/react-components";
+import {
+  Accordion,
+  ActionButton,
+  List,
+  Modal,
+  Notification,
+  Tabs,
+} from "@canonical/react-components";
 import CodeSnippetWithCopyButton from "components/CodeSnippetWithCopyButton";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 
 interface Props {
   onClose: () => void;
@@ -10,25 +19,123 @@ interface Props {
 }
 
 const CreateIdentityModal: FC<Props> = ({ onClose, token, identityName }) => {
+  const [isConfirmed, setConfirmed] = useState(false);
+  const [howToUseActiveTab, setHowToUseActiveTab] = useState("cli-tab");
+
   return (
     <Modal
-      close={onClose}
       className="create-tls-identity"
-      title="Identity created"
+      title={
+        <>
+          Identity{" "}
+          <ResourceLabel
+            type="certificate"
+            value={identityName}
+            bold
+            truncate
+          />{" "}
+          created successfully
+        </>
+      }
+      buttonRow={[
+        <span className="u-float-left confirm-input" key="confirm-input">
+          <ConfirmationCheckbox
+            label="I have copied the token"
+            confirmed={[isConfirmed, setConfirmed]}
+          />
+        </span>,
+        <ActionButton
+          key="confirm-action-button"
+          appearance="positive"
+          className="u-no-margin--bottom"
+          onClick={onClose}
+          disabled={!isConfirmed}
+        >
+          Done
+        </ActionButton>,
+      ]}
+      closeOnOutsideClick={false}
     >
       {token && (
         <>
-          <p>
-            The identity trust token below can be used to log in with the newly
-            created identity{" "}
-            <ResourceLabel type="certificate" value={identityName} /> .{" "}
-            <b>
-              Once this modal is closed, the identity trust token can&rsquo;t be
-              generated again.
-            </b>
-          </p>
+          <CodeSnippetWithCopyButton
+            code={token}
+            title="Your identity trust token"
+            tooltipMessage="Copy token"
+            onCopyButtonClick={() => {
+              setConfirmed(true);
+            }}
+          />
+          <Notification
+            severity="caution"
+            title="Copy the identity trust token"
+          >
+            You will need the token to authenticate your client. <br />
+            Make sure to copy it now as you will not be able to see this again.
+          </Notification>
+          <Accordion
+            sections={[
+              {
+                title: "How to use it?",
+                content: (
+                  <>
+                    <Tabs
+                      links={[
+                        {
+                          label: "CLI",
+                          active: howToUseActiveTab === "cli-tab",
+                          onClick: () => {
+                            setHowToUseActiveTab("cli-tab");
+                          },
+                        },
+                        {
+                          label: "UI",
+                          active: howToUseActiveTab === "ui-tab",
+                          onClick: () => {
+                            setHowToUseActiveTab("ui-tab");
+                          },
+                        },
+                      ]}
+                    />
+                    {howToUseActiveTab === "cli-tab" && (
+                      <>
+                        For use with the LXC command-line tool, run:
+                        <CodeSnippetWithCopyButton
+                          code={`lxc remote add ${location.hostname} ${token}`}
+                          tooltipMessage="Copy command"
+                          className="u-no-margin--bottom"
+                        />
+                        <span className="u-text--muted p-text--small u-sv3">
+                          You can replace <code>{location.hostname}</code> with
+                          a nickname for this server.
+                        </span>
+                      </>
+                    )}
 
-          <CodeSnippetWithCopyButton code={token} />
+                    {howToUseActiveTab === "ui-tab" && (
+                      <List
+                        className="u-no-margin--bottom"
+                        items={[
+                          <>
+                            Open an unauthenticated browser on{" "}
+                            <code>{location.origin}</code>.
+                          </>,
+                          <>
+                            Select <b>Setup TLS login</b> and follow the
+                            instructions to configure the browser certificate.
+                          </>,
+                          <>
+                            Use this identity trust token to add the new browser
+                            certificate to this server&apos;s trust store.
+                          </>,
+                        ]}
+                      />
+                    )}
+                  </>
+                ),
+              },
+            ]}
+          />
         </>
       )}
     </Modal>

--- a/src/sass/_configuration_table.scss
+++ b/src/sass/_configuration_table.scss
@@ -43,10 +43,6 @@
     @include vf-icon-close-themed;
   }
 
-  .mono-font {
-    font-family: unquote($font-monospace);
-  }
-
   .configuration-help {
     @extend %small-text;
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -403,6 +403,12 @@ body {
     @include large {
       width: 40rem;
     }
+
+    .p-modal__header {
+      .resource-label {
+        max-width: 14rem;
+      }
+    }
   }
 }
 
@@ -430,4 +436,8 @@ body {
 
 .u-margin-left--small {
   margin-left: $sph--small;
+}
+
+.mono-font {
+  font-family: unquote($font-monospace);
 }


### PR DESCRIPTION
## Done

- improve CreateIdentityModal

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions > Identities
    - Click on "Create TLS Identity" (top right corner of the page)
    - Input a name, like "foo"
    - Press Enter, or click on "Create identity" (bottom right corner of the page)
    - Make sure the modal gives clear guidance in what the token is and how it is to be used
    - Make sure you can't close the modal unless the checkbox is ticked
    - Make sure the "Done" button is enabled after you tick the "I have copied the token" checkbox
    - Make sure the "Done" button is enabled after you click on the "Copy token" button
    - Make sure the CLI and UI tabs are correctly displayed and that you can switch from one to the other

## Screenshots

Before
<img width="795" height="327" alt="before" src="https://github.com/user-attachments/assets/4f4e3f7b-0a84-47b0-95a3-dfbda5011dbe" />

After
<img width="801" height="781" alt="Screenshot from 2026-01-09 15-00-41" src="https://github.com/user-attachments/assets/2cd3f8fa-800f-4aba-9b6e-b3caff2cb13b" />
