### PR TITLE
fix(Network device): Disable Edit button for custom network

### DIFF
--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceFormCustom.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceFormCustom.tsx
@@ -50,7 +50,7 @@ const NetworkDeviceFormCustom: FC<Props> = ({
       actions: typedDevice.type?.includes("nic") ? (
         <NetworkDeviceActionButtons
           formik={formik}
-          device={typedDevice as LxdNicDevice}
+          device={typedDevice}
           inheritedDevice={inheritedDevice}
         />
       ) : null,

--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceFormInherited.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceFormInherited.tsx
@@ -4,12 +4,14 @@ import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfi
 import type { InheritedNetwork } from "util/configInheritance";
 import type { LxdNetwork } from "types/network";
 import type { LxdNicDevice, LxdNoneDevice } from "types/device";
-import { isNicDevice, isNoneDevice } from "util/devices";
+import { isCustomNic, isNicDevice, isNoneDevice } from "util/devices";
 import { isDeviceModified } from "util/formChangeCount";
 import NetworkDeviceActionButtons from "components/forms/NetworkDevicesForm/read/NetworkDeviceActionButtons";
 import ConfigurationTable from "components/ConfigurationTable";
 import { getNetworkDeviceRows } from "components/forms/NetworkDevicesForm/read/NetworkDeviceRows";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
+import type { CustomNetworkDevice, FormDevice } from "types/formDevice";
+import { isCustomNicFormDevice } from "util/formDevices";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -26,25 +28,50 @@ const NetworkDeviceFormInherited: FC<Props> = ({
 }) => {
   if (inheritedNetworkDevices.length === 0) return null;
 
-  const rows = inheritedNetworkDevices.flatMap((device) => {
+  const rows = inheritedNetworkDevices.flatMap((inherited) => {
     const overrideDevice = formik.values.devices.find(
-      (t) => t.name === device.key,
-    ) as LxdNicDevice | LxdNoneDevice | undefined;
+      (t) => t.name === inherited.key,
+    ) as LxdNicDevice | LxdNoneDevice | CustomNetworkDevice | undefined;
 
     const isOverridden = overrideDevice !== undefined;
     const isDetached = overrideDevice && isNoneDevice(overrideDevice);
     const hasNicOverride =
-      device && overrideDevice && isNicDevice(overrideDevice);
+      inherited && overrideDevice && isNicDevice(overrideDevice);
+    const hasCustomOverride =
+      inherited &&
+      overrideDevice &&
+      isCustomNicFormDevice(overrideDevice as FormDevice);
 
-    const effectiveDevice =
-      overrideDevice && isNicDevice(overrideDevice)
-        ? overrideDevice
-        : ({ ...device.network, name: device.key } as LxdNicDevice);
+    const getEffectiveDevice = () => {
+      if (overrideDevice && isNicDevice(overrideDevice)) {
+        return overrideDevice;
+      }
+      if (
+        overrideDevice &&
+        isCustomNicFormDevice(overrideDevice as FormDevice)
+      ) {
+        return overrideDevice as CustomNetworkDevice;
+      }
+      if (inherited.network) {
+        if (isCustomNic(inherited.network)) {
+          return {
+            name: inherited.key,
+            type: "custom-nic",
+            bare: inherited.network,
+          } as CustomNetworkDevice;
+        }
+
+        return { ...inherited.network, name: inherited.key } as LxdNicDevice;
+      }
+      return null;
+    };
+
+    const effectiveDevice = getEffectiveDevice();
 
     const deviceModified =
-      overrideDevice && isDeviceModified(formik, device.key);
+      overrideDevice && isDeviceModified(formik, inherited.key);
     const initialOverride = formik.initialValues.devices.find(
-      (t) => t.name === device.key,
+      (t) => t.name === inherited.key,
     );
     const hasOverrideBeenRemoved = initialOverride && !overrideDevice;
 
@@ -58,13 +85,13 @@ const NetworkDeviceFormInherited: FC<Props> = ({
       sourceProfile: (
         <>
           <ProfileRichChip
-            profileName={device.sourceProfile}
+            profileName={inherited.sourceProfile}
             projectName={project}
             className={classnames({
               "u-text--line-through": isOverridden,
             })}
           />
-          {hasNicOverride && (
+          {(hasNicOverride || hasCustomOverride) && (
             <>
               <br />
               <i className="u-text--muted p-text--small">with local override</i>
@@ -82,7 +109,7 @@ const NetworkDeviceFormInherited: FC<Props> = ({
         <NetworkDeviceActionButtons
           formik={formik}
           device={overrideDevice}
-          inheritedDevice={device}
+          inheritedDevice={inherited}
         />
       ),
     });

--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
@@ -46,7 +46,7 @@ export const getNetworkDeviceRows = ({
 }: {
   project: string;
   managedNetworks: LxdNetwork[];
-  device: LxdNicDevice | CustomNetworkDevice;
+  device: LxdNicDevice | CustomNetworkDevice | null;
   showIpAddresses?: boolean;
   isDetached?: boolean;
   hasChanges?: boolean;
@@ -86,13 +86,18 @@ export const getNetworkDeviceRows = ({
   if (device.type === "custom-nic") {
     rows.push(
       getConfigurationRowBase({
+        className: "no-border-top",
         configuration: (
-          <>
+          <span
+            className={classnames({
+              "u-text--line-through": isDetached,
+            })}
+          >
             custom network{" "}
             <Tooltip message="A custom network can be viewed and edited only from the YAML configuration">
               <Icon name="information" />
             </Tooltip>
-          </>
+          </span>
         ),
         inherited: null,
         override: null,

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -31,8 +31,9 @@ export const isHostDiskDevice = (device: LxdDiskDevice): boolean => {
   );
 };
 
-export const isNoneDevice = (device: LxdDeviceValue): device is LxdNoneDevice =>
-  device.type === "none";
+export const isNoneDevice = (
+  device: LxdDeviceValue | FormDevice,
+): device is LxdNoneDevice => device.type === "none";
 
 export const isVolumeDevice = (
   device: FormDiskDevice | LxdDiskDevice,
@@ -64,6 +65,21 @@ export const isOtherDevice = (
     "unix-hotplug",
   ];
   return otherDeviceTypes.includes(device.type ?? "");
+};
+
+export const isCustomNic = (device: LxdDeviceValue): boolean => {
+  const standardKeys = [
+    "type",
+    "name",
+    "network",
+    "security.acls",
+    "ipv4.address",
+    "ipv6.address",
+  ];
+  return (
+    isNicDevice(device) &&
+    Object.keys(device).some((key) => !standardKeys.includes(key))
+  );
 };
 
 export const deviceKeyToLabel = (input: string): string => {


### PR DESCRIPTION
## Done

- Network device of an instance: disable Edit button for custom networks
- Handle inherited custom networks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a profile with a nic device. Change the YAML configuration to make the nic device custom: add `hwaddr: 00:16:3e:00:00:01` in the network device configuration.
    - Create an instance with this profile.
    - Go to the instance configuration and make sure the inherited device is displayed as custom and the `Edit` button is disabled.
    - Attach a network to the instance. Update the YAML configuration: add `hwaddr: 00:16:3e:00:00:01` in the network device configuration.
    - Make sure the newly attached device is displayed as custom and the `Edit` button is disabled.


## Screenshots

<img width="939" height="257" alt="image" src="https://github.com/user-attachments/assets/bf0f4df1-f6c0-4863-9cad-d6c19ffd5337" />
<img width="871" height="214" alt="image" src="https://github.com/user-attachments/assets/25fac52b-9f73-4210-8d1e-9192be136841" />

