### PR TITLE
fix(acl) improve ux for discovering what ACLs are

### DIFF
--- a/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
+++ b/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
@@ -361,7 +361,7 @@ const NetworkDevicePanel: FC<Props> = ({
               inheritedAcls={networkAcls}
               canSelectManualAcls={supportsNicDeviceAcls(selectedNetwork)}
               help={getAclHelperText()}
-              label="ACLs"
+              label="Access Control Lists"
             />
 
             <NetworkDefaultACLSelector

--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
@@ -169,7 +169,9 @@ export const getNetworkDeviceRows = ({
       rows.push(
         getConfigurationRowBase({
           className: "no-border-top",
-          configuration: <div className="u-text--muted">ACLs</div>,
+          configuration: (
+            <div className="u-text--muted">Access control lists</div>
+          ),
           inherited: (
             <div>
               <ExpandableList

--- a/src/pages/networks/CreateNetworkAcl.tsx
+++ b/src/pages/networks/CreateNetworkAcl.tsx
@@ -114,7 +114,11 @@ const CreateNetworkAcl: FC = () => {
 
   return (
     <BaseLayout
-      title="Create a network ACL"
+      title={
+        <>
+          Create a network <abbr title="Access Control List">ACL</abbr>
+        </>
+      }
       contentClassName="create-network-acl"
     >
       <Row>

--- a/src/pages/networks/NetworkAclDetailHeader.tsx
+++ b/src/pages/networks/NetworkAclDetailHeader.tsx
@@ -95,7 +95,7 @@ const NetworkAclDetailHeader: FC<Props> = ({ name, networkAcl, project }) => {
           to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acls`}
           key={1}
         >
-          Network ACLs
+          Network Access Control Lists
         </Link>,
       ]}
       renameDisabledReason={getRenameDisableReason()}

--- a/src/pages/networks/NetworkAclList.tsx
+++ b/src/pages/networks/NetworkAclList.tsx
@@ -133,9 +133,9 @@ const NetworkAclList: FC = () => {
             <PageHeader.Title>
               <HelpLink
                 docPath="/howto/network_acls/"
-                title="Learn more about network ACLs"
+                title="Learn more about network access control lists"
               >
-                Network ACLs
+                Network Access Control Lists
               </HelpLink>
             </PageHeader.Title>
           </PageHeader.Left>
@@ -160,7 +160,7 @@ const NetworkAclList: FC = () => {
           <EmptyState
             className="empty-state"
             image={<Icon className="empty-state-icon" name="exposed" />}
-            title="No network ACLs found"
+            title="No network access control lists found"
           >
             <p>There are no network ACLs in this project.</p>
             <p>

--- a/src/pages/networks/forms/NetworkAclSelector.tsx
+++ b/src/pages/networks/forms/NetworkAclSelector.tsx
@@ -1,6 +1,8 @@
 import type { FC, ReactNode } from "react";
 import { MultiSelect } from "@canonical/react-components";
 import { useNetworkAcls } from "context/useNetworkAcls";
+import { Link } from "react-router-dom";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   project: string;
@@ -37,6 +39,22 @@ const NetworkAclSelector: FC<Props> = ({
   const hasAcls = availableAcls.length > 0;
   const isEnabled = canSelectManualAcls && hasAcls;
 
+  const aclLink = (label: string) => (
+    <Link
+      to={`${ROOT_PATH}/ui/project/${project}/network-acls`}
+      target="_blank"
+    >
+      {label}
+    </Link>
+  );
+
+  const helpManage =
+    availableAcls.length > 0 ? (
+      <>Manage {aclLink("ACLs")} for this project.</>
+    ) : (
+      <>Create an {aclLink("ACL")} to control network access.</>
+    );
+
   const getPlaceholder = () => {
     if (!canSelectManualAcls) {
       return "-";
@@ -70,7 +88,7 @@ const NetworkAclSelector: FC<Props> = ({
         disabledItems={inheritedAcls?.map((t) => {
           return { label: t, value: t };
         })}
-        help={help}
+        help={help ?? helpManage}
       />
     </>
   );

--- a/src/pages/networks/forms/NetworkAcls.tsx
+++ b/src/pages/networks/forms/NetworkAcls.tsx
@@ -33,7 +33,7 @@ const NetworkAcls: FC<Props> = ({ formik, project }) => {
   return (
     <div className="general-field">
       <div className="general-field-label can-edit">
-        <Label forId={networlAclSelectorId}>ACLs</Label>
+        <Label forId={networlAclSelectorId}>Access Control Lists</Label>
       </div>
       <div
         className="general-field-content"

--- a/src/pages/projects/forms/NetworkSelector.tsx
+++ b/src/pages/projects/forms/NetworkSelector.tsx
@@ -35,7 +35,7 @@ const NetworkSelector: FC<
               {network.type}
             </span>
             <span
-              title="network ACLs"
+              title="network access control lists"
               className="network-option u-truncate u-align--right"
             >
               {getNetworkAcls(network).length || "-"}
@@ -74,7 +74,7 @@ const NetworkSelector: FC<
               -
             </span>
             <span
-              title="network ACLs"
+              title="network access control lists"
               className="network-option u-truncate u-align--right"
             >
               -

--- a/tests/helpers/network-acls.ts
+++ b/tests/helpers/network-acls.ts
@@ -98,7 +98,7 @@ export const attachNetworkAclsToNetwork = async (
   await visitNetwork(page, network);
   await page
     .locator(".general-field")
-    .filter({ hasText: "ACLs" })
+    .filter({ hasText: "Access control lists" })
     .getByRole("button", { name: "Edit" })
     .click();
   const aclDropdown = page.getByRole("listbox");
@@ -116,7 +116,7 @@ export const detachNetworkAclsFromNetwork = async (
   await visitNetwork(page, network);
   await page
     .locator(".general-field")
-    .filter({ hasText: "ACLs" })
+    .filter({ hasText: "Access control lists" })
     .getByRole("button", { name: "Edit" })
     .click();
 

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -107,6 +107,7 @@ export const visitNetwork = async (page: Page, network: string) => {
   const link = await getNetworkLink(page, network);
   await link.click();
   await page.getByTestId("tab-link-Configuration").click();
+  await page.waitForLoadState("networkidle"); // ensure network loaded
 };
 
 export const prepareNetworkTabEdit = async (

--- a/tests/network-acls.spec.ts
+++ b/tests/network-acls.spec.ts
@@ -108,7 +108,7 @@ test.describe("apply ACLs", () => {
     await expect(page.getByText("NameTypeACLs")).toBeVisible();
     await page.getByLabel("sub").getByText(network).first().click();
 
-    const aclList = page.getByLabel("ACLs");
+    const aclList = page.getByLabel("Access control lists");
     await expect(aclList).toContainText(`${acl}, ${acl2}`);
     await expect(aclList).toBeDisabled();
 
@@ -164,7 +164,7 @@ test.describe("apply ACLs", () => {
     await page.getByRole("button", { name: "* Network" }).click();
     await page.getByLabel("sub").getByText(bridge).first().click();
 
-    const aclButton = page.getByLabel("ACLs");
+    const aclButton = page.getByLabel("Access control lists");
     await expect(aclButton).toBeVisible();
     await expect(aclButton).toBeDisabled();
     await expect(
@@ -183,7 +183,7 @@ test.describe("apply ACLs", () => {
     await expect(page.getByLabel("Egress traffic")).toBeDisabled();
     await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
 
-    await page.getByLabel("ACLs").click();
+    await page.getByLabel("Access control lists").click();
     await selectNetworkAcls(page, [acl, acl2]);
 
     await setAclDefaults(page, "drop", "reject");


### PR DESCRIPTION
## Done

- fix(acl) improve ux for discovering what ACLs are

Fixes WD-34213

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check network acl list heading and acld detail page heading
    - check create acl heading
    - configure and instance/profile and check the acl selector labels

## Screenshots

<img width="3848" height="1918" alt="image" src="https://github.com/user-attachments/assets/70dec801-c9a6-4ab1-8bfb-3d15319fcdb4" />

<img width="3848" height="1918" alt="image" src="https://github.com/user-attachments/assets/3f3345da-4a37-40c9-ba77-3a9d4095997d" />

<img width="3848" height="1918" alt="image" src="https://github.com/user-attachments/assets/8bb1a983-a9c5-4b9f-9982-772caed273b8" />

<img width="3848" height="1918" alt="image" src="https://github.com/user-attachments/assets/99b76236-2465-4125-bed8-a6ca584beee9" />
