### PR TITLE
fix(project) rely on operation for project deletion when api extension is present

### DIFF
--- a/src/api/projects.tsx
+++ b/src/api/projects.tsx
@@ -91,14 +91,18 @@ export const renameProject = async (
 export const deleteProject = async (
   project: LxdProject,
   force?: boolean,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   if (force) {
     params.set("force", "1");
   }
   const url = `${ROOT_PATH}/1.0/projects/${encodeURIComponent(project.name)}?${params.toString()}`;
 
-  await fetch(url, {
+  return fetch(url, {
     method: "DELETE",
-  }).then(handleResponse);
+  })
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -47,5 +47,6 @@ export const useSupportedFeatures = () => {
     hasProjectForceDelete: apiExtensions.has("projects_force_delete"),
     hasInstanceForceDelete: apiExtensions.has("instance_force_delete"),
     hasInstanceBootMode: apiExtensions.has("instance_boot_mode"),
+    hasProjectDeleteOperation: apiExtensions.has("project_delete_operation"),
   };
 };


### PR DESCRIPTION
## Done

- fix(project) rely on operation for project deletion when api extension is present
- follow up to https://github.com/canonical/lxd/pull/17648

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - delete a project with latest/edge backend and ensure the success notification appears together with a info notification announcing the delete is started.