### PR TITLE
fix(TLS login): Update CLI to create TLS identity

### DIFF
--- a/src/pages/login/CertificateAddToken.tsx
+++ b/src/pages/login/CertificateAddToken.tsx
@@ -21,7 +21,7 @@ const CertificateAddToken: FC = () => {
   const { isAuthenticated, isAuthLoading, authMethod } = useAuth();
   const notify = useNotify();
   const identityTrustTokenCommand =
-    "if ! lxc auth group show admins ; then lxc auth group create admins ; lxc auth group permission add admins server admin ; fi ; lxc auth identity create tls/lxd-ui --group admins";
+    "if ! lxc auth group show admins >/dev/null 2>&1; then lxc auth group create admins && lxc auth group permission add admins server admin; fi; lxc auth identity create tls/lxd-ui --group admins";
 
   if (isAuthLoading) {
     return <Spinner className="u-loader" text="Loading..." isMainComponent />;
@@ -62,12 +62,14 @@ const CertificateAddToken: FC = () => {
                       </p>
                       <div>
                         First, the command checks to see if there is an auth
-                        group <code>admins</code>.
+                        group <code>admins</code>. The{" "}
+                        <code>{`>/dev/null 2>&1`}</code> part ensures that if
+                        the group is missing, no error is shown.
                       </div>
                       <CodeSnippet
                         blocks={[
                           {
-                            code: `if ! lxc auth group show admins`,
+                            code: `if ! lxc auth group show admins >/dev/null 2>&1;`,
                             wrapLines: true,
                           },
                         ]}


### PR DESCRIPTION
## Done

- TLS login > Certificate add : update CLI so that it doesn't throw an error if `admins` group does not exist


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Log out of LXD UI
    - Delete `admins` group: `lxc auth group delete admins`
    - From Login page, click on TLS login, then skip to step 2.
    - Make sure you understand you understand what the command does.
    - Copy paste the command line in a terminal
    - Make sure no errors is thrown

## Screenshots
<img width="982" height="548" alt="image" src="https://github.com/user-attachments/assets/42795692-9cf0-429e-868d-aff2ab6e8834" />

<img width="1852" height="1057" alt="image" src="https://github.com/user-attachments/assets/31bc754a-5c70-4ec6-8285-3370b6ffaeb2" />

