### PR TITLE
fix(instance) allow vga clipboard sharing with windows guests

### DIFF
--- a/src/lib/spice/src/display.js
+++ b/src/lib/spice/src/display.js
@@ -853,7 +853,10 @@ SpiceDisplayConn.prototype.hook_events = function()
         canvas.focus();
 
         this.focusListener = () => this.parent.send_clipboard_grab()
-        canvas.addEventListener("focus", this.focusListener);
+        // send host clipboard when the canvas is rendered initially
+        this.focusListener();
+        // register focus event to grab host clipboard when the canvas gets focus
+        canvas.addEventListener('focus', this.focusListener);
     }
 }
 
@@ -871,7 +874,7 @@ SpiceDisplayConn.prototype.unhook_events = function()
         canvas.removeEventListener('mouseout', handle_mouseout);
         canvas.removeEventListener('mouseover', handle_mouseover);
         canvas.removeEventListener('wheel', Inputs.handle_mousewheel);
-        canvas.removeEventListener("focus", this.focusListener);
+        canvas.removeEventListener('focus', this.focusListener);
     }
 }
 

--- a/src/lib/spice/src/main.js
+++ b/src/lib/spice/src/main.js
@@ -75,6 +75,7 @@ function SpiceMainConn()
     this.file_xfer_task_id = 0;
     this.file_xfer_read_queue = [];
     this.ports = [];
+    this.agent_caps = [0]
 }
 
 SpiceMainConn.prototype = Object.create(SpiceConn.prototype);
@@ -233,6 +234,7 @@ SpiceMainConn.prototype.process_channel_message = function(msg)
         if (agent_data.type == Constants.VD_AGENT_ANNOUNCE_CAPABILITIES)
         {
             var agent_caps = new Messages.VDAgentAnnounceCapabilities(agent_data.data);
+            this.agent_caps = [agent_caps.caps];
             if (agent_caps.request)
                 this.announce_agent_capabilities(0);
             return true;
@@ -256,6 +258,11 @@ SpiceMainConn.prototype.process_channel_message = function(msg)
         {
             this.handle_clipboard_send();
             return true;
+        }
+        else if (agent_data.type == Constants.VD_AGENT_CLIPBOARD_RELEASE)
+        {
+          // Currently we don't need to do anything when the agent releases the clipboard
+          return true;
         }
 
         return false;
@@ -494,7 +501,7 @@ SpiceMainConn.prototype.handle_clipboard_grab = function()
 
     // agent is requesting clipboard grab, so we send a message to request clipboard contents
     const type = Constants.VD_AGENT_CLIPBOARD_UTF8_TEXT;
-    const clipboard_request = new Messages.SpiceMsgClipboardRequest(type);
+    const clipboard_request = new Messages.SpiceMsgClipboardRequest(type, this.agent_caps);
     this.send_agent_message(Constants.VD_AGENT_CLIPBOARD_REQUEST, clipboard_request);
 }
 
@@ -503,28 +510,34 @@ SpiceMainConn.prototype.handle_clipboard_receive = function(agent_data)
     DEBUG > 1 && console.log("received clipboard data from agent");
 
     // received clipboard data from agent, copy it to browser clipboard
-    const received_clipboard = new Messages.SpiceMsgClipboardReceive(agent_data);
-    if (received_clipboard.type === Constants.VD_AGENT_CLIPBOARD_UTF8_TEXT) {
+    const received_clipboard = new Messages.SpiceMsgClipboardReceive(agent_data, this.agent_caps);
+    if (received_clipboard.type === Constants.VD_AGENT_CLIPBOARD_UTF8_TEXT)
+    {
         // write it to the browser clipboard
-        if (navigator.clipboard && navigator.clipboard.writeText) {
+        if (navigator.clipboard && navigator.clipboard.writeText)
+        {
             const text = received_clipboard.get_text();
             navigator.clipboard.writeText(text).catch(err => {
                 console.warn("Failed to write to navigator clipboard:", err);
             });
         }
-    } else {
+    }
+    else
+    {
         console.log("Unsupported clipboard type:", received_clipboard.type);
     }
 }
 
-SpiceMainConn.prototype.handle_clipboard_send = function() {
+SpiceMainConn.prototype.handle_clipboard_send = function()
+{
     DEBUG > 1 && console.log("sending clipboard data to agent");
 
     // agent is requesting clipboard data, read it from browser clipboard and send it.
-    if (navigator.clipboard && navigator.clipboard.readText) {
+    if (navigator.clipboard && navigator.clipboard.readText)
+    {
         navigator.clipboard.readText().then(text => {
             const type = Constants.VD_AGENT_CLIPBOARD_UTF8_TEXT;
-            const clipboard_msg = new Messages.SpiceMsgClipboardSend(type, text);
+            const clipboard_msg = new Messages.SpiceMsgClipboardSend(type, text, this.agent_caps);
             this.send_agent_message(Constants.VD_AGENT_CLIPBOARD, clipboard_msg);
         }).catch(err => {
             console.log("Failed to read clipboard:", err);
@@ -538,7 +551,7 @@ SpiceMainConn.prototype.send_clipboard_grab = function()
 
     // Send clipboard grab to agent. Agent will then ask for the host os clipboard contents in a dedicated message.
     const type = Constants.VD_AGENT_CLIPBOARD_UTF8_TEXT;
-    const grab_message = new Messages.SpiceMsgClipboardGrab(type);
+    const grab_message = new Messages.SpiceMsgClipboardGrab(type, this.agent_caps);
     this.send_agent_message(Constants.VD_AGENT_CLIPBOARD_GRAB, grab_message)
 }
 

--- a/src/lib/spice/src/spiceconn.js
+++ b/src/lib/spice/src/spiceconn.js
@@ -424,7 +424,7 @@ SpiceConn.prototype =
         else if (this.type == Constants.SPICE_CHANNEL_SMARTCARD)
             return "smartcard";
         else if (this.type == Constants.SPICE_CHANNEL_USBREDIR)
-            return "Fusbredir";
+            return "usbredir";
         else if (this.type == Constants.SPICE_CHANNEL_PORT)
             return "port";
         else if (this.type == Constants.SPICE_CHANNEL_WEBDAV)

--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -17,10 +17,6 @@
 
   .spice-wrapper {
     overflow: auto;
-
-    canvas {
-      cursor: none;
-    }
   }
 
   #spice-screen canvas {


### PR DESCRIPTION
## Done

- fix(instance) allow vga clipboard sharing with windows guests

See https://gitlab.freedesktop.org/spice/spice-html5/-/merge_requests/16

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run a windows 11 desktop vm, [see tutorial](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd#1-overview), then install windows [quemu agent](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win-guest-tools.exe). Ensure copy-paste from the browser VGA console works between host and guest.

## Screenshots

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/287ec5d3-ab7e-4df0-bb0d-0eb7d63a462c" />
