### PR TITLE
fix(Delete project): Remove project name in button, handle mobile

### DIFF
--- a/src/pages/projects/actions/DeleteProjectModal.tsx
+++ b/src/pages/projects/actions/DeleteProjectModal.tsx
@@ -62,7 +62,7 @@ const DeleteProjectModal: FC<Props> = ({
           loading={isLoading}
           disabled={disableConfirm}
         >
-          Permanently delete {project.name}
+          Permanently delete
         </ActionButton>,
       ]}
     >

--- a/src/sass/_project_configuration.scss
+++ b/src/sass/_project_configuration.scss
@@ -23,12 +23,25 @@
       display: flex;
       gap: $sph--large;
 
+      @include mobile {
+        flex-direction: column;
+        gap: 0;
+      }
+
       .confirm-input {
         flex: 1;
+
+        @include mobile {
+          width: 100%;
+        }
       }
 
       .p-action-button {
         flex: 1;
+
+        @include mobile {
+          width: 100%;
+        }
       }
     }
   }

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -61,12 +61,12 @@ export const confirmDelete = async (page: Page, project: string) => {
   if (await projectNameInputBox.isVisible()) {
     const permanentlyDeleteButton = page
       .getByRole("dialog", { name: "Confirm delete" })
-      .getByRole("button", { name: `Permanently delete ${project}` });
+      .getByRole("button", { name: "Permanently delete" });
     await expect(permanentlyDeleteButton).toBeDisabled();
     await projectNameInputBox.fill(project);
     await page
       .getByRole("dialog", { name: "Confirm delete" })
-      .getByRole("button", { name: `Permanently delete ${project}` })
+      .getByRole("button", { name: "Permanently delete" })
       .click();
     await page.waitForSelector(`text=Project ${project} deleted.`);
   } else {


### PR DESCRIPTION
## Done

- Delete project: Remove project name in button
- Delete project: handle mobile

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a project configuration, click on Delete project
    - Make sure the button "Permanently delete" never span on more than one line, regardless of screen size

## Screenshots

Desktop
<img width="802" height="679" alt="Screenshot from 2026-02-16 09-18-40" src="https://github.com/user-attachments/assets/996126dd-0a25-4425-b3cd-b2e49a64449d" />

Mobile
<img width="502" height="947" alt="Screenshot from 2026-02-16 09-18-22" src="https://github.com/user-attachments/assets/0dd6ae3e-6af7-414c-afee-d52385889896" />
