### PR TITLE
feat(instances): support selective state recursion

### DIFF
--- a/src/api/instances.spec.ts
+++ b/src/api/instances.spec.ts
@@ -1,0 +1,32 @@
+import { addRecursion, instanceFields } from "./instances";
+
+describe("addRecursion", () => {
+  it("uses selective recursion when supported and not fine-grained", () => {
+    const params = new URLSearchParams();
+    addRecursion(params, true, false);
+    expect(params.get("recursion")).toBe(
+      `2;fields=${instanceFields.join(",")}`,
+    );
+  });
+
+  it("falls back to plain recursion when feature is not supported", () => {
+    const params = new URLSearchParams();
+    addRecursion(params, false, false);
+    expect(params.get("recursion")).toBe("2");
+  });
+
+  it("falls back to plain recursion when fine-grained permissions are enabled", () => {
+    // Server doesn't support selective recursion with entitlements
+    const params = new URLSearchParams();
+    addRecursion(params, true, true);
+    expect(params.get("recursion")).toBe("2");
+  });
+
+  it("uses selective recursion when isFineGrained is null", () => {
+    const params = new URLSearchParams();
+    addRecursion(params, true, null);
+    expect(params.get("recursion")).toBe(
+      `2;fields=${instanceFields.join(",")}`,
+    );
+  });
+});

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -28,14 +28,33 @@ export const instanceEntitlements = [
   "can_update_state",
 ];
 
+// Only state.disk and state.network are valid selective recursion fields.
+// Other state fields (cpu, memory, pid, processes, status) are always included.
+export const instanceFields = ["state.disk", "state.network"];
+
+export const addRecursion = (
+  params: URLSearchParams,
+  hasSelectiveRecursion: boolean,
+  isFineGrained: boolean | null,
+): void => {
+  // Server doesn't support selective recursion with entitlements,
+  // so only use selective recursion when not requesting entitlements
+  if (hasSelectiveRecursion && isFineGrained !== true) {
+    params.set("recursion", `2;fields=${instanceFields.join(",")}`);
+  } else {
+    params.set("recursion", "2");
+  }
+};
+
 export const fetchInstance = async (
   name: string,
   project: string,
   isFineGrained: boolean | null,
+  hasSelectiveRecursion: boolean,
 ): Promise<LxdInstance> => {
   const params = new URLSearchParams();
   params.set("project", project);
-  params.set("recursion", "2");
+  addRecursion(params, hasSelectiveRecursion, isFineGrained);
   addEntitlements(params, isFineGrained, instanceEntitlements);
 
   return fetch(
@@ -50,9 +69,10 @@ export const fetchInstance = async (
 export const fetchInstances = async (
   project: string | null,
   isFineGrained: boolean | null,
+  hasSelectiveRecursion: boolean,
 ): Promise<LxdInstance[]> => {
   const params = new URLSearchParams();
-  params.set("recursion", "2");
+  addRecursion(params, hasSelectiveRecursion, isFineGrained);
   if (project) {
     params.set("project", project);
   } else {

--- a/src/context/useInstances.tsx
+++ b/src/context/useInstances.tsx
@@ -3,15 +3,23 @@ import { queryKeys } from "util/queryKeys";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { fetchInstance, fetchInstances } from "api/instances";
 import { useAuth } from "./auth";
+import { useSupportedFeatures } from "./useSupportedFeatures";
 import type { LxdInstance } from "types/instance";
 
 export const useInstances = (
   project: string | null,
 ): UseQueryResult<LxdInstance[]> => {
   const { isFineGrained } = useAuth();
+  const { hasInstanceStateSelectiveRecursion } = useSupportedFeatures();
+
   return useQuery({
     queryKey: [queryKeys.instances, project],
-    queryFn: async () => fetchInstances(project, isFineGrained),
+    queryFn: async () =>
+      fetchInstances(
+        project,
+        isFineGrained,
+        hasInstanceStateSelectiveRecursion,
+      ),
     enabled: isFineGrained !== null,
   });
 };
@@ -22,9 +30,17 @@ export const useInstance = (
   enabled?: boolean,
 ): UseQueryResult<LxdInstance> => {
   const { isFineGrained } = useAuth();
+  const { hasInstanceStateSelectiveRecursion } = useSupportedFeatures();
+
   return useQuery({
     queryKey: [queryKeys.instances, name, project],
-    queryFn: async () => fetchInstance(name, project, isFineGrained),
-    enabled: enabled && isFineGrained !== null,
+    queryFn: async () =>
+      fetchInstance(
+        name,
+        project,
+        isFineGrained,
+        hasInstanceStateSelectiveRecursion,
+      ),
+    enabled: (enabled ?? true) && isFineGrained !== null,
   });
 };

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -47,6 +47,9 @@ export const useSupportedFeatures = () => {
     hasProjectForceDelete: apiExtensions.has("projects_force_delete"),
     hasInstanceForceDelete: apiExtensions.has("instance_force_delete"),
     hasInstanceBootMode: apiExtensions.has("instance_boot_mode"),
+    hasInstanceStateSelectiveRecursion: apiExtensions.has(
+      "instances_state_selective_recursion",
+    ),
     hasProjectDeleteOperation: apiExtensions.has("project_delete_operation"),
     hasRemoteDropSource: apiExtensions.has("storage_remote_drop_source"),
     hasClusteringControlPlane: apiExtensions.has("clustering_control_plane"),


### PR DESCRIPTION
## Done

- Support the `instances_state_selective_recursion` API extension in instance queries
- Request only `state.network` when selective recursion is supported
- Keep fine-grained permissions working by fetching `access_entitlements` separately and merging them client-side
- Fall back to regular `recursion=2` when the extension is unavailable
- Add targeted tests for selective recursion, fallback behavior, and separate entitlement fetching

Fixes #1857

## QA

- I tested locally against two Multipass-backed LXD servers:
  - `6/stable` for the optimized path (`instances_state_selective_recursion`)
  - `5.21/stable` for the fallback path

- Provision the two local LXD backends:
````bash mode=EXCERPT
multipass launch 24.04 --name lxd-67 --cpus 2 --memory 4G --disk 20G
multipass exec lxd-67 -- sudo snap install lxd --channel=6/stable
multipass exec lxd-67 -- sudo lxd init --auto --network-address='[::]' --trust-password test123
multipass launch 24.04 --name lxd-521 --cpus 2 --memory 4G --disk 20G
multipass exec lxd-521 -- sudo snap install lxd --channel=5.21/stable
multipass exec lxd-521 -- sudo lxd init --auto --network-address='[::]' --trust-password test123
````

- Add both remotes, create a test instance on each, and confirm the extension difference:
````bash mode=EXCERPT
lxc remote add lxd67 "$(multipass info lxd-67 | awk '/IPv4/{print $2; exit}')" --password test123 --accept-certificate
lxc remote add lxd521 "$(multipass info lxd-521 | awk '/IPv4/{print $2; exit}')" --password test123 --accept-certificate
lxc launch ubuntu:24.04 lxd67:qa-c1
lxc launch ubuntu:24.04 lxd521:qa-c1
lxc query lxd67:/1.0 | jq -r '.api_extensions[]' | grep instances_state_selective_recursion
lxc query lxd521:/1.0 | jq -r '.api_extensions[]' | grep instances_state_selective_recursion || true
````

- Generate the local `dotrun` cert once, then trust it on both backends:
````bash mode=EXCERPT
dotrun
# stop it after keys/lxd-ui.crt has been generated
multipass transfer keys/lxd-ui.crt lxd-67:/home/ubuntu/lxd-ui.crt
multipass transfer keys/lxd-ui.crt lxd-521:/home/ubuntu/lxd-ui.crt
multipass exec lxd-67 -- lxc auth identity create tls/dotrun-cert /home/ubuntu/lxd-ui.crt --group admins
multipass exec lxd-521 -- lxc auth identity create tls/dotrun-cert /home/ubuntu/lxd-ui.crt --group admins
````

- Point `dotrun` at each backend in separate runs and compare behavior:
````bash mode=EXCERPT
echo "LXD_UI_BACKEND_IP=$(multipass info lxd-67 | awk '/IPv4/{print $2; exit}')" > .env.local
dotrun
echo "LXD_UI_BACKEND_IP=$(multipass info lxd-521 | awk '/IPv4/{print $2; exit}')" > .env.local
dotrun
````

- On the `6.7` run:
  - Open `https://localhost:8407/ui/` and go to the Instances page
  - Confirm instances load without errors
  - In DevTools Network, verify the main instances request uses `recursion=2;fields=state.network`
  - In fine-grained mode, verify a second request is made with `with-access-entitlements`
  - Confirm instance actions and IP/network data still render correctly

- On the `5.21` run:
  - Open the same page after restarting `dotrun`
  - Confirm instances still load without errors
  - Verify the UI falls back to plain `recursion=2`

- To compare the optimization:
  - Load the same Instances page against both backends
  - Compare the `/1.0/instances` request URL, transferred size, and total time in DevTools
  - On `6.7`, the main payload should be smaller because only `state.network` is requested
  - In fine-grained mode, the `6.7` path should show the optimized main request plus a separate entitlement request

## Screenshots
Not applicable for this change; verification is primarily through instance loading behavior and DevTools network requests.

## Small note
I intentionally kept this QA section focused on **local reproduction with `dotrun`** and not on any shared/demo deployment. But I think we should do a test deployment here and have others verify the change