### PR TITLE
fix(instance) hide ellipsis when clipping text on the instance list table

### DIFF
--- a/src/pages/cluster/ClusterMemberRichChip.tsx
+++ b/src/pages/cluster/ClusterMemberRichChip.tsx
@@ -38,6 +38,7 @@ const ClusterMemberRichChip: FC<Props> = ({
   return (
     <Tooltip
       zIndex={1000}
+      positionElementClassName="cluster-member-rich-chip-position-element"
       message={<ClusterMemberRichTooltip clusterMember={clusterMember} />}
     >
       {resourceLink}

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -79,6 +79,11 @@
     display: none;
   }
 
+  // allow text in cluster member chip to identify available space and clip with ellipsis in the chip if necessary
+  .cluster-member-rich-chip-position-element {
+    display: inherit !important;
+  }
+
   td:last-child {
     padding-bottom: 0;
     padding-right: $sph--large;


### PR DESCRIPTION
## Done

- fix(instance) hide ellipsis when clipping text on the instance list table

Fixes  #1792

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - see linked issue for a reproducer
    - happens at 1699x594 with the memory column active and a started instance in the list
    - 