### PR TITLE
fix(instance) ensure multiple ip addresses for an instance are visible

### DIFF
--- a/src/components/TruncatedList.tsx
+++ b/src/components/TruncatedList.tsx
@@ -13,7 +13,7 @@ const TruncatedList: FC<Props> = ({ items, numberToShow = 2 }) => {
   return (
     <>
       {items.slice(0, numberToShow).map((item, index) => (
-        <Fragment key={index}>{item}</Fragment>
+        <div key={index}>{item}</div>
       ))}
       <div className="p-text--x-small u-text--muted u-no-margin">
         + {items.length - numberToShow} more

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -27,7 +27,7 @@ import { useInstanceLoading } from "context/instanceLoading";
 import InstanceLink from "pages/instances/InstanceLink";
 import SelectableMainTable from "components/SelectableMainTable";
 import InstanceBulkActions from "pages/instances/actions/InstanceBulkActions";
-import { getIpAddresses } from "util/networks";
+import { getIpAddresses, sortIpv6Addresses } from "util/networks";
 import InstanceBulkDelete from "pages/instances/actions/InstanceBulkDelete";
 import InstanceSearchFilter from "./InstanceSearchFilter";
 import type { InstanceFilters } from "util/instanceFilter";
@@ -431,12 +431,8 @@ const InstanceList: FC = () => {
         panelParams.openInstanceSummary(instance.name, instance.project);
       };
 
-      const ipv4 = getIpAddresses(instance, "inet")
-        .filter((val) => !val.address.startsWith("127"))
-        .map((val) => val.address);
-      const ipv6 = getIpAddresses(instance, "inet6")
-        .filter((val) => !val.address.startsWith("fe80"))
-        .map((val) => val.address);
+      const ipv4 = getIpAddresses(instance, "inet");
+      const ipv6 = sortIpv6Addresses(getIpAddresses(instance, "inet6"));
 
       const loadingType = instanceLoading.getType(instance);
 
@@ -523,7 +519,7 @@ const InstanceList: FC = () => {
           },
           {
             key: `ipv4-${ipv4.length}`,
-            content: <TruncatedList items={ipv4} />,
+            content: <TruncatedList items={ipv4.map((val) => val.address)} />,
             role: "cell",
             className: "u-align--right clickable-cell",
             "aria-label": IPV4,
@@ -532,7 +528,7 @@ const InstanceList: FC = () => {
           },
           {
             key: `ipv6-${ipv6.length}`,
-            content: <TruncatedList items={ipv6} />,
+            content: <TruncatedList items={ipv6.map((val) => val.address)} />,
             role: "cell",
             "aria-label": IPV6,
             onClick: openSummary,

--- a/src/pages/instances/InstanceRichTooltip.tsx
+++ b/src/pages/instances/InstanceRichTooltip.tsx
@@ -70,7 +70,7 @@ export const InstanceRichTooltip: FC<Props> = ({
     {
       title: "IPV4",
       value: ipv4Addresses.length ? (
-        <TruncatedList items={ipv4Addresses} numberToShow={1} />
+        <TruncatedList items={ipv4Addresses} />
       ) : (
         "-"
       ),
@@ -78,18 +78,14 @@ export const InstanceRichTooltip: FC<Props> = ({
     {
       title: "IPV6",
       value: ipv6Addresses.length ? (
-        <TruncatedList items={ipv6Addresses} numberToShow={1} />
+        <TruncatedList items={ipv6Addresses} />
       ) : (
         "-"
       ),
     },
     {
       title: "MAC addresses",
-      value: instance ? (
-        <TruncatedList items={macAddresses} numberToShow={1} />
-      ) : (
-        "-"
-      ),
+      value: instance ? <TruncatedList items={macAddresses} /> : "-",
     },
     {
       title: "Created",


### PR DESCRIPTION
## Done

- fix(instance) ensure multiple ip addresses for an instance are visible in the instance list and not wrapped on the first line

Fixes #1807

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance list with an instance that has multiple ip addresses
    - ensure two addresses are visible and the +n more text is visible on an instance with more than two addresses
    - drive by change: show up to two ip or mac addresses in the instance rich tooltip

## Screenshots

before:

<img width="3846" height="1920" alt="image" src="https://github.com/user-attachments/assets/b8564c6d-3f75-44f4-ba4a-37854be26eea" />


after:

<img width="3846" height="1920" alt="image" src="https://github.com/user-attachments/assets/2c7666fb-4ba2-40d5-b24e-a7ca2e126c3b" />
