### PR TITLE
feat(instance config): Add custom ISOs in devices > disk

### DIFF
--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -17,9 +17,15 @@ import {
   getInheritedSourceRow,
 } from "components/forms/InheritedDeviceRow";
 import { ensureEditMode, isInstanceCreation } from "util/instanceEdit";
-import { getProfileFromSource, isHostDiskDevice } from "util/devices";
+import {
+  getProfileFromSource,
+  isHostDiskDevice,
+  isIsoDiskDevice,
+} from "util/devices";
 import DeviceName from "components/forms/DeviceName";
 import { isDeviceModified } from "util/formChangeCount";
+import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
+import classnames from "classnames";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -90,42 +96,72 @@ const DiskDeviceFormInherited: FC<Props> = ({
       }),
     );
 
-    if (isHostDiskDevice(item.disk)) {
+    if (isIsoDiskDevice(item)) {
       rows.push(
         getInheritedDeviceRow({
-          label: "Host path",
+          label: "Source",
           inheritValue: item.disk.source,
           readOnly: readOnly,
           isDeactivated: isNoneDevice,
           disabledReason: formik.values.editRestriction,
         }),
       );
-    } else {
       rows.push(
         getInheritedDeviceRow({
-          label: "Pool / volume",
+          label: "Pool",
           inheritValue: (
-            <>
-              {item.disk.pool} / {item.disk.source}
-            </>
+            <StoragePoolRichChip
+              poolName={item.disk.pool ?? ""}
+              projectName={project}
+              className={classnames({
+                "u-text--line-through": isNoneDevice,
+              })}
+            />
           ),
           readOnly: readOnly,
           isDeactivated: isNoneDevice,
           disabledReason: formik.values.editRestriction,
+          monoFont: false,
+        }),
+      );
+    } else {
+      if (isHostDiskDevice(item.disk)) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: "Host path",
+            inheritValue: item.disk.source,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+          }),
+        );
+      } else {
+        rows.push(
+          getInheritedDeviceRow({
+            label: "Pool / volume",
+            inheritValue: (
+              <>
+                {item.disk.pool} / {item.disk.source}
+              </>
+            ),
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+          }),
+        );
+      }
+
+      rows.push(
+        getInheritedDeviceRow({
+          label: "Mount point",
+          inheritValue: item.disk.path,
+          readOnly: readOnly,
+          isDeactivated: isNoneDevice,
+          disabledReason: formik.values.editRestriction,
+          className: "device-last-row",
         }),
       );
     }
-
-    rows.push(
-      getInheritedDeviceRow({
-        label: "Mount point",
-        inheritValue: item.disk.path,
-        readOnly: readOnly,
-        isDeactivated: isNoneDevice,
-        disabledReason: formik.values.editRestriction,
-        className: "device-last-row",
-      }),
-    );
   });
 
   return inheritedDiskDevices.length > 0 ? (

--- a/src/pages/images/CustomIsoModal.tsx
+++ b/src/pages/images/CustomIsoModal.tsx
@@ -5,25 +5,52 @@ import type { LxdImageType, RemoteImage } from "types/image";
 import UploadCustomIso from "pages/storage/UploadCustomIso";
 import CustomIsoSelector from "pages/images/CustomIsoSelector";
 import type { IsoImage } from "types/iso";
+import BackLink from "components/BackLink";
 
 interface Props {
   onClose: () => void;
   onSelect: (image: RemoteImage, type?: LxdImageType) => void;
+  onCancel?: () => void;
+  cancelButtonText?: string;
+  backLinkText?: string;
 }
 
 const SELECT_ISO = "selectIso";
 const UPLOAD_ISO = "uploadIso";
 
-const CustomIsoModal: FC<Props> = ({ onClose, onSelect }) => {
+const CustomIsoModal: FC<Props> = ({
+  onClose,
+  onSelect,
+  onCancel,
+  cancelButtonText,
+  backLinkText,
+}) => {
   const [content, setContent] = useState(SELECT_ISO);
   const [primary, setPrimary] = useState<IsoImage | null>(null);
+  const SELECT_CUSTOM_ISO_TITLE = "Select custom ISO";
 
   const getTitle = () => {
     switch (content) {
       case SELECT_ISO:
-        return "Select custom ISO";
+        return backLinkText ? (
+          <BackLink
+            title={SELECT_CUSTOM_ISO_TITLE}
+            onClick={onCancel ?? onClose}
+            linkText={backLinkText}
+          />
+        ) : (
+          SELECT_CUSTOM_ISO_TITLE
+        );
       case UPLOAD_ISO:
-        return "Upload custom ISO";
+        return (
+          <BackLink
+            title="Upload custom ISO"
+            onClick={() => {
+              setContent(SELECT_ISO);
+            }}
+            linkText={SELECT_CUSTOM_ISO_TITLE}
+          />
+        );
       default:
         return "";
     }
@@ -38,7 +65,8 @@ const CustomIsoModal: FC<Props> = ({ onClose, onSelect }) => {
           onUpload={() => {
             setContent(UPLOAD_ISO);
           }}
-          onCancel={onClose}
+          onCancel={onCancel ?? onClose}
+          cancelButtonText={cancelButtonText}
         />
       )}
       {content === UPLOAD_ISO && (

--- a/src/pages/images/CustomIsoSelector.tsx
+++ b/src/pages/images/CustomIsoSelector.tsx
@@ -11,6 +11,7 @@ interface Props {
   onSelect: (image: RemoteImage, type?: LxdImageType) => void;
   onUpload: () => void;
   onCancel: () => void;
+  cancelButtonText?: string;
 }
 
 const CustomIsoSelector: FC<Props> = ({
@@ -18,6 +19,7 @@ const CustomIsoSelector: FC<Props> = ({
   onSelect,
   onUpload,
   onCancel,
+  cancelButtonText = "Cancel",
 }) => {
   const { project } = useCurrentProject();
   const projectName = project?.name ?? "";
@@ -127,7 +129,7 @@ const CustomIsoSelector: FC<Props> = ({
           className="u-no-margin--bottom"
           onClick={onCancel}
         >
-          Cancel
+          {cancelButtonText}
         </Button>
         <Button
           appearance={rows.length === 0 ? "positive" : ""}

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -88,6 +88,7 @@ import NetworkDevicePanel from "components/forms/NetworkDevicesForm/edit/Network
 import { InstanceRichChip } from "./InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
+import { ISO_VOLUME_TYPE } from "util/devices";
 
 interface PresetFormState {
   retryFormValues?: CreateInstanceFormValues;
@@ -359,7 +360,7 @@ const CreateInstance: FC = () => {
     formik.setFieldValue("image", image);
 
     const devices: FormDevice[] = formik.values.devices.filter(
-      (item) => item.type !== "iso-volume",
+      (item) => item.type !== ISO_VOLUME_TYPE,
     );
     if (image.server === LOCAL_ISO) {
       const isoDevice = remoteImageToIsoDevice(image);

--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -21,6 +21,7 @@ import ResourceLink from "components/ResourceLink";
 import { useInstanceEntitlements } from "util/entitlements/instances";
 import { InstanceRichChip } from "../InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import { ISO_VOLUME_NAME } from "util/devices";
 
 interface Props {
   instance: LxdInstance;
@@ -36,14 +37,14 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
   const { canEditInstance } = useInstanceEntitlements();
 
   const attachedIso = getInstanceEditValues(instance).devices.find((device) => {
-    return device.name === "iso-volume";
+    return device.name === ISO_VOLUME_NAME;
   }) as FormDiskDevice | undefined;
 
   const detachIso = () => {
     setLoading(true);
     const values = getInstanceEditValues(instance);
     values.devices = values.devices.filter((device) => {
-      return device.name !== "iso-volume";
+      return device.name !== ISO_VOLUME_NAME;
     });
     const instanceMinusIso = getInstancePayload(
       instance,

--- a/src/pages/storage/AttachDiskDeviceBtn.tsx
+++ b/src/pages/storage/AttachDiskDeviceBtn.tsx
@@ -3,14 +3,14 @@ import type { ButtonProps } from "@canonical/react-components";
 import { Button, usePortal } from "@canonical/react-components";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import AttachDiskDeviceModal from "./AttachDiskDeviceModal";
-import type { LxdDiskDevice } from "types/device";
+import type { CustomDiskDevice } from "types/formDevice";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
   children: ReactNode;
   buttonProps?: ButtonProps;
   project: string;
-  setValue: (device: LxdDiskDevice) => void;
+  setValue: (device: CustomDiskDevice) => void;
 }
 
 const AttachDiskDeviceBtn: FC<Props> = ({
@@ -21,7 +21,7 @@ const AttachDiskDeviceBtn: FC<Props> = ({
   setValue,
 }) => {
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
-  const handleFinish = (device: LxdDiskDevice) => {
+  const handleFinish = (device: CustomDiskDevice) => {
     setValue(device);
     closePortal();
   };

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -180,7 +180,7 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
           onClick={handleCancel}
           className="u-no-margin--bottom"
         >
-          Cancel
+          Back
         </Button>
         <ActionButton
           appearance="positive"

--- a/src/sass/_custom_isos.scss
+++ b/src/sass/_custom_isos.scss
@@ -1,7 +1,6 @@
 .custom-iso-modal {
   @include large {
     > section {
-      min-height: 25rem;
       width: 50rem;
     }
 

--- a/src/types/formDevice.d.ts
+++ b/src/types/formDevice.d.ts
@@ -27,6 +27,8 @@ export interface IsoVolumeDevice {
   type: "iso-volume";
   name: string;
   bare: LxdIsoDevice;
+  source: string;
+  pool: string;
 }
 
 export interface CustomNetworkDevice {
@@ -58,3 +60,5 @@ export type FormDevice =
   | LxdProxyDevice
   | LxdOtherDevice
   | EmptyDevice;
+
+export type CustomDiskDevice = LxdDiskDevice | IsoVolumeDevice;

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -11,10 +11,15 @@ import type {
 } from "types/device";
 import type { LxdProfile } from "types/profile";
 import type { FormDevice, FormDiskDevice } from "types/formDevice";
+import type { InheritedDiskDevice } from "./configInheritance";
 import { getAppliedProfiles } from "./configInheritance";
 import type { LxdNetwork } from "types/network";
 import { typesWithNicStaticIPSupport } from "./networks";
 import type { NetworkDeviceFormValues } from "types/forms/networkDevice";
+
+export const ISO_VOLUME_TYPE = "iso-volume";
+export const ISO_VOLUME_NAME = "iso-volume";
+export const ISO_VOLUME_PROFILE_NAME = "iso-volume-profile";
 
 export const isValidIPV6 = (ip: string): boolean => {
   const ipv6Regex =
@@ -39,6 +44,19 @@ export const isHostDiskDevice = (device: LxdDiskDevice): boolean => {
   return (
     device.type === "disk" && device.pool === undefined && device.path !== "/"
   );
+};
+
+export const isIsoDiskDevice = (
+  device: LxdDiskDevice | FormDevice | InheritedDiskDevice,
+): boolean => {
+  if ("disk" in device && "key" in device) {
+    return (
+      isDiskDevice(device.disk) &&
+      (device.key === ISO_VOLUME_NAME || device.key === ISO_VOLUME_PROFILE_NAME)
+    );
+  }
+
+  return device.type === ISO_VOLUME_TYPE;
 };
 
 export const isNoneDevice = (


### PR DESCRIPTION
## Done

- Manage ISOs from instance configuration > Devices > Disk

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In an instance configuration > Devices > Disk, click on `Attach disk device` > `Attach ISO`. Select existing ISO volume. Make sure the newly added ISO appears in the `Custom disks devices` section with a blue dot. Save changes. 
    - Make sure the button `Attach ISO` is disabled when the instance has an ISO volume attached.
    - Detach ISO, save changes.
    - Create a profile with a custom ISO. Create an instance with this profile. Make sure the inherited custom ISO appears in the `Inherited disk devices` list. Make sure you can detach and re-attach the inherited ISO.
    - From the console tab, attach a custom ISO. Make sure it appears in the configuration tab under the `Custom disks devices` section. Make sure you can detach the ISO from the configuration tab and console tab.

## Screenshots

<img width="835" height="379" alt="image" src="https://github.com/user-attachments/assets/d23c99c2-2d39-499f-98c6-db950ee35000" />
<img width="765" height="211" alt="image" src="https://github.com/user-attachments/assets/e88e7846-5617-4be9-bdb1-307d871227de" />
<img width="742" height="319" alt="inherited-detached" src="https://github.com/user-attachments/assets/5061d725-aa20-4e39-ac23-9bcca64e5994" />
<img width="739" height="265" alt="inherited" src="https://github.com/user-attachments/assets/10959e37-0033-46c2-80c8-383cf9efd38a" />

