### PR TITLE
fix(network) show partial network list on one cluster member being down

### DIFF
--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -60,11 +60,19 @@ export const fetchNetworksFromClusterMembers = async (
           const memberName = clusterMembers[i].server_name;
           const result = results[i];
           if (result.status === "rejected") {
-            reject(constructMemberError(result, memberName));
+            networksOnMembers.push({
+              ...result,
+              memberName,
+              promiseStatus: "rejected",
+            });
           }
           if (result.status === "fulfilled") {
             result.value.forEach((network) =>
-              networksOnMembers.push({ ...network, memberName }),
+              networksOnMembers.push({
+                ...network,
+                memberName,
+                promiseStatus: "fulfilled",
+              }),
             );
           }
         }
@@ -116,7 +124,11 @@ export const fetchNetworkFromClusterMembers = async (
           }
           if (result.status === "fulfilled") {
             const promise = results[i] as PromiseFulfilledResult<LxdNetwork>;
-            networkOnMembers.push({ ...promise.value, memberName: memberName });
+            networkOnMembers.push({
+              ...promise.value,
+              memberName: memberName,
+              promiseStatus: "fulfilled",
+            });
           }
         }
         resolve(networkOnMembers);

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
 import {
   Button,
   EmptyState,
@@ -20,7 +20,11 @@ import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
 import NetworkForwardCount from "pages/networks/NetworkForwardCount";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
-import { renderNetworkType } from "util/networks";
+import {
+  isNetwork,
+  notifyNetworkError,
+  renderNetworkType,
+} from "util/networks";
 import { useClusterMembers } from "context/useClusterMembers";
 import PageHeader from "components/PageHeader";
 import type { NetworkFilters } from "pages/networks/NetworkSearchFilter";
@@ -31,7 +35,7 @@ import NetworkSearchFilter, {
   TYPE,
   QUERY,
 } from "pages/networks/NetworkSearchFilter";
-import type { LXDNetworkOnClusterMember } from "types/network";
+import type { LXDNetworkOnClusterMemberFulfilled } from "types/network";
 import NetworkClusterMemberChip from "pages/networks/NetworkClusterMemberChip";
 import {
   useNetworks,
@@ -85,15 +89,21 @@ const NetworkList: FC = () => {
     }
   }, [clusterNetworkError]);
 
-  const renderNetworks: LXDNetworkOnClusterMember[] = networks
+  useEffect(() => {
+    notifyNetworkError(networksOnClusterMembers, notify);
+  }, [networksOnClusterMembers]);
+
+  const renderNetworks: LXDNetworkOnClusterMemberFulfilled[] = networks
     .filter((network) => !isClustered || network.managed)
     .map((network) => {
       return {
         ...network,
+        promiseStatus: "fulfilled",
         memberName: "Cluster-wide",
       };
     });
-  networksOnClusterMembers.forEach((network) => {
+
+  networksOnClusterMembers.filter(isNetwork).forEach((network) => {
     if (!network.managed) {
       renderNetworks.push(network);
     }

--- a/src/pages/networks/NetworkParentTooltipRow.tsx
+++ b/src/pages/networks/NetworkParentTooltipRow.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useNetworkFromClusterMembers } from "context/useNetworks";
 import type { LxdNetwork } from "types/network";
+import { isNetwork } from "util/networks";
 
 interface Props {
   network: LxdNetwork;
@@ -14,6 +15,7 @@ export const NetworkParentTooltipRow: FC<Props> = ({ network, project }) => {
   );
   if (networksFromClusterMembers && networksFromClusterMembers.length > 0) {
     const parents = networksFromClusterMembers
+      .filter(isNetwork)
       .filter((n) => n !== undefined && n.config && n.config.parent)
       .map((n) => n.config.parent);
 

--- a/src/types/network.d.ts
+++ b/src/types/network.d.ts
@@ -79,9 +79,19 @@ export interface LxdNetwork {
   access_entitlements?: string[];
 }
 
-export type LXDNetworkOnClusterMember = LxdNetwork & {
+export type LXDNetworkOnClusterMemberRejected = {
+  promiseStatus: "rejected";
   memberName: string;
-};
+} & PromiseRejectedResult;
+
+export type LXDNetworkOnClusterMemberFulfilled = {
+  promiseStatus: "fulfilled";
+  memberName: string;
+} & LxdNetwork;
+
+export type LXDNetworkOnClusterMember =
+  | LXDNetworkOnClusterMemberFulfilled
+  | LXDNetworkOnClusterMemberRejected;
 
 export interface LxdNetworkStateAddress {
   family: string;

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -2,7 +2,7 @@ import type {
   LxdNetwork,
   LxdNetworkBridgeDriver,
   LxdNetworkDnsMode,
-  LXDNetworkOnClusterMember,
+  LXDNetworkOnClusterMemberFulfilled,
 } from "types/network";
 import type { NetworkFormValues } from "types/forms/network";
 import { getNetworkAcls, getNetworkKey } from "util/networks";
@@ -10,7 +10,7 @@ import type { ClusterSpecificValues } from "types/cluster";
 
 export const toNetworkFormValues = (
   network: LxdNetwork,
-  networkOnMembers?: LXDNetworkOnClusterMember[],
+  networkOnMembers?: LXDNetworkOnClusterMemberFulfilled[],
   editRestriction?: string,
 ): NetworkFormValues => {
   const parentPerClusterMember: ClusterSpecificValues = {};


### PR DESCRIPTION
## Done

- fix(network) show partial network list on one cluster member being down

Fixes WD-33679

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - browse network list of a cluster
    - switch off one of the cluster members
    - ensure network list still shows partial information with an error

## Screenshots

<img width="3838" height="1914" alt="image" src="https://github.com/user-attachments/assets/328dd470-2586-4240-83c0-f25d80289fcb" />
