### PR TITLE
fix: Add ceph back to CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -122,9 +122,9 @@ jobs:
           dotrun &
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
-      # - name: Setup Ceph
-      #   if: ${{ matrix.lxd_channel != '5.0/edge' }}
-      #   uses: canonical/lxd/.github/actions/setup-microceph@main
+      - name: Setup Ceph
+        if: ${{ matrix.lxd_channel != '5.0/edge' }}
+        uses: canonical/lxd/.github/actions/setup-microceph@main
 
       - name: Setup OVN
         if: ${{ matrix.lxd_channel != '5.0/edge' }}


### PR DESCRIPTION
## Done

- Adds ceph back to CI

Necessary for: https://github.com/canonical/lxd-ui/pull/1798

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

N/A