### PR TITLE
feat: show available pool size WD-34210

### DIFF
--- a/src/components/forms/CpuLimitAvailable.tsx
+++ b/src/components/forms/CpuLimitAvailable.tsx
@@ -1,7 +1,5 @@
 import type { FC } from "react";
 import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
-import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
-import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
 import { Icon } from "@canonical/react-components";
 import { useResourceLimit } from "context/useResourceLimit";
 import { ResourceLimitIcon } from "components/ResourceLimitIcon";
@@ -11,11 +9,7 @@ interface Props {
 }
 
 export const CpuLimitAvailable: FC<Props> = ({ formik }) => {
-  const values = formik?.values as
-    | CreateInstanceFormValues
-    | EditInstanceFormValues;
-
-  const resourceLimit = useResourceLimit("cpu", values);
+  const resourceLimit = useResourceLimit("cpu", formik);
   if (!resourceLimit) {
     return null;
   }

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -22,6 +22,8 @@ import { focusField } from "util/formFields";
 import DiskSizeQuotaLimitation from "components/forms/DiskSizeQuotaLimitation";
 import { getProfileFromSource } from "util/devices";
 import { isDeviceModified } from "util/formChangeCount";
+import StoragePoolSizeAvailable from "./StoragePoolSizeAvailable";
+import { getInstanceClusterMember } from "util/instances";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -48,14 +50,18 @@ const DiskDeviceFormRoot: FC<Props> = ({
     formik.values.entityType === "instance" &&
     formik.values.instanceType === "virtual-machine";
   const defaultSize = isVirtualMachine ? "10GiB" : "unlimited";
-  const poolDriver = pools.find(
+
+  const rootStoragePool = pools.find(
     (item) => item.name === formRootDevice?.pool,
-  )?.driver;
+  );
+  const poolDriver = rootStoragePool?.driver;
 
   const [inheritValue, inheritSource] = getInheritedRootStorage(
     formik.values,
     profiles,
   );
+
+  const clusterMemberName = getInstanceClusterMember(formik);
 
   const addRootStorage = () => {
     const copy = [...formik.values.devices];
@@ -235,8 +241,15 @@ const DiskDeviceFormRoot: FC<Props> = ({
                 />
                 <p className="p-form-help-text">
                   <DiskSizeQuotaLimitation driver={poolDriver} />
-                  Size of root storage. If empty, root storage will{" "}
-                  {isVirtualMachine ? "be 10GiB." : "not have a size limit."}
+                  If empty, root storage will{" "}
+                  {isVirtualMachine
+                    ? "be limited at 10GiB."
+                    : "not have a size limit."}
+                  <br />
+                  <StoragePoolSizeAvailable
+                    pool={rootStoragePool}
+                    clusterMember={clusterMemberName}
+                  />
                 </p>
               </>
             ),

--- a/src/components/forms/MemoryLimitAvailable.tsx
+++ b/src/components/forms/MemoryLimitAvailable.tsx
@@ -1,22 +1,16 @@
 import type { FC } from "react";
 import { humanFileSize } from "util/helpers";
 import { Icon } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
-import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
-import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
 import { useResourceLimit } from "context/useResourceLimit";
 import { ResourceLimitIcon } from "components/ResourceLimitIcon";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
 }
 
 const MemoryLimitAvailable: FC<Props> = ({ formik }) => {
-  const values = formik?.values as
-    | CreateInstanceFormValues
-    | EditInstanceFormValues;
-
-  const resourceLimit = useResourceLimit("memory", values);
+  const resourceLimit = useResourceLimit("memory", formik);
   if (!resourceLimit) {
     return null;
   }

--- a/src/components/forms/StoragePoolSizeAvailable.tsx
+++ b/src/components/forms/StoragePoolSizeAvailable.tsx
@@ -1,0 +1,52 @@
+import type { FC } from "react";
+import { humanFileSize } from "util/helpers";
+import { Icon } from "@canonical/react-components";
+import { useStoragePoolResourceLimit } from "context/useStoragePoolResourceLimit";
+import type { LxdStoragePool } from "types/storage";
+import { ResourceLimitIcon } from "components/ResourceLimitIcon";
+import { isClusterLocalDriver } from "util/storagePool";
+
+interface Props {
+  pool?: LxdStoragePool;
+  clusterMember?: string;
+}
+
+const StoragePoolSizeAvailable: FC<Props> = ({ pool, clusterMember }) => {
+  const resourceLimit = useStoragePoolResourceLimit(pool, clusterMember);
+  if (!resourceLimit) {
+    return null;
+  }
+  const { min: minSize, max: maxSize, sourceName } = resourceLimit;
+
+  const showHelpIcon = minSize !== maxSize;
+  const helpIconText =
+    "The available space depends on the target cluster member.";
+
+  return (
+    <>
+      Available space:{" "}
+      <b>
+        {humanFileSize(minSize)}
+        {minSize !== maxSize && ` - ${humanFileSize(maxSize)}`}
+        {showHelpIcon && (
+          <>
+            {" "}
+            <Icon
+              name="information"
+              className="help-link-icon"
+              title={helpIconText}
+            />
+          </>
+        )}
+      </b>
+      {sourceName && isClusterLocalDriver(pool?.driver ?? "") && (
+        <>
+          {" "}
+          <ResourceLimitIcon source={sourceName} sourceType="cluster-member" />
+        </>
+      )}
+      {"."}
+    </>
+  );
+};
+export default StoragePoolSizeAvailable;

--- a/src/context/useResourceLimit.tsx
+++ b/src/context/useResourceLimit.tsx
@@ -1,28 +1,18 @@
 import { useNotify } from "@canonical/react-components";
 import { useResources } from "context/useResources";
-import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
-import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
-import { CLUSTER_GROUP_PREFIX } from "util/instances";
+import { getInstanceClusterMember } from "util/instances";
 import { getResourceLimit } from "util/resourceLimits";
-import { useIsClustered } from "./useIsClustered";
 import { useCurrentProject } from "./useCurrentProject";
 import { limitToBytes } from "util/limits";
-import type { LxdResources } from "types/resources";
-
-export const ensureArray = (resources: LxdResources | LxdResources[]) =>
-  Array.isArray(resources) ? resources : [resources];
+import { ensureArray } from "util/helpers";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 export const useResourceLimit = (
   mode: "cpu" | "memory",
-  formValues: CreateInstanceFormValues | EditInstanceFormValues,
+  formik: InstanceAndProfileFormikProps,
 ) => {
   const notify = useNotify();
-  const isClustered = useIsClustered();
-  const { target } = formValues as CreateInstanceFormValues;
-  const { location } = formValues as EditInstanceFormValues;
-  const isClusterGroupTarget = target?.startsWith(CLUSTER_GROUP_PREFIX);
-  const validTarget = target && !isClusterGroupTarget ? target : undefined;
-  const clusterMember = isClustered ? (validTarget ?? location) : undefined;
+  const clusterMember = getInstanceClusterMember(formik);
   const { data: resources, error, isLoading } = useResources(clusterMember);
   const { project } = useCurrentProject();
   const resourceLimitName = mode === "memory" ? "limits.memory" : "limits.cpu";

--- a/src/context/useStoragePoolResourceLimit.tsx
+++ b/src/context/useStoragePoolResourceLimit.tsx
@@ -1,0 +1,34 @@
+import type { LxdStoragePool } from "types/storage";
+import { useClusterMember } from "./useClusterMembers";
+import { useStoragePoolResources } from "./useStoragePoolResources";
+import { useNotify } from "@canonical/react-components";
+import { getResourceLimit } from "util/resourceLimits";
+import { ensureArray } from "util/helpers";
+
+export const useStoragePoolResourceLimit = (
+  pool?: LxdStoragePool,
+  clusterMemberName?: string,
+) => {
+  const notify = useNotify();
+  const { data: clusterMember } = useClusterMember(clusterMemberName ?? "");
+  const {
+    data: resources,
+    isLoading,
+    error,
+  } = useStoragePoolResources(pool, clusterMember);
+
+  if (error) {
+    notify.failure("Loading resources failed", error);
+    return null;
+  }
+
+  if (isLoading || !resources) {
+    return null;
+  }
+
+  const resourceArray = ensureArray(resources);
+  const availableSpaces = resourceArray.map(
+    (r) => r.space.total - (r.space.used ?? 0),
+  );
+  return getResourceLimit(availableSpaces, clusterMemberName);
+};

--- a/src/context/useStoragePoolResources.tsx
+++ b/src/context/useStoragePoolResources.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { useClusteredStoragePoolResources } from "./useStoragePools";
+import { useIsClustered } from "./useIsClustered";
+import type { LxdStoragePool } from "types/storage";
+import { isClusterLocalDriver } from "util/storagePool";
+import type { LxdClusterMember } from "types/cluster";
+import { queryKeys } from "util/queryKeys";
+import { fetchStoragePoolResources } from "api/storage-pools";
+
+export const useStoragePoolResources = (
+  pool?: LxdStoragePool,
+  member?: LxdClusterMember,
+) => {
+  const isClustered = useIsClustered();
+  const hasMemberSpecificSize =
+    isClusterLocalDriver(pool?.driver ?? "") && isClustered;
+  const clusteredQuery = useClusteredStoragePoolResources(
+    pool?.name,
+    member,
+    hasMemberSpecificSize,
+  );
+  const nonlocalDriverOrUnclusteredQuery = useQuery({
+    queryKey: [
+      queryKeys.storage,
+      pool?.name,
+      queryKeys.resources,
+      member?.server_name,
+    ],
+    queryFn: async () => fetchStoragePoolResources(pool?.name ?? ""),
+    enabled: !!pool && !hasMemberSpecificSize,
+  });
+
+  return hasMemberSpecificSize
+    ? clusteredQuery
+    : nonlocalDriverOrUnclusteredQuery;
+};

--- a/src/context/useStoragePools.tsx
+++ b/src/context/useStoragePools.tsx
@@ -54,17 +54,22 @@ export const usePoolFromClusterMembers = (
 };
 
 export const useClusteredStoragePoolResources = (
-  pool: string,
+  pool?: string,
   member?: LxdClusterMember,
+  enabled = true,
 ): UseQueryResult<LxdStoragePoolResources[]> => {
   const { data: clusterMembers = [] } = useClusterMembers();
+  const members = member ? [member] : clusterMembers;
   return useQuery({
-    queryKey: [queryKeys.storage, pool, queryKeys.cluster, queryKeys.resources],
+    queryKey: [
+      queryKeys.storage,
+      pool,
+      queryKeys.cluster,
+      queryKeys.resources,
+      members,
+    ],
     queryFn: async () =>
-      fetchClusteredStoragePoolResources(
-        pool,
-        member ? [member] : clusterMembers,
-      ),
-    enabled: clusterMembers.length > 0,
+      fetchClusteredStoragePoolResources(pool ?? "", members),
+    enabled: enabled && !!pool && members.length > 0,
   });
 };

--- a/src/pages/projects/ProjectCpuLimitInput.tsx
+++ b/src/pages/projects/ProjectCpuLimitInput.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { useNotify } from "@canonical/react-components";
 import type { InputProps } from "@canonical/react-components";
 import { Input } from "@canonical/react-components";
-import { ensureArray } from "context/useResourceLimit";
+import { ensureArray } from "util/helpers";
 
 type Props = InputProps;
 

--- a/src/pages/projects/ProjectMemoryLimit.tsx
+++ b/src/pages/projects/ProjectMemoryLimit.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { humanFileSize } from "util/helpers";
 import { useNotify } from "@canonical/react-components";
 import { Spinner } from "@canonical/react-components";
-import { ensureArray } from "context/useResourceLimit";
+import { ensureArray } from "util/helpers";
 
 export const ProjectMemoryLimit: FC = () => {
   const notify = useNotify();

--- a/src/pages/storage/CustomVolumeCreateModal.tsx
+++ b/src/pages/storage/CustomVolumeCreateModal.tsx
@@ -22,6 +22,7 @@ import { createStorageVolume } from "api/storage-volumes";
 import { hasMemberLocalVolumes } from "util/hasMemberLocalVolumes";
 import { useEventQueue } from "context/eventQueue";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import type { LxdClusterMember } from "types/cluster";
 
 interface Props {
   project: string;
@@ -78,10 +79,12 @@ const CustomVolumeCreateModal: FC<Props> = ({
       name: "",
       project: project,
       pool: "",
+      clusterMember: instanceLocation,
       size: "GiB",
       volumeType: "custom",
       readOnly: false,
       isCreating: true,
+      isClusterMemberLocked: true,
       entityType: "storageVolume",
     },
     validationSchema: StorageVolumeSchema,
@@ -129,7 +132,17 @@ const CustomVolumeCreateModal: FC<Props> = ({
   return (
     <>
       <div className="volume-create-form">
-        <StorageVolumeFormMain formik={formik} poolError={poolError} />
+        <StorageVolumeFormMain
+          formik={formik}
+          poolError={poolError}
+          pools={pools}
+          settings={settings}
+          clusterMembers={
+            instanceLocation
+              ? ([{ server_name: instanceLocation }] as LxdClusterMember[])
+              : []
+          }
+        />
       </div>
       <footer className="p-modal__footer">
         <Button

--- a/src/pages/storage/StoragePoolSize.tsx
+++ b/src/pages/storage/StoragePoolSize.tsx
@@ -1,14 +1,11 @@
 import type { FC } from "react";
 import type { LxdStoragePool } from "types/storage";
-import { humanFileSize } from "util/helpers";
+import { ensureArray, humanFileSize } from "util/helpers";
 import Meter from "components/Meter";
-import { useClusteredStoragePoolResources } from "context/useStoragePools";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { fetchStoragePoolResources } from "api/storage-pools";
 import { isClusterLocalDriver } from "util/storagePool";
 import { useIsClustered } from "context/useIsClustered";
 import type { LxdClusterMember } from "types/cluster";
+import { useStoragePoolResources } from "context/useStoragePoolResources";
 
 interface Props {
   pool: LxdStoragePool;
@@ -24,23 +21,18 @@ const StoragePoolSize: FC<Props> = ({
   forceSingleLine,
 }) => {
   // When a single member is provided, the resource usage is shown for that member only
-  const { data: clusteredPoolResources = [] } =
-    useClusteredStoragePoolResources(pool.name, member);
+
   const isClustered = useIsClustered();
   const hasMemberSpecificSize =
     isClusterLocalDriver(pool.driver) && isClustered;
-
-  const { data: poolResources } = useQuery({
-    queryKey: [queryKeys.storage, pool.name, queryKeys.resources],
-    queryFn: async () => fetchStoragePoolResources(pool.name),
-    enabled: !hasMemberSpecificSize,
-  });
-
-  const resourceList = hasMemberSpecificSize
-    ? clusteredPoolResources
-    : [poolResources];
-
-  if (hasMemberSpecificSize && forceSingleLine && !member) {
+  const { data: resources } = useStoragePoolResources(pool, member);
+  const resourceList = ensureArray(resources);
+  if (
+    hasMemberSpecificSize &&
+    forceSingleLine &&
+    !member &&
+    resourceList.length > 1
+  ) {
     return "Cluster member dependent";
   }
 

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -15,6 +15,7 @@ import type { LxdStoragePool } from "types/storage";
 import type { LxdSettings } from "types/server";
 import type { LxdClusterMember } from "types/cluster";
 import DiskSizeQuotaLimitation from "components/forms/DiskSizeQuotaLimitation";
+import StoragePoolSizeAvailable from "components/forms/StoragePoolSizeAvailable";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
@@ -31,10 +32,8 @@ const StorageVolumeFormMain: FC<Props> = ({
   pools = [],
   settings,
 }) => {
-  const poolDriver = pools.find(
-    (item) => item.name === formik.values.pool,
-  )?.driver;
-
+  const pool = pools.find((item) => item.name === formik.values.pool);
+  const poolDriver = pool?.driver;
   return (
     <ScrollableForm>
       <Row>
@@ -85,7 +84,10 @@ const StorageVolumeFormMain: FC<Props> = ({
                     value: member.server_name,
                   };
                 })}
-                disabled={!formik.values.isCreating}
+                disabled={
+                  !formik.values.isCreating ||
+                  formik.values.isClusterMemberLocked
+                }
                 required={formik.values.isCreating}
                 help={
                   formik.values.isCreating
@@ -114,8 +116,13 @@ const StorageVolumeFormMain: FC<Props> = ({
                 <>
                   <DiskSizeQuotaLimitation driver={poolDriver} />
                   {formik.values.volumeType === "custom"
-                    ? "Size of storage volume. If empty, volume will not have a size limit within its storage pool."
+                    ? "If empty, volume will not have a size limit within its storage pool."
                     : "Size is immutable for non-custom volumes."}
+                  <br />
+                  <StoragePoolSizeAvailable
+                    pool={pool}
+                    clusterMember={formik.values.clusterMember}
+                  />
                 </>
               ) as unknown as string
             }

--- a/src/types/forms/storageVolume.d.ts
+++ b/src/types/forms/storageVolume.d.ts
@@ -29,4 +29,5 @@ export interface StorageVolumeFormValues {
   entityType: "storageVolume";
   editRestriction?: string;
   clusterMember?: string;
+  isClusterMemberLocked?: boolean;
 }

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -472,3 +472,6 @@ export const isBearerAuthError = (error: Error | null) => {
   if (!error?.message) return false;
   return isBearerTokenExpired(error) || isBearerTokenInvalid(error);
 };
+
+export const ensureArray = <T,>(data: T | T[]): T[] =>
+  Array.isArray(data) ? data : [data];

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -11,6 +11,8 @@ import ResourceLabel from "components/ResourceLabel";
 import ResourceLink from "components/ResourceLink";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
 import { instanceCreationTypes } from "./instanceOptions";
+import { getInstanceLocation } from "./instanceLocation";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 export const CLUSTER_GROUP_PREFIX = "@";
 
@@ -117,4 +119,18 @@ export const getInstanceMacAddresses = (instance: LxdInstance) => {
 export const getInstanceType = (instance: LxdInstance) => {
   return instanceCreationTypes.find((item) => item.value === instance.type)
     ?.label;
+};
+
+export const getInstanceClusterMember = (
+  formik: InstanceAndProfileFormikProps,
+) => {
+  const location = getInstanceLocation(formik);
+  if (!location || location === "any") {
+    return undefined;
+  }
+  const isClusterGroup = location?.startsWith(CLUSTER_GROUP_PREFIX);
+  if (isClusterGroup) {
+    return undefined;
+  }
+  return location;
 };


### PR DESCRIPTION
## Done

- Show available memory in a pool when configuring size
## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to instance create/edit -> Configuration -> Disk
    - Edit the root disk device
    - Ensure the pool available size is reported correctly
    - Go to Storage -> Volume -> Create/edit
    - Ensure the pool available size is reported correctly
## Screenshots

Clustered
<img width="1916" height="952" alt="image" src="https://github.com/user-attachments/assets/042bf71c-4525-4df1-bf73-87b387d96aeb" />
<img width="1916" height="952" alt="image" src="https://github.com/user-attachments/assets/df25d397-1dec-4cbd-9938-c4011d6e311a" />

Unclustered

<img width="1916" height="952" alt="image" src="https://github.com/user-attachments/assets/fdad18c1-c019-47d2-96be-9d3b3edc155e" />
