### PR TITLE
fix(confirmation) ensure force flags are in sync with ui selections

### DIFF
--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { useEffect, useRef } from "react";
 import { useState } from "react";
 import type { LxdInstance } from "types/instance";
 import { useQueryClient } from "@tanstack/react-query";
@@ -27,6 +28,13 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
     instanceLoading.getType(instance) === "Restarting" ||
     instance.status === "Restarting";
   const { canUpdateInstanceState } = useInstanceEntitlements();
+  const isForceRef = useRef(isForce);
+
+  // The MountedConfirmationButton saves a reference to the handleRestart callback when the modal is opened,
+  // so we need to use a ref to ensure we have the latest value of isForce when the user confirms the action.
+  useEffect(() => {
+    isForceRef.current = isForce;
+  }, [isForce]);
 
   const instanceLink = (
     <InstanceRichChip
@@ -37,7 +45,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
 
   const handleRestart = () => {
     instanceLoading.setLoading(instance, "Restarting");
-    restartInstance(instance, isForce)
+    restartInstance(instance, isForceRef.current)
       .then((operation) => {
         eventQueue.set(
           operation.metadata.id,

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { useEffect, useRef } from "react";
 import { useState } from "react";
 import type { LxdInstance } from "types/instance";
 import { useQueryClient } from "@tanstack/react-query";
@@ -24,6 +25,13 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
   const [isForce, setForce] = useState(false);
   const queryClient = useQueryClient();
   const { canUpdateInstanceState } = useInstanceEntitlements();
+  const isForceRef = useRef(isForce);
+
+  // The MountedConfirmationButton saves a reference to the handleStop callback when the modal is opened,
+  // so we need to use a ref to ensure we have the latest value of isForce when the user confirms the action.
+  useEffect(() => {
+    isForceRef.current = isForce;
+  }, [isForce]);
 
   const clearCache = () => {
     queryClient.invalidateQueries({
@@ -44,7 +52,7 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
 
   const handleStop = () => {
     instanceLoading.setLoading(instance, "Stopping");
-    stopInstance(instance, isForce)
+    stopInstance(instance, isForceRef.current)
       .then((operation) => {
         eventQueue.set(
           operation.metadata.id,


### PR DESCRIPTION
## Done

- fix(confirmation) ensure force flags are in sync with ui selections.

Fixes #1746

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
  - Go to an instance detail page and start the instance.
  - Refresh the instance detail page
  - Click stop > enable force flag > confirm stop
  - Investigate in the network tab that the request is sent with `force: true`

## Screenshots

<img width="3816" height="1912" alt="image" src="https://github.com/user-attachments/assets/17400042-e810-4313-94d4-1bf5cde3e2c4" />
