### PR TITLE
fix(instance) validate terminal message to be trusted and coming from server origin

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -170,7 +170,12 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
 
     data.binaryType = "arraybuffer";
     data.onmessage = (message: MessageEvent<ArrayBuffer>) => {
-      xtermRef.current?.write(new Uint8Array(message.data));
+      const isOriginMatch = message.origin === `${protocol}://${location.host}`;
+      if (message.isTrusted && isOriginMatch) {
+        xtermRef.current?.write(new Uint8Array(message.data));
+      } else {
+        console.error("Ignoring untrusted message", message);
+      }
     };
 
     return [data, control];

--- a/src/pages/instances/InstanceTextConsole.tsx
+++ b/src/pages/instances/InstanceTextConsole.tsx
@@ -124,7 +124,12 @@ const InstanceTextConsole: FC<Props> = ({
 
     data.binaryType = "arraybuffer";
     data.onmessage = (message: MessageEvent<ArrayBuffer>) => {
-      xtermRef.current?.write(new Uint8Array(message.data));
+      const isOriginMatch = message.origin === `${protocol}://${location.host}`;
+      if (message.isTrusted && isOriginMatch) {
+        xtermRef.current?.write(new Uint8Array(message.data));
+      } else {
+        console.warn("Ignored untrusted message", message);
+      }
     };
 
     return [data, control];


### PR DESCRIPTION
## Done

- fix(instance) validate terminal message to be trusted and coming from server origin

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance terminal works as expected

## Screenshots

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/880fa6b8-48e7-40aa-8595-24125c1e3aff" />
