### PR TITLE
feat(YAML config): Add expanded when editing an instance

### DIFF
--- a/src/components/forms/FormFooterLayout.tsx
+++ b/src/components/forms/FormFooterLayout.tsx
@@ -1,9 +1,23 @@
 import type { FC, PropsWithChildren } from "react";
+import classnames from "classnames";
 
-const FormFooterLayout: FC<PropsWithChildren> = ({ children }) => {
+interface Props {
+  isAlignRight?: boolean;
+}
+
+const FormFooterLayout: FC<PropsWithChildren<Props>> = ({
+  children,
+  isAlignRight = true,
+}) => {
   return (
     <div className="p-bottom-controls form-footer" id="form-footer">
-      <footer className="u-align--right bottom-btns">{children}</footer>
+      <footer
+        className={classnames("bottom-btns", {
+          "u-align--right": isAlignRight,
+        })}
+      >
+        {children}
+      </footer>
     </div>
   );
 };

--- a/src/components/forms/YamlConfirmation.tsx
+++ b/src/components/forms/YamlConfirmation.tsx
@@ -16,8 +16,7 @@ const YamlConfirmation: FC<Props> = ({ onConfirm, close }) => {
       title="Confirm"
     >
       <p>
-        Switching back to guided forms will discard all changes in the YAML
-        editor.
+        This will discard all changes in the YAML editor.
         <br />
         Are you sure you want to proceed?
       </p>

--- a/src/components/forms/YamlSwitch.tsx
+++ b/src/components/forms/YamlSwitch.tsx
@@ -48,19 +48,23 @@ const YamlSwitch: FC<Props> = ({
   return (
     <div
       title={disableReason}
-      className={classnames("u-float-left", { "is-disabled": disableReason })}
+      className={classnames("u-float-left", {
+        "is-disabled": disableReason,
+      })}
     >
       {isOpen && (
         <Portal>
           <YamlConfirmation onConfirm={handleConfirm} close={closePortal} />
         </Portal>
       )}
-      <Switch
-        label={isSmallScreen ? "YAML" : "YAML Configuration"}
-        checked={isChecked}
-        onChange={handleSwitch}
-        disabled={disableReason !== undefined}
-      />
+      <div className="u-flex">
+        <Switch
+          label={isSmallScreen ? "YAML" : "YAML Configuration"}
+          checked={isChecked}
+          onChange={handleSwitch}
+          disabled={disableReason !== undefined}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/forms/YamlTypeSelector.tsx
+++ b/src/components/forms/YamlTypeSelector.tsx
@@ -1,0 +1,80 @@
+import type { FC, FormEvent } from "react";
+import { useState } from "react";
+import { RadioInput, usePortal } from "@canonical/react-components";
+import YamlConfirmation from "components/forms/YamlConfirmation";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
+
+export type YamlType = "local" | "expandInheritedValues";
+
+interface Props {
+  yamlType: YamlType;
+  setYamlType: (yamlType: YamlType) => void;
+  formik: InstanceAndProfileFormikProps;
+}
+
+const YamlTypeSelector: FC<Props> = ({ yamlType, setYamlType, formik }) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const [pendingYamlType, setPendingYamlType] = useState<YamlType | null>(null);
+
+  const performSwitch = (newYamlType: YamlType) => {
+    void formik.setFieldValue("yaml", undefined);
+
+    if (newYamlType === "expandInheritedValues") {
+      void formik.setFieldValue("readOnly", true);
+    }
+
+    setYamlType(newYamlType);
+  };
+
+  const handleChange = (
+    newYamlType: YamlType,
+    e: FormEvent<HTMLInputElement>,
+  ) => {
+    if (formik.values.yaml) {
+      setPendingYamlType(newYamlType);
+      openPortal(e);
+      return;
+    }
+
+    performSwitch(newYamlType);
+  };
+
+  const handleConfirm = () => {
+    if (pendingYamlType) {
+      performSwitch(pendingYamlType);
+    }
+    setPendingYamlType(null);
+    closePortal();
+  };
+
+  const handleCancel = () => {
+    setPendingYamlType(null);
+    closePortal();
+  };
+
+  return (
+    <div className="yaml-type-radio-wrapper">
+      {isOpen && (
+        <Portal>
+          <YamlConfirmation onConfirm={handleConfirm} close={handleCancel} />
+        </Portal>
+      )}
+      <RadioInput
+        label="Local"
+        checked={yamlType === "local"}
+        onChange={(e) => {
+          handleChange("local", e);
+        }}
+      />
+      <RadioInput
+        label="Expand inherited values"
+        checked={yamlType === "expandInheritedValues"}
+        onChange={(e) => {
+          handleChange("expandInheritedValues", e);
+        }}
+      />
+    </div>
+  );
+};
+
+export default YamlTypeSelector;

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -12,7 +12,11 @@ import { useFormik } from "formik";
 import { updateInstance } from "api/instances";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { objectToYaml, yamlToObject } from "util/yaml";
+import {
+  expandInheritedValuesYaml,
+  objectToYaml,
+  yamlToObject,
+} from "util/yaml";
 import { useNavigate, useParams } from "react-router-dom";
 import type { LxdInstance } from "types/instance";
 import SecurityPoliciesForm from "components/forms/SecurityPoliciesForm";
@@ -48,7 +52,6 @@ import {
 import { slugify } from "util/slugify";
 import { useEventQueue } from "context/eventQueue";
 import { hasDiskError, hasNetworkError } from "util/instanceValidation";
-import FormFooterLayout from "components/forms/FormFooterLayout";
 import MigrationForm from "components/forms/MigrationForm";
 import GPUDeviceForm from "components/forms/GPUDeviceForm";
 import OtherDeviceForm from "components/forms/OtherDeviceForm";
@@ -65,6 +68,9 @@ import NetworkDevicePanel from "components/forms/NetworkDevicesForm/edit/Network
 import { InstanceRichChip } from "./InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
+import type { YamlType } from "components/forms/YamlTypeSelector";
+import YamlTypeSelector from "components/forms/YamlTypeSelector";
+import FormFooterLayout from "components/forms/FormFooterLayout";
 
 interface Props {
   instance: LxdInstance;
@@ -83,6 +89,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
   const navigate = useNavigate();
   const [version, setVersion] = useState(0);
   const { canEditInstance } = useInstanceEntitlements();
+  const [yamlType, setYamlType] = useState<YamlType>("local");
 
   if (!project) {
     return <>Missing project</>;
@@ -174,13 +181,20 @@ const EditInstance: FC<Props> = ({ instance }) => {
       "expanded_devices",
       "etag",
     ]);
+
     const bareInstance = Object.fromEntries(
-      Object.entries(instance).filter((e) => !exclude.has(e[0])),
+      Object.entries(instance).filter(([key]) => !exclude.has(key)),
     );
-    return objectToYaml(bareInstance);
+
+    if (yamlType === "local") {
+      return objectToYaml(bareInstance);
+    }
+
+    return expandInheritedValuesYaml(instance, profiles);
   };
 
   const readOnly = formik.values.readOnly;
+  const isYamlSection = section === slugify(YAML_CONFIGURATION);
 
   return (
     <div className="edit-instance">
@@ -256,16 +270,23 @@ const EditInstance: FC<Props> = ({ instance }) => {
               />
             )}
 
-            {section === slugify(YAML_CONFIGURATION) && (
+            {isYamlSection && (
               <YamlForm
-                key={`yaml-form-${version}`}
+                key={`yaml-form-${yamlType}-${version}`}
                 yaml={getYaml()}
                 setYaml={(yaml) => {
                   ensureEditMode(formik);
                   formik.setFieldValue("yaml", yaml);
                 }}
-                readOnly={!!formik.values.editRestriction}
-                readOnlyMessage={formik.values.editRestriction}
+                readOnly={
+                  yamlType === "expandInheritedValues" ||
+                  !!formik.values.editRestriction
+                }
+                readOnlyMessage={
+                  yamlType === "expandInheritedValues"
+                    ? "Expanded configuration is read-only"
+                    : formik.values.editRestriction
+                }
               >
                 <YamlNotification entity="instance" docPath="/instances" />
               </YamlForm>
@@ -273,14 +294,21 @@ const EditInstance: FC<Props> = ({ instance }) => {
           </Col>
         </Row>
       </Form>
-      <FormFooterLayout>
+      <FormFooterLayout isAlignRight={false}>
         <YamlSwitch
           formik={formik}
           section={section}
           setSection={updateSection}
         />
+        {isYamlSection && (
+          <YamlTypeSelector
+            yamlType={yamlType}
+            setYamlType={setYamlType}
+            formik={formik}
+          />
+        )}
         {readOnly ? null : (
-          <>
+          <div className="cancel-save-container">
             <Button
               appearance="base"
               onClick={() => {
@@ -295,10 +323,10 @@ const EditInstance: FC<Props> = ({ instance }) => {
             <FormSubmitBtn
               formik={formik}
               baseUrl={baseUrl}
-              isYaml={section === slugify(YAML_CONFIGURATION)}
+              isYaml={isYamlSection}
               disabled={hasDiskError(formik) || hasNetworkError(formik)}
             />
-          </>
+          </div>
         )}
       </FormFooterLayout>
 

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -337,6 +337,74 @@
   padding-bottom: 0;
 }
 
+.create-profile,
+.create-project,
+.edit-project,
+.create-storage-pool,
+.storage-volume-form {
+  .bottom-btns {
+    max-width: 72rem;
+    min-height: 3.5rem;
+    padding-right: 1.5rem;
+  }
+}
+
+.edit-instance,
+.edit-network,
+.edit-network-acl,
+.edit-profile,
+.edit-storage-pool,
+.edit-storage-volume {
+  .bottom-btns {
+    max-width: 70.5rem;
+    min-height: 3.5rem;
+  }
+
+  .form-footer {
+    margin-top: 1rem;
+  }
+
+  .form {
+    max-width: 70.5rem;
+  }
+
+  .form-contents:has(.code-editor-wrapper) {
+    padding-left: 0;
+
+    .code-editor-wrapper {
+      .monaco-hover,
+      .monaco-hover-content {
+        display: none;
+      }
+    }
+  }
+}
+
+.edit-instance {
+  .form-footer {
+    .bottom-btns {
+      align-items: flex-end;
+      display: flex;
+      flex-wrap: wrap;
+      gap: $sph--large;
+      padding-bottom: $spv--large;
+
+      .yaml-expanded-radio-wrapper {
+        margin-left: $sph--x-large;
+      }
+
+      .cancel-save-container {
+        margin-left: auto;
+        white-space: nowrap;
+
+        > button {
+          margin-bottom: $spv--x-small;
+        }
+      }
+    }
+  }
+}
+
 .image-select-modal {
   > section {
     min-height: 100%;
@@ -417,12 +485,6 @@
 .edit-project,
 .create-storage-pool,
 .storage-volume-form {
-  .bottom-btns {
-    max-width: 72rem;
-    min-height: 3.5rem;
-    padding-right: 1.5rem;
-  }
-
   .form-footer {
     margin-top: 1rem;
   }
@@ -433,37 +495,6 @@
 
   .form-contents:has(.code-editor-wrapper) {
     padding-left: 1.5rem;
-  }
-}
-
-.edit-instance,
-.edit-network,
-.edit-network-acl,
-.edit-profile,
-.edit-storage-pool,
-.edit-storage-volume {
-  .bottom-btns {
-    max-width: 70.5rem;
-    min-height: 3.5rem;
-  }
-
-  .form-footer {
-    margin-top: 1rem;
-  }
-
-  .form {
-    max-width: 70.5rem;
-  }
-
-  .form-contents:has(.code-editor-wrapper) {
-    padding-left: 0;
-
-    .code-editor-wrapper {
-      .monaco-hover,
-      .monaco-hover-content {
-        display: none;
-      }
-    }
   }
 }
 

--- a/src/sass/_yaml_type_selector.scss
+++ b/src/sass/_yaml_type_selector.scss
@@ -1,0 +1,5 @@
+.yaml-type-radio-wrapper {
+  align-items: flex-end;
+  display: flex;
+  gap: $sph--x-large;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -164,6 +164,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "upload_instance_modal";
 @import "upper_controls_bar";
 @import "warnings_table";
+@import "yaml_type_selector";
 
 body {
   // needed for notification list expanding animation

--- a/src/util/yaml.spec.ts
+++ b/src/util/yaml.spec.ts
@@ -1,0 +1,125 @@
+import { expandInheritedValuesYaml } from "./yaml";
+import type { LxdInstance } from "types/instance";
+import type { LxdProfile } from "types/profile";
+
+describe("expandInheritedValuesYaml", () => {
+  const profiles: LxdProfile[] = [
+    {
+      name: "default",
+      description: "Default LXD profile",
+      config: { "boot.autostart": "true" },
+      devices: {
+        root: { path: "/", pool: "default", type: "disk" },
+      },
+    },
+    {
+      name: "cloud-init",
+      description: "Cloud-init configuration",
+      config: {
+        "cloud-init.user-data": "#cloud-config\npackage_update: true\n",
+      },
+      devices: {
+        eth0: {
+          nictype: "bridged",
+          parent: "lxdbr0",
+          type: "nic",
+          network: "lxdbr0",
+        },
+      },
+    },
+  ];
+
+  const instance: LxdInstance = {
+    name: "test-vm",
+    status: "Running",
+    profiles: ["default", "cloud-init"],
+    config: {
+      "user.meta": "local-value",
+    },
+    expanded_config: {
+      "boot.autostart": "true",
+      "user.meta": "local-value",
+      "cloud-init.user-data": "#cloud-config\npackage_update: true\n",
+    },
+    devices: {
+      root: { path: "/", pool: "default", type: "disk" },
+    },
+    expanded_devices: {
+      root: { path: "/", pool: "default", type: "disk" },
+      eth0: {
+        nictype: "bridged",
+        parent: "lxdbr0",
+        type: "nic",
+        network: "lxdbr0",
+      },
+    },
+    architecture: "x86_64",
+    created_at: "2024-01-01T00:00:00Z",
+    description: "A test VM",
+    ephemeral: false,
+    last_used_at: "2024-01-02T00:00:00Z",
+    location: "local",
+    project: "default",
+    stateful: false,
+    type: "virtual-machine",
+    snapshots: null,
+  };
+
+  it("should generate an annotated expanded YAML", () => {
+    const expectedYaml = `name: test-vm
+status: Running
+profiles:
+  - default
+  - cloud-init
+architecture: x86_64
+created_at: '2024-01-01T00:00:00Z'
+description: A test VM
+ephemeral: false
+last_used_at: '2024-01-02T00:00:00Z'
+location: local
+project: default
+stateful: false
+type: virtual-machine
+config:
+  boot.autostart: 'true' # inherited from profile: default
+  user.meta: local-value
+  cloud-init.user-data: | # inherited from profile: cloud-init
+    #cloud-config
+    package_update: true
+
+devices:
+  root:
+    path: /
+    pool: default
+    type: disk
+  eth0: # inherited from profile: cloud-init
+    nictype: bridged
+    parent: lxdbr0
+    type: nic
+    network: lxdbr0`;
+
+    const result = expandInheritedValuesYaml(instance, profiles);
+    expect(result).toBe(expectedYaml);
+  });
+
+  it("should handle empty inherited values with single quotes", () => {
+    const instanceWithEmpty = {
+      ...instance,
+      config: {},
+      expanded_config: { "user.empty": "" },
+    };
+    const profilesWithEmpty = [
+      { ...profiles[0], config: { "user.empty": "" } },
+    ];
+
+    const result = expandInheritedValuesYaml(
+      instanceWithEmpty,
+      profilesWithEmpty,
+    );
+
+    // Checks specific formatting for empty strings from js-yaml
+    expect(result).toContain(
+      "user.empty: '' # inherited from profile: default",
+    );
+  });
+});

--- a/src/util/yaml.tsx
+++ b/src/util/yaml.tsx
@@ -1,4 +1,6 @@
 import { dump as dumpYaml, load as loadYaml } from "js-yaml";
+import type { LxdInstance } from "types/instance";
+import type { LxdProfile } from "types/profile";
 
 export const yamlToObject = (yamlString: string): object => {
   return loadYaml(yamlString.trim()) as object;
@@ -6,4 +8,110 @@ export const yamlToObject = (yamlString: string): object => {
 
 export const objectToYaml = (obj: object): string => {
   return dumpYaml(obj, { lineWidth: -1 });
+};
+
+const getSourceProfile = (
+  profileNames: string[],
+  allProfiles: LxdProfile[],
+  key: string,
+  deviceName?: string,
+): string => {
+  for (const profileName of profileNames) {
+    const profile = allProfiles.find((profile) => profile.name === profileName);
+    if (!profile) continue;
+
+    if (deviceName) {
+      const device = profile.devices?.[deviceName];
+      if (device) {
+        return profileName;
+      }
+    } else {
+      if (profile.config?.[key] !== undefined) {
+        return profileName;
+      }
+    }
+  }
+  return "profile";
+};
+
+export const expandInheritedValuesYaml = (
+  instance: LxdInstance,
+  profiles: LxdProfile[],
+): string => {
+  const reversedProfiles = [...(instance.profiles || [])].reverse();
+  const sections: string[] = [];
+
+  const exclude = [
+    "config",
+    "devices",
+    "expanded_config",
+    "expanded_devices",
+    "backups",
+    "snapshots",
+    "state",
+    "etag",
+  ];
+
+  const metadata = Object.fromEntries(
+    Object.entries(instance).filter(([key]) => !exclude.includes(key)),
+  );
+
+  sections.push(objectToYaml(metadata).trim());
+
+  const expandedConfig = instance.expanded_config || {};
+  const localConfig = instance.config || {};
+
+  if (Object.keys(expandedConfig).length > 0) {
+    sections.push("config:");
+    Object.entries(expandedConfig).forEach(([key, value]) => {
+      const isLocal = Object.prototype.hasOwnProperty.call(localConfig, key);
+      let entryYaml = objectToYaml({ [key]: value }).trimEnd();
+
+      if (!isLocal) {
+        const source = getSourceProfile(reversedProfiles, profiles, key);
+        const lines = entryYaml.split("\n");
+        lines[0] = `${lines[0]} # inherited from profile: ${source}`;
+        entryYaml = lines.join("\n");
+      }
+
+      const padding = String(value).includes("\n") ? "\n" : "";
+      sections.push(entryYaml.replace(/^/gm, "  ") + padding);
+    });
+  }
+
+  const expandedDevices = instance.expanded_devices || {};
+  const localDevices = instance.devices || {};
+
+  if (Object.keys(expandedDevices).length > 0) {
+    sections.push("devices:");
+    Object.entries(expandedDevices).forEach(([name, config]) => {
+      const localDevice = localDevices[name];
+
+      if (!localDevice) {
+        // Device is inherited from a profile
+        const source = getSourceProfile(
+          reversedProfiles,
+          profiles,
+          "type",
+          name,
+        );
+        sections.push(`  ${name}: # inherited from profile: ${source}`);
+        sections.push(objectToYaml(config).replace(/^/gm, "    ").trimEnd());
+      } else {
+        sections.push(`  ${name}:`);
+        Object.entries(config as unknown as Record<string, unknown>).forEach(
+          ([propKey, propVal]) => {
+            const propYaml = objectToYaml({ [propKey]: propVal }).trimEnd();
+            const padding = String(propVal).includes("\n") ? "\n" : "";
+            sections.push(propYaml.replace(/^/gm, "    ") + padding);
+          },
+        );
+      }
+    });
+  }
+
+  return sections
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 };


### PR DESCRIPTION
## Done

- When editing an instance, add expanded YAML configuration

Fixes #1456

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Use an instance that inherits from a profile, preferably a profile with a device.
    - Go to the instance configuration, switch to YAML configuration: 2 radio buttons should appear (`Instance only` and `Expanded`)
    - Check `Expanded`. Make sure the YAML is read only with a hover text and `Cancel` and `Save` buttons are not displayed. Make sure you can see the inherited profile configuration.

## Screenshots

<img width="1556" height="1000" alt="image" src="https://github.com/user-attachments/assets/32f551ed-868b-488e-a2f9-563180ca37fd" />

Medium screen with line break
<img width="1178" height="1061" alt="image" src="https://github.com/user-attachments/assets/83771ced-7932-4b2f-a448-06914e30fb6d" />

Annotated expanded YAML
<img width="1564" height="980" alt="image" src="https://github.com/user-attachments/assets/71f78dee-c9f4-4b8a-8652-18f53f2af699" />

