### PR TITLE
fix(permissions) avoid using role in context of permissions

### DIFF
--- a/src/util/permissions.spec.ts
+++ b/src/util/permissions.spec.ts
@@ -159,7 +159,7 @@ describe("General util functions for permissions feature", () => {
       const expected = [
         {
           disabled: true,
-          label: "Built-in roles",
+          label: "Broad entitlement sets",
           value: "group",
         },
         {
@@ -201,7 +201,7 @@ describe("General util functions for permissions feature", () => {
       expect(entitlementOptions).toEqual([
         {
           disabled: true,
-          label: "Built-in roles",
+          label: "Broad entitlement sets",
           value: "group",
         },
         {

--- a/src/util/permissions.tsx
+++ b/src/util/permissions.tsx
@@ -213,7 +213,7 @@ export const generateEntitlementOptions = (
   ) {
     genericEntitlementOptions.unshift({
       disabled: true,
-      label: "Built-in roles",
+      label: "Broad entitlement sets",
       value: "group",
     });
 


### PR DESCRIPTION
## Done

- fix(permissions) avoid using "role" terminology in context of permissions

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check permissions > group > edit/create > edit permissions > instances/server > entitlement dropdown.
    - no more mentioning of roles, but clearer description with a new copy.

## Screenshots

<img width="3844" height="1920" alt="image" src="https://github.com/user-attachments/assets/37bda4d7-10f5-42ec-9466-5401a06ad004" />
