### PR TITLE
fix(instance) force ips to be shown in two rows on instance list

### DIFF
--- a/src/components/TruncatedList.tsx
+++ b/src/components/TruncatedList.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const TruncatedList: FC<Props> = ({ items, numberToShow = 2 }) => {
   if (items.length <= numberToShow) {
-    return items.map((item, index) => <Fragment key={index}>{item}</Fragment>);
+    return items.map((item, index) => <div key={index}>{item}</div>);
   }
 
   return (


### PR DESCRIPTION
## Done

- fix(instance) force ips to be shown in two rows on instance list when instance has exactly two ip addresses.

Fixes #1807

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance list with a started instance that has exactly two ipv4 or ipv6 addresses
    - ensure both addresses are displayed underneath each other on the instance list.

## Screenshots

before:

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/df867991-a47c-481a-9f82-25b078af8165" />


after:

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/13d4fd2f-917a-41a8-8e68-ce48bc401e9d" />

