### PR TITLE
fix: [WD-34764] Change information icon to help icon

### DIFF
--- a/src/components/HelpLink.tsx
+++ b/src/components/HelpLink.tsx
@@ -13,7 +13,7 @@ const HelpLink: FC<Props> = ({ children, title, docPath }) => {
     <div className="help-link">
       {children}
       <DocLink docPath={docPath} title={title} className="help-link-doc-link">
-        <Icon name="information" className="help-link-icon" />
+        <Icon name="help" className="help-link-icon" />
       </DocLink>
     </div>
   );


### PR DESCRIPTION
## Done

- Change information icon to help icon following UX testing and design discussion.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Observe the icon change in the header(s).
    
## Screenshots

New:
<img width="1044" height="64" alt="image" src="https://github.com/user-attachments/assets/c1d1e945-ca24-4fd6-9a6f-86483a3e4474" />
