### PR TITLE
fix(image) use single api call to create image with aliases from an instance or an instance snapshot

### DIFF
--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -5,7 +5,6 @@ import type { LxdImage } from "types/image";
 import type { LxdApiResponse } from "types/apiResponse";
 import type { LxdOperationResponse } from "types/operation";
 import type { EventQueue } from "context/eventQueue";
-import type { LxdInstance } from "types/instance";
 import type { UploadState } from "types/storage";
 import type { AxiosResponse } from "axios";
 import axios from "axios";
@@ -125,10 +124,10 @@ export const createImageAlias = async (
 
 export const createImage = async (
   body: string,
-  instance: LxdInstance,
+  project: string,
 ): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
-  params.set("project", instance.project);
+  params.set("project", project);
 
   return fetch(`${ROOT_PATH}/1.0/images?${params.toString()}`, {
     method: "POST",

--- a/src/util/images.tsx
+++ b/src/util/images.tsx
@@ -93,3 +93,11 @@ export const getImageName = (image: LxdImage): string => {
 export const getImageAlias = (image: LxdImage): string => {
   return image.aliases.map((alias) => alias.name).join(", ");
 };
+
+// API format for aliases on image posts
+// @see https://github.com/canonical/lxd/blob/main/shared/api/image.go#L60-L64
+export const imageAliasPost = (aliases: string) => {
+  return aliases.split(",").map((alias) => ({
+    name: alias,
+  }));
+};


### PR DESCRIPTION
## Done

- fix(image) use single api call to create image with aliases from an instance or an instance snapshot

Fixes #1010

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create an image from an instance with a custom alias.
      -  immediately close or refresh the tab after submitting the create form. ensure the image gets created with the alias
    - create an image from an instance snapshot. 
      -  immediately close or refresh the tab after submitting the create form. ensure the image gets created with the alias