### PR TITLE
fix(back-link) allow click on arrow in back link to also go back to previous step

### DIFF
--- a/src/components/BackLink.tsx
+++ b/src/components/BackLink.tsx
@@ -10,13 +10,14 @@ interface Props {
 const BackLink: FC<Props> = ({ linkText, title, onClick }) => {
   const backLink = (
     <>
-      <Icon name="chevron-left" />{" "}
       <Button
         onClick={onClick}
         dense
+        hasIcon
         appearance="link"
         className="p-heading--4"
       >
+        <Icon name="chevron-left" className="back-link-icon" />
         {linkText}
       </Button>
     </>

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -459,3 +459,8 @@ body.is-dark .lxd-icon {
 .mono-font {
   font-family: unquote($font-monospace);
 }
+
+.back-link-icon {
+  margin-left: $sph--small !important;
+  margin-right: $sph--small !important;
+}


### PR DESCRIPTION
## Done

- fix(back-link) allow click on arrow in back link to also go back to previous step

Fixes WD-34152

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check back link on instance > migrate > any of the migration options
    - check back link on permission > group > create and  > identities and permissions
    - back link arrow should act as a link.