### PR TITLE
fix(network) ipam page link generation for network forwards

### DIFF
--- a/src/pages/networks/NetworkIPAM.tsx
+++ b/src/pages/networks/NetworkIPAM.tsx
@@ -78,8 +78,8 @@ const NetworkIPAM: FC = () => {
       if (allocation.type === "network") {
         return `/ui/project/${encodeURIComponent(item.project)}/network/${encodeURIComponent(item.name)}`;
       }
-      if (allocation.type === "network-forward") {
-        return `/ui/project/${encodeURIComponent(item.project)}/network/${encodeURIComponent(item.name)}/forward`;
+      if (allocation.type === "network-forward" && item.network) {
+        return `/ui/project/${encodeURIComponent(item.project)}/network/${encodeURIComponent(item.network)}/forwards`;
       }
 
       return "";

--- a/src/util/resourceDetails.tsx
+++ b/src/util/resourceDetails.tsx
@@ -6,6 +6,7 @@ export interface ResourceDetail {
   pool?: string;
   instance?: string;
   volume?: string;
+  network?: string;
   description?: string;
   imageType?: string;
   fingerprint?: string;
@@ -72,6 +73,10 @@ export const extractResourceDetailsFromUrl = (
       resourceDetail.pool = urlSegments[4];
       resourceDetail.volume = urlSegments[7];
     }
+  }
+
+  if (resourceType === "network-forward") {
+    resourceDetail.network = urlSegments[4];
   }
 
   // storage volumes could be related to images, so we check if a match can be found based on fingerprint

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -10,6 +10,7 @@ export interface LxdUsedBy {
   project: string;
   instance?: string;
   volume?: string;
+  network?: string;
   pool?: string;
   target?: string;
 }
@@ -66,6 +67,7 @@ export const filterUsedByType = (
           project: resource.project ?? "default",
           instance: resource.instance,
           volume: resource.volume,
+          network: resource.network,
           pool: resource.pool,
           target: resource.target,
         };


### PR DESCRIPTION
## Done

- fix(network) ipam page link generation for network forwards to consider network name and produce correct url

Fixes #1725

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure you have a network forward on a bridge or other network type that supports network forwards
    - visit "networking" > "ipam" page and find the entry for the forward
    - click on the chip for the forward in the used by column, ensure the target is correct
    - ensure you have a custom project, you can create one from the project dropdown if needed
    - visit the custom projects ipam page and ensure the link works as well.

## Screenshots

<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/c2af44b3-9ffa-49dc-bb1d-487163591228" />