### PR TITLE
fix(initial access): Change temporary to initial, prevent changing group

### DIFF
--- a/src/pages/login/CreateTlsIdentityWithBearerToken.tsx
+++ b/src/pages/login/CreateTlsIdentityWithBearerToken.tsx
@@ -134,13 +134,7 @@ const CreateTlsIdentityWithBearerToken: FC = () => {
           setSelectedGroups={(newGroups: string[]) => {
             formik.setFieldValue("groups", newGroups);
           }}
-          toggleGroup={(group: string) => {
-            const currentGroups = formik.values.groups ?? [];
-            const newGroups = currentGroups.includes(group)
-              ? currentGroups.filter((g) => g !== group)
-              : [...currentGroups, group];
-            formik.setFieldValue("groups", newGroups);
-          }}
+          toggleGroup={(_: string) => {}}
           scrollDependencies={[
             groups,
             formik.values.groups?.length,
@@ -151,6 +145,7 @@ const CreateTlsIdentityWithBearerToken: FC = () => {
             "create-tls-identity-with-bearer-token-footer",
             "status-bar",
           ]}
+          disabled={true}
         />
         <div
           id="create-tls-identity-with-bearer-token-footer"

--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom";
 import { pluralize } from "util/instanceBulkActions";
 import useSortTableData from "util/useSortTableData";
 import { ROOT_PATH } from "util/rootPath";
+import classnames from "classnames";
 
 interface Props {
   groups: LxdAuthGroup[];
@@ -26,6 +27,7 @@ interface Props {
   scrollDependencies: DependencyList;
   preselectedGroups?: Set<string>;
   belowIds?: string[];
+  disabled?: boolean;
 }
 
 const GroupSelection: FC<Props> = ({
@@ -40,6 +42,7 @@ const GroupSelection: FC<Props> = ({
   scrollDependencies,
   preselectedGroups,
   belowIds = [],
+  disabled = false,
 }) => {
   const [search, setSearch] = useState("");
 
@@ -82,7 +85,9 @@ const GroupSelection: FC<Props> = ({
         : "";
 
     const toggleRow = () => {
-      toggleGroup(group.name);
+      if (!disabled) {
+        toggleGroup(group.name);
+      }
     };
 
     return {
@@ -95,14 +100,18 @@ const GroupSelection: FC<Props> = ({
           title: group.name,
           onClick: toggleRow,
           role: "rowheader",
-          className: "name u-truncate clickable-cell",
+          className: classnames("name u-truncate", {
+            "clickable-cell": !disabled,
+          }),
           "aria-label": "Name",
         },
         {
           content: <span>{group.description || ""}</span>,
           onClick: toggleRow,
           role: "cell",
-          className: "description clickable-cell",
+          className: classnames("description", {
+            "clickable-cell": !disabled,
+          }),
           "aria-label": "Description",
           title: group.description,
         },
@@ -159,6 +168,7 @@ const GroupSelection: FC<Props> = ({
             indeterminateNames={Array.from(indeterminateGroups ?? new Set())}
             onToggleRow={toggleGroup}
             hideContextualMenu
+            disableSelect={disabled}
           />
         </ScrollableTable>
       ) : (

--- a/src/util/seconds.tsx
+++ b/src/util/seconds.tsx
@@ -65,10 +65,10 @@ export const getExpiryMessage = (secondsLeft: number | null): string | null => {
   }
 
   if (secondsLeft <= 0) {
-    return "Temporary access has expired";
+    return "Initial access has expired";
   }
 
   const timeString = formatCountdown(secondsLeft);
 
-  return `Temporary access expires in ${timeString}`;
+  return `Initial access expires in ${timeString}`;
 };


### PR DESCRIPTION
## Done

- Change `temporary` into `initial`
- Prevent user to change auth groups in Authentication setup


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Connect with bearer token. Make sure that all texts include `initial` and not `temporary`.
    - Setup TLS permanent access. Make sure you cannot unselect `admins` group.

## Screenshots
<img width="632" height="67" alt="image" src="https://github.com/user-attachments/assets/54670f0f-14af-4c44-9199-c90292160749" />
<img width="1075" height="602" alt="image" src="https://github.com/user-attachments/assets/99a25e9b-8886-4cdf-b186-22f959e4308d" />
<img width="1323" height="1038" alt="image" src="https://github.com/user-attachments/assets/ceeb8ca3-d846-4224-bfb4-280623f031db" />
