### PR TITLE
chore(ci) ensure ceph and ovn are setup also in coverage and screenshot automation workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,6 +42,12 @@ jobs:
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
+      # - name: Setup Ceph
+      #   uses: canonical/lxd/.github/actions/setup-microceph@main
+
+      - name: Setup OVN
+        uses: canonical/lxd/.github/actions/setup-microovn@main
+
       - name: Install LXD
         uses: canonical/setup-lxd@v1
         with:

--- a/.github/workflows/screenshot_automation.yaml
+++ b/.github/workflows/screenshot_automation.yaml
@@ -48,6 +48,12 @@ jobs:
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
+      # - name: Setup Ceph
+      #   uses: canonical/lxd/.github/actions/setup-microceph@main
+
+      - name: Setup OVN
+        uses: canonical/lxd/.github/actions/setup-microovn@main
+
       - name: Install LXD
         uses: canonical/setup-lxd@v1
         with:


### PR DESCRIPTION
## Done

- chore(ci) ensure ceph and ovn are setup also in coverage and screenshot automation workflows