### PR TITLE
fix(instance) on narrow graphic console, rely on the scaled height of the area to avoid scrollbars

### DIFF
--- a/src/lib/spice/src/display.js
+++ b/src/lib/spice/src/display.js
@@ -524,8 +524,6 @@ SpiceDisplayConn.prototype.process_channel_message = function(msg)
             canvas.context.save();
             document.getElementById(this.parent.screen_id).appendChild(canvas);
 
-            /* We're going to leave width dynamic, but correctly set the height */
-            document.getElementById(this.parent.screen_id).style.height = m.surface.height + "px";
             this.hook_events();
         }
         return true;

--- a/src/lib/spice/src/resize.js
+++ b/src/lib/spice/src/resize.js
@@ -46,7 +46,9 @@ function resize_helper(sc)
       || document.mozFullScreenElement
       || document.msFullscreenElement;
 
-    var height = window.innerHeight - wrapper.getBoundingClientRect().top;
+    var height = window.innerHeight
+      - wrapper.getBoundingClientRect().top // removing space above by taking wrappers top position
+      - wrapper.parentNode.scrollTop; // spice wrapper might be scrolled down, reduce available height by it
 
     /* leave a margin at the bottom (and reserve status bar height) when not in full screen */
     if (!isFullScreen) {

--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -21,6 +21,7 @@
 
   #spice-screen canvas {
     background: black;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
## Done

- fix(instance) on narrow graphic console, rely on the scaled height of the area to avoid scrollbars

Fixes #1748

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open graphical console of a desktop vm
    - resize screen to narrow browser width. Ensure no scrollbars appear

## Screenshots

<img width="2326" height="1812" alt="image" src="https://github.com/user-attachments/assets/2db4e895-beb2-4792-8ca5-3d30808c093c" />