### PR TITLE
feat: [WD-32447] Rich tooltips for pools

### DIFF
--- a/src/components/DeviceDetails.tsx
+++ b/src/components/DeviceDetails.tsx
@@ -4,23 +4,25 @@ import type { FormDevice } from "util/formDevices";
 import type { LxdDeviceValue } from "types/device";
 import ResourceLink from "components/ResourceLink";
 import { isHostDiskDevice } from "util/devices";
+import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
 import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   device: LxdDeviceValue;
   project: string;
+  location?: string;
 }
 
-const DeviceDetails: FC<Props> = ({ device, project }) => {
+const DeviceDetails: FC<Props> = ({ device, project, location }) => {
   if (device.type === "disk") {
     if (isRootDisk(device as FormDevice)) {
       return (
         <>
           Pool{" "}
-          <ResourceLink
-            type="pool"
-            value={device.pool || ""}
-            to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}`}
+          <StoragePoolRichChip
+            poolName={device.pool ?? ""}
+            projectName={project}
+            location={location}
           />
         </>
       );
@@ -39,10 +41,10 @@ const DeviceDetails: FC<Props> = ({ device, project }) => {
           to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}/volumes/custom/${encodeURIComponent(device.source ?? "")}`}
         />{" "}
         on pool{" "}
-        <ResourceLink
-          type="pool"
-          value={device.pool || ""}
-          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(device.pool ?? "")}`}
+        <StoragePoolRichChip
+          poolName={device.pool ?? ""}
+          projectName={project}
+          location={location}
         />
       </>
     );

--- a/src/components/DeviceListTable.tsx
+++ b/src/components/DeviceListTable.tsx
@@ -16,9 +16,10 @@ import type { LxdDeviceValue, LxdDevices } from "types/device";
 interface Props {
   configBaseURL: string;
   devices: LxdDevices;
+  location?: string;
 }
 
-const DeviceListTable: FC<Props> = ({ configBaseURL, devices }) => {
+const DeviceListTable: FC<Props> = ({ configBaseURL, devices, location }) => {
   const { project } = useParams<{ project: string }>();
 
   const byTypeAndName = (
@@ -88,7 +89,11 @@ const DeviceListTable: FC<Props> = ({ configBaseURL, devices }) => {
         },
         {
           content: (
-            <DeviceDetails device={device} project={project as string} />
+            <DeviceDetails
+              device={device}
+              project={project as string}
+              location={location}
+            />
           ),
           role: "cell",
           "aria-label": "Details",

--- a/src/context/useClusterMembers.tsx
+++ b/src/context/useClusterMembers.tsx
@@ -21,5 +21,6 @@ export const useClusterMember = (
   return useQuery({
     queryKey: [queryKeys.cluster, queryKeys.members, name],
     queryFn: async () => fetchClusterMember(name),
+    enabled: name !== "" && name !== "none",
   });
 };

--- a/src/context/useStoragePools.tsx
+++ b/src/context/useStoragePools.tsx
@@ -14,6 +14,7 @@ import {
   fetchStoragePools,
 } from "api/storage-pools";
 import { useClusterMembers } from "./useClusterMembers";
+import type { LxdClusterMember } from "types/cluster";
 
 export const useStoragePool = (
   pool: string,
@@ -54,12 +55,16 @@ export const usePoolFromClusterMembers = (
 
 export const useClusteredStoragePoolResources = (
   pool: string,
+  member?: LxdClusterMember,
 ): UseQueryResult<LxdStoragePoolResources[]> => {
   const { data: clusterMembers = [] } = useClusterMembers();
   return useQuery({
     queryKey: [queryKeys.storage, pool, queryKeys.cluster, queryKeys.resources],
     queryFn: async () =>
-      fetchClusteredStoragePoolResources(pool, clusterMembers),
+      fetchClusteredStoragePoolResources(
+        pool,
+        member ? [member] : clusterMembers,
+      ),
     enabled: clusterMembers.length > 0,
   });
 };

--- a/src/pages/instances/InstanceDetailPanelContent.tsx
+++ b/src/pages/instances/InstanceDetailPanelContent.tsx
@@ -20,6 +20,7 @@ import type { LxdDevices } from "types/device";
 import NetworkRichChip from "pages/networks/NetworkRichChip";
 import ExpandableList from "components/ExpandableList";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
+import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
 
 const RECENT_SNAPSHOT_LIMIT = 5;
 
@@ -110,10 +111,10 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
         <tr>
           <th className="u-text--muted">Root storage</th>
           <td>
-            <ResourceLink
-              type="pool"
-              value={rootPool}
-              to={`${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/storage/pool/${encodeURIComponent(rootPool)}`}
+            <StoragePoolRichChip
+              poolName={rootPool}
+              projectName={instance.project}
+              location={instance.location}
             />
           </td>
         </tr>

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -151,6 +151,7 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
           <DeviceListTable
             configBaseURL={`${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/instance/${encodeURIComponent(instance.name)}/configuration`}
             devices={instance.expanded_devices as LxdDevices}
+            location={instance.location}
           />
         </Col>
       </Row>

--- a/src/pages/profiles/ProfileDetailPanelContent.tsx
+++ b/src/pages/profiles/ProfileDetailPanelContent.tsx
@@ -7,11 +7,10 @@ import ProfileInstances from "./ProfileInstances";
 import DevicesSummaryList from "components/DevicesSummaryList";
 import type { LxdProject } from "types/project";
 import { isProjectWithProfiles } from "util/projects";
-import ResourceLink from "components/ResourceLink";
 import { getDefaultStoragePool } from "util/helpers";
-import { ROOT_PATH } from "util/rootPath";
 import ProfileConfigurationSections from "pages/profiles/ProfileConfigurationSections";
 import ProfileResourceLimits from "pages/profiles/ProfileResourceLimits";
+import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
 
 interface Props {
   profile: LxdProfile;
@@ -50,10 +49,9 @@ const ProfileDetailPanelContent: FC<Props> = ({ profile, project }) => {
           <th className="u-text--muted">Root storage</th>
           <td>
             {defaultStoragePool ? (
-              <ResourceLink
-                type="pool"
-                value={defaultStoragePool}
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project.name)}/storage/pool/${encodeURIComponent(defaultStoragePool)}`}
+              <StoragePoolRichChip
+                poolName={defaultStoragePool}
+                projectName={project.name}
               />
             ) : (
               "-"

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -30,7 +30,7 @@ import { MAIN_CONFIGURATION } from "./forms/StoragePoolFormMenu";
 import { yamlToObject } from "util/yaml";
 import type { LxdStoragePool } from "types/storage";
 import YamlSwitch from "components/forms/YamlSwitch";
-import ResourceLink from "components/ResourceLink";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 import { ROOT_PATH } from "util/rootPath";
 
 const CreateStoragePool: FC = () => {
@@ -93,10 +93,9 @@ const CreateStoragePool: FC = () => {
           toastNotify.success(
             <>
               Storage pool{" "}
-              <ResourceLink
-                type="pool"
-                value={storagePool.name}
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(values.name)}`}
+              <StoragePoolRichChip
+                poolName={storagePool.name}
+                projectName={project}
               />{" "}
               created.
             </>,

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -29,9 +29,9 @@ import { useSettings } from "context/useSettings";
 import { cephDriver, getSupportedStorageDrivers } from "util/storageOptions";
 import YamlSwitch from "components/forms/YamlSwitch";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
-import ResourceLink from "components/ResourceLink";
 import { useStoragePoolEntitlements } from "util/entitlements/storage-pools";
 import { usePoolFromClusterMembers } from "context/useStoragePools";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 
 interface Props {
   pool: LxdStoragePool;
@@ -112,10 +112,9 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
           toastNotify.success(
             <>
               Storage pool{" "}
-              <ResourceLink
-                type="pool"
-                value={savedPool.name}
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(savedPool.name)}`}
+              <StoragePoolRichChip
+                poolName={savedPool.name}
+                projectName={project}
               />{" "}
               updated.
             </>,

--- a/src/pages/storage/StorageBuckets.tsx
+++ b/src/pages/storage/StorageBuckets.tsx
@@ -34,7 +34,6 @@ import StorageBucketActions from "./actions/StorageBucketActions";
 import CreateStorageBucketBtn from "./actions/CreateStorageBucketBtn";
 import SelectableMainTable from "components/SelectableMainTable";
 import SelectedTableNotification from "components/SelectedTableNotification";
-import ResourceLink from "components/ResourceLink";
 import usePanelParams, { panels } from "util/usePanelParams";
 import StorageBucketBulkDelete from "./actions/StorageBucketBulkDelete";
 import type { LxdStorageBucket } from "types/storage";
@@ -43,7 +42,7 @@ import EditStorageBucketPanel from "./panels/EditStorageBucketPanel";
 import StorageBucketLink from "./StorageBucketLink";
 import StorageBucketKeyCount from "./StorageBucketKeyCount";
 import DocLink from "components/DocLink";
-import { ROOT_PATH } from "util/rootPath";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 
 const StorageBuckets: FC = () => {
   const notify = useNotify();
@@ -146,10 +145,10 @@ const StorageBuckets: FC = () => {
         },
         {
           content: (
-            <ResourceLink
-              type="pool"
-              value={bucket.pool}
-              to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(bucket.pool)}`}
+            <StoragePoolRichChip
+              poolName={bucket.pool}
+              projectName={project}
+              location={bucket.location}
             />
           ),
           role: "cell",

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -9,8 +9,8 @@ import * as Yup from "yup";
 import { testDuplicateStoragePoolName } from "util/storagePool";
 import { useFormik } from "formik";
 import { renameStoragePool } from "api/storage-pools";
-import ResourceLink from "components/ResourceLink";
 import { ROOT_PATH } from "util/rootPath";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 
 interface Props {
   name: string;
@@ -49,7 +49,10 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
           toastNotify.success(
             <>
               Storage pool <strong>{name}</strong> renamed to{" "}
-              <ResourceLink type="pool" value={values.name} to={url} />.
+              <StoragePoolRichChip
+                poolName={values.name}
+                projectName={project}
+              />
             </>,
           );
           formik.setFieldValue("isRenaming", false);

--- a/src/pages/storage/StoragePoolOptionLabel.tsx
+++ b/src/pages/storage/StoragePoolOptionLabel.tsx
@@ -20,7 +20,7 @@ const StoragePoolOptionLabel: FC<Props> = ({ pool }) => {
         {pool.driver || "-"}
       </span>
       <span key="usage" title="Usage" className="resource-usage u-truncate">
-        <StoragePoolSize key={pool.name} pool={pool} />
+        <StoragePoolSize key={pool.name} pool={pool} forceSingleLine />
       </span>
     </div>
   );

--- a/src/pages/storage/StoragePoolRichChip.tsx
+++ b/src/pages/storage/StoragePoolRichChip.tsx
@@ -1,0 +1,59 @@
+import type { FC } from "react";
+import { Tooltip } from "@canonical/react-components";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
+import ResourceLink from "components/ResourceLink";
+import { SMALL_TOOLTIP_BREAKPOINT } from "components/RichTooltipTable";
+import StoragePoolRichTooltip from "./StoragePoolRichTooltip";
+import { ROOT_PATH } from "util/rootPath";
+
+interface Props {
+  poolName: string;
+  projectName: string;
+  className?: string;
+  disabled?: boolean;
+  location?: string;
+}
+
+const StoragePoolRichChip: FC<Props> = ({
+  poolName,
+  projectName,
+  className,
+  disabled,
+  location,
+}) => {
+  const showTooltip = !useIsScreenBelow(SMALL_TOOLTIP_BREAKPOINT, "height");
+
+  const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/storage/pool/${encodeURIComponent(poolName)}`;
+
+  const resourceLink = (
+    <ResourceLink
+      type="pool"
+      value={poolName}
+      to={url}
+      hasTitle={!showTooltip}
+      className={className}
+      disabled={disabled}
+    />
+  );
+
+  if (!showTooltip) {
+    return <>{resourceLink}</>;
+  }
+
+  return (
+    <Tooltip
+      zIndex={1000}
+      message={
+        <StoragePoolRichTooltip
+          poolName={poolName}
+          url={url}
+          location={location}
+        />
+      }
+    >
+      {resourceLink}
+    </Tooltip>
+  );
+};
+
+export default StoragePoolRichChip;

--- a/src/pages/storage/StoragePoolRichTooltip.tsx
+++ b/src/pages/storage/StoragePoolRichTooltip.tsx
@@ -1,0 +1,105 @@
+import { type FC } from "react";
+import { Spinner } from "@canonical/react-components";
+import { type TooltipRow } from "components/RichTooltipRow";
+import {
+  MEDIUM_TOOLTIP_BREAKPOINT,
+  RichTooltipTable,
+} from "components/RichTooltipTable";
+import ResourceLabel from "components/ResourceLabel";
+import { Link } from "react-router-dom";
+import ItemName from "components/ItemName";
+import { useStoragePool } from "context/useStoragePools";
+import { useClusterMember } from "context/useClusterMembers";
+import StoragePoolSize from "./StoragePoolSize";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
+
+interface Props {
+  poolName: string;
+  url: string;
+  location?: string;
+}
+
+const StoragePoolRichTooltip: FC<Props> = ({ poolName, url, location }) => {
+  const { data: pool, isLoading: isPoolLoading } = useStoragePool(poolName);
+  const { data: member, isLoading: isMemberLoading } = useClusterMember(
+    location || "none",
+  );
+
+  if (!pool && !isPoolLoading) {
+    return (
+      <>
+        Storage pool <ResourceLabel type="pool" value={poolName} bold /> not
+        found
+      </>
+    );
+  }
+
+  const showDriverDetails = !useIsScreenBelow(
+    MEDIUM_TOOLTIP_BREAKPOINT,
+    "height",
+  );
+
+  const rows: TooltipRow[] = [
+    {
+      title: "Storage pool",
+      value: pool ? (
+        <Link
+          to={url}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          <ItemName item={{ name: poolName }} />
+        </Link>
+      ) : (
+        <Spinner />
+      ),
+      valueTitle: poolName,
+    },
+    {
+      title: "Description",
+      value: pool?.description || "-",
+      valueTitle: pool?.description || "-",
+    },
+    {
+      title: "Driver",
+      value: pool?.driver || "-",
+    },
+    {
+      title: "Status",
+      value: pool?.status || "-",
+    },
+  ];
+
+  if (showDriverDetails) {
+    rows.push(
+      {
+        title: "Size",
+        value: pool ? (
+          isMemberLoading ? (
+            "-"
+          ) : (
+            <StoragePoolSize
+              pool={pool}
+              member={member ?? undefined}
+              hasMeterBar
+              forceSingleLine
+            />
+          )
+        ) : (
+          "-"
+        ),
+      },
+      {
+        title: "Used by",
+        value: pool ? pool.used_by?.length : "-",
+      },
+    );
+  }
+
+  return (
+    <RichTooltipTable rows={rows} className="storage-pool-rich-tooltip-table" />
+  );
+};
+
+export default StoragePoolRichTooltip;

--- a/src/pages/storage/StorageVolumeOverview.tsx
+++ b/src/pages/storage/StorageVolumeOverview.tsx
@@ -5,12 +5,11 @@ import StorageUsedBy from "pages/storage/StorageUsedBy";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import type { LxdStorageVolume } from "types/storage";
 import { isoTimeToString } from "util/helpers";
-import { ROOT_PATH } from "util/rootPath";
 import StorageVolumeSize from "pages/storage/StorageVolumeSize";
 import { renderContentType, renderVolumeType } from "util/storageVolume";
 import { useSettings } from "context/useSettings";
-import ResourceLink from "components/ResourceLink";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -63,10 +62,10 @@ const StorageVolumeOverview: FC<Props> = ({ volume }) => {
               <tr>
                 <th className="u-text--muted">Pool</th>
                 <td>
-                  <ResourceLink
-                    type="pool"
-                    value={volume.pool}
-                    to={`${ROOT_PATH}/ui/project/${encodeURIComponent(volume.project)}/storage/pool/${encodeURIComponent(volume.pool)}`}
+                  <StoragePoolRichChip
+                    poolName={volume.pool}
+                    projectName={volume.project}
+                    location={volume.location}
                   />
                 </td>
               </tr>

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -62,6 +62,7 @@ import DocLink from "components/DocLink";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
+import StoragePoolRichChip from "./StoragePoolRichChip";
 
 const StorageVolumes: FC = () => {
   const notify = useNotify();
@@ -251,10 +252,10 @@ const StorageVolumes: FC = () => {
         },
         {
           content: (
-            <ResourceLink
-              type="pool"
-              value={volume.pool}
-              to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(volume.pool)}`}
+            <StoragePoolRichChip
+              poolName={volume.pool}
+              projectName={volume.project}
+              location={volume.location}
             />
           ),
           role: "cell",

--- a/src/sass/_pool_rich_tooltip.scss
+++ b/src/sass/_pool_rich_tooltip.scss
@@ -1,0 +1,9 @@
+$medium-tooltip-breakpoint: 900px;
+
+.storage-pool-rich-tooltip-table {
+  min-height: 300px !important;
+
+  @media (height <= $medium-tooltip-breakpoint) {
+    min-height: 200px !important;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -128,6 +128,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "permission_idp_groups";
 @import "permission_group_selection";
 @import "permission_groups";
+@import "pool_rich_tooltip";
 @import "prefixed_ip_input";
 @import "profile_detail_overview";
 @import "profile_detail_panel";

--- a/src/util/instanceMigration.tsx
+++ b/src/util/instanceMigration.tsx
@@ -7,12 +7,12 @@ import type { LxdInstance } from "types/instance";
 import type { ReactNode } from "react";
 import { capitalizeFirstLetter } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
-import ResourceLink from "components/ResourceLink";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
 import { useNavigate } from "react-router-dom";
 import { useToastNotification } from "@canonical/react-components";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
+import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
 
 export type MigrationType =
   | "cluster member"
@@ -64,10 +64,10 @@ export const useInstanceMigration = ({
             projectName={instance.project}
           />{" "}
           root storage successfully moved to pool{" "}
-          <ResourceLink
-            type="pool"
-            value={target}
-            to={`${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/storage/pool/${encodeURIComponent(target)}`}
+          <StoragePoolRichChip
+            poolName={target}
+            projectName={instance.project}
+            location={instance.location}
           />
         </>
       );


### PR DESCRIPTION
## Done

- Created and added a Rich tooltip for pools in multiple places in the codebase.

Notes:
- ~~Please critique on whether the chip content is appropriate, should be spliced, or needds amendments.~~
- Includes special behaviour for cluster member specific pools so that only space usage on the primary member node is shown.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

<img width="1262" height="766" alt="image" src="https://github.com/user-attachments/assets/e3966761-8a94-486e-8a44-2bdcf4899ad8" />