### PR TITLE
fix(instance) avoid duplicate iso selection api call when clicking select on an iso image

### DIFF
--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -80,7 +80,10 @@ const CustomIsoSelector: FC<Props> = ({
                   ? "positive"
                   : ""
               }
-              onClick={selectIso}
+              onClick={(e) => {
+                e.stopPropagation();
+                selectIso();
+              }}
               dense
             >
               Select


### PR DESCRIPTION
## Done

- fix(instance) avoid duplicate iso selection api call when clicking select on an iso image
- see linked issue

Fixes https://github.com/canonical/lxd-ui/issues/1737

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a running VM console
    - click detach/attach iso. Select an ISO image with the "select" button on the iso row. Make sure no errors appear. See linked issue for details.

## Screenshots

<img width="3840" height="1914" alt="image" src="https://github.com/user-attachments/assets/468d63f0-458f-49b3-8b11-27a0926b88b9" />
