### PR TITLE
feat(instance) allow detach/attach iso while instance is powered off

### DIFF
--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -89,18 +89,24 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
               }}
             />
           </div>
-          {isGraphic && isRunning && (
+          {isGraphic && (
             <div>
               {hasCustomVolumeIso && <AttachIsoBtn instance={instance} />}
               <Button
                 className="u-no-margin--bottom"
+                disabled={!isRunning}
+                title={
+                  isRunning
+                    ? undefined
+                    : "Start the instance to enter fullscreen"
+                }
                 onClick={() => {
                   handleFullScreen();
                 }}
               >
                 <span>Fullscreen</span>
               </Button>
-              <InstanceConsoleShortcuts />
+              <InstanceConsoleShortcuts disabled={!isRunning} />
             </div>
           )}
         </div>

--- a/src/pages/instances/InstanceConsoleShortcuts.tsx
+++ b/src/pages/instances/InstanceConsoleShortcuts.tsx
@@ -24,7 +24,11 @@ import {
   toggleCtrl,
 } from "lib/spice/src/inputs.js";
 
-const InstanceConsoleShortcuts: FC = () => {
+interface Props {
+  disabled?: boolean;
+}
+
+const InstanceConsoleShortcuts: FC<Props> = ({ disabled }) => {
   const [isAlt, setIsAlt] = useState(false);
   const [isCtrl, setIsCtrl] = useState(false);
 
@@ -60,6 +64,10 @@ const InstanceConsoleShortcuts: FC = () => {
       hasToggleIcon
       toggleLabel="Shortcuts"
       toggleClassName="u-no-margin--bottom"
+      toggleDisabled={disabled}
+      toggleProps={{
+        title: disabled ? "Start the instance to access shortcuts" : undefined,
+      }}
       dropdownClassName="instance-console-shortcut-dropdown"
       links={[
         {

--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -9,11 +9,11 @@ import {
   usePortal,
 } from "@canonical/react-components";
 import { getInstanceEditValues, getInstancePayload } from "util/instanceEdit";
-import type { LxdIsoDevice } from "types/device";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import type { RemoteImage } from "types/image";
 import CustomIsoModal from "pages/images/CustomIsoModal";
+import type { FormDiskDevice } from "util/formDevices";
 import { remoteImageToIsoDevice } from "util/formDevices";
 import { useEventQueue } from "context/eventQueue";
 import { instanceLinkFromOperation } from "util/instances";
@@ -34,9 +34,9 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
   const [isLoading, setLoading] = useState(false);
   const { canEditInstance } = useInstanceEntitlements();
 
-  const attachedIso = instance.devices["iso-volume"] as
-    | LxdIsoDevice
-    | undefined;
+  const attachedIso = getInstanceEditValues(instance).devices.find((device) => {
+    return device.name === "iso-volume";
+  }) as FormDiskDevice | undefined;
 
   const detachIso = () => {
     setLoading(true);
@@ -65,7 +65,7 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
                 <ResourceLink
                   to={`/ui/project/${encodeURIComponent(project ?? "")}/storage/custom-isos`}
                   type="iso-volume"
-                  value={attachedIso?.source ?? ""}
+                  value={attachedIso?.bare?.source ?? ""}
                 />{" "}
                 detached from {instanceLink}
               </>,
@@ -143,7 +143,9 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
 
   return attachedIso ? (
     <>
-      <span className="u-text--muted margin-right">{attachedIso.source}</span>
+      <span className="u-text--muted margin-right">
+        {attachedIso?.bare?.source}
+      </span>
       <ActionButton
         loading={isLoading}
         onClick={detachIso}


### PR DESCRIPTION
## Done

- feat(instance) allow detach/attach iso while instance is powered off

Fixes #1732

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a virtual machine
    - on the graphic console tab for the vm, ensure you can attach/detach an iso when the instance is power on and also when it is powered off.

## Screenshots

<img width="1923" height="958" alt="image" src="https://github.com/user-attachments/assets/9b32931b-97ab-40ab-9d53-4621e4792d89" />