### PR TITLE
fix: Address empty icon on menu collapse

### DIFF
--- a/src/components/NavAccordion.tsx
+++ b/src/components/NavAccordion.tsx
@@ -10,7 +10,7 @@ export type AccordionNavMenu =
   | "clustering";
 
 interface Props {
-  baseUrl: string;
+  baseUrls: string[];
   title: string;
   children: ReactNode;
   iconName: string;
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const NavAccordion: FC<Props> = ({
-  baseUrl,
+  baseUrls,
   title,
   children,
   iconName,
@@ -31,7 +31,9 @@ const NavAccordion: FC<Props> = ({
   disabled,
 }) => {
   const location = useLocation();
-  const isActive = location.pathname.includes(baseUrl);
+  const isActive = baseUrls.some((baseUrl) =>
+    location.pathname.includes(baseUrl),
+  );
 
   return (
     <>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -300,6 +300,7 @@ const Navigation: FC = () => {
                           Instances
                         </NavLink>
                       </SideNavigationItem>
+
                       <SideNavigationItem>
                         <NavLink
                           to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/profiles`}
@@ -317,7 +318,9 @@ const Navigation: FC = () => {
 
                       <SideNavigationItem>
                         <NavAccordion
-                          baseUrl={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network`}
+                          baseUrls={[
+                            `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network`,
+                          ]}
                           title={getNavTitle("networking")}
                           disabled={isAllProjects}
                           iconName="exposed"
@@ -325,7 +328,10 @@ const Navigation: FC = () => {
                           onOpen={() => {
                             toggleAccordionNav("networking");
                           }}
-                          open={openNavMenus.includes("networking")}
+                          open={
+                            openNavMenus.includes("networking") &&
+                            !menuCollapsed
+                          }
                         >
                           {[
                             <SideNavigationItem
@@ -374,7 +380,9 @@ const Navigation: FC = () => {
                       </SideNavigationItem>
                       <SideNavigationItem>
                         <NavAccordion
-                          baseUrl={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/storage`}
+                          baseUrls={[
+                            `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/storage`,
+                          ]}
                           title={getNavTitle("storage")}
                           disabled={isAllProjects}
                           iconName="storage-pool"
@@ -382,7 +390,9 @@ const Navigation: FC = () => {
                           onOpen={() => {
                             toggleAccordionNav("storage");
                           }}
-                          open={openNavMenus.includes("storage")}
+                          open={
+                            openNavMenus.includes("storage") && !menuCollapsed
+                          }
                         >
                           {[
                             <SideNavigationItem
@@ -482,14 +492,20 @@ const Navigation: FC = () => {
                       {isClustered && (
                         <SideNavigationItem>
                           <NavAccordion
-                            baseUrl={`${ROOT_PATH}/ui/cluster`}
+                            baseUrls={[
+                              `${ROOT_PATH}/ui/cluster`,
+                              `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/placement-groups`,
+                            ]}
                             title={getNavTitle("clustering")}
                             iconName="cluster-host"
                             label="Clustering"
                             onOpen={() => {
                               toggleAccordionNav("clustering");
                             }}
-                            open={openNavMenus.includes("clustering")}
+                            open={
+                              openNavMenus.includes("clustering") &&
+                              !menuCollapsed
+                            }
                           >
                             {[
                               <SideNavigationItem key="members">
@@ -572,14 +588,17 @@ const Navigation: FC = () => {
                       {hasAccessManagement && (
                         <SideNavigationItem>
                           <NavAccordion
-                            baseUrl={`${ROOT_PATH}/ui/permissions`}
+                            baseUrls={[`${ROOT_PATH}/ui/permissions`]}
                             title={`Permissions`}
                             iconName="user"
                             label="Permissions"
                             onOpen={() => {
                               toggleAccordionNav("permissions");
                             }}
-                            open={openNavMenus.includes("permissions")}
+                            open={
+                              openNavMenus.includes("permissions") &&
+                              !menuCollapsed
+                            }
                           >
                             {[
                               <SideNavigationItem key="/ui/permissions/identities">


### PR DESCRIPTION
## Done

- [x] On navigation collapse, sub-sections should no longer have space where their icons would be (navigation becomes compressed).
- [x] With menu closed, we should highlight the matching parent item in the collapsed menu.
- [x] On uncollapsing the navigation, we can restore the sub-menu open state from before and highlight the active sub-page again.

Issues: One teeeny tiny issue: If you select a submenu, close the Navigation (parent menu should be highlighted), and then refresh the page of the submenu _and close the Navigation again_, the parent menu is no longer highlighted as I believe context has been lost. By this thinking, I also assume that if you navigate to a submenu via URL rather than via navigation, this may also be the case. Investigating a URL based approach may be a related task.

Fixes:
- https://github.com/canonical/lxd-ui/issues/1770

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Find an entity that has subpages (Eg; Networks, Storage, clustering or permissions)
    - Navigate to one of these subpages (Eg; ACLs, Volumes, Groups)
    - Minimise the main navigation and ensure that:
      - There is no space where the subsection would have been (menu is compressed)
      - The parent entity icon is highlighted.

## Screenshots

New behaviour:
<img width="394" height="746" alt="image" src="https://github.com/user-attachments/assets/4f4ba804-4458-490f-ae67-4bad4b5f45c8" />
<img width="351" height="651" alt="image" src="https://github.com/user-attachments/assets/8f30d6d9-95e5-4906-ab47-b0b4a886a423" />