### PR TITLE
feat(delete instance): Disable delete button when instance is protected

### DIFF
--- a/src/pages/instances/actions/DeleteInstanceBtn.tsx
+++ b/src/pages/instances/actions/DeleteInstanceBtn.tsx
@@ -134,17 +134,24 @@ const DeleteInstanceBtn: FC<Props> = ({
   };
 
   const isDeletableStatus = deletableStatuses.includes(instance.status);
+  const isProtectedFromDelete =
+    instance.expanded_config["security.protection.delete"] === "true";
   const isDisabled =
     isLoading ||
     !isDeletableStatus ||
     instanceLoading.getType(instance) === "Migrating" ||
-    !canDeleteInstance(instance);
+    !canDeleteInstance(instance) ||
+    isProtectedFromDelete;
+
   const getHoverText = () => {
     if (!canDeleteInstance(instance)) {
       return "You do not have permission to delete this instance";
     }
     if (!isDeletableStatus) {
       return "Stop the instance to delete it";
+    }
+    if (isProtectedFromDelete) {
+      return "Update security policies to remove the delete protection.";
     }
     return "Delete instance";
   };


### PR DESCRIPTION
## Done

- Disable delete button when instance is protected

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Delete an instance that is not protected from deletion: the Delete button should be enabled
    - Go to the instance's security policies and set "Protect deletion" to `Yes`. Save change. The Delete button should now be disabled. When hovered, the button's title should display a meaningful message: `Instance is protected from deletion. Update security policies to allow deletion.`

## Screenshots

<img width="1843" height="1056" alt="image" src="https://github.com/user-attachments/assets/21f3fa44-3e59-479c-9999-e013cb97e470" />

<img width="1843" height="1056" alt="image" src="https://github.com/user-attachments/assets/8c78eeff-11d4-4e2c-9c21-9b539bec35d7" />
