### PR TITLE
add placeholer to source field in storagepool form

### DIFF
--- a/src/pages/storage/forms/ClusteredSourceSelector.tsx
+++ b/src/pages/storage/forms/ClusteredSourceSelector.tsx
@@ -27,6 +27,7 @@ const ClusteredSourceSelector: FC<Props> = ({
       <ClusterSpecificInput
         values={formik.values.sourcePerClusterMember}
         id="sourcePerClusterMember"
+        placeholder="Enter value"
         isReadOnly={false}
         onChange={(value) => {
           formik.setFieldValue("sourcePerClusterMember", value);


### PR DESCRIPTION
## Done

- add placeholer to source field in storagepool form WD-34658


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Storage -> Pools -> Create/Edit
    - Ensure Source input field has a placeholder.

## Screenshots

<img width="1916" height="952" alt="image" src="https://github.com/user-attachments/assets/87f0b574-dd17-439c-8b96-70d32e76058a" />