### PR TITLE
test(local peering): add e2e tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
       uses: tim-actions/dco@master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -196,11 +196,11 @@ jobs:
         path: blob-reports
         pattern: blob-report-*
         merge-multiple: true
-    
+
     # NOTE: there is no need to install playwright dependencies since we only need to merge reports here
     - name: Merge into HTML Report
       run: npx playwright merge-reports --config=merge.playwright.config.ts ./blob-reports
-    
+
     - uses: actions/upload-artifact@v6
       if: always()
       with:

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -224,15 +224,18 @@ test("network peering", async ({ page }) => {
   await page.getByTestId("notification-close-button").click();
 
   // Create network
-  await createNetwork(page, network, "ovn", false, networkACL);
+  await createNetwork(page, network, "ovn", {
+    hasMemberSpecificParents: false,
+    networkACL,
+  });
   await createNetwork(page, network2, "ovn");
   await createNetwork(page, network3, "ovn");
-  await createNetworkLocalPeering(page, network, network2, "LocalPeering1");
+  await createNetworkLocalPeering(page, "LocalPeering1", network, network2);
   await createNetworkLocalPeering(
     page,
+    "LocalPeering2",
     network,
     network3,
-    "LocalPeering2",
     true,
   );
   await page.getByTestId("notification-close-button").click();
@@ -715,7 +718,7 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
 
   // Network forwards screenshots
 
-  await createNetwork(page, network2, "bridge");
+  await createNetwork(page, network2);
   await visitNetwork(page, network2);
 
   await page.getByText("/24").getByRole("button").click();

--- a/tests/network-local-peering-clustered.spec.ts
+++ b/tests/network-local-peering-clustered.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from "./fixtures/lxd-test";
+import { skipIfNotClustered, skipIfNotSupported } from "./helpers/cluster";
+import {
+  createNetwork,
+  createNetworkLocalPeering,
+  createOvnUplink,
+  deleteLocalPeerings,
+  deleteNetwork,
+  randomNetworkName,
+  visitNetwork,
+} from "./helpers/network";
+
+test.describe("Network Local Peering", () => {
+  const UPLINK_NAME = "ovn-uplink";
+
+  test.beforeEach(async ({ lxdVersion, page }, testInfo) => {
+    skipIfNotSupported(lxdVersion);
+    skipIfNotClustered(testInfo.project.name);
+
+    await createOvnUplink(page, UPLINK_NAME);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await deleteNetwork(page, UPLINK_NAME);
+  });
+
+  test("Create mutual peering between two OVN networks", async ({ page }) => {
+    const networkA = randomNetworkName();
+    const networkB = randomNetworkName();
+    const peering = "peer-mutual";
+
+    await createNetwork(page, networkA, "ovn", {
+      uplink: UPLINK_NAME,
+    });
+    await createNetwork(page, networkB, "ovn", {
+      uplink: UPLINK_NAME,
+    });
+
+    await createNetworkLocalPeering(page, peering, networkA, networkB, true);
+
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Created"),
+    ).toBeVisible();
+
+    await visitNetwork(page, networkB);
+    await page.getByRole("link", { name: "Local peerings" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Created"),
+    ).toBeVisible();
+
+    await deleteLocalPeerings(page, networkA, peering);
+    await deleteLocalPeerings(page, networkB, peering);
+
+    await deleteNetwork(page, networkA);
+    await deleteNetwork(page, networkB);
+  });
+
+  test("Create non-mutual peering between two OVN networks", async ({
+    page,
+  }) => {
+    const networkA = randomNetworkName();
+    const networkB = randomNetworkName();
+    const peering = "peer-one-way";
+
+    await createNetwork(page, networkA, "ovn", {
+      uplink: UPLINK_NAME,
+    });
+    await createNetwork(page, networkB, "ovn", {
+      uplink: UPLINK_NAME,
+    });
+
+    await createNetworkLocalPeering(page, peering, networkA, networkB, false);
+
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Pending"),
+    ).toBeVisible();
+
+    await visitNetwork(page, networkB);
+    await page.getByRole("link", { name: "Local peerings" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }),
+    ).not.toBeVisible();
+
+    await createNetworkLocalPeering(page, peering, networkB, networkA, false);
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Created"),
+    ).toBeVisible();
+
+    await visitNetwork(page, networkA);
+    await page.getByRole("link", { name: "Local peerings" }).click();
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Created"),
+    ).toBeVisible();
+
+    await deleteLocalPeerings(page, networkA, peering);
+    await deleteLocalPeerings(page, networkB, peering);
+
+    await deleteNetwork(page, networkA);
+    await deleteNetwork(page, networkB);
+  });
+
+  test("Manual entry should disable mutual peering checkbox", async ({
+    page,
+  }) => {
+    const networkA = randomNetworkName();
+    const peering = "peer-manual-test";
+    const randomProject = `project-${Math.random().toString(36).substring(7)}`;
+    const randomTargetNetwork = randomNetworkName();
+
+    await createNetwork(page, networkA, "ovn", {
+      uplink: UPLINK_NAME,
+    });
+    await visitNetwork(page, networkA);
+    await page.getByRole("link", { name: "Local peerings" }).click();
+    await page.getByRole("button", { name: "Create local peering" }).click();
+    await page.getByRole("textbox", { name: "* Name" }).fill(peering);
+
+    await page.getByRole("button", { name: "* Target project" }).click();
+    await page.getByRole("option", { name: "Manually enter project" }).click();
+    await page
+      .getByPlaceholder("Enter target project name")
+      .fill(randomProject);
+
+    await page
+      .getByPlaceholder("Enter target network name")
+      .fill(randomTargetNetwork);
+
+    const mutualCheckbox = page.getByLabel("Create mutual peering");
+    await expect(mutualCheckbox).toBeDisabled();
+
+    await page
+      .getByLabel("Side panel")
+      .getByRole("button", { name: "Create local peering" })
+      .click();
+
+    await expect(
+      page.getByText(`Local peering ${peering} created`),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("row").filter({ hasText: peering }).getByText("Pending"),
+    ).toBeVisible();
+
+    await deleteLocalPeerings(page, networkA, peering);
+    await deleteNetwork(page, networkA);
+  });
+});

--- a/tests/networks-clustered.spec.ts
+++ b/tests/networks-clustered.spec.ts
@@ -31,7 +31,9 @@ test.describe("Network operations in a clustered environment with a single node"
     skipIfNotSupported(lxdVersion);
     skipIfNotClustered(testInfo.project.name);
 
-    await createNetwork(page, network, "physical", true);
+    await createNetwork(page, network, "physical", {
+      hasMemberSpecificParents: true,
+    });
     await deleteNetwork(page, network);
   });
 
@@ -44,7 +46,9 @@ test.describe("Network operations in a clustered environment with a single node"
     skipIfNotSupported(lxdVersion);
     skipIfNotClustered(testInfo.project.name);
 
-    await createNetwork(page, network, "macvlan", true);
+    await createNetwork(page, network, "macvlan", {
+      hasMemberSpecificParents: true,
+    });
     await deleteNetwork(page, network);
   });
 });


### PR DESCRIPTION
---

### Pending issue:
I don't know how to create the other part of a peering in case of manual entry. Please help

---

## Done

- Add e2e tests to local peering:
    - Mutual peering
    - Non mutual peering
    - Manual entry


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Tests should pass locally and on CI
    - To run the tests locally: `npx playwright test tests/networks-clustered.spec.ts --project="chromium:lxd-latest-edge:clustered" --no-deps`

## Screenshots

<img width="983" height="367" alt="image" src="https://github.com/user-attachments/assets/985b6c81-1f79-40ca-a2b6-1b2709aed0dc" />
