### PR TITLE
fix(instance) clear error on instance console when the instance is reaching a stopped status

### DIFF
--- a/src/context/instanceLoading.tsx
+++ b/src/context/instanceLoading.tsx
@@ -8,7 +8,7 @@ import { getInstanceName, getProjectName } from "util/operations";
 import type { LxdOperation } from "types/operation";
 import { mapsAreEqual } from "util/mapsAreEqual";
 
-type LoadingTypes =
+export type LoadingTypes =
   | "Starting"
   | "Stopping"
   | "Restarting"

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   ActionButton,
   Button,
@@ -33,6 +33,21 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
     useInstanceEntitlements();
 
   const isRunning = isInstanceRunning(instance);
+
+  const clearErrorOnStop = () => {
+    const isStopped = instance.status === "Stopped";
+    if (!isStopped) {
+      return;
+    }
+
+    if (isGraphic) {
+      notify.clear();
+    } else {
+      showNotRunningInfo();
+    }
+  };
+
+  useEffect(clearErrorOnStop, [instance.status, notify.notification]);
 
   const onFailure = (title: string, e: unknown, message?: string) => {
     notify.failure(title, e, message);

--- a/src/pages/instances/InstanceGraphicConsole.tsx
+++ b/src/pages/instances/InstanceGraphicConsole.tsx
@@ -10,6 +10,8 @@ import type { LxdInstance } from "types/instance";
 import { useListener, useNotify, Spinner } from "@canonical/react-components";
 import { isInstanceRunning } from "util/instanceStatus";
 import { useMounted } from "context/useMounted";
+import type { LoadingTypes } from "context/instanceLoading";
+import { useInstanceLoading } from "context/instanceLoading";
 
 declare global {
   interface Window {
@@ -44,9 +46,15 @@ const InstanceGraphicConsole: FC<Props> = ({
   const isMounted = useMounted();
 
   const isRunning = isInstanceRunning(instance);
+  const instanceLoading = useInstanceLoading();
+  const loadingRef = useRef<LoadingTypes | undefined>(null);
+  loadingRef.current = instanceLoading.getType(instance);
 
-  const handleError = (e: object, message?: string) => {
-    if (isMounted.current) {
+  const handleError = (e: object | string, message?: string) => {
+    // we need the refs here, because this is called from the websocket,
+    // so state might be outdated.
+    const isStopping = loadingRef.current === "Stopping";
+    if (isMounted.current && !isStopping) {
       onFailure("Console error", e, message);
     }
   };
@@ -88,7 +96,7 @@ const InstanceGraphicConsole: FC<Props> = ({
 
     control.onclose = (event) => {
       if (1005 !== event.code && isMounted.current) {
-        onFailure("Console error", event.reason, getWsErrorMsg(event.code));
+        handleError(event.reason, getWsErrorMsg(event.code));
       }
     };
 


### PR DESCRIPTION
## Done

- fix(instance) clear error on instance console when the instance is reaching a stopped status

Fixes #1842

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open graphic console on a running instance and stop the instance, ensure no error is displayed
    - open text console on a stopped instance, ensure the info is visible
    - open text console on a running instance and stop the instance, ensure the info is visible

## Screenshots

<img width="3854" height="1916" alt="image" src="https://github.com/user-attachments/assets/b10be4d9-7cea-4059-8d71-eeb6bd076001" />

<img width="3854" height="1916" alt="image" src="https://github.com/user-attachments/assets/3c1557a8-79bb-4c03-853a-3796466bcd23" />
