### PR TITLE
feat(instance) highlight active instance and profile configuration sections

### DIFF
--- a/src/components/forms/FormMenuItem.tsx
+++ b/src/components/forms/FormMenuItem.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { Fragment } from "react";
 import { slugify } from "util/slugify";
 import { Button } from "@canonical/react-components";
 import classnames from "classnames";
@@ -9,6 +10,7 @@ interface Props {
   label: string;
   disableReason?: string;
   hasError?: boolean;
+  isBold?: boolean;
 }
 
 const FormMenuItem: FC<Props> = ({
@@ -17,7 +19,10 @@ const FormMenuItem: FC<Props> = ({
   label,
   disableReason,
   hasError,
+  isBold,
 }) => {
+  const ValueWrapper = isBold ? "strong" : Fragment;
+
   if (disableReason) {
     return (
       <li className="p-side-navigation__item">
@@ -26,7 +31,7 @@ const FormMenuItem: FC<Props> = ({
           disabled={true}
           title={disableReason}
         >
-          {label}
+          <ValueWrapper>{label}</ValueWrapper>
         </Button>
       </li>
     );
@@ -44,7 +49,7 @@ const FormMenuItem: FC<Props> = ({
         }}
         aria-current={slugify(label) === slugify(active) ? "page" : undefined}
       >
-        {label}
+        <ValueWrapper>{label}</ValueWrapper>
       </a>
     </li>
   );

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -466,6 +466,7 @@ const CreateInstance: FC = () => {
             isDisabled={!formik.values.image}
             hasDiskError={diskError || hasNoRootDisk(formik.values, profiles)}
             hasNetworkError={networkError}
+            formik={formik}
           />
         )}
         <Row className="form-contents" key={section}>

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -223,6 +223,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
             isDisabled={false}
             hasDiskError={hasDiskError(formik)}
             hasNetworkError={hasNetworkError(formik)}
+            formik={formik}
           />
         )}
         <Row className="form-contents" key={section}>

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -4,6 +4,15 @@ import MenuItem from "components/forms/FormMenuItem";
 import { Button, useListener, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
+import { hasPrefixValue } from "util/formFields";
+import {
+  isDiskDevice,
+  isGPUDevice,
+  isNicDevice,
+  isOtherDevice,
+  isProxyDevice,
+} from "util/devices";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -25,6 +34,7 @@ interface Props {
   setActive: (val: string) => void;
   hasDiskError: boolean;
   hasNetworkError: boolean;
+  formik: InstanceAndProfileFormikProps;
 }
 
 const InstanceFormMenu: FC<Props> = ({
@@ -33,6 +43,7 @@ const InstanceFormMenu: FC<Props> = ({
   setActive,
   hasDiskError,
   hasNetworkError,
+  formik,
 }) => {
   const notify = useNotify();
   const [isDeviceExpanded, setDeviceExpanded] = useState(true);
@@ -58,7 +69,7 @@ const InstanceFormMenu: FC<Props> = ({
     <div className="p-side-navigation--accordion form-navigation">
       <nav aria-label="Instance form navigation">
         <ul className="p-side-navigation__list">
-          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
           <li className="p-side-navigation__item">
             <Button
               type="button"
@@ -72,7 +83,11 @@ const InstanceFormMenu: FC<Props> = ({
               disabled={isDisabled}
               title={disableReason}
             >
-              Devices
+              {formik.values.devices.length > 0 ? (
+                <strong>Devices</strong>
+              ) : (
+                "Devices"
+              )}
             </Button>
             <ul
               className="p-side-navigation__list"
@@ -82,25 +97,70 @@ const InstanceFormMenu: FC<Props> = ({
                 label={DISK_DEVICES}
                 hasError={hasDiskError}
                 {...menuItemProps}
+                isBold={formik.values.devices.some(isDiskDevice)}
               />
               <MenuItem
                 label={NETWORK_DEVICES}
                 hasError={hasNetworkError}
                 {...menuItemProps}
+                isBold={formik.values.devices.some(isNicDevice)}
               />
-              <MenuItem label={GPU_DEVICES} {...menuItemProps} />
-              <MenuItem label={PROXY_DEVICES} {...menuItemProps} />
+              <MenuItem
+                label={GPU_DEVICES}
+                {...menuItemProps}
+                isBold={formik.values.devices.some(isGPUDevice)}
+              />
+              <MenuItem
+                label={PROXY_DEVICES}
+                {...menuItemProps}
+                isBold={formik.values.devices.some(isProxyDevice)}
+              />
               {hasMetadataConfiguration && (
-                <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+                <MenuItem
+                  label={OTHER_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isOtherDevice)}
+                />
               )}
             </ul>
           </li>
-          <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
-          <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
-          <MenuItem label={SNAPSHOTS} {...menuItemProps} />
-          <MenuItem label={MIGRATION} {...menuItemProps} />
-          <MenuItem label={BOOT} {...menuItemProps} />
-          <MenuItem label={CLOUD_INIT} {...menuItemProps} />
+          <MenuItem
+            label={RESOURCE_LIMITS}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "limits_")}
+          />
+          <MenuItem
+            label={SECURITY_POLICIES}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "security_")}
+          />
+          <MenuItem
+            label={SNAPSHOTS}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "snapshots_")}
+          />
+          <MenuItem
+            label={MIGRATION}
+            {...menuItemProps}
+            isBold={
+              hasPrefixValue(formik, "migration_") ||
+              hasPrefixValue(formik, "cluster_")
+            }
+          />
+          <MenuItem
+            label={BOOT}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "boot_")}
+          />
+          <MenuItem
+            label={CLOUD_INIT}
+            {...menuItemProps}
+            isBold={hasPrefixValue(
+              formik,
+              "cloud_init_",
+              "cloud_init_ssh_keys",
+            )}
+          />
         </ul>
       </nav>
     </div>

--- a/src/pages/profiles/forms/ProfileFormMenu.tsx
+++ b/src/pages/profiles/forms/ProfileFormMenu.tsx
@@ -6,6 +6,14 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
 import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { hasPrefixValue } from "util/formFields";
+import {
+  isDiskDevice,
+  isGPUDevice,
+  isNicDevice,
+  isOtherDevice,
+  isProxyDevice,
+} from "util/devices";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -58,7 +66,7 @@ const ProfileFormMenu: FC<Props> = ({
     <div className="p-side-navigation--accordion form-navigation">
       <nav aria-label="Profile form navigation">
         <ul className="p-side-navigation__list">
-          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} />
+          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
           <li className="p-side-navigation__item">
             <Button
               type="button"
@@ -72,7 +80,11 @@ const ProfileFormMenu: FC<Props> = ({
               disabled={isDisabled}
               title={disableReason}
             >
-              Devices
+              {formik.values.devices.length > 0 ? (
+                <strong>Devices</strong>
+              ) : (
+                "Devices"
+              )}
             </Button>
             <ul
               className="p-side-navigation__list"
@@ -82,25 +94,70 @@ const ProfileFormMenu: FC<Props> = ({
                 label={DISK_DEVICES}
                 hasError={hasDiskError(formik)}
                 {...menuItemProps}
+                isBold={formik.values.devices.some(isDiskDevice)}
               />
               <MenuItem
                 label={NETWORK_DEVICES}
                 hasError={hasNetworkError(formik)}
                 {...menuItemProps}
+                isBold={formik.values.devices.some(isNicDevice)}
               />
-              <MenuItem label={GPU_DEVICES} {...menuItemProps} />
-              <MenuItem label={PROXY_DEVICES} {...menuItemProps} />
+              <MenuItem
+                label={GPU_DEVICES}
+                {...menuItemProps}
+                isBold={formik.values.devices.some(isGPUDevice)}
+              />
+              <MenuItem
+                label={PROXY_DEVICES}
+                {...menuItemProps}
+                isBold={formik.values.devices.some(isProxyDevice)}
+              />
               {hasMetadataConfiguration && (
-                <MenuItem label={OTHER_DEVICES} {...menuItemProps} />
+                <MenuItem
+                  label={OTHER_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isOtherDevice)}
+                />
               )}
             </ul>
           </li>
-          <MenuItem label={RESOURCE_LIMITS} {...menuItemProps} />
-          <MenuItem label={SECURITY_POLICIES} {...menuItemProps} />
-          <MenuItem label={SNAPSHOTS} {...menuItemProps} />
-          <MenuItem label={MIGRATION} {...menuItemProps} />
-          <MenuItem label={BOOT} {...menuItemProps} />
-          <MenuItem label={CLOUD_INIT} {...menuItemProps} />
+          <MenuItem
+            label={RESOURCE_LIMITS}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "limits_")}
+          />
+          <MenuItem
+            label={SECURITY_POLICIES}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "security_")}
+          />
+          <MenuItem
+            label={SNAPSHOTS}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "snapshots_")}
+          />
+          <MenuItem
+            label={MIGRATION}
+            {...menuItemProps}
+            isBold={
+              hasPrefixValue(formik, "migration_") ||
+              hasPrefixValue(formik, "cluster_")
+            }
+          />
+          <MenuItem
+            label={BOOT}
+            {...menuItemProps}
+            isBold={hasPrefixValue(formik, "boot_")}
+          />
+          <MenuItem
+            label={CLOUD_INIT}
+            {...menuItemProps}
+            isBold={hasPrefixValue(
+              formik,
+              "cloud_init_",
+              "cloud_init_ssh_keys",
+            )}
+          />
         </ul>
       </nav>
     </div>

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -15,11 +15,13 @@ import type { LxdProfile } from "types/profile";
 import type { FormDevice, FormDiskDevice } from "util/formDevices";
 import { getAppliedProfiles } from "./configInheritance";
 
-export const isNicDevice = (device: LxdDeviceValue): device is LxdNicDevice =>
-  device.type === "nic";
+export const isNicDevice = (
+  device: LxdDeviceValue | FormDevice,
+): device is LxdNicDevice => device.type === "nic";
 
-export const isDiskDevice = (device: LxdDeviceValue): device is LxdDiskDevice =>
-  device.type === "disk";
+export const isDiskDevice = (
+  device: LxdDeviceValue | FormDevice,
+): device is LxdDiskDevice => device.type === "disk";
 
 export const isRootDisk = (device: FormDevice): boolean => {
   return device.type === "disk" && device.path === "/" && !device.source;
@@ -43,11 +45,12 @@ export const isVolumeDevice = (
   return device.type === "disk" && !!device.pool && !isRoot;
 };
 
-export const isGPUDevice = (device: LxdDeviceValue): device is LxdGPUDevice =>
-  device.type === "gpu";
+export const isGPUDevice = (
+  device: LxdDeviceValue | FormDevice,
+): device is LxdGPUDevice => device.type === "gpu";
 
 export const isProxyDevice = (
-  device: LxdDeviceValue,
+  device: LxdDeviceValue | FormDevice,
 ): device is LxdProxyDevice => device.type === "proxy";
 
 export const isOtherDevice = (

--- a/src/util/formFields.tsx
+++ b/src/util/formFields.tsx
@@ -4,6 +4,7 @@ import type { OptionHTMLAttributes } from "react";
 import type { LxdConfigPair } from "types/config";
 import type { LxdProject } from "types/project";
 import type { LxdStorageVolume } from "types/storage";
+import type { InstanceAndProfileFormikProps } from "components/forms/instanceAndProfileFormValues";
 
 export const getUnhandledKeyValues = (
   item:
@@ -40,4 +41,15 @@ export const optionRenderer = (
 
 export const focusField = (name: string) => {
   setTimeout(() => document.getElementById(name)?.focus(), 100);
+};
+
+export const hasPrefixValue = (
+  formik: InstanceAndProfileFormikProps,
+  keyPrefix: string,
+  ignoreKey?: string,
+): boolean => {
+  return Object.entries(formik.values).some(
+    ([key, value]) =>
+      key.startsWith(keyPrefix) && value !== undefined && key !== ignoreKey,
+  );
 };


### PR DESCRIPTION
## Done

- feat(instance) highlight active instance and profile configuration sections

Fixes #1599

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open an instance configuration and ensure all local configuration sections in the menu with overrides are bold and those without are not bold
    - Repeat for profile configuration and both instance and profile creation.

## Screenshots

<img width="1921" height="955" alt="image" src="https://github.com/user-attachments/assets/f53733ef-7449-4519-bc84-4d53e58ff4e3" />
