### PR TITLE
chore(test) add ovn and ceph to ci suite. fixes WD-32416

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -119,6 +119,14 @@ jobs:
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
+      - name: Setup Ceph
+        if: ${{ matrix.lxd_channel != '5.0/edge' }}
+        uses: canonical/lxd/.github/actions/setup-microceph@main
+
+      - name: Setup OVN
+        if: ${{ matrix.lxd_channel != '5.0/edge' }}
+        uses: canonical/lxd/.github/actions/setup-microovn@main
+
       - name: Install LXD
         uses: canonical/setup-lxd@v1
         with:


### PR DESCRIPTION
## Done

- add ovn and ceph to ci suite
- this will enable future ui e2e tests that rely on ceph or OVN. Such as testing local peerings with ovn networks and also storage buckets, which rely on a ceph storage pool.

Fixes WD-32416

Sibling PRs introducing the ceph and ovn setup for ci into [LXD](https://github.com/canonical/lxd/pull/17465) and [LXD-CI](https://github.com/canonical/lxd-ci/pull/665) projects