### PR TITLE
fix(instance) hide cursor only on spice screen, not on spice wrapper

### DIFF
--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -16,8 +16,11 @@
   }
 
   .spice-wrapper {
-    cursor: none;
     overflow: auto;
+
+    canvas {
+      cursor: none;
+    }
   }
 
   #spice-screen canvas {


### PR DESCRIPTION
## Done

- fix(instance) hide cursor only on spice screen, not on spice wrapper

Fixes #1768

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open a desktop vm graphic console
    - ensure the cursor of the host system is visible on the edges of the virtual screen.
    - resize browser window and ensure screen edges are precisely used for hiding the cursor
    - see linked issue for more details

## Screenshots

<img width="1870" height="2155" alt="image" src="https://github.com/user-attachments/assets/d9453995-de92-48f1-ac8f-e4e3e5539412" />
