### PR TITLE
feat: use prefixedInput for user configuration WD-34345

### DIFF
--- a/src/pages/settings/SettingsRow.tsx
+++ b/src/pages/settings/SettingsRow.tsx
@@ -3,7 +3,12 @@ import type { ClusterSpecificValues } from "types/cluster";
 import SettingForm from "pages/settings/SettingForm";
 import type { ConfigField } from "types/config";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
-import { Input, Button, Form } from "@canonical/react-components";
+import {
+  Input,
+  Button,
+  Form,
+  PrefixedInput,
+} from "@canonical/react-components";
 import { generateUUID } from "util/helpers";
 import { getConfigFieldValue, type UserSetting } from "util/settings";
 import type { LxdSettings } from "types/server";
@@ -86,35 +91,25 @@ export const getUserSettingInputRow = (
       },
       {
         content: (
-          <>
-            <Input
-              aria-label="new user key"
-              id={`new-user-defined-key-${index}`}
-              placeholder="User key"
-              type="text"
-              value={userSetting.key}
-              autoFocus
-              error={
-                isKeyDuplicate && <>Setting with this name already exists</>
-              }
-              onChange={(e) => {
-                setUserSettings((prev) => {
-                  const copy = [...prev];
-                  copy[index] = {
-                    ...copy[index],
-                    key: e.target.value,
-                  };
-                  return copy;
-                });
-              }}
-              help={
-                <>
-                  Key will be saved as <code>{"user.{your-key}"}</code>. Enter
-                  only the part after user.
-                </>
-              }
-            />
-          </>
+          <PrefixedInput
+            aria-label="new user key"
+            id={`new-user-defined-key-${index}`}
+            placeholder="key"
+            value={userSetting.key}
+            autoFocus
+            error={isKeyDuplicate && <>Setting with this name already exists</>}
+            immutableText="user."
+            onChange={(e) => {
+              setUserSettings((prev) => {
+                const copy = [...prev];
+                copy[index] = {
+                  ...copy[index],
+                  key: e.target.value,
+                };
+                return copy;
+              });
+            }}
+          />
         ),
         role: "rowheader",
         className: "key",

--- a/src/sass/_settings_page.scss
+++ b/src/sass/_settings_page.scss
@@ -1,6 +1,16 @@
 .settings {
   min-height: initial !important;
 
+  .prefixed-input__input {
+    @include extra-large {
+      padding-top: 0.25rem !important;
+    }
+
+    @include mobile {
+      padding-top: 0.2rem !important;
+    }
+  }
+
   .group {
     width: 8rem;
 

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -117,7 +117,7 @@ export const addUserSetting = async (
   await page
     .getByRole("button", { name: "Add user setting", exact: true })
     .click();
-  await page.getByPlaceholder("User key").fill(key);
+  await page.getByPlaceholder("key").fill(key);
   await page.getByPlaceholder("Value").fill(value);
   await page.getByRole("button", { name: "Save", exact: true }).click();
 };


### PR DESCRIPTION
## Done

- use prefixedInput for user configuration

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Settings
    - Add a user config and ensure prefixed input component is used properly

## Screenshots

<img width="1907" height="960" alt="image" src="https://github.com/user-attachments/assets/c3c71b59-6813-4aaf-ae67-dcbc8e56bb8e" />
