### PR TITLE
feat: [WD-32154] Anonymise domain name

### DIFF
--- a/src/util/reportBug.tsx
+++ b/src/util/reportBug.tsx
@@ -1,5 +1,8 @@
 import { UI_VERSION } from "./version";
 
+const anonymiseHostname = (stack: string) =>
+  stack.replaceAll(location.hostname, "<ANONYMOUS_HOST>");
+
 export const getReportBugBodyTemplate = (error?: Error) => {
   return `\
   # Description
@@ -10,13 +13,13 @@ export const getReportBugBodyTemplate = (error?: Error) => {
   # Metadata
     
   UI Version: ${UI_VERSION}
-  Path: ${location.toString()}
+  Path: ${anonymiseHostname(location.toString())}
     
   ${
     error && error.stack
       ? `# Stacktrace
-    
-    ${error.stack}`
+
+    ${anonymiseHostname(error.stack)}`
       : ""
   } `;
 };


### PR DESCRIPTION
## Done

- Anonymises hostnames in stack traces using regex.

Outstanding questions:
- The regex targets urls that begin with 'https://' and have '/ui/' after the host portion. Does the https syntax have any limitations, or is it always expected LXD will run on a https web?
- I must generate a real error to test the stack trace.

Related to: https://github.com/canonical/lxd-ui/issues/1670

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an error in the UI (Or not) and select "Report a bug" in the navigation bar.
    - Ensure in the generated Github issue, that the hostname has been replaced with the <ANONYMOUS_HOST> placeholder.

## Screenshots

Example:
<img width="1024" height="410" alt="image" src="https://github.com/user-attachments/assets/074dc3d8-e573-4217-bcdc-80a7dcc13941" />