### PR TITLE
fix(image) show image name in volume list instead of fingerprint

### DIFF
--- a/src/pages/images/ImageList.tsx
+++ b/src/pages/images/ImageList.tsx
@@ -16,7 +16,11 @@ import { humanFileSize, isoTimeToString } from "util/helpers";
 import DeleteImageBtn from "./actions/DeleteImageBtn";
 import { useParams } from "react-router-dom";
 import CreateInstanceFromImageBtn from "pages/images/actions/CreateInstanceFromImageBtn";
-import { localLxdToRemoteImage } from "util/images";
+import {
+  getImageAlias,
+  getImageName,
+  localLxdToRemoteImage,
+} from "util/images";
 import useSortTableData from "util/useSortTableData";
 import SelectableMainTable from "components/SelectableMainTable";
 import BulkDeleteImageBtn from "pages/images/actions/BulkDeleteImageBtn";
@@ -119,15 +123,15 @@ const ImageList: FC = () => {
       />
     );
 
-    const imageAlias = image.aliases.map((alias) => alias.name).join(", ");
-    const description = image.properties?.description ?? image.fingerprint;
+    const imageAlias = getImageAlias(image);
+    const imageName = getImageName(image);
 
     return {
       key: image.fingerprint,
       name: image.fingerprint,
       columns: [
         {
-          content: description,
+          content: imageName,
           role: "rowheader",
           "aria-label": "Name",
         },
@@ -175,7 +179,7 @@ const ImageList: FC = () => {
         },
       ],
       sortData: {
-        name: description.toLowerCase(),
+        name: imageName.toLowerCase(),
         alias: imageAlias.toLowerCase(),
         architecture: image.architecture,
         cached: image.cached,

--- a/src/pages/images/actions/DeleteImageBtn.tsx
+++ b/src/pages/images/actions/DeleteImageBtn.tsx
@@ -12,6 +12,7 @@ import {
 import { useEventQueue } from "context/eventQueue";
 import ResourceLabel from "components/ResourceLabel";
 import { useImageEntitlements } from "util/entitlements/images";
+import { getImageName } from "util/images";
 
 interface Props {
   image: LxdImage;
@@ -25,11 +26,11 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
   const queryClient = useQueryClient();
   const { canDeleteImage } = useImageEntitlements();
 
-  const description = image.properties?.description ?? image.fingerprint;
+  const imageName = getImageName(image);
 
   const handleDelete = () => {
     setLoading(true);
-    const imageLabel = <ResourceLabel bold type="image" value={description} />;
+    const imageLabel = <ResourceLabel bold type="image" value={imageName} />;
     deleteImage(image, project)
       .then((operation) => {
         eventQueue.set(
@@ -45,7 +46,7 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
           },
           (msg) =>
             toastNotify.failure(
-              `Image ${description} deletion failed`,
+              `Image ${imageName} deletion failed`,
               new Error(msg),
               imageLabel,
             ),
@@ -56,7 +57,7 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
       })
       .catch((e) => {
         toastNotify.failure(
-          `Image ${description} deletion failed`,
+          `Image ${imageName} deletion failed`,
           e,
           imageLabel,
         );
@@ -72,7 +73,7 @@ const DeleteImageBtn: FC<Props> = ({ image, project }) => {
         children: (
           <p>
             This will permanently delete image{" "}
-            <ResourceLabel type="image" value={description} bold />.<br />
+            <ResourceLabel type="image" value={imageName} bold />.<br />
             This action cannot be undone, and can result in data loss.
           </p>
         ),

--- a/src/pages/images/actions/DownloadImageBtn.tsx
+++ b/src/pages/images/actions/DownloadImageBtn.tsx
@@ -8,6 +8,7 @@ import {
 } from "@canonical/react-components";
 import ResourceLink from "components/ResourceLink";
 import { ROOT_PATH } from "util/rootPath";
+import { getImageName } from "util/images";
 
 interface Props {
   image: LxdImage;
@@ -17,7 +18,7 @@ interface Props {
 const DownloadImageBtn: FC<Props> = ({ image, project }) => {
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
-  const description = image.properties?.description ?? image.fingerprint;
+  const imageName = getImageName(image);
   const isUnifiedTarball = image.update_source == null; //Only Split Tarballs have an update_source.
   const url = `${ROOT_PATH}/1.0/images/${encodeURIComponent(image.fingerprint)}/export?project=${encodeURIComponent(project)}`;
 
@@ -27,7 +28,7 @@ const DownloadImageBtn: FC<Props> = ({ image, project }) => {
       <ResourceLink
         to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/images`}
         type="image"
-        value={description}
+        value={imageName}
       />
     );
 
@@ -46,7 +47,7 @@ const DownloadImageBtn: FC<Props> = ({ image, project }) => {
       );
     } catch (e) {
       toastNotify.failure(
-        `Image ${description} was unable to download.`,
+        `Image ${imageName} was unable to download.`,
         e,
         imageLink,
       );

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -6,6 +6,7 @@ import classnames from "classnames";
 import { linkForVolumeDetail, hasVolumeDetailPage } from "util/storageVolume";
 import { useInstances } from "context/useInstances";
 import { useImagesInProject } from "context/useImages";
+import { getImageAlias, getImageName } from "util/images";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -34,7 +35,16 @@ const StorageVolumeNameLink: FC<Props> = ({
 
   const isCustom = volume.type === "custom";
   const displayLink = instance || image || isCustom;
-  const caption = overrideName ? overrideName : volume.name;
+  const getCaption = () => {
+    if (overrideName) {
+      return overrideName;
+    }
+    if (image) {
+      return `${getImageName(image)} ${getImageAlias(image)}`;
+    }
+    return volume.name;
+  };
+  const caption = getCaption();
 
   if (overrideName && !displayLink) {
     return null;

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -85,3 +85,11 @@ export const byOSRelease = (a: RemoteImage, b: RemoteImage): number => {
   }
   return 0;
 };
+
+export const getImageName = (image: LxdImage): string => {
+  return image.properties?.description ?? image.fingerprint;
+};
+
+export const getImageAlias = (image: LxdImage): string => {
+  return image.aliases.map((alias) => alias.name).join(", ");
+};

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -10,6 +10,7 @@ import EntitlementOptionLabel from "pages/permissions/panels/EntitlementOptionLa
 import type { CustomSelectOption } from "@canonical/react-components";
 import { getOptionText } from "@canonical/react-components/dist/components/CustomSelect/CustomSelectDropdown";
 import { getIdentityName } from "util/permissionIdentities";
+import { getImageName } from "util/images";
 
 export const noneAvailableOption = {
   disabled: true,
@@ -312,7 +313,7 @@ export const getImageLookup = (
   for (const image of images) {
     nameLookup[image.fingerprint] = {
       ...image,
-      name: `${image.properties?.description || image.fingerprint} (${image.type})`,
+      name: `${getImageName(image)} (${image.type})`,
     };
   }
 


### PR DESCRIPTION
## Done

- fix(image) show image name in volume list instead of fingerprint

Fixes #1799

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open storage > volume list and check for volume type "image" entries. Ensure the name of the volume is displayed as the image name.

## Screenshots

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/16485d82-9603-4e72-bd51-497d6974f060" />
