### PR TITLE
fix(instance) render custom iso correctly 

### DIFF
--- a/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
+++ b/src/pages/instances/forms/InstanceCreateDetailsForm.tsx
@@ -99,6 +99,10 @@ const InstanceCreateDetailsForm: FC<Props> = ({
       return `${image.os} ${image.release} ${image.aliases.split(",")[0]}`;
     }
 
+    if (image.variant === "iso") {
+      return `${image.os} - ${image.aliases.split(",")[0]}`;
+    }
+
     return `${image.os} ${image.release} ${image.release_title}`;
   };
 

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -26,6 +26,7 @@ test("upload and delete custom iso", async ({ page, lxdVersion }) => {
   await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
   await page.getByRole("button", { name: "Create instance" }).click();
 
+  await expect(page.getByText(`Custom ISO - ${isoName}`)).toBeVisible();
   await page.getByText("YAML configuration").click();
   await assertTextVisible(page, "devices:", true);
   await assertTextVisible(page, "iso-volume:", true);


### PR DESCRIPTION
## Done

- fix(instance) render custom iso correctly on preselecting it from iso list and starting a create instance operation

Fixes #1704

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - select a custom iso on instance creation and ensure the iso name is correctly displayed in the create instance screen.

## Screenshots

<img width="1297" height="934" alt="image" src="https://github.com/user-attachments/assets/28d934fc-708a-4a5e-a4e6-ab8cc6c11558" />