### PR TITLE
fix(instance) secure boot option has been moved to boot.mode in newer lxd versions

### DIFF
--- a/src/components/forms/BootForm.tsx
+++ b/src/components/forms/BootForm.tsx
@@ -1,12 +1,13 @@
 import type { FC } from "react";
 import { Input, Select } from "@canonical/react-components";
-import { optionYesNo } from "util/instanceOptions";
+import { bootModeOptions, optionYesNo } from "util/instanceOptions";
 import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
 import type { BootFormValues } from "types/forms/instanceAndProfile";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export const bootPayload = (values: BootFormValues) => {
   return {
@@ -17,6 +18,7 @@ export const bootPayload = (values: BootFormValues) => {
       values.boot_autostart_priority?.toString(),
     [getInstanceField("boot_host_shutdown_timeout")]:
       values.boot_host_shutdown_timeout?.toString(),
+    [getInstanceField("boot_mode")]: values.boot_mode?.toString(),
     [getInstanceField("boot_stop_priority")]:
       values.boot_stop_priority?.toString(),
   };
@@ -27,6 +29,8 @@ interface Props {
 }
 
 const BootForm: FC<Props> = ({ formik }) => {
+  const { hasInstanceBootMode } = useSupportedFeatures();
+
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -63,6 +67,18 @@ const BootForm: FC<Props> = ({ formik }) => {
           defaultValue: "",
           children: <Input placeholder="Enter number" type="number" />,
         }),
+
+        ...(hasInstanceBootMode
+          ? [
+              getConfigurationRow({
+                formik,
+                label: "Boot mode",
+                name: "boot_mode",
+                defaultValue: "",
+                children: <Select options={bootModeOptions} />,
+              }),
+            ]
+          : []),
 
         getConfigurationRow({
           formik,

--- a/src/components/forms/SecurityPoliciesForm.tsx
+++ b/src/components/forms/SecurityPoliciesForm.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Input, Select } from "@canonical/react-components";
+import { Button, Input, Select } from "@canonical/react-components";
 import type {
   CreateInstanceFormValues,
   SecurityPoliciesFormValues,
@@ -12,10 +12,15 @@ import {
 } from "util/instanceOptions";
 import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
 
-import { getConfigurationRow } from "components/ConfigurationRow";
+import {
+  getConfigurationRow,
+  getConfigurationRowBase,
+} from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { getInstanceField } from "util/instanceConfigFields";
 import { optionRenderer } from "util/formFields";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { BOOT } from "pages/instances/forms/InstanceFormMenu";
 
 export const securityPoliciesPayload = (values: SecurityPoliciesFormValues) => {
   return {
@@ -39,9 +44,11 @@ export const securityPoliciesPayload = (values: SecurityPoliciesFormValues) => {
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
+  setSection: (section: string) => void;
 }
 
-const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
+const SecurityPoliciesForm: FC<Props> = ({ formik, setSection }) => {
+  const { hasInstanceBootMode } = useSupportedFeatures();
   const isInstance = formik.values.entityType === "instance";
   const isContainerOnlyDisabled =
     isInstance &&
@@ -203,35 +210,67 @@ const SecurityPoliciesForm: FC<Props> = ({ formik }) => {
           ),
         }),
 
-        getConfigurationRow({
-          formik,
-          label: "Enable secureboot (VMs only)",
-          name: "security_secureboot",
-          defaultValue: "",
-          disabled: isVmOnlyDisabled,
-          disabledReason: isVmOnlyDisabled
-            ? "Only available for virtual machines"
-            : undefined,
-          readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
-          children: (
-            <Select options={optionTrueFalse} disabled={isVmOnlyDisabled} />
-          ),
-        }),
+        ...(hasInstanceBootMode
+          ? [
+              getConfigurationRowBase({
+                className: "u-text--muted",
+                configuration: (
+                  <>
+                    <b>Enable secureboot (VMs only)</b> and{" "}
+                    <b>Enable CSM (VMs only)</b>
+                  </>
+                ),
+                inherited: "",
+                override: (
+                  <Button
+                    appearance="link"
+                    type="button"
+                    onClick={() => {
+                      setSection(BOOT);
+                    }}
+                  >
+                    See boot mode
+                  </Button>
+                ),
+              }),
+            ]
+          : [
+              getConfigurationRow({
+                formik,
+                label: "Enable secureboot (VMs only)",
+                name: "security_secureboot",
+                defaultValue: "",
+                disabled: isVmOnlyDisabled,
+                disabledReason: isVmOnlyDisabled
+                  ? "Only available for virtual machines"
+                  : undefined,
+                readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
+                children: (
+                  <Select
+                    options={optionTrueFalse}
+                    disabled={isVmOnlyDisabled}
+                  />
+                ),
+              }),
 
-        getConfigurationRow({
-          formik,
-          label: "Enable CSM (VMs only)",
-          name: "security_csm",
-          defaultValue: "",
-          disabled: isVmOnlyDisabled,
-          disabledReason: isVmOnlyDisabled
-            ? "Only available for virtual machines"
-            : undefined,
-          readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
-          children: (
-            <Select options={optionTrueFalse} disabled={isVmOnlyDisabled} />
-          ),
-        }),
+              getConfigurationRow({
+                formik,
+                label: "Enable CSM (VMs only)",
+                name: "security_csm",
+                defaultValue: "",
+                disabled: isVmOnlyDisabled,
+                disabledReason: isVmOnlyDisabled
+                  ? "Only available for virtual machines"
+                  : undefined,
+                readOnlyRenderer: (val) => optionRenderer(val, optionTrueFalse),
+                children: (
+                  <Select
+                    options={optionTrueFalse}
+                    disabled={isVmOnlyDisabled}
+                  />
+                ),
+              }),
+            ]),
       ]}
     />
   );

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -46,5 +46,6 @@ export const useSupportedFeatures = () => {
     ),
     hasProjectForceDelete: apiExtensions.has("projects_force_delete"),
     hasInstanceForceDelete: apiExtensions.has("instance_force_delete"),
+    hasInstanceBootMode: apiExtensions.has("instance_boot_mode"),
   };
 };

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -489,7 +489,10 @@ const CreateInstance: FC = () => {
             )}
 
             {section === SECURITY_POLICIES && (
-              <SecurityPoliciesForm formik={formik} />
+              <SecurityPoliciesForm
+                formik={formik}
+                setSection={updateSection}
+              />
             )}
 
             {section === SNAPSHOTS && <InstanceSnapshotsForm formik={formik} />}

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -232,7 +232,10 @@ const EditInstance: FC<Props> = ({ instance }) => {
             )}
 
             {section === slugify(SECURITY_POLICIES) && (
-              <SecurityPoliciesForm formik={formik} />
+              <SecurityPoliciesForm
+                formik={formik}
+                setSection={updateSection}
+              />
             )}
 
             {section === slugify(SNAPSHOTS) && (

--- a/src/pages/profiles/CreateProfile.tsx
+++ b/src/pages/profiles/CreateProfile.tsx
@@ -226,7 +226,10 @@ const CreateProfile: FC = () => {
             )}
 
             {section === SECURITY_POLICIES && (
-              <SecurityPoliciesForm formik={formik} />
+              <SecurityPoliciesForm
+                formik={formik}
+                setSection={updateSection}
+              />
             )}
 
             {section === SNAPSHOTS && <InstanceSnapshotsForm formik={formik} />}

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -227,7 +227,10 @@ const EditProfile: FC<Props> = ({ profile }) => {
             )}
 
             {section === slugify(SECURITY_POLICIES) && (
-              <SecurityPoliciesForm formik={formik} />
+              <SecurityPoliciesForm
+                formik={formik}
+                setSection={updateSection}
+              />
             )}
 
             {section === slugify(SNAPSHOTS) && (

--- a/src/types/forms/instanceAndProfile.d.ts
+++ b/src/types/forms/instanceAndProfile.d.ts
@@ -8,6 +8,7 @@ export interface BootFormValues {
   boot_autostart_delay?: string;
   boot_autostart_priority?: string;
   boot_host_shutdown_timeout?: string;
+  boot_mode?: string;
   boot_stop_priority?: string;
 }
 

--- a/src/util/instanceConfigFields.tsx
+++ b/src/util/instanceConfigFields.tsx
@@ -27,6 +27,7 @@ const instanceConfigFormFieldsToPayload: Record<string, string> = {
   boot_autostart_delay: "boot.autostart.delay",
   boot_autostart_priority: "boot.autostart.priority",
   boot_host_shutdown_timeout: "boot.host_shutdown_timeout",
+  boot_mode: "boot.mode",
   boot_stop_priority: "boot.stop.priority",
   cloud_init_network_config: "cloud-init.network-config",
   cloud_init_user_data: "cloud-init.user-data",

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -69,6 +69,7 @@ const getEditValues = (
     boot_autostart_delay: item.config["boot.autostart.delay"],
     boot_autostart_priority: item.config["boot.autostart.priority"],
     boot_host_shutdown_timeout: item.config["boot.host_shutdown_timeout"],
+    boot_mode: item.config["boot.mode"],
     boot_stop_priority: item.config["boot.stop.priority"],
 
     cloud_init_network_config: item.config["cloud-init.network-config"],

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -152,3 +152,23 @@ export const optionNvmeSdc = [
     value: "sdc",
   },
 ];
+
+export const bootModeOptions = [
+  {
+    label: "Select option",
+    value: "",
+    disabled: true,
+  },
+  {
+    label: "UEFI firmware with secure boot enabled",
+    value: "uefi-secureboot",
+  },
+  {
+    label: "UEFI firmware with secure boot disabled",
+    value: "uefi-nosecureboot",
+  },
+  {
+    label: "Legacy BIOS firmware (SeaBIOS), x86_64 (amd64) only",
+    value: "bios",
+  },
+];

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -209,10 +209,17 @@ test("instance edit cloud init configuration", async ({ page }) => {
   await assertCode(page, "Vendor data", "baz:");
 });
 
-test("instance create vm", async ({ page }) => {
+test("instance create vm with security.secureboot", async ({
+  page,
+  lxdVersion,
+}) => {
   test.skip(
     Boolean(process.env.DISABLE_VM_TESTS),
     "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+  test.skip(
+    lxdVersion === "latest-edge",
+    "security.secureboot is not supported in newer LXD versions",
   );
 
   await editInstance(page, vmInstance);
@@ -223,6 +230,26 @@ test("instance create vm", async ({ page }) => {
   await saveInstance(page, vmInstance, 1);
 
   await assertReadMode(page, "Enable secureboot (VMs only)", "true");
+});
+
+test("instance create vm with boot.mode", async ({ page, lxdVersion }) => {
+  test.skip(
+    Boolean(process.env.DISABLE_VM_TESTS),
+    "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+  test.skip(
+    lxdVersion === "5.21-edge" || lxdVersion === "5.0-edge",
+    "Boot mode configuration is not supported in older LXD versions",
+  );
+
+  await editInstance(page, vmInstance);
+
+  await page.getByText("Boot").click();
+  await setOption(page, "Boot mode", "uefi-nosecureboot");
+
+  await saveInstance(page, vmInstance, 1);
+
+  await assertReadMode(page, "Boot mode", "uefi-nosecureboot");
 });
 
 test("instance yaml edit", async ({ page, lxdVersion }) => {

--- a/tests/profiles.spec.ts
+++ b/tests/profiles.spec.ts
@@ -93,7 +93,10 @@ test("profile resource limits", async ({ page }) => {
   await assertReadMode(page, "Max number of processes (Containers only)", "2");
 });
 
-test("profile security policies", async ({ page }) => {
+test("profile security policies", async ({ page, lxdVersion }) => {
+  const hasSecuritySecureBoot =
+    lxdVersion === "5.21-edge" || lxdVersion === "5.0-edge";
+
   await editProfile(page, profile);
   await page.getByText("Security policies").click();
 
@@ -105,8 +108,11 @@ test("profile security policies", async ({ page }) => {
   await setOption(page, "Unique idmap", "true");
   await setOption(page, "Allow /dev/lxd in the instance", "true");
   await setOption(page, "Make /1.0/images API available", "true");
-  await setOption(page, "Enable secureboot", "true");
-  await saveProfile(page, profile, 9);
+  if (hasSecuritySecureBoot) {
+    await setOption(page, "Enable secureboot", "true");
+  }
+  const changeCount = hasSecuritySecureBoot ? 9 : 8;
+  await saveProfile(page, profile, changeCount);
 
   await assertReadMode(page, "Protect deletion", "Yes");
   await assertReadMode(page, "Privileged (Containers only)", "Allow");
@@ -124,7 +130,9 @@ test("profile security policies", async ({ page }) => {
     "Make /1.0/images API available over /dev/lxd (Containers only)",
     "Yes",
   );
-  await assertReadMode(page, "Enable secureboot (VMs only)", "true");
+  if (hasSecuritySecureBoot) {
+    await assertReadMode(page, "Enable secureboot (VMs only)", "true");
+  }
 });
 
 test("profile snapshots", async ({ page, lxdVersion }) => {

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -140,7 +140,12 @@ test("navigate to custom volume via pool used by list", async ({ page }) => {
   await expect(page).toHaveURL(/volumes\/custom\//);
 });
 
-test("storage pool with driver zfs", async ({ page }) => {
+test("storage pool with driver zfs", async ({ page, lxdVersion }) => {
+  test.skip(
+    lxdVersion === "5.0-edge",
+    "ZFS driver in 5.0 is not compatible in github runners or any environment with zfs > 2.2",
+  );
+
   const pool = randomPoolName();
   await createPool(page, pool, "ZFS");
 


### PR DESCRIPTION
## Done

- fix(instance) secure boot option has been moved to boot.mode in newer lxd versions

relates to https://github.com/canonical/lxd/pull/17560

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - test instance / profile configuration > security with a 6/edge lxd backend and older backends
    - older backends should show secureboot and csm options
    - newer backends show a link to boot section and have an additional boot mode configuration

## Screenshots

## New versions link to the boot mode
<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/45eafd54-b833-44d4-bcf6-070b68e45098" />

## Boot mode available in newer versions
<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/ed0f963a-5315-4a90-92e1-8a7146b28a02" />

## Old version has secureboot option
<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/dc2f9fc0-0484-4145-8403-da1d3de97214" />

## Old version has no boot mode
<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/1553ecfc-ab26-4707-9690-cbb7fa1f620d" />
