### PR TITLE
fix(network) align acl label on network create/edit with input

### DIFF
--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -25,7 +25,7 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
 
   return (
     <div className="general-field">
-      <div className="general-field-label">
+      <div className="general-field-label can-edit">
         <Label forId={networlAclSelectorId}>ACLs</Label>
       </div>
       <div

--- a/src/sass/_network_form.scss
+++ b/src/sass/_network_form.scss
@@ -127,3 +127,8 @@
     }
   }
 }
+
+// align multi select height to other inputs
+.multi-select__select-button {
+  height: inherit !important;
+}


### PR DESCRIPTION
## Done

- fix(network) align acl label on network create/edit with input
- ensure multiselect input is same height as other inputs

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - created and edit a network and ensure the acl label is aligned with the content next to it

## Screenshots

before:

<img width="3370" height="1924" alt="image" src="https://github.com/user-attachments/assets/9253a4a1-a7d4-4de4-894b-aa9a58deb8a6" />

after:

<img width="3370" height="1924" alt="image" src="https://github.com/user-attachments/assets/ddf69dce-4abe-4189-b3f4-8a38749dffe6" />