### PR TITLE
fix: Temp fix to remove the Ceph step in PR CI until later fixes are …

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,9 +122,9 @@ jobs:
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
-      - name: Setup Ceph
-        if: ${{ matrix.lxd_channel != '5.0/edge' }}
-        uses: canonical/lxd/.github/actions/setup-microceph@main
+      # - name: Setup Ceph
+      #   if: ${{ matrix.lxd_channel != '5.0/edge' }}
+      #   uses: canonical/lxd/.github/actions/setup-microceph@main
 
       - name: Setup OVN
         if: ${{ matrix.lxd_channel != '5.0/edge' }}


### PR DESCRIPTION
…introduced

## Done

- Commented out the Ceph setup lines in PR.yaml to account for the fact that we must wait on the backend team to find a new way to setup Ceph.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
- N/A

## Screenshots

N/A