### PR TITLE
feat(delete instance): Use force flag

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -276,9 +276,14 @@ export const updateInstanceBulkAction = async (
 
 export const deleteInstance = async (
   instance: LxdInstance,
+  force?: boolean,
 ): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", instance.project);
+
+  if (force) {
+    params.set("force", "1");
+  }
 
   return fetch(
     `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instance.name)}?${params.toString()}`,

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -45,5 +45,6 @@ export const useSupportedFeatures = () => {
       "storage_and_profile_operations",
     ),
     hasProjectForceDelete: apiExtensions.has("projects_force_delete"),
+    hasInstanceForceDelete: apiExtensions.has("instance_force_delete"),
   };
 };

--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -21,6 +21,7 @@ import { Notification } from "@canonical/react-components";
 import { InstanceRichChip } from "../InstanceRichChip";
 import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   instance: LxdInstance;
@@ -42,6 +43,7 @@ const DeleteInstanceBtn: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { canDeleteInstance } = useInstanceEntitlements();
+  const { hasInstanceForceDelete } = useSupportedFeatures();
   const [isForce, setForce] = useState(false);
 
   const isRunningOrFrozen =
@@ -55,7 +57,7 @@ const DeleteInstanceBtn: FC<Props> = ({
       />
     );
 
-    deleteInstance(instance)
+    deleteInstance(instance, hasInstanceForceDelete && isForce)
       .then((operation) => {
         eventQueue.set(
           operation.metadata.id,
@@ -102,7 +104,8 @@ const DeleteInstanceBtn: FC<Props> = ({
 
     setLoading(true);
 
-    if (isRunningOrFrozen) {
+    // If backend doesn't support force delete, stop the instance first
+    if (isRunningOrFrozen && !hasInstanceForceDelete) {
       const instanceLink = (
         <InstanceRichChip
           instanceName={instance.name}

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -410,3 +410,30 @@ test("'Other' tab is removed when config/creating Instances, on LXD Version 5.0"
   await editInstance(page, instance);
   await expect(page.getByText("Other", { exact: true })).not.toBeVisible();
 });
+
+test("instance deletion (with and without force delete support)", async ({
+  page,
+}) => {
+  await visitAndStartInstance(page, instance);
+
+  await page.getByRole("button", { name: "Delete" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Confirm delete" });
+  await expect(dialog).toBeVisible();
+
+  const forceCheckbox = page.getByLabel("Force delete", { exact: true });
+  const deleteButton = dialog.getByRole("button", { name: "Delete" });
+
+  await expect(deleteButton).toBeDisabled();
+  await forceCheckbox.check({ force: true });
+  await expect(deleteButton).toBeEnabled();
+
+  await deleteButton.click();
+
+  await expect(page.getByText(`Instance ${instance} deleted.`)).toBeVisible();
+  await page
+    .getByRole("link", { name: "Instances", exact: true })
+    .first()
+    .click();
+  await expect(page.getByText(instance)).not.toBeVisible();
+});


### PR DESCRIPTION
## Done

- Delete instance: use force flag


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Have a running instance. Delete it, make sure in the Network tab that the force flag is sent to back end.
    - If you are connected to the latest version of back end, the deletion should work.

## Screenshots
<img width="850" height="59" alt="image" src="https://github.com/user-attachments/assets/efda0f1a-c492-4a06-bd08-99ff7987a7c3" />
<img width="763" height="167" alt="image" src="https://github.com/user-attachments/assets/b7f1be9a-4248-4dc8-a613-7d17b2430b16" />
