### PR TITLE
fix: adjust spacing for prefixedIpInputs

### DIFF
--- a/src/sass/_network_device_panel.scss
+++ b/src/sass/_network_device_panel.scss
@@ -1,3 +1,5 @@
-.prefixed-input__input {
-  padding-top: 0.35rem !important;
+@include extra-large {
+  .prefixed-input__input {
+    padding-top: 0.35rem !important;
+  }
 }


### PR DESCRIPTION
## Done

- Fix spacing of prefixedIPInput on small screens


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to {instance} -> Configuration -> Network -> Attach network / Edit.
    - Make sure spacing of static ip input is correct on all screen sizes.

## Screenshots

before
<img width="1908" height="944" alt="image" src="https://github.com/user-attachments/assets/354d2684-87dc-46c2-ae44-c01c3f94fb67" />


after
<img width="1908" height="944" alt="image" src="https://github.com/user-attachments/assets/ea31a754-bb24-46cb-8f37-b88a1e6e8796" />
