### PR TITLE
feat(docs): validate documentation links

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "Scanning for disallowed Unicode characters..."
           # Match non-ASCII characters except — ü and →
-          NON_ASCII_FILES=$(grep --color=always -P -n "[^\x00-\x7F—ü→]" -r . \
+          NON_ASCII_FILES=$(grep --color=always -P -n "[^\x00-\x7F—ü→\x{2713}\x{2717}]" -r . \
             --exclude-dir=.git \
             --exclude=*.png \
             --exclude=*.woff2 \

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,13 +70,13 @@ const config: PlaywrightTestConfig<TestOptions> = {
     {
       name: "enable-clustering-chrome",
       // enable clustering for subsequent tests
-      use: { ...devices["Desktop Chrome"]},
+      use: { ...devices["Desktop Chrome"] },
       testMatch: "enable-clustering.spec.ts",
     },
     {
       name: "enable-clustering-firefox",
       // enable clustering for subsequent tests
-      use: { ...devices["Desktop Firefox"]},
+      use: { ...devices["Desktop Firefox"] },
       testMatch: "enable-clustering.spec.ts",
     },
     {

--- a/tests/helpers/doc-links.ts
+++ b/tests/helpers/doc-links.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
-import { expect } from "../fixtures/lxd-test";
+import { expect, test } from "../fixtures/lxd-test";
+import { execSync } from "child_process";
 
 export const validateLink = async (
   page: Page,
@@ -10,3 +11,50 @@ export const validateLink = async (
     page.getByRole("link", { name: linkText, exact: true }).first(),
   ).toHaveAttribute("href", link);
 };
+
+export function collectAllDocPaths(): Set<string> {
+  const allDocPaths = new Set<string>();
+
+  try {
+    const command = `git grep -A2 "<DocLink" | grep 'docPath="'`;
+    const output = execSync(command, { encoding: "utf-8" });
+
+    output.split("\n").forEach((line) => {
+      const match = line.match(/docPath="([^"]+)"/);
+      if (match) {
+        allDocPaths.add(match[1]);
+      }
+    });
+  } catch {
+    console.warn("No DocLink components found.");
+  }
+
+  return allDocPaths;
+}
+
+export async function checkDocumentationExists(
+  page: Page,
+  docPath: string,
+): Promise<{
+  exists: boolean;
+  status?: number;
+  error?: string;
+}> {
+  try {
+    const fullUrl = `/documentation${docPath}`;
+    const response = await page.request.head(fullUrl);
+    const status = response.status();
+    const exists = status === 200;
+    return { exists, status };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { exists: false, error: errorMessage };
+  }
+}
+
+export function skipIfNotSupported(lxdVersion: string) {
+  test.skip(
+    lxdVersion === "5.0-edge",
+    "Embedded documentation is not supported in LXD 5.0 and older; skipping link validation.",
+  );
+}


### PR DESCRIPTION
## Done

- 


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run `npx playwright test tests/doc-links-validation.spec.ts --project="chromium:lxd-5.21-edge:unclustered" --no-deps`
    
## Screenshots

<img width="978" height="475" alt="image" src="https://github.com/user-attachments/assets/fb563ff9-d158-4949-bcfd-2e899f8683f2" />

