### PR TITLE
feat(device config): Set all labels in muted text

### DIFF
--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -93,7 +93,6 @@ const DiskDeviceFormInherited: FC<Props> = ({
     if (isHostDiskDevice(item.disk)) {
       rows.push(
         getInheritedDeviceRow({
-          mutedLabel: true,
           label: "Host path",
           inheritValue: item.disk.source,
           readOnly: readOnly,
@@ -104,7 +103,6 @@ const DiskDeviceFormInherited: FC<Props> = ({
     } else {
       rows.push(
         getInheritedDeviceRow({
-          mutedLabel: true,
           label: "Pool / volume",
           inheritValue: (
             <>
@@ -120,7 +118,6 @@ const DiskDeviceFormInherited: FC<Props> = ({
 
     rows.push(
       getInheritedDeviceRow({
-        mutedLabel: true,
         label: "Mount point",
         inheritValue: item.disk.path,
         readOnly: readOnly,

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -147,7 +147,6 @@ const DiskDeviceFormRoot: FC<Props> = ({
             : []),
 
           getInheritedDeviceRow({
-            mutedLabel: true,
             label: "Pool",
             id: "storage-pool-selector-disk",
             className: "override-with-form has-margin-left",
@@ -199,7 +198,6 @@ const DiskDeviceFormRoot: FC<Props> = ({
           }),
 
           getInheritedDeviceRow({
-            mutedLabel: true,
             label: "Size",
             id: "limits_disk",
             className: "override-with-form has-margin-left",

--- a/src/components/forms/InheritedDeviceRow.tsx
+++ b/src/components/forms/InheritedDeviceRow.tsx
@@ -19,7 +19,6 @@ interface Props {
   className?: string;
   disabledReason?: string;
   monoFont?: boolean;
-  mutedLabel?: boolean;
 }
 
 export const getInheritedDeviceRow = ({
@@ -36,36 +35,21 @@ export const getInheritedDeviceRow = ({
   className,
   disabledReason,
   monoFont = true,
-  mutedLabel = false,
 }: Props): MainTableRow => {
   return getConfigurationRowBase({
     className: classnames("no-border-top", className),
     configuration: id ? (
       !readOnly && overrideValue ? (
-        <Label
-          forId={id}
-          className={classnames({
-            "u-text--muted": mutedLabel || isDeactivated,
-          })}
-        >
+        <Label forId={id} className="u-text--muted">
           {label}
         </Label>
       ) : (
-        <p
-          className={classnames(
-            "p-form__label u-no-margin--bottom u-no-padding--top",
-            { "u-text--muted": mutedLabel || isDeactivated },
-          )}
-        >
+        <p className="p-form__label u-no-margin--bottom u-no-padding--top u-text--muted">
           {label}
         </p>
       )
     ) : (
-      <div
-        className={classnames({ "u-text--muted": mutedLabel || isDeactivated })}
-      >
-        {label}
-      </div>
+      <div className="u-text--muted">{label}</div>
     ),
     inherited: inheritValue && (
       <div
@@ -144,7 +128,6 @@ export const getInheritedSourceRow = ({
 }) => {
   return getInheritedDeviceRow({
     className,
-    mutedLabel: true,
     label: "From profile",
     inheritValue: (
       <>

--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -234,7 +234,7 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
 
     customRows.push(
       getConfigurationRowBase({
-        className: "no-border-top inherited-with-form",
+        className: "no-border-top inherited-with-form u-text--muted",
         configuration: <Label forId={`devices.${index}.type`}>Type</Label>,
         inherited: (
           <Select
@@ -297,7 +297,7 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
 
       customRows.push(
         getConfigurationRowBase({
-          className: "no-border-top inherited-with-form",
+          className: "no-border-top inherited-with-form u-text--muted",
           configuration: (
             <Label forId={key}>{deviceKeyToLabel(field.key)}</Label>
           ),

--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -95,7 +95,7 @@ const ProxyDeviceForm: FC<Props> = ({ formik, project }) => {
     const key = `devices.${index}.${fieldName}`;
 
     return getConfigurationRowBase({
-      className: "no-border-top inherited-with-form",
+      className: "no-border-top inherited-with-form u-text--muted",
       configuration: <Label forId={key}>{label}</Label>,
       inherited: (
         <Select

--- a/src/util/proxyDevices.tsx
+++ b/src/util/proxyDevices.tsx
@@ -23,7 +23,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form p-heading--6",
+      className: "no-border-top inherited-with-form p-heading--6 u-text--muted",
       configuration: headingTitle,
       inherited: "",
       override: "",
@@ -32,7 +32,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form",
+      className: "no-border-top inherited-with-form u-text--muted",
       configuration: (
         <Label forId={`devices.${index}.${connectionType}`}>Type</Label>
       ),
@@ -81,7 +81,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form",
+      className: "no-border-top inherited-with-form u-text--muted",
       configuration:
         deviceType === "unix" ? (
           <Label
@@ -140,7 +140,7 @@ export const getProxyAddress = (
   if (deviceType !== "unix") {
     customRows.push(
       getConfigurationRowBase({
-        className: "no-border-top inherited-with-form",
+        className: "no-border-top inherited-with-form u-text--muted",
         configuration: (
           <Label forId={`devices.${index}.${connectionType}.port`} required>
             Port


### PR DESCRIPTION
## Done

- In instance config > Devices > GPU, Proxy and Other, all labels should be in muted text, similar to Disk and Networks


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to any instance configuration screen > Devices
    - Check GPU, Proxy and Other tabs
    - Make sure all labels are in muted text

## Screenshots

GPU
<img width="1087" height="639" alt="image" src="https://github.com/user-attachments/assets/039f6289-a6cd-4509-964d-89332da910f3" />

Proxy
<img width="1092" height="734" alt="image" src="https://github.com/user-attachments/assets/7439a3fa-3029-4fdd-98a7-3b035ffc072c" />

Other
<img width="1092" height="734" alt="image" src="https://github.com/user-attachments/assets/94ddfb20-9605-4dee-9adf-ac2b69ca1d7d" />
