### PR TITLE
feat: [WD-34757] Reevaluate expiry logic for instances and volumes

### DIFF
--- a/src/pages/instances/forms/ExportInstanceModal.tsx
+++ b/src/pages/instances/forms/ExportInstanceModal.tsx
@@ -192,20 +192,6 @@ const ExportInstanceModal: FC<Props> = ({ instance, close }) => {
             { value: "none", label: "None" },
           ]}
         />
-        <Select
-          {...formik.getFieldProps("expirationHours")}
-          id="project"
-          label="Expiration"
-          help="Duration that the backup remains on the server"
-          options={[
-            { value: 1, label: "1 hour" },
-            { value: 6, label: "6 hours" },
-            { value: 12, label: "12 hours" },
-            { value: 24, label: "1 day" },
-            { value: 72, label: "3 days" },
-            { value: 168, label: "7 days" },
-          ]}
-        />
         {hasBackupMetadataVersion && (
           <Select
             {...formik.getFieldProps("exportVersion")}

--- a/src/pages/storage/forms/ExportVolumeModal.tsx
+++ b/src/pages/storage/forms/ExportVolumeModal.tsx
@@ -170,20 +170,6 @@ const ExportVolumeModal: FC<Props> = ({ volume, close }) => {
             { value: "none", label: "None" },
           ]}
         />
-        <Select
-          {...formik.getFieldProps("expirationHours")}
-          id="project"
-          label="Expiration"
-          help="Duration that the backup remains on the server"
-          options={[
-            { value: 1, label: "1 hour" },
-            { value: 6, label: "6 hours" },
-            { value: 12, label: "12 hours" },
-            { value: 24, label: "1 day" },
-            { value: 72, label: "3 days" },
-            { value: 168, label: "7 days" },
-          ]}
-        />
         {hasBackupMetadataVersion && (
           <Select
             {...formik.getFieldProps("exportVersion")}


### PR DESCRIPTION
## Done

- Removed default expiry time select for instances **and** volumes.
- Default expiry time remains 6 hours following this [thread conversation](https://chat.canonical.com/canonical/pl/d9hyzssdmtn35mpopwix5auqdo).

Fixes concerns regarding export transparency highlighted during user testing.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Verify expiry time is removed in instance / volume export.

## Screenshots
Before:
<img width="1920" height="871" alt="image" src="https://github.com/user-attachments/assets/bc975ae6-4f49-44fa-acc3-3d9a8e7d46e8" />

After:
<img width="1920" height="871" alt="image" src="https://github.com/user-attachments/assets/a62cb082-103e-441b-916f-2c3446bea38d" />
