### PR TITLE
fix(footer layout): of Create ACLs, Create network and Create forwards

### DIFF
--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -338,6 +338,8 @@
 }
 
 .create-instance,
+.create-network,
+.create-network-acl,
 .create-profile,
 .create-project,
 .edit-project,
@@ -479,8 +481,6 @@
 }
 
 .create-instance,
-.create-network,
-.create-network-acl,
 .create-profile,
 .create-project,
 .edit-project,


### PR DESCRIPTION
## Done

- Create ACLs, Create network, Create network forwards: the footer was too long

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Make sure that the buttons are horizontally aligned with the rest of the page to the right

## Screenshots

Create ACL before
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/669be005-7ef5-4217-b46d-e5c55730b4e6" />

Create ACL after
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/f7f2a76c-a03a-4619-a67a-586c849503a7" />


Create network before
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/8dc724fe-a9f3-47be-af23-2d5f8a40761f" />

Create network after
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/370e6f66-4ab7-4bce-b027-e2f11912ccd3" />


Create network forwards before
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/38de0b19-1c98-4119-852e-b1a7666f7e97" />

Create network forwards after
<img width="1851" height="1057" alt="image" src="https://github.com/user-attachments/assets/b7063b7b-a198-4558-ba5e-a7e5ced950cf" />
