### PR TITLE
fix(network) allow network edit on localhost to give success message

### DIFF
--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -175,8 +175,9 @@ export const areNetworksEqual = (
     return false;
   }
 
+  const ignoreForDiff = ["config", "etag", "access_entitlements"];
   const hasMainKeyDiff = (Object.keys(a) as Array<keyof typeof a>).some(
-    (key) => (key === "config" || key === "etag" ? false : a[key] !== b[key]),
+    (key) => (ignoreForDiff.includes(key) ? false : a[key] !== b[key]),
   );
 
   return !hasMainKeyDiff;


### PR DESCRIPTION
## Done

- fix(network) allow network edit on localhost to give success message

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run ui on localhost
    - edit a network bridge mtu value
    - see the success notification.