### PR TITLE
feat(Ceph): drop source

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -48,5 +48,6 @@ export const useSupportedFeatures = () => {
     hasInstanceForceDelete: apiExtensions.has("instance_force_delete"),
     hasInstanceBootMode: apiExtensions.has("instance_boot_mode"),
     hasProjectDeleteOperation: apiExtensions.has("project_delete_operation"),
+    hasRemoteDropSource: apiExtensions.has("storage_remote_drop_source"),
   };
 };

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -32,6 +32,7 @@ import type { LxdStoragePool } from "types/storage";
 import YamlSwitch from "components/forms/YamlSwitch";
 import StoragePoolRichChip from "./StoragePoolRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 const CreateStoragePool: FC = () => {
   const navigate = useNavigate();
@@ -42,6 +43,7 @@ const CreateStoragePool: FC = () => {
   const [section, setSection] = useState(slugify(MAIN_CONFIGURATION));
   const controllerState = useState<AbortController | null>(null);
   const { data: clusterMembers = [] } = useClusterMembers();
+  const { hasRemoteDropSource } = useSupportedFeatures();
 
   if (!project) {
     return <>Missing project</>;
@@ -68,7 +70,7 @@ const CreateStoragePool: FC = () => {
     onSubmit: (values) => {
       const storagePool = values.yaml
         ? (yamlToObject(values.yaml) as LxdStoragePool)
-        : toStoragePool(values);
+        : toStoragePool(values, hasRemoteDropSource);
 
       const mutation =
         clusterMembers.length > 0

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -27,15 +27,13 @@ import type { LxdStoragePool } from "types/storage";
 import {
   alletraDriver,
   btrfsDriver,
-  cephDriver,
-  cephFSDriver,
   cephObject,
   getSupportedStorageDrivers,
   powerFlex,
   pureStorage,
   zfsDriver,
 } from "util/storageOptions";
-import { getPoolKey } from "util/storagePool";
+import { getPoolKey, isCephDriver, isCephFSDriver } from "util/storagePool";
 import { slugify } from "util/slugify";
 import YamlForm from "components/forms/YamlForm";
 import { handleConfigKeys } from "util/storagePoolForm";
@@ -61,9 +59,8 @@ interface Props {
 
 export const toStoragePool = (
   values: StoragePoolFormValues,
+  hasRemoteDropSource?: boolean,
 ): LxdStoragePool => {
-  const isCephDriver = values.driver === cephDriver;
-  const isCephFSDriver = values.driver === cephFSDriver;
   const isPowerFlexDriver = values.driver === powerFlex;
   const isPureDriver = values.driver === pureStorage;
   const isZFSDriver = values.driver === zfsDriver;
@@ -72,7 +69,7 @@ export const toStoragePool = (
   const hasValidSize = values.size?.match(/^\d/);
 
   const getConfig = () => {
-    if (isCephDriver) {
+    if (isCephDriver(values)) {
       return {
         [getPoolKey("ceph_cluster_name")]: values.ceph_cluster_name,
         [getPoolKey("ceph_osd_pg_num")]: values.ceph_osd_pg_num?.toString(),
@@ -80,18 +77,22 @@ export const toStoragePool = (
         [getPoolKey("ceph_rbd_du")]: values.ceph_rbd_du,
         [getPoolKey("ceph_user_name")]: values.ceph_user_name,
         [getPoolKey("ceph_rbd_features")]: values.ceph_rbd_features,
-        source: values.source,
+        source: hasRemoteDropSource ? undefined : values.source,
+        [getPoolKey("ceph_osd_pool_name")]: hasRemoteDropSource
+          ? values.ceph_osd_pool_name
+          : undefined,
       };
     }
-    if (isCephFSDriver) {
+    if (isCephFSDriver(values)) {
       return {
         [getPoolKey("cephfs_cluster_name")]: values.cephfs_cluster_name,
         [getPoolKey("cephfs_create_missing")]: values.cephfs_create_missing,
         [getPoolKey("cephfs_fscache")]: values.cephfs_fscache,
         [getPoolKey("cephfs_osd_pg_num")]: values.cephfs_osd_pg_num?.toString(),
-        [getPoolKey("cephfs_path")]: values.cephfs_path,
-        [getPoolKey("cephfs_user_name")]: values.cephfs_user_name,
-        source: values.source,
+        source: hasRemoteDropSource ? undefined : values.source,
+        [getPoolKey("cephfs_path")]: hasRemoteDropSource
+          ? values.cephfs_path
+          : undefined,
       };
     }
     if (isCephObjectDriver) {

--- a/src/pages/storage/forms/StoragePoolFormCeph.tsx
+++ b/src/pages/storage/forms/StoragePoolFormCeph.tsx
@@ -5,15 +5,29 @@ import { getConfigurationRow } from "components/ConfigurationRow";
 import { Input, Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormCeph: FC<Props> = ({ formik }) => {
+  const { hasRemoteDropSource } = useSupportedFeatures();
+
   return (
     <ScrollableConfigurationTable
       rows={[
+        ...(hasRemoteDropSource
+          ? [
+              getConfigurationRow({
+                formik,
+                label: "Ceph OSD pool name",
+                name: "ceph_osd_pool_name",
+                defaultValue: "",
+                children: <Input type="text" placeholder="Enter pool name" />,
+              }),
+            ]
+          : []),
         getConfigurationRow({
           formik,
           label: "Cluster name",

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -23,8 +23,11 @@ import {
   getPowerflexPoolFormFields,
   getPureStoragePoolFormFields,
   getZfsStoragePoolFormFields,
+  isCephDriver,
+  isCephFSDriver,
 } from "util/storagePool";
 import { useSettings } from "context/useSettings";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ScrollableForm from "components/ScrollableForm";
 import { ensureEditMode } from "util/instanceEdit";
 import ClusteredSourceSelector from "./ClusteredSourceSelector";
@@ -41,6 +44,7 @@ interface Props {
 
 const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const { data: settings } = useSettings();
+  const { hasRemoteDropSource } = useSupportedFeatures();
 
   const getFormProps = (id: "name" | "description" | "size" | "source") => {
     return {
@@ -60,12 +64,16 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const isAlletraDriver = formik.values.driver === alletraDriver;
   const storageDriverOptions = getStorageDriverOptions(settings);
   const isClusterWideSource = isClusterWideSourceDriver(formik.values.driver);
+  const isCephVariant =
+    isCephDriver(formik.values) || isCephFSDriver(formik.values);
+  const isCephVariantWithoutSource = isCephVariant && hasRemoteDropSource;
 
   const hasSource =
     !isPureDriver &&
     !isPowerFlexDriver &&
     !isCephObjectDriver &&
-    !isAlletraDriver;
+    !isAlletraDriver &&
+    !isCephVariantWithoutSource;
 
   const sourceHelpText = formik.values.isCreating
     ? getSourceHelpForDriver(formik.values.driver)

--- a/src/types/forms/storagePool.d.ts
+++ b/src/types/forms/storagePool.d.ts
@@ -5,6 +5,7 @@ export interface StoragePoolFormValues {
   barePool?: LxdStoragePool;
   ceph_cluster_name?: string;
   ceph_osd_pg_num?: string;
+  ceph_osd_pool_name?: string;
   ceph_rbd_clone_copy?: string;
   ceph_rbd_du?: string;
   ceph_user_name?: string;

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -20,6 +20,7 @@ import {
 export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   ceph_cluster_name: "ceph.cluster_name",
   ceph_osd_pg_num: "ceph.osd.pg_num",
+  ceph_osd_pool_name: "ceph.osd.pool_name",
   ceph_rbd_clone_copy: "ceph.rbd.clone_copy",
   ceph_rbd_du: "ceph.rbd.du",
   ceph_user_name: "ceph.user.name",
@@ -180,4 +181,12 @@ export const isAlletraIncomplete = (
       !formik.values.alletra_user_password ||
       !formik.values.alletra_cpg)
   );
+};
+
+export const isCephDriver = (values: StoragePoolFormValues) => {
+  return values.driver === cephDriver;
+};
+
+export const isCephFSDriver = (values: StoragePoolFormValues) => {
+  return values.driver === cephFSDriver;
 };


### PR DESCRIPTION
## Done

- Drop source config key for Ceph RBD and CephFS drivers

Fixes #1877 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a storage pool, enter a name, select `driver=Ceph`
    - Make sure `Source` doesn't appear on the main configuration screen
    - Make sure `Ceph OSD pool name` appears on the Ceph specific screen
    - Save
    - Edit
    - Create a storage pool, enter a name, select `driver=CephFS`
    - Make sure `Source` doesn't appear on the main configuration screen
    - Make sure `Path` appears on the Ceph specific screen (it was already there)
    - Save
    - Edit

## Screenshots

<img width="1473" height="1013" alt="image" src="https://github.com/user-attachments/assets/6ae5d35e-ca1b-4cce-ad5e-8b5f035a5021" />

<img width="1473" height="1013" alt="image" src="https://github.com/user-attachments/assets/82302787-e9c1-493c-8c1d-27144c2740a6" />

