### PR TITLE
feat(Create network forwards): Use PrefixedIpInput

### DIFF
--- a/src/components/forms/NetworkDevicesForm/edit/NetworkDeviceIPAddressEdit.tsx
+++ b/src/components/forms/NetworkDevicesForm/edit/NetworkDeviceIPAddressEdit.tsx
@@ -5,11 +5,12 @@ import type { FormikProps } from "formik";
 import { Input, PrefixedIpInput } from "@canonical/react-components";
 import { getNicIpDisableReason } from "util/devices";
 import { getNetworkMetadata } from "util/configInheritance";
+import type { IpAddressFamily } from "types/forms/network";
 
 interface Props {
   formik: FormikProps<NetworkDeviceFormValues>;
   network: LxdNetwork;
-  family: "IPv4" | "IPv6";
+  family: IpAddressFamily;
 }
 
 const NetworkDeviceIPAddressEdit: FC<Props> = ({ formik, network, family }) => {

--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
@@ -14,6 +14,7 @@ import { getDeviceAcls } from "util/devices";
 import NetworkRichChip from "pages/networks/NetworkRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import NetworkDefaultACLRead from "pages/networks/forms/NetworkDefaultACLRead";
+import type { IpAddressFamily } from "types/forms/network";
 
 const getNetworkDeviceIpAddress = ({
   network,
@@ -22,7 +23,7 @@ const getNetworkDeviceIpAddress = ({
 }: {
   network?: LxdNetwork;
   device: LxdNicDevice;
-  family: "IPv4" | "IPv6";
+  family: IpAddressFamily;
 }) => {
   if (!network || !network.config) {
     return null;

--- a/src/pages/networks/forms/IpAddressSelector.tsx
+++ b/src/pages/networks/forms/IpAddressSelector.tsx
@@ -1,11 +1,12 @@
 import type { FC } from "react";
 import { Input, RadioInput } from "@canonical/react-components";
+import type { IpAddressFamily } from "types/forms/network";
 
 interface Props {
   id: string;
   address?: string;
   setAddress: (address: string) => void;
-  family: "IPv4" | "IPv6";
+  family: IpAddressFamily;
 }
 
 const IpAddressSelector: FC<Props> = ({ id, address, setAddress, family }) => {

--- a/src/pages/networks/forms/NetworkForwardForm.tsx
+++ b/src/pages/networks/forms/NetworkForwardForm.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Label,
   Notification,
+  PrefixedIpInput,
   RadioInput,
   Row,
   useListener,
@@ -17,7 +18,13 @@ import type { FormikProps } from "formik/dist/types";
 import * as Yup from "yup";
 import type { LxdNetwork, LxdNetworkForward } from "types/network";
 import { updateMaxHeight } from "util/updateMaxHeight";
-import { isTypeOvn, testValidIp, testValidPort } from "util/networks";
+import {
+  isTypeOvn,
+  testValidIp,
+  testValidPort,
+  getIpAddressFamily,
+  getCidr,
+} from "util/networks";
 import NotificationRow from "components/NotificationRow";
 import NetworkForwardFormPorts from "pages/networks/forms/NetworkForwardFormPorts";
 import ScrollableForm from "components/ScrollableForm";
@@ -50,6 +57,11 @@ export const NetworkForwardSchema = Yup.object().shape({
   listenAddress: Yup.string()
     .test("valid-ip", "Invalid IP address", testValidIp)
     .required("Listen address is required"),
+  defaultTargetAddress: Yup.string().test(
+    "valid-ip",
+    "Invalid IP address",
+    (value) => !value || testValidIp(value),
+  ),
   ports: Yup.array().of(
     Yup.object().shape({
       listenPort: Yup.string()
@@ -77,12 +89,23 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
   const { data: members = [] } = useClusterMembers();
   const isClusterMemberSpecific =
     members.length > 0 && network?.type === bridgeType;
+  const isListenAddressValid =
+    formik.values.listenAddress && testValidIp(formik.values.listenAddress);
+  const targetAddressFamily = isListenAddressValid
+    ? getIpAddressFamily(formik.values.listenAddress)
+    : null;
 
   useEffect(() => {
     if (isClusterMemberSpecific && !formik.values.location) {
       formik.setFieldValue("location", members[0].server_name);
     }
   }, [members]);
+
+  useEffect(() => {
+    if (!isListenAddressValid) {
+      formik.setFieldValue("defaultTargetAddress", undefined);
+    }
+  }, [isListenAddressValid]);
 
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
@@ -177,7 +200,7 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
                   disabled={isEdit || !isManualListenAddress}
                   help={
                     isEdit
-                      ? "Listen address can't be changed after creation."
+                      ? "Listen address cannot be changed after creation."
                       : "Any address routed to LXD."
                   }
                   error={
@@ -188,22 +211,41 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
                 />
               </Col>
             </Row>
-            <Input
-              {...formik.getFieldProps("defaultTargetAddress")}
-              id="defaultTargetAddress"
-              type="text"
-              label="Default target address"
-              help={
-                <>
-                  Fallback target for traffic that does not match a port
-                  specified below.
-                  <br />
-                  Must be from the network <b>{network?.name}</b>.
-                </>
-              }
-              placeholder="Enter IP address"
-              stacked
-            />
+            <Row>
+              <Col size={4}>
+                <Label forId="defaultTargetAddress">
+                  Default target address
+                </Label>
+              </Col>
+              <Col size={8}>
+                <PrefixedIpInput
+                  id="defaultTargetAddress"
+                  name="defaultTargetAddress"
+                  cidr={getCidr(targetAddressFamily, network)}
+                  ip={formik.values.defaultTargetAddress || ""}
+                  onIpChange={(ip: string) => {
+                    formik.setFieldValue("defaultTargetAddress", ip);
+                  }}
+                  onBlur={() => {
+                    void formik.setFieldTouched("defaultTargetAddress", true);
+                  }}
+                  error={
+                    formik.touched.defaultTargetAddress
+                      ? formik.errors.defaultTargetAddress
+                      : undefined
+                  }
+                  disabled={!isListenAddressValid}
+                  help={
+                    <>
+                      Fallback target for traffic that does not match a port
+                      specified below.
+                      <br />
+                      Must be from the network <b>{network?.name}</b>.
+                    </>
+                  }
+                />
+              </Col>
+            </Row>
             {isClusterMemberSpecific && (
               <ClusterMemberSelector
                 {...formik.getFieldProps("location")}
@@ -214,7 +256,7 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
                     ? "Location can't be changed after creation."
                     : "Cluster member to create the forward on."
                 }
-                disabled={isEdit}
+                disabled={isEdit || !isListenAddressValid}
                 stacked
               />
             )}
@@ -225,11 +267,21 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
               label="Description"
               placeholder="Enter description"
               stacked
+              disabled={!isListenAddressValid}
             />
             {formik.values.ports.length > 0 && (
-              <NetworkForwardFormPorts formik={formik} network={network} />
+              <NetworkForwardFormPorts
+                formik={formik}
+                network={network}
+                targetAddressFamily={targetAddressFamily}
+              />
             )}
-            <Button hasIcon onClick={addPort} type="button">
+            <Button
+              hasIcon
+              onClick={addPort}
+              type="button"
+              disabled={!isListenAddressValid}
+            >
               <Icon name="plus" />
               <span>Add port</span>
             </Button>

--- a/src/pages/networks/forms/NetworkForwardFormPorts.tsx
+++ b/src/pages/networks/forms/NetworkForwardFormPorts.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   Input,
   Label,
+  PrefixedIpInput,
   Select,
 } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
@@ -12,13 +13,20 @@ import type {
   NetworkForwardPortFormValues,
 } from "types/forms/networkForward";
 import type { LxdNetwork } from "types/network";
+import type { IpAddressFamily } from "types/forms/network";
+import { getCidr } from "util/networks";
 
 interface Props {
   formik: FormikProps<NetworkForwardFormValues>;
+  targetAddressFamily: IpAddressFamily | null;
   network?: LxdNetwork;
 }
 
-const NetworkForwardFormPorts: FC<Props> = ({ formik, network }) => {
+const NetworkForwardFormPorts: FC<Props> = ({
+  formik,
+  targetAddressFamily,
+  network,
+}) => {
   return (
     <table className="u-no-margin--bottom forward-ports">
       <thead>
@@ -97,12 +105,25 @@ const NetworkForwardFormPorts: FC<Props> = ({ formik, network }) => {
                 />
               </td>
               <td className="target-address">
-                <Input
-                  {...formik.getFieldProps(`ports.${index}.targetAddress`)}
+                <PrefixedIpInput
                   id={`ports.${index}.targetAddress`}
-                  type="text"
-                  aria-label={`Port ${index} target address`}
-                  placeholder="Enter IP address"
+                  name={`ports.${index}.targetAddress`}
+                  cidr={getCidr(targetAddressFamily, network)}
+                  ip={formik.values.ports[index].targetAddress || ""}
+                  onIpChange={(ip: string) => {
+                    formik.setFieldValue(`ports.${index}.targetAddress`, ip);
+                  }}
+                  onBlur={() => {
+                    void formik.setFieldTouched(
+                      `ports.${index}.targetAddress`,
+                      true,
+                    );
+                  }}
+                  error={
+                    formik.touched.ports?.[index]?.targetAddress
+                      ? portError?.targetAddress
+                      : undefined
+                  }
                   help={
                     index === formik.values.ports.length - 1 && (
                       <>
@@ -110,11 +131,7 @@ const NetworkForwardFormPorts: FC<Props> = ({ formik, network }) => {
                       </>
                     )
                   }
-                  error={
-                    formik.touched.ports?.[index]?.targetAddress
-                      ? portError?.targetAddress
-                      : undefined
-                  }
+                  aria-label={`Port ${index} target address`}
                 />
               </td>
               <td className="target-port">

--- a/src/sass/_network_forwards_form.scss
+++ b/src/sass/_network_forwards_form.scss
@@ -5,6 +5,21 @@
     max-width: 67rem !important;
   }
 
+  .target-address-family-radio-wrapper {
+    gap: $sph--x-large;
+    margin-bottom: $spv--large;
+
+    .p-radio {
+      margin-top: 0;
+    }
+  }
+
+  @include extra-large {
+    .prefixed-input__input {
+      padding-top: 0.3rem !important;
+    }
+  }
+
   .forward-ports {
     .listen-port,
     .protocol,
@@ -27,6 +42,12 @@
       .protocol,
       .target-port {
         width: 8rem;
+      }
+    }
+
+    @include extra-large {
+      .prefixed-input__input {
+        padding-top: 0.25rem !important;
       }
     }
   }

--- a/src/types/forms/network.d.ts
+++ b/src/types/forms/network.d.ts
@@ -59,3 +59,5 @@ export interface NetworkFormValues {
   security_acls_default_egress?: string;
   security_acls_default_ingress?: string;
 }
+
+export type IpAddressFamily = "IPv4" | "IPv6";

--- a/src/util/devices.tsx
+++ b/src/util/devices.tsx
@@ -16,6 +16,7 @@ import { getAppliedProfiles } from "./configInheritance";
 import type { LxdNetwork } from "types/network";
 import { typesWithNicStaticIPSupport } from "./networks";
 import type { NetworkDeviceFormValues } from "types/forms/networkDevice";
+import type { IpAddressFamily } from "types/forms/network";
 
 export const ISO_VOLUME_TYPE = "iso-volume";
 export const ISO_VOLUME_NAME = "iso-volume";
@@ -203,7 +204,7 @@ export const getProfileFromSource = (source: string) => {
 export const getNicIpDisableReason = (
   values: NetworkDeviceFormValues,
   network: LxdNetwork,
-  family: "IPv4" | "IPv6",
+  family: IpAddressFamily,
   dhcpDefault?: string,
   dhcpStatefulDefault?: string,
 ): React.ReactNode => {
@@ -258,7 +259,7 @@ export const getNicIpDisableReason = (
 
 const getNetworkDHCPOrDefault = (
   network: LxdNetwork,
-  family: "IPv4" | "IPv6",
+  family: IpAddressFamily,
   defaultValue?: string,
 ): boolean => {
   const result =
@@ -270,7 +271,7 @@ const getNetworkDHCPOrDefault = (
 
 const getNetworkDHCPStatefulOrDefault = (
   network: LxdNetwork,
-  family: "IPv4" | "IPv6",
+  family: IpAddressFamily,
   defaultValue?: string,
 ): boolean => {
   const result =

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -12,6 +12,7 @@ import type { AnyObject, TestFunction } from "yup";
 import { checkDuplicateName } from "./helpers";
 import type { AbortControllerState } from "./helpers";
 import type { useNotify } from "@canonical/react-components";
+import type { IpAddressFamily } from "types/forms/network";
 
 export const bridgeType = "bridge";
 export const macvlanType = "macvlan";
@@ -298,4 +299,30 @@ export const isNetwork = (
   network: LXDNetworkOnClusterMember,
 ): network is LXDNetworkOnClusterMemberFulfilled => {
   return network.promiseStatus === "fulfilled";
+};
+
+export const getIpAddressFamily = (ip: string | null | undefined) => {
+  if (!ip) {
+    return null;
+  }
+
+  if (ip.includes(".")) return "IPv4";
+  if (ip.includes(":")) return "IPv6";
+
+  return null;
+};
+
+export const getCidr = (
+  family: IpAddressFamily | null,
+  network?: LxdNetwork,
+) => {
+  if (family === "IPv4") {
+    return network?.config["ipv4.address"] || "";
+  }
+
+  if (family === "IPv6") {
+    return network?.config["ipv6.address"] || "";
+  }
+
+  return "";
 };

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -5,6 +5,7 @@ import { gotoURL } from "./navigate";
 import { expect } from "../fixtures/lxd-test";
 import { isServerClustered } from "./cluster";
 import { execSync } from "child_process";
+import type { IpAddressFamily } from "types/forms/network";
 
 interface NetworkOptions {
   hasMemberSpecificParents?: boolean;
@@ -134,7 +135,9 @@ export const createNetworkForward = async (page: Page, network: string) => {
   const networkSubnet = await page.inputValue("input#ipv4_address");
 
   const listenAddress = networkSubnet.replace("1/24", "1");
-  const targetAddress = networkSubnet.replace("1/24", "3");
+
+  const targetAddressHostId = "3";
+  const targetAddress = networkSubnet.replace("1/24", targetAddressHostId);
 
   await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByRole("button", { name: "Create forward" }).click();
@@ -146,14 +149,15 @@ export const createNetworkForward = async (page: Page, network: string) => {
   await portInput.click();
   await portInput.fill("80");
   await addressInput.click();
-  await addressInput.fill(targetAddress);
+  // The prefix is already prefilled
+  await addressInput.fill(targetAddressHostId);
   await page.getByRole("button", { name: "Add port" }).click();
   portInput = page.getByLabel("1 listen port");
   addressInput = page.getByLabel("1 target address");
   await portInput.click();
   await portInput.fill("23,443-455");
   await addressInput.click();
-  await addressInput.fill(targetAddress);
+  await addressInput.fill(targetAddressHostId);
 
   if (serverClustered) {
     await page.getByLabel("Location").selectOption({ index: 1 });
@@ -355,7 +359,7 @@ export const makeNetworkOvnUplink = async (
 const setNetworkIP = async (
   page: Page,
   CIDR: string,
-  family: "IPv4" | "IPv6",
+  family: IpAddressFamily,
 ) => {
   const container = page.locator(".ip-address", {
     hasText: `${family} address`,


### PR DESCRIPTION
## Done

- Use PrefixedIpInput in CreateNetworkForwards


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a network forwards.
    - Edit a network forwards: you should not be able to change the target address family

## Screenshots

<img width="1417" height="942" alt="image" src="https://github.com/user-attachments/assets/ce7a0bea-4db1-4706-b109-111f8b96caff" />
