### PR TITLE
fix(cluster) fix quick link menu on cluster member hardware section

### DIFF
--- a/src/pages/cluster/ClusterMemberHardware.tsx
+++ b/src/pages/cluster/ClusterMemberHardware.tsx
@@ -138,7 +138,7 @@ const ClusterMemberHardware: FC<Props> = ({ member }) => {
                   <li className="p-side-navigation__item" key={sectionName}>
                     <a
                       className="p-side-navigation__link"
-                      href={`#${sectionName.toLowerCase()}`}
+                      href={`${window.location.pathname}#${sectionName.toLowerCase()}`}
                       aria-current={
                         section === sectionName.toLowerCase()
                           ? "page"

--- a/src/pages/cluster/ClusterMemberMemoryUsage.tsx
+++ b/src/pages/cluster/ClusterMemberMemoryUsage.tsx
@@ -1,55 +1,38 @@
 import type { FC } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Meter from "components/Meter";
-import { fetchClusterMemberState } from "api/cluster-members";
 import { queryKeys } from "util/queryKeys";
 import { humanFileSize } from "util/helpers";
 import type { LxdClusterMember } from "types/cluster";
+import { fetchResources } from "api/server";
 
 interface Props {
   member: LxdClusterMember;
 }
 
 const ClusterMemberMemoryUsage: FC<Props> = ({ member }) => {
-  const { data: state } = useQuery({
+  const { data: resources } = useQuery({
     queryKey: [
       queryKeys.cluster,
       queryKeys.members,
-      member.server_name,
-      queryKeys.state,
+      member?.server_name ?? undefined,
+      queryKeys.resources,
     ],
-    queryFn: async () => fetchClusterMemberState(member.server_name),
+    queryFn: async () => fetchResources(member?.server_name),
   });
 
-  const totalMemory = state?.sysinfo?.total_ram ?? 0;
+  const totalMemory = resources?.memory?.total ?? 0;
+  const usedMemory = resources?.memory?.used ?? 0;
 
-  if (!state?.sysinfo || totalMemory === 0) {
+  if (totalMemory === 0) {
     return <span className="u-text--muted">-</span>;
   }
 
-  const freeMemory = state?.sysinfo.free_ram ?? 0;
-  const sharedMemory = state?.sysinfo.shared_ram ?? 0;
-  const bufferedMemory = state?.sysinfo.buffered_ram ?? 0;
-
-  const usedMemory = totalMemory - freeMemory;
   const memoryPercentage = (usedMemory / totalMemory) * 100;
-  const secondaryMemory = sharedMemory + bufferedMemory;
-  const secondaryPercentage = (secondaryMemory / totalMemory) * 100;
 
   const memoryText = `${humanFileSize(usedMemory)} of ${humanFileSize(totalMemory)}`;
 
-  let hoverText = `free: ${humanFileSize(freeMemory)}\n`;
-  hoverText += `used: ${humanFileSize(usedMemory)}\n`;
-  hoverText += `cached: ${humanFileSize(bufferedMemory + sharedMemory)}\n`;
-
-  return (
-    <Meter
-      percentage={memoryPercentage}
-      secondaryPercentage={secondaryPercentage}
-      text={memoryText}
-      hoverText={hoverText}
-    />
-  );
+  return <Meter percentage={memoryPercentage} text={memoryText} />;
 };
 
 export default ClusterMemberMemoryUsage;


### PR DESCRIPTION
## Done

- fix(cluster) fix quick link menu on cluster member hardware section
- pull information for cluster member memory from same source as cli

Fixes #1791

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - in a clustered environment open the cluster > members view and ensure the memory usage column is correct. see linked issue for details.