### PR TITLE
fix(network) show warning on peering target network when access is not restricted with ACLs

### DIFF
--- a/src/pages/networks/LocalPeeringTargetWarning.tsx
+++ b/src/pages/networks/LocalPeeringTargetWarning.tsx
@@ -1,0 +1,33 @@
+import { Icon, Tooltip } from "@canonical/react-components";
+import type { FC } from "react";
+import { useNetwork } from "context/useNetworks";
+
+interface Props {
+  network: string;
+  project: string;
+}
+
+const LocalPeeringTargetWarning: FC<Props> = ({
+  network: networkName,
+  project,
+}) => {
+  const { data: network } = useNetwork(networkName, project);
+  const networkACLs = network?.config["security.acls"];
+
+  return (
+    (!networkACLs || networkACLs?.length == 0) && (
+      <Tooltip
+        message={
+          <div>
+            <div>Target network has unrestricted ingress and egress.</div>
+            <div>To enforce filtering, add ACLs to the target network.</div>
+          </div>
+        }
+      >
+        <Icon name="warning" />
+      </Tooltip>
+    )
+  );
+};
+
+export default LocalPeeringTargetWarning;

--- a/src/pages/networks/NetworkPeers.tsx
+++ b/src/pages/networks/NetworkPeers.tsx
@@ -20,6 +20,7 @@ import LocalPeeringStatusIcon from "./LocalPeeringStatusIcon";
 import LocalPeeringWarning from "./LocalPeeringWarning";
 import NetworkRichChip from "./NetworkRichChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
+import LocalPeeringTargetWarning from "pages/networks/LocalPeeringTargetWarning";
 
 interface Props {
   network: LxdNetwork;
@@ -79,10 +80,16 @@ const NetworkPeers: FC<Props> = ({ network, project }) => {
         },
         {
           content: localPeering.target_network ? (
-            <NetworkRichChip
-              networkName={localPeering.target_network}
-              projectName={localPeering.target_project ?? ""}
-            />
+            <>
+              <NetworkRichChip
+                networkName={localPeering.target_network}
+                projectName={localPeering.target_project ?? ""}
+              />
+              <LocalPeeringTargetWarning
+                network={localPeering.target_network}
+                project={localPeering.target_project}
+              />
+            </>
           ) : (
             "-"
           ),


### PR DESCRIPTION
## Done

- fix(network) show warning on peering target network when access is not restricted with ACLs

## Screenshots

This network `ovn-3` has no ACLs, so there was already a warning in place before this PR

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/53064394-1c97-43aa-baed-92fcfea96df6" />

However, if we created the peering from the other side through `ovn-2` as mutual peering, then we would never see the warning, because `ovn-2` has ACLs assigned:

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/e125cadb-9239-48c8-8d50-664fe4379df0" />

New warning on `ovn-2`, checking the target network:

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/b6b5c88e-9d58-49fe-90fe-a01ffc8a7501" />

With more details on hover:

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/1d28d7a7-fbab-47be-96a1-62329e9d53c6" />
