### PR TITLE
fix(YAML): Remove hover text to be able to close widget

### DIFF
--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -457,6 +457,13 @@
 
   .form-contents:has(.code-editor-wrapper) {
     padding-left: 0;
+
+    .code-editor-wrapper {
+      .monaco-hover,
+      .monaco-hover-content {
+        display: none;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Done

- Yaml configuration: remove hover text, to be able to close search widget


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open a YAML configuration (instance, profile, ACL or storage pool), type `Ctrl + F`. Make sure you can close the search wdiget

## Screenshots

BEFORE
https://github.com/user-attachments/assets/c7eefd55-781d-4acc-844b-8a33b0f97bc0

AFTER
https://github.com/user-attachments/assets/72a17f07-9288-4446-97d3-fcd2f076b4ae

