### PR TITLE
fix(instance) in graphic console ensure numbers on the numpad are sent as numbers

### DIFF
--- a/src/lib/spice/src/atKeynames.js
+++ b/src/lib/spice/src/atKeynames.js
@@ -183,7 +183,8 @@ var KeyNames = {
   KEY_Prefix0     :/* special               0x60  */   96,
   KEY_Prefix1     :/* specail               0x61  */   97,
 
-  KEY_DELETE      :/* Delete           0xe0 0x53  */   21472,
+  KEY_Delete      :/* Delete           0xe0 0x53  */   21472,
+  KEY_PrintScreen :/* Print screen     0xe0 0x37  */   14304,
 };
 
 export {

--- a/src/lib/spice/src/inputs.js
+++ b/src/lib/spice/src/inputs.js
@@ -219,7 +219,7 @@ function sendCtrlAltDel(sc)
         update_modifier(true, KeyNames.KEY_Alt, sc);
         Alt_state = true;
         Alt_locked = false;
-        send_key(sc, KeyNames.KEY_DELETE);
+        send_key(sc, KeyNames.KEY_Delete);
         const release = () => {
             update_modifier(false, KeyNames.KEY_LCtrl, sc);
             Ctrl_state = false;
@@ -347,6 +347,13 @@ function sendF12(sc)
 {
     if (sc && sc.inputs && sc.inputs.state === "ready"){
         send_key(sc, KeyNames.KEY_F12);
+    }
+}
+
+function sendPrintScreen(sc)
+{
+    if (sc && sc.inputs && sc.inputs.state === "ready"){
+        send_key(sc, KeyNames.KEY_PrintScreen);
     }
 }
 
@@ -489,6 +496,7 @@ export {
   sendF10,
   sendF11,
   sendF12,
+  sendPrintScreen,
   toggleAlt,
   toggleCtrl,
   isAltPressed,

--- a/src/lib/spice/src/spicemsg.js
+++ b/src/lib/spice/src/spicemsg.js
@@ -1185,7 +1185,7 @@ function SpiceMsgcKeyDown(e)
 {
     if (e)
     {
-        this.code = keycode_to_start_scan(e.keyCode, e.code);
+        this.code = keycode_to_start_scan(e.keyCode, e.code, e);
     }
     else
     {
@@ -1212,7 +1212,7 @@ function SpiceMsgcKeyUp(e)
 {
     if (e)
     {
-        this.code = keycode_to_end_scan(e.keyCode, e.code);
+        this.code = keycode_to_end_scan(e.keyCode, e.code, e);
     }
     else
     {

--- a/src/lib/spice/src/utils.js
+++ b/src/lib/spice/src/utils.js
@@ -231,8 +231,25 @@ DOM_scanmap[189]                = KeyNames.KEY_Minus;
 DOM_scanmap[187]                = KeyNames.KEY_Equal;
 DOM_scanmap[186]                = KeyNames.KEY_SemiColon;
 
-function get_scancode(keyCode, code)
+/* Map the numpad keys to number keys */
+var numpad_scanmap = [];
+numpad_scanmap["Numpad0"] = KeyNames.KEY_0;
+numpad_scanmap["Numpad1"] = KeyNames.KEY_1;
+numpad_scanmap["Numpad2"] = KeyNames.KEY_2;
+numpad_scanmap["Numpad3"] = KeyNames.KEY_3;
+numpad_scanmap["Numpad4"] = KeyNames.KEY_4;
+numpad_scanmap["Numpad5"] = KeyNames.KEY_5;
+numpad_scanmap["Numpad6"] = KeyNames.KEY_6;
+numpad_scanmap["Numpad7"] = KeyNames.KEY_7;
+numpad_scanmap["Numpad8"] = KeyNames.KEY_8;
+numpad_scanmap["Numpad9"] = KeyNames.KEY_9;
+
+function get_scancode(keyCode, code, e)
 {
+    if (e && e.getModifierState('NumLock') && numpad_scanmap[code] !== undefined) {
+        return numpad_scanmap[code];
+    }
+
     if (code_to_scancode[code] !== undefined) {
         return code_to_scancode[code];
     }
@@ -248,9 +265,9 @@ function get_scancode(keyCode, code)
         return common_scanmap[keyCode];
 }
 
-function keycode_to_start_scan(keyCode, code)
+function keycode_to_start_scan(keyCode, code, e)
 {
-    var scancode = get_scancode(keyCode, code);
+    var scancode = get_scancode(keyCode, code, e);
     if (scancode === undefined)
     {
         alert('no map for ' + keyCode);
@@ -260,9 +277,9 @@ function keycode_to_start_scan(keyCode, code)
     return scancode;
 }
 
-function keycode_to_end_scan(keyCode, code)
+function keycode_to_end_scan(keyCode, code, e)
 {
-    var scancode = get_scancode(keyCode, code);
+    var scancode = get_scancode(keyCode, code, e);
     if (scancode === undefined)
         return 0;
 

--- a/src/pages/instances/InstanceConsoleShortcuts.tsx
+++ b/src/pages/instances/InstanceConsoleShortcuts.tsx
@@ -20,6 +20,7 @@ import {
   sendF10,
   sendF11,
   sendF12,
+  sendPrintScreen,
   toggleAlt,
   toggleCtrl,
 } from "lib/spice/src/inputs.js";
@@ -94,6 +95,12 @@ const InstanceConsoleShortcuts: FC<Props> = ({ disabled }) => {
           children: "Send Alt + F4",
           onClick: () => {
             sendAltF4(window.spice_connection);
+          },
+        },
+        {
+          children: "Send Print Screen",
+          onClick: () => {
+            sendPrintScreen(window.spice_connection);
           },
         },
         {

--- a/src/types/spice-inputs.d.ts
+++ b/src/types/spice-inputs.d.ts
@@ -16,6 +16,7 @@ declare module "lib/spice/src/inputs.js" {
   export function sendF10(connection?: SpiceHtml5.SpiceMainConn): void;
   export function sendF11(connection?: SpiceHtml5.SpiceMainConn): void;
   export function sendF12(connection?: SpiceHtml5.SpiceMainConn): void;
+  export function sendPrintScreen(connection?: SpiceHtml5.SpiceMainConn): void;
 
   export function isAltPressed(connection?: SpiceHtml5.SpiceMainConn): boolean;
   export function isCtrlPressed(connection?: SpiceHtml5.SpiceMainConn): boolean;


### PR DESCRIPTION
## Done

- fix(instance) in graphic console ensure numbers on the numpad are sent as numbers

Fixes #1786

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run a vm with graphic mode
    - try the numpad keys. numbers should appear as numbers if numkey on the host system is enabled, otherwise they should act as arrows.
    - try the new "print screen" shortcut dropdown. It should be received in the guest OS.