### PR TITLE
fix(instance) ensure acls column is fully visible on instance detail page

### DIFF
--- a/src/components/NetworkListTable.tsx
+++ b/src/components/NetworkListTable.tsx
@@ -124,6 +124,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
           interfaceName: deviceName.toLowerCase(),
           macAddress:
             instance?.config?.[`volatile.${deviceName}.hwaddr`] || "-",
+          acls: aclsCount,
         },
       };
     })

--- a/src/sass/_instance_detail_overview.scss
+++ b/src/sass/_instance_detail_overview.scss
@@ -45,11 +45,11 @@
       }
 
       &:nth-child(2) {
-        width: 6rem;
+        width: 6.5rem;
       }
 
       &:nth-child(5) {
-        width: 3rem;
+        width: 4.5rem;
       }
     }
 


### PR DESCRIPTION
## Done

- fix(instance) ensure acls column is fully visible on instnace detail page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open instance detail page, ensure network section > acls is fully visible and sorting by the acl column works fine.

## Screenshots

<img width="3842" height="1916" alt="image" src="https://github.com/user-attachments/assets/174364af-1fdc-4247-90a8-3ccc1be09da8" />
