### PR TITLE
test(initial access): Add e2e for initial access link flow

### DIFF
--- a/haproxy-dev.cfg
+++ b/haproxy-dev.cfg
@@ -10,17 +10,14 @@ defaults
 frontend lxd_frontend
   bind 0.0.0.0:8407 ssl verify optional crt keys/lxd-ui.pem ca-file keys/lxd-ui.crt
 
-  acl is_ui_no_slash path /ui
-  http-request redirect code 301 location /ui/ if is_ui_no_slash
-
+  acl has_token query -m reg token=
   acl is_root path /
-  http-request redirect code 301 location /ui/ if is_root
+  acl is_ui_path path_beg /ui
+  acl is_api_path path_beg /1.0 /oidc /documentation /bearer
 
-  acl is_core path_beg /1.0
-  acl is_oidc path_beg /oidc
-  acl is_docs path_beg /documentation
-  acl is_bearer path_beg /bearer
-  use_backend lxd_core if is_core || is_oidc || is_docs || is_bearer
+  use_backend lxd_core if is_root has_token
+  use_backend lxd_core if is_api_path
+  http-request redirect code 301 location /ui/ if is_root !has_token
   default_backend lxd_ui
 
 backend lxd_ui

--- a/src/pages/login/CertificateGenerate.tsx
+++ b/src/pages/login/CertificateGenerate.tsx
@@ -17,8 +17,8 @@ import AuthenticationTlsStepper from "components/AuthenticationTlsStepper";
 import classnames from "classnames";
 
 const CertificateGenerate: FC = () => {
-  const { isAuthenticated, isAuthLoading, authMethod } = useAuth();
   const navigate = useNavigate();
+  const { isAuthenticated, isAuthLoading, authMethod } = useAuth();
   const { data: settings } = useSettings();
   const hasCertificate = settings?.client_certificate;
   const isBearerToken = authMethod === AUTH_METHOD.BEARER;

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,0 +1,42 @@
+import { gotoURLWithNetworkIdle } from "./navigate";
+import { runCommand } from "./shell";
+import type { Page } from "@playwright/test";
+
+export const removeCertificateTrust = () => {
+  try {
+    const fingerprint = runCommand(
+      "lxc config trust list | grep lxd-ui.crt | awk '{print $8}'",
+    );
+
+    if (fingerprint) {
+      runCommand(`lxc config trust remove ${fingerprint}`);
+    }
+    runCommand("lxc auth identity delete tls/lxd-ui || true");
+  } catch (err) {
+    console.error("Error occurred while removing certificate trust:", err);
+  }
+};
+
+export const restoreCertificateTrust = () => {
+  runCommand("lxc config trust add keys/lxd-ui.crt");
+};
+
+const initAccessLink = () => {
+  const output = runCommand("lxd init --ui-initial-access-link");
+  const urlMatch = output.match(/https?:\/\/[^\s]+/);
+
+  if (!urlMatch) {
+    throw new Error("Could not find the UI access link in the command output!");
+  }
+
+  const originalUrl = new URL(urlMatch[0]);
+  // Replace the LXD direct port with your HAProxy dev port
+  const initialAccessLink = `https://localhost:8407/${originalUrl.search}`;
+
+  return initialAccessLink;
+};
+
+export const visitInitialAccessLink = async (page: Page) => {
+  const initialAccessLink = initAccessLink();
+  await gotoURLWithNetworkIdle(page, initialAccessLink);
+};

--- a/tests/helpers/navigate.ts
+++ b/tests/helpers/navigate.ts
@@ -3,3 +3,7 @@ import type { Page } from "@playwright/test";
 export const gotoURL = async (page: Page, url: string) => {
   await page.goto(url, { waitUntil: "commit" });
 };
+
+export const gotoURLWithNetworkIdle = async (page: Page, url: string) => {
+  await page.goto(url, { waitUntil: "networkidle" });
+};

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -4,8 +4,8 @@ import { activateAllTableOverrides } from "./configuration";
 import { gotoURL } from "./navigate";
 import { expect } from "../fixtures/lxd-test";
 import { isServerClustered } from "./cluster";
-import { execSync } from "child_process";
 import type { IpAddressFamily } from "types/forms/network";
+import { runCommand } from "./shell";
 
 interface NetworkOptions {
   hasMemberSpecificParents?: boolean;
@@ -21,8 +21,8 @@ export const randomNetworkName = (): string => {
 
 export const ensureOvnNorthboundConnection = () => {
   try {
-    execSync(
-      'sudo -E lxc config set network.ovn.northbound_connection "ssl:127.0.0.1:6641"',
+    runCommand(
+      'lxc config set network.ovn.northbound_connection "ssl:127.0.0.1:6641"',
     );
   } catch (error) {
     console.log("Failed to set OVN northbound connection:", error);

--- a/tests/helpers/permissions.ts
+++ b/tests/helpers/permissions.ts
@@ -1,4 +1,3 @@
-import { execSync } from "child_process";
 import type { LxdVersions } from "../fixtures/lxd-test";
 import { test, expect } from "../fixtures/lxd-test";
 import type { Page } from "@playwright/test";
@@ -51,11 +50,4 @@ export const confirmGroupsModifiedForIdentity = async (
   for (const group of groups) {
     await expect(identityRow.getByText(`${symbol} ${group}`)).toBeVisible();
   }
-};
-
-export const runCommand = (command: string) => {
-  console.log("Running command: ", command);
-  const result = execSync(`sudo -E ${command}`).toString();
-  console.log("Result: ", result);
-  return result;
 };

--- a/tests/helpers/shell.ts
+++ b/tests/helpers/shell.ts
@@ -1,0 +1,8 @@
+import { execSync } from "child_process";
+
+export const runCommand = (command: string) => {
+  console.log("Running command: ", command);
+  const result = execSync(`sudo -E ${command}`).toString();
+  console.log("Result: ", result);
+  return result;
+};

--- a/tests/initial-access.spec.ts
+++ b/tests/initial-access.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "./fixtures/lxd-test";
+import {
+  removeCertificateTrust,
+  restoreCertificateTrust,
+  visitInitialAccessLink,
+} from "./helpers/auth";
+import { randomIdentityName } from "./helpers/permission-identities";
+import type { LxdVersions } from "./fixtures/lxd-test";
+
+const skipIfNotSupported = (lxdVersion: LxdVersions) => {
+  test.skip(
+    lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge",
+    "Initial access link is not available for LXD prior to 6.7",
+  );
+};
+
+test.describe("Initial access with bearer token", () => {
+  test.beforeAll(({ lxdVersion }) => {
+    if (lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge") {
+      return;
+    }
+
+    removeCertificateTrust();
+  });
+
+  test.afterAll(({ lxdVersion }) => {
+    if (lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge") {
+      return;
+    }
+
+    restoreCertificateTrust();
+  });
+
+  test("Should authenticate with bearer token and setup TLS", async ({
+    page,
+    lxdVersion,
+  }) => {
+    skipIfNotSupported(lxdVersion);
+
+    await visitInitialAccessLink(page);
+
+    await expect(page).toHaveURL(/\/ui\/project\/.*\/instances/);
+    await expect(page.getByText("Initial access expires in")).toBeVisible();
+    await page.getByRole("link", { name: "Set up permanent access" }).click();
+    await page.getByRole("link", { name: "Set up TLS login" }).click();
+    await expect(page).toHaveURL(/.*\/ui\/login\/certificate-generate/);
+
+    await expect(
+      page.getByText(
+        "LXD uses mutual TLS for server client-server authentication. Your browser must have a client certificate installed and selected in order to proceed.",
+      ),
+    ).toBeVisible();
+
+    // Pre-load CertificateAdd page to avoid flaky test on dev server
+    await page.getByText("Create TLS identity", { exact: true }).click();
+    await expect(
+      page.getByText(
+        "Confirm the name and auth groups for your permanent access.",
+      ),
+    ).toBeVisible();
+    await page.getByText("Browser certificate").click();
+
+    const generateBtn = page.getByRole("button", {
+      name: "Generate certificate",
+    });
+    await generateBtn.click();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Generate and download" }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toContain(".pfx");
+
+    await expect(
+      page.getByText("Client certificate already present"),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "It looks like you already have a client certificate installed and selected, skip to the next step.",
+      ),
+    ).toBeVisible();
+    await page
+      .getByRole("button", {
+        name: "Skip to step 2: Create TLS identity",
+      })
+      .click();
+
+    await expect(page).toHaveURL(/.*\/ui\/login\/certificate-add/);
+    const nameInput = page.getByRole("textbox", { name: "Name" });
+    await expect(nameInput).toHaveValue(/lxd-ui.*/);
+    const identityName = randomIdentityName();
+    await nameInput.fill(identityName);
+    await expect(nameInput).toHaveValue(identityName);
+
+    const adminsCheckbox = page.getByRole("checkbox", { name: /admins/i });
+    await expect(adminsCheckbox).toBeChecked();
+    await expect(adminsCheckbox).toBeDisabled();
+
+    await page.getByRole("button", { name: "Create identity" }).click();
+
+    await expect(page).toHaveURL(/\/ui\/project\/.*\/instances/);
+    await expect(
+      page.getByRole("link", { name: "Set up permanent access" }),
+    ).not.toBeVisible();
+    await page
+      .getByRole("button", { name: "Permissions", exact: true })
+      .click();
+    await page.getByRole("link", { name: "Identities", exact: true }).click();
+
+    const myIdentityRow = page
+      .getByRole("row")
+      .filter({ hasText: identityName });
+    await expect(myIdentityRow).toBeVisible();
+    await expect(myIdentityRow.getByText("You", { exact: true })).toBeVisible();
+    await expect(myIdentityRow.getByText("Client certificate")).toBeVisible();
+
+    await myIdentityRow
+      .getByRole("button", {
+        name: "Delete identity",
+      })
+      .click();
+    await page
+      .getByRole("button", {
+        name: "Delete",
+        exact: true,
+      })
+      .click();
+
+    await expect(page).toHaveURL(/\/ui\/login/);
+  });
+});

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -1,7 +1,10 @@
 import type { Page } from "@playwright/test";
 import { test, expect } from "./fixtures/lxd-test";
-import { execSync } from "child_process";
 import { gotoURL } from "./helpers/navigate";
+import {
+  removeCertificateTrust,
+  restoreCertificateTrust,
+} from "./helpers/auth";
 
 const loginUser = async (page: Page) => {
   await page.getByRole("link", { name: "Login with SSO" }).click();
@@ -16,15 +19,12 @@ const loginUser = async (page: Page) => {
 test("login", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("login"));
   // remove tls certificate from trust store so we can test oidc login
-  const fingerprint = execSync(
-    "sudo -E lxc config trust list | grep lxd-ui.crt | awk '{print $8}'",
-  ).toString();
-  execSync(`sudo -E lxc config trust remove ${fingerprint}`);
+  removeCertificateTrust();
 
   await gotoURL(page, "/ui/");
   await loginUser(page);
   await page.getByText("Log out").click();
 
   // add tls certificate to trust store so rest of tests can run correctly
-  execSync("sudo -E lxc config trust add keys/lxd-ui.crt");
+  restoreCertificateTrust();
 });

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -17,7 +17,12 @@ import { randomNetworkAclName, visitNetworkAcl } from "./helpers/network-acls";
 import { randomGroupName } from "./helpers/permission-groups";
 import { randomIdentityName } from "./helpers/permission-identities";
 import { openInstancePanel } from "./helpers/instancePanel";
-import { runCommand, skipIfNotSupported } from "./helpers/permissions";
+import { skipIfNotSupported } from "./helpers/permissions";
+import { runCommand } from "./helpers/shell";
+import {
+  removeCertificateTrust,
+  restoreCertificateTrust,
+} from "./helpers/auth";
 
 test.describe("Given a user with Viewer Server permissions...", () => {
   const ISO_FILE = "./tests/fixtures/foo.iso";
@@ -41,7 +46,7 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     }
 
     try {
-      runCommand(`sudo -E lxc project switch default`);
+      runCommand("lxc project switch default");
       runCommand(`lxc init ubuntu:24.04 ${instanceName1}`);
       runCommand(`lxc init ubuntu:24.04 ${instanceName2}`);
       runCommand(`lxc profile create ${profileName}`);
@@ -61,10 +66,7 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     }
 
     try {
-      const fingerprint = runCommand(
-        `lxc config trust list | grep lxd-ui.crt | awk '{print $8}'`,
-      );
-      runCommand(`lxc config trust remove ${fingerprint}`);
+      removeCertificateTrust();
       runCommand(`lxc auth group create test-viewers`);
       runCommand(`lxc auth group permission add test-viewers server viewer`);
       runCommand(
@@ -97,9 +99,9 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     }
 
     try {
-      runCommand(`lxc auth identity delete tls/lxd-ui`);
-      runCommand(`lxc auth group delete test-viewers`);
-      runCommand(`lxc config trust add keys/lxd-ui.crt`);
+      runCommand("lxc auth identity delete tls/lxd-ui");
+      runCommand("lxc auth group delete test-viewers");
+      restoreCertificateTrust();
     } catch (err) {
       console.error("Error occurred during afterAll cleanup:", err);
     }


### PR DESCRIPTION
## Done

- Add e2e for initial access link flow

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI passing
    
## Screenshots

<img width="1003" height="91" alt="image" src="https://github.com/user-attachments/assets/cd0061eb-0e5a-4187-bdaa-eb71b085bc4c" />

