### PR TITLE
feat(instance) allow to hold alt and ctl keys in instance console.

### DIFF
--- a/src/lib/spice/src/atKeynames.js
+++ b/src/lib/spice/src/atKeynames.js
@@ -182,6 +182,8 @@ var KeyNames = {
 
   KEY_Prefix0     :/* special               0x60  */   96,
   KEY_Prefix1     :/* specail               0x61  */   97,
+
+  KEY_DELETE      :/* Delete           0xe0 0x53  */   21472,
 };
 
 export {

--- a/src/lib/spice/src/inputs.js
+++ b/src/lib/spice/src/inputs.js
@@ -30,9 +30,13 @@ import { DEBUG } from './utils.js';
  **     out of sync.
  **------------------------------------------------------------------------*/
 var Shift_state = -1;
-var Ctrl_state = -1;
-var Alt_state = -1;
+var Ctrl_state = false;
+var Alt_state = false;
 var Meta_state = -1;
+
+var Alt_locked = false;
+var Ctrl_locked = false;
+
 
 /*----------------------------------------------------------------------------
 **  SpiceInputsConn
@@ -210,11 +214,17 @@ function sendCtrlAltDel(sc)
 {
     if (sc && sc.inputs && sc.inputs.state === "ready"){
         update_modifier(true, KeyNames.KEY_LCtrl, sc);
+        Ctrl_state = true;
+        Ctrl_locked = false;
         update_modifier(true, KeyNames.KEY_Alt, sc);
-        send_key(sc, KeyNames.KEY_KP_Decimal);
+        Alt_state = true;
+        Alt_locked = false;
+        send_key(sc, KeyNames.KEY_DELETE);
         const release = () => {
             update_modifier(false, KeyNames.KEY_LCtrl, sc);
+            Ctrl_state = false;
             update_modifier(false, KeyNames.KEY_Alt, sc);
+            Alt_state = false;
         }
         setTimeout(release, 100);
     }
@@ -224,9 +234,15 @@ function sendAltF4(sc)
 {
     if (sc && sc.inputs && sc.inputs.state === "ready"){
         update_modifier(true, KeyNames.KEY_Alt, sc);
+        Alt_state = true;
+        Alt_locked = false;
+        update_modifier(false, KeyNames.KEY_LCtrl, sc);
+        Ctrl_state = false;
+        Ctrl_locked = false;
         send_key(sc, KeyNames.KEY_F4);
         const release = () => {
             update_modifier(false, KeyNames.KEY_Alt, sc);
+            Alt_state = false;
         }
         setTimeout(release, 100);
     }
@@ -236,12 +252,130 @@ function sendAltTab(sc)
 {
     if (sc && sc.inputs && sc.inputs.state === "ready"){
         update_modifier(true, KeyNames.KEY_Alt, sc);
+        Alt_state = true;
+        Alt_locked = false;
+        update_modifier(false, KeyNames.KEY_LCtrl, sc);
+        Ctrl_state = false;
+        Ctrl_locked = false;
         send_key(sc, KeyNames.KEY_Tab);
         const release = () => {
             update_modifier(false, KeyNames.KEY_Alt, sc);
+            Alt_state = false;
         }
         setTimeout(release, 100);
     }
+}
+
+function sendF1(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F1);
+    }
+}
+
+function sendF2(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F2);
+    }
+}
+
+function sendF3(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F3);
+    }
+}
+
+function sendF4(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F4);
+    }
+}
+
+function sendF5(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F5);
+    }
+}
+
+function sendF6(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F6);
+    }
+}
+
+function sendF7(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F7);
+    }
+}
+
+function sendF8(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F8);
+    }
+}
+
+function sendF9(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F9);
+    }
+}
+
+function sendF10(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F10);
+    }
+}
+
+function sendF11(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F11);
+    }
+}
+
+function sendF12(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_F12);
+    }
+}
+
+function toggleAlt(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        Alt_state = !Alt_state;
+        Alt_locked = !Alt_locked;
+        update_modifier(Alt_state, KeyNames.KEY_Alt, sc);
+    }
+}
+
+function isAltPressed()
+{
+    return Alt_state === true;
+}
+
+function toggleCtrl(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        Ctrl_state = !Ctrl_state;
+        Ctrl_locked = !Ctrl_locked;
+        update_modifier(Ctrl_state, KeyNames.KEY_LCtrl, sc);
+    }
+}
+
+function isCtrlPressed()
+{
+    return Ctrl_state === true;
 }
 
 function update_modifier(state, code, sc)
@@ -268,25 +402,37 @@ function check_and_update_modifiers(e, code, sc)
     if (Shift_state === -1)
     {
         Shift_state = e.shiftKey;
-        Ctrl_state = e.ctrlKey;
-        Alt_state = e.altKey;
+        if (!Ctrl_locked) {
+            Ctrl_state = e.ctrlKey;
+        }
+        if (!Alt_locked) {
+            Alt_state = e.altKey;
+        }
         Meta_state = e.metaKey;
     }
 
     if (code === KeyNames.KEY_ShiftL)
         Shift_state = true;
-    else if (code === KeyNames.KEY_Alt)
+    else if (code === KeyNames.KEY_Alt) {
         Alt_state = true;
-    else if (code === KeyNames.KEY_LCtrl)
+        Alt_locked = false;
+    }
+    else if (code === KeyNames.KEY_LCtrl) {
         Ctrl_state = true;
+        Ctrl_locked = false;
+    }
     else if (code === 0xE0B5)
         Meta_state = true;
     else if (code === (0x80|KeyNames.KEY_ShiftL))
         Shift_state = false;
-    else if (code === (0x80|KeyNames.KEY_Alt))
+    else if (code === (0x80|KeyNames.KEY_Alt)) {
         Alt_state = false;
-    else if (code === (0x80|KeyNames.KEY_LCtrl))
+        Alt_locked = false;
+    }
+    else if (code === (0x80|KeyNames.KEY_LCtrl)) {
         Ctrl_state = false;
+        Ctrl_locked = false;
+    }
     else if (code === (0x80|0xE0B5))
         Meta_state = false;
 
@@ -298,13 +444,13 @@ function check_and_update_modifiers(e, code, sc)
             update_modifier(e.shiftKey, KeyNames.KEY_ShiftL, sc);
             Shift_state = e.shiftKey;
         }
-        if (Alt_state != e.altKey)
+        if (Alt_state != e.altKey && !Alt_locked)
         {
             console.log("Alt state out of sync");
             update_modifier(e.altKey, KeyNames.KEY_Alt, sc);
             Alt_state = e.altKey;
         }
-        if (Ctrl_state != e.ctrlKey)
+        if (Ctrl_state != e.ctrlKey && !Ctrl_locked)
         {
             console.log("Ctrl state out of sync");
             update_modifier(e.ctrlKey, KeyNames.KEY_LCtrl, sc);
@@ -331,4 +477,20 @@ export {
   sendCtrlAltDel,
   sendAltTab,
   sendAltF4,
+  sendF1,
+  sendF2,
+  sendF3,
+  sendF4,
+  sendF5,
+  sendF6,
+  sendF7,
+  sendF8,
+  sendF9,
+  sendF10,
+  sendF11,
+  sendF12,
+  toggleAlt,
+  toggleCtrl,
+  isAltPressed,
+  isCtrlPressed,
 };

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import {
   ActionButton,
   Button,
-  ContextualMenu,
   EmptyState,
   Icon,
   Notification,
@@ -14,12 +13,12 @@ import InstanceGraphicConsole from "./InstanceGraphicConsole";
 import type { LxdInstance } from "types/instance";
 import InstanceTextConsole from "./InstanceTextConsole";
 import { useInstanceStart } from "util/instanceStart";
-import { sendAltF4, sendAltTab, sendCtrlAltDel } from "lib/spice/src/inputs.js";
 import AttachIsoBtn from "pages/instances/actions/AttachIsoBtn";
 import NotificationRow from "components/NotificationRow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { isInstanceRunning } from "util/instanceStatus";
+import InstanceConsoleShortcuts from "pages/instances/InstanceConsoleShortcuts";
 
 interface Props {
   instance: LxdInstance;
@@ -101,31 +100,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
               >
                 <span>Fullscreen</span>
               </Button>
-              <ContextualMenu
-                hasToggleIcon
-                toggleLabel="Shortcuts"
-                toggleClassName="u-no-margin--bottom"
-                links={[
-                  {
-                    children: "Send Ctrl + Alt + Del",
-                    onClick: () => {
-                      sendCtrlAltDel(window.spice_connection);
-                    },
-                  },
-                  {
-                    children: "Send Alt + TAB",
-                    onClick: () => {
-                      sendAltTab(window.spice_connection);
-                    },
-                  },
-                  {
-                    children: "Send Alt + F4",
-                    onClick: () => {
-                      sendAltF4(window.spice_connection);
-                    },
-                  },
-                ]}
-              />
+              <InstanceConsoleShortcuts />
             </div>
           )}
         </div>

--- a/src/pages/instances/InstanceConsoleShortcuts.tsx
+++ b/src/pages/instances/InstanceConsoleShortcuts.tsx
@@ -1,0 +1,168 @@
+import type { FC } from "react";
+import { useEffect } from "react";
+import { useState } from "react";
+import { ContextualMenu } from "@canonical/react-components";
+import {
+  isAltPressed,
+  isCtrlPressed,
+  sendAltF4,
+  sendAltTab,
+  sendCtrlAltDel,
+  sendF1,
+  sendF2,
+  sendF3,
+  sendF4,
+  sendF5,
+  sendF6,
+  sendF7,
+  sendF8,
+  sendF9,
+  sendF10,
+  sendF11,
+  sendF12,
+  toggleAlt,
+  toggleCtrl,
+} from "lib/spice/src/inputs.js";
+
+const InstanceConsoleShortcuts: FC = () => {
+  const [isAlt, setIsAlt] = useState(false);
+  const [isCtrl, setIsCtrl] = useState(false);
+
+  const updateKeys = () => {
+    const newAlt = isAltPressed(window.spice_connection);
+    const newCtrl = isCtrlPressed(window.spice_connection);
+    if (newAlt !== isAlt) {
+      setIsAlt(newAlt);
+    }
+    if (newCtrl !== isCtrl) {
+      setIsCtrl(newCtrl);
+    }
+  };
+
+  useEffect(() => {
+    // Update the key states every second to reflect any changes within the spice connection
+    const interval = setInterval(updateKeys, 500);
+    return () => {
+      clearInterval(interval);
+    };
+  });
+
+  const handleAlt = () => {
+    toggleAlt(window.spice_connection);
+  };
+
+  const handleCtrl = () => {
+    toggleCtrl(window.spice_connection);
+  };
+
+  return (
+    <ContextualMenu
+      hasToggleIcon
+      toggleLabel="Shortcuts"
+      toggleClassName="u-no-margin--bottom"
+      dropdownClassName="instance-console-shortcut-dropdown"
+      links={[
+        {
+          children: isAlt ? "Release and unlock Alt" : "Hold and lock Alt",
+          onClick: handleAlt,
+        },
+        {
+          children: isCtrl ? "Release and unlock Ctrl" : "Hold and lock Ctrl",
+          onClick: handleCtrl,
+        },
+        {
+          children: "Send Ctrl + Alt + Del",
+          onClick: () => {
+            sendCtrlAltDel(window.spice_connection);
+          },
+        },
+        {
+          children: "Send Alt + Tab",
+          onClick: () => {
+            sendAltTab(window.spice_connection);
+          },
+        },
+        {
+          children: "Send Alt + F4",
+          onClick: () => {
+            sendAltF4(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F1",
+          onClick: () => {
+            sendF1(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F2",
+          onClick: () => {
+            sendF2(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F3",
+          onClick: () => {
+            sendF3(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F4",
+          onClick: () => {
+            sendF4(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F5",
+          onClick: () => {
+            sendF5(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F6",
+          onClick: () => {
+            sendF6(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F7",
+          onClick: () => {
+            sendF7(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F8",
+          onClick: () => {
+            sendF8(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F9",
+          onClick: () => {
+            sendF9(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F10",
+          onClick: () => {
+            sendF10(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F11",
+          onClick: () => {
+            sendF11(window.spice_connection);
+          },
+        },
+        {
+          children: "Send F12",
+          onClick: () => {
+            sendF12(window.spice_connection);
+          },
+        },
+      ]}
+    />
+  );
+};
+
+export default InstanceConsoleShortcuts;

--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -24,3 +24,8 @@
     background: black;
   }
 }
+
+.instance-console-shortcut-dropdown {
+  max-height: 300px;
+  overflow-y: scroll;
+}

--- a/src/types/spice-inputs.d.ts
+++ b/src/types/spice-inputs.d.ts
@@ -4,4 +4,22 @@ declare module "lib/spice/src/inputs.js" {
   export function sendAltF4(connection?: SpiceHtml5.SpiceMainConn): void;
   export function sendAltTab(connection?: SpiceHtml5.SpiceMainConn): void;
   export function sendCtrlAltDel(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF1(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF2(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF3(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF4(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF5(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF6(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF7(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF8(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF9(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF10(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF11(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendF12(connection?: SpiceHtml5.SpiceMainConn): void;
+
+  export function isAltPressed(connection?: SpiceHtml5.SpiceMainConn): boolean;
+  export function isCtrlPressed(connection?: SpiceHtml5.SpiceMainConn): boolean;
+
+  export function toggleAlt(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function toggleCtrl(connection?: SpiceHtml5.SpiceMainConn): void;
 }


### PR DESCRIPTION
## Done

- feat(instance) allow to hold alt and ctl keys in instance console.

Fixes #1705

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a vm with desktop image
    - use the alt and ctrl shortcuts and holding buttons

## Screenshots
<img width="1923" height="960" alt="image" src="https://github.com/user-attachments/assets/14778117-f2c5-48e6-b560-c143b56a045a" />


