### PR TITLE
feat: [WD-32423] Add ACL default action for Instance NICs

### DIFF
--- a/src/pages/networks/forms/NetworkAclSelector.tsx
+++ b/src/pages/networks/forms/NetworkAclSelector.tsx
@@ -1,7 +1,6 @@
 import type { FC, ReactNode } from "react";
 import { MultiSelect } from "@canonical/react-components";
 import { useNetworkAcls } from "context/useNetworkAcls";
-import classnames from "classnames";
 
 interface Props {
   project: string;
@@ -52,16 +51,7 @@ const NetworkAclSelector: FC<Props> = ({
 
   return (
     <>
-      {label && (
-        <label
-          className={classnames({
-            "u-text--muted": !isEnabled,
-          })}
-          htmlFor={id}
-        >
-          {label}
-        </label>
-      )}
+      {label && <label htmlFor={id}>{label}</label>}
       <MultiSelect
         items={toOptionList(
           availableAcls.map((acl) => acl.name),

--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -7,7 +7,9 @@ import FormEditButton from "components/FormEditButton";
 import { ensureEditMode } from "util/instanceEdit";
 import NetworkAclSelector from "pages/networks/forms/NetworkAclSelector";
 import { Label } from "@canonical/react-components";
-import NetworkDefaultACLSelector from "./NetworkDefaultACLSelector";
+import NetworkDefaultACLSelector, {
+  type Direction,
+} from "./NetworkDefaultACLSelector";
 import NetworkDefaultACLRead from "./NetworkDefaultACLRead";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -21,6 +23,11 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
   const defaultEgressIngress = {
     Egress: formik.values.security_acls_default_egress ?? "",
     Ingress: formik.values.security_acls_default_ingress ?? "",
+  };
+
+  const directionField: Record<Direction, string> = {
+    Egress: "security_acls_default_egress",
+    Ingress: "security_acls_default_ingress",
   };
 
   return (
@@ -87,6 +94,7 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
             }}
             values={defaultEgressIngress}
             disabled={formik.values.security_acls.length === 0}
+            directionField={directionField}
           />
         )}
       </div>

--- a/src/pages/networks/forms/NetworkDefaultACLRead.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLRead.tsx
@@ -14,11 +14,11 @@ const NetworkDefaultACLRead: FC<{
       When no ACL rule matches:
       <br />
       <Icon name="arrow-left" className="network-default-acl-icon" />
-      Egress traffic will be{" "}
+      Egress traffic is:{" "}
       <code>{conjugateACLAction(egressAction || "reject")}</code>
       <br />
       <Icon name="arrow-right" className="network-default-acl-icon" />
-      Ingress traffic will be{" "}
+      Ingress traffic is:{" "}
       <code>{conjugateACLAction(ingressAction || "reject")}</code>
     </div>
   );

--- a/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
@@ -9,19 +9,17 @@ interface Props {
   onChange: (fieldValue: string, value: string) => void;
   values?: Record<Direction, string>;
   disabled?: boolean;
+  directionField: Record<Direction, string>;
 }
 
 const NetworkDefaultACLSelector: FC<Props> = ({
   values,
   onChange,
   disabled,
+  directionField,
 }) => {
   const DIRECTIONS: Direction[] = ["Egress", "Ingress"];
   const ACTIONS = ["allow", "drop", "reject"];
-  const FIELD_BY_DIRECTION: Record<Direction, string> = {
-    Egress: "security_acls_default_egress",
-    Ingress: "security_acls_default_ingress",
-  };
 
   const options = [
     { label: "Select option", value: "" },
@@ -50,7 +48,7 @@ const NetworkDefaultACLSelector: FC<Props> = ({
                   className="u-no-margin--bottom"
                   options={options}
                   onChange={(e) => {
-                    onChange(FIELD_BY_DIRECTION[direction], e.target.value);
+                    onChange(directionField[direction], e.target.value);
                   }}
                   value={values?.[direction]}
                   disabled={disabled}

--- a/src/sass/_network_device_form.scss
+++ b/src/sass/_network_device_form.scss
@@ -1,4 +1,15 @@
 .network-device-form {
+  .acl-defaults .inherited {
+    padding-top: 0;
+  }
+
+  .custom-devices,
+  .inherited-devices {
+    .inherited {
+      width: 12rem;
+    }
+  }
+
   .scrollable-container {
     .content-details {
       .inherited-network-device-configuration-table,

--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -27,6 +27,8 @@ export interface LxdNicDevice {
   "ipv4.address"?: string;
   "ipv6.address"?: string;
   "security.acls"?: string;
+  "security.acls.default.egress.action"?: string;
+  "security.acls.default.ingress.action"?: string;
 }
 
 export interface LxdPhysicalGPUDevice {

--- a/src/types/forms/networkDevice.d.ts
+++ b/src/types/forms/networkDevice.d.ts
@@ -4,4 +4,6 @@ export interface NetworkDeviceFormValues {
   acls?: string;
   ipv4?: string;
   ipv6?: string;
+  security_acls_default_ingress_action?: string;
+  security_acls_default_egress_action?: string;
 }

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -85,6 +85,8 @@ export const isCustomNic = (device: LxdDeviceValue): boolean => {
     "security.acls",
     "ipv4.address",
     "ipv6.address",
+    "security.acls.default.egress.action",
+    "security.acls.default.ingress.action",
   ];
   return (
     isNicDevice(device) &&

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -80,6 +80,10 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
           network: item.network,
           type: "nic",
           "security.acls": item["security.acls"],
+          "security.acls.default.egress.action":
+            item["security.acls.default.egress.action"],
+          "security.acls.default.ingress.action":
+            item["security.acls.default.ingress.action"],
         };
       case "disk":
         return {


### PR DESCRIPTION
## Done
Add ACL default action for Instance NICs
~~Currently NON-FUNCTIONAL~~

- [x] Show ACL default action selector in Instance NIC side panel
- [x] Be able to edit default action selector (DAS)
- [x] Be able to display accurate values in DAS
- [x] Show read-only DAS accurately
- [x] Disable DAS for non-OVN networks (but still fetch data on bridge networks)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an OVN network X
    - Create an ACL for OVN network rejecting everything and assign to OVN network
    - Create an instance and add custom network X to it.
    - Edit the custom network to have ACL default values that are NOT the same as those assigned to the network, such as Allow.
    - Save, and verify that the changes are reflected in the Read-Only and the YAML configuration.

## Screenshots

<img width="1623" height="1021" alt="image" src="https://github.com/user-attachments/assets/69d2142e-8c54-4b2a-b6d8-3313232265db" />