### PR TITLE
feat(create auth group): disable all fields as long as name is invalid

### DIFF
--- a/src/components/FormLink.tsx
+++ b/src/components/FormLink.tsx
@@ -7,15 +7,27 @@ interface Props {
   onClick: () => void;
   isModified?: boolean;
   subText?: ReactNode;
+  disabled?: boolean;
+  onHoverText?: string;
 }
 
-const FormLink: FC<Props> = ({ title, icon, onClick, subText, isModified }) => {
+const FormLink: FC<Props> = ({
+  title,
+  icon,
+  onClick,
+  subText,
+  isModified,
+  disabled,
+  onHoverText,
+}) => {
   return (
     <Button
       appearance="base"
       className="form-link"
       onClick={onClick}
       type="button"
+      disabled={disabled}
+      title={onHoverText}
     >
       <span className="form-link__column">
         <Icon name={icon} className="form-link__icon" />

--- a/src/pages/permissions/forms/GroupForm.tsx
+++ b/src/pages/permissions/forms/GroupForm.tsx
@@ -52,6 +52,22 @@ const GroupForm: FC<Props> = ({
       ? ""
       : "You do not have permission to modify this group";
 
+  const isNameInvalid = !formik.values.name || !!formik.errors.name;
+  const isFieldDisabled = !!groupEditRestriction || isNameInvalid;
+
+  const getDisableReason = () => {
+    if (groupEditRestriction) {
+      return groupEditRestriction;
+    }
+
+    if (isNameInvalid) {
+      return "Enter a valid group name first";
+    }
+
+    return undefined;
+  };
+  const disableReason = getDisableReason();
+
   return (
     <Form onSubmit={formik.handleSubmit}>
       {/* hidden submit to enable enter key in inputs */}
@@ -68,8 +84,8 @@ const GroupForm: FC<Props> = ({
       <AutoExpandingTextArea
         {...getFormProps("description")}
         label="Description"
-        disabled={!!groupEditRestriction}
-        title={groupEditRestriction}
+        disabled={isFieldDisabled}
+        title={disableReason}
       />
       <FormLink
         title={(isEditing ? "Edit " : "Add ") + pluralize("identity", 2)}
@@ -83,6 +99,8 @@ const GroupForm: FC<Props> = ({
             ? `No ${pluralize("identity", 2)}`
             : `${identityCount} ${pluralize("identity", identityCount)}`
         }
+        disabled={isFieldDisabled}
+        onHoverText={disableReason}
       />
       <FormLink
         title={(isEditing ? "Edit " : "Add ") + pluralize("permission", 2)}
@@ -96,6 +114,8 @@ const GroupForm: FC<Props> = ({
             ? `No ${pluralize("permission", 2)}`
             : `${permissionCount} ${pluralize("permission", permissionCount)}`
         }
+        disabled={isFieldDisabled}
+        onHoverText={disableReason}
       />
     </Form>
   );


### PR DESCRIPTION
## Done

- Create auth group: disable all fields in the side panel as long as name is invalid

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions > Groups > Create auth group
    - All fields should be disabled
    - Type a valid name
    - All fields should be enabled

## Screenshots

<img width="1862" height="1054" alt="Screenshot from 2026-02-04 11-25-39" src="https://github.com/user-attachments/assets/c48c9494-18cd-42d0-b9c6-5e81eb8feb76" />
