### PR TITLE
test(ACLs): e2e tests on applying ACLs on network and instance/profile

### DIFF
--- a/src/pages/networks/forms/NetworkAclSelector.tsx
+++ b/src/pages/networks/forms/NetworkAclSelector.tsx
@@ -53,6 +53,7 @@ const NetworkAclSelector: FC<Props> = ({
     <>
       {label && <label htmlFor={id}>{label}</label>}
       <MultiSelect
+        label={label}
         items={toOptionList(
           availableAcls.map((acl) => acl.name),
           inheritedAcls,

--- a/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLSelector.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Fragment } from "react";
-import { Icon, Select } from "@canonical/react-components";
+import { Icon, Label, Select } from "@canonical/react-components";
 import { conjugateACLAction } from "util/helpers";
 
 export type Direction = "Ingress" | "Egress";
@@ -29,6 +29,9 @@ const NetworkDefaultACLSelector: FC<Props> = ({
     })),
   ];
 
+  const getId = (direction: Direction) =>
+    `${direction.toLowerCase()}-default-action`;
+
   return (
     <div>
       <div className="u-sv2">When no ACL rule matches:</div>
@@ -36,13 +39,13 @@ const NetworkDefaultACLSelector: FC<Props> = ({
         {DIRECTIONS.map((direction) => {
           return (
             <Fragment key={direction}>
-              <div>
+              <Label forId={getId(direction)}>
                 <Icon
                   name={direction === "Egress" ? "arrow-left" : "arrow-right"}
                   className="network-default-acl-icon"
                 />
-                {direction} traffic will be{" "}
-              </div>
+                {direction} traffic is{" "}
+              </Label>
               <div>
                 <Select
                   className="u-no-margin--bottom"
@@ -52,6 +55,7 @@ const NetworkDefaultACLSelector: FC<Props> = ({
                   }}
                   value={values?.[direction]}
                   disabled={disabled}
+                  id={getId(direction)}
                 />
               </div>
             </Fragment>

--- a/tests/network-acls.spec.ts
+++ b/tests/network-acls.spec.ts
@@ -1,11 +1,30 @@
-import { test } from "./fixtures/lxd-test";
+import { test, expect } from "./fixtures/lxd-test";
+import { skipIfNotClustered, skipIfNotSupported } from "./helpers/cluster";
 import {
+  createNetwork,
+  deleteNetwork,
+  getNetworkLink,
+  randomNetworkName,
+  visitNetwork,
+} from "./helpers/network";
+import {
+  attachNetworkAclsToNetwork,
   createNetworkAcl,
   deleteNetworkAcl,
+  detachNetworkAclsFromNetwork,
   editNetworkAcl,
   randomNetworkAclName,
   renameNetworkAcl,
+  selectNetworkAcls,
+  setAclDefaults,
 } from "./helpers/network-acls";
+import {
+  deleteProfile,
+  finishProfileCreation,
+  randomProfileName,
+  startProfileCreation,
+  visitProfile,
+} from "./helpers/profile";
 
 test("create a network acl", async ({ page }) => {
   const networkAcl = randomNetworkAclName();
@@ -14,4 +33,180 @@ test("create a network acl", async ({ page }) => {
   await editNetworkAcl(page, networkAcl);
   await renameNetworkAcl(page, networkAcl, newName);
   await deleteNetworkAcl(page, newName);
+});
+
+test.describe("apply ACLs", () => {
+  const acl = randomNetworkAclName();
+  const acl2 = randomNetworkAclName();
+  const network = randomNetworkName();
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await createNetworkAcl(page, acl);
+    await createNetworkAcl(page, acl2);
+    await createNetwork(page, network);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await deleteNetwork(page, network);
+    await deleteNetworkAcl(page, acl);
+    await deleteNetworkAcl(page, acl2);
+    await page.close();
+  });
+
+  test("apply 2 ACLs to a network", async ({ page }) => {
+    await attachNetworkAclsToNetwork(page, [acl, acl2], network);
+    await setAclDefaults(page, "allow", "drop");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await page.waitForTimeout(5000);
+    const networkLink = await getNetworkLink(page, network);
+    await expect(networkLink).toBeVisible();
+    await visitNetwork(page, network);
+
+    const aclChip = page.locator(".p-chip", { hasText: acl });
+    await expect(aclChip).toBeVisible();
+    const aclChip2 = page.locator(".p-chip", { hasText: acl2 });
+    await expect(aclChip2).toBeVisible();
+
+    await expect(page.locator("text=Egress traffic is: allowed")).toBeVisible();
+    await expect(
+      page.locator("text=Ingress traffic is: dropped"),
+    ).toBeVisible();
+
+    await detachNetworkAclsFromNetwork(page, [acl, acl2], network);
+    await expect(page.getByLabel("Egress traffic")).toBeDisabled();
+    await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await page.waitForTimeout(5000);
+    await visitNetwork(page, network);
+
+    await expect(aclChip).not.toBeVisible();
+    await expect(aclChip2).not.toBeVisible();
+    await expect(page.getByLabel("Egress traffic")).not.toBeVisible();
+    await expect(page.getByLabel("Ingress traffic")).not.toBeVisible();
+  });
+
+  test("attach network with ACLs to a profile", async ({ page }) => {
+    await attachNetworkAclsToNetwork(page, [acl, acl2], network);
+    await setAclDefaults(page, "reject", "allow");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await page.waitForTimeout(5000);
+
+    const profile = randomProfileName();
+    await startProfileCreation(page, profile);
+    await page.getByText("Network", { exact: true }).click();
+    await page.getByRole("button", { name: "Attach network" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Create network device" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "* Network" }).click();
+    await expect(page.getByText("NameTypeACLs")).toBeVisible();
+    await page.getByLabel("sub").getByText(network).first().click();
+
+    const aclList = page.getByLabel("ACLs");
+    await expect(aclList).toContainText(`${acl}, ${acl2}`);
+    await expect(aclList).toBeDisabled();
+
+    await expect(
+      page.getByText("Network must be of type OVN to customize ACLs."),
+    ).toBeVisible();
+
+    await expect(page.getByLabel("Egress traffic")).toBeDisabled();
+    await expect(page.getByLabel("Egress traffic")).toHaveValue("reject");
+    await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
+    await expect(page.getByLabel("Ingress traffic")).toHaveValue("allow");
+
+    await page.getByRole("button", { name: "Apply changes" }).click();
+    await finishProfileCreation(page, profile);
+
+    await visitProfile(page, profile);
+    await page.getByTestId("tab-link-Configuration").click();
+    await page.getByText("Network", { exact: true }).click();
+
+    const aclChip = page.locator(".p-chip", { hasText: acl });
+    await expect(aclChip).toBeVisible();
+    const aclChip2 = page.locator(".p-chip", { hasText: acl2 });
+    await expect(aclChip2).toBeVisible();
+
+    await expect(
+      page.locator("text=Egress traffic is: rejected"),
+    ).toBeVisible();
+    await expect(
+      page.locator("text=Ingress traffic is: allowed"),
+    ).toBeVisible();
+
+    await deleteProfile(page, profile);
+  });
+
+  test("attach network to a profile then add ACLs to the nic device", async ({
+    page,
+    lxdVersion,
+  }, testInfo) => {
+    skipIfNotSupported(lxdVersion);
+    skipIfNotClustered(testInfo.project.name);
+
+    const bridge = randomNetworkName();
+    await createNetwork(page, bridge);
+
+    const ovn = randomNetworkName();
+    await createNetwork(page, ovn, "ovn");
+
+    const profile = randomProfileName();
+    await startProfileCreation(page, profile);
+    await page.getByText("Network", { exact: true }).click();
+    await page.getByRole("button", { name: "Attach network" }).click();
+
+    await page.getByRole("button", { name: "* Network" }).click();
+    await page.getByLabel("sub").getByText(bridge).first().click();
+
+    const aclButton = page.getByLabel("ACLs");
+    await expect(aclButton).toBeVisible();
+    await expect(aclButton).toBeDisabled();
+    await expect(
+      page.getByText("Network must be of type OVN to customize ACLs."),
+    ).toBeVisible();
+
+    await expect(page.getByLabel("Egress traffic")).toBeDisabled();
+    await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
+
+    await page.getByRole("button", { name: "* Network" }).click();
+    await page.getByLabel("sub").getByText(ovn).first().click();
+    await expect(aclButton).toBeEnabled();
+    await expect(
+      page.getByText("Network must be of type OVN to customize ACLs."),
+    ).not.toBeVisible();
+    await expect(page.getByLabel("Egress traffic")).toBeDisabled();
+    await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
+
+    await page.getByLabel("ACLs").click();
+    await selectNetworkAcls(page, [acl, acl2]);
+
+    await setAclDefaults(page, "drop", "reject");
+
+    await page.getByRole("button", { name: "Apply changes" }).click();
+    await finishProfileCreation(page, profile);
+
+    await visitProfile(page, profile);
+    await page.getByTestId("tab-link-Configuration").click();
+    await page.getByText("Network", { exact: true }).click();
+
+    const aclChip = page.locator(".p-chip", { hasText: acl });
+    await expect(aclChip).toBeVisible();
+    const aclChip2 = page.locator(".p-chip", { hasText: acl2 });
+    await expect(aclChip2).toBeVisible();
+
+    await expect(page.locator("text=Egress traffic is: dropped")).toBeVisible();
+    await expect(
+      page.locator("text=Ingress traffic is: rejected"),
+    ).toBeVisible();
+
+    await deleteProfile(page, profile);
+    await deleteNetwork(page, bridge);
+    await deleteNetwork(page, ovn);
+  });
 });


### PR DESCRIPTION
## Done

- Add e2e tests on applying ACLs to a network
- Add e2e tests on applying ACLs to a nic device on a profile

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI passing

## Screenshots

<img width="463" height="218" alt="image" src="https://github.com/user-attachments/assets/e31b4403-8e75-4f7d-8795-f26b2ff65ff6" />
