### PR TITLE
fix(instance) ensure root size copy for containers is clear

### DIFF
--- a/src/components/forms/BootForm.tsx
+++ b/src/components/forms/BootForm.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { Input, Select } from "@canonical/react-components";
 import { bootModeOptions, optionYesNo } from "util/instanceOptions";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { optionRenderer } from "util/formFields";

--- a/src/components/forms/CloudInitForm.tsx
+++ b/src/components/forms/CloudInitForm.tsx
@@ -2,7 +2,7 @@ import type { FC } from "react";
 import { useState } from "react";
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import CloudInitConfig from "components/forms/CloudInitConfig";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { getConfigurationRowBase } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { getInstanceField } from "util/instanceConfigFields";

--- a/src/components/forms/CpuLimitAvailable.tsx
+++ b/src/components/forms/CpuLimitAvailable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { Icon } from "@canonical/react-components";
 import { useResourceLimit } from "context/useResourceLimit";
 import { ResourceLimitIcon } from "components/ResourceLimitIcon";

--- a/src/components/forms/CpuLimitInput.tsx
+++ b/src/components/forms/CpuLimitInput.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { Input } from "@canonical/react-components";
 import type { Props as InputProps } from "@canonical/react-components/dist/components/Input/Input";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { CpuLimitAvailable } from "./CpuLimitAvailable";
 
 type Props = {

--- a/src/components/forms/CpuLimitSelector.tsx
+++ b/src/components/forms/CpuLimitSelector.tsx
@@ -3,7 +3,7 @@ import { RadioInput } from "@canonical/react-components";
 import type { CpuLimit } from "types/limits";
 import { CPU_LIMIT_TYPE } from "types/limits";
 import CpuLimitInput from "components/forms/CpuLimitInput";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 interface Props {
   cpuLimit?: CpuLimit;

--- a/src/components/forms/DiskDeviceForm.tsx
+++ b/src/components/forms/DiskDeviceForm.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Input, useNotify, Spinner } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { getInheritedDiskDevices } from "util/configInheritance";
 import DiskDeviceFormRoot from "./DiskDeviceFormRoot";
 import DiskDeviceFormInherited from "./DiskDeviceFormInherited";

--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Button, Icon, Input, Label } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
 import CustomVolumeSelectBtn from "pages/storage/CustomVolumeSelectBtn";
 import type {

--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import ConfigurationTable from "components/ConfigurationTable";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
 import { getConfigurationRowBase } from "components/ConfigurationRow";

--- a/src/components/forms/DiskDeviceFormRoot.tsx
+++ b/src/components/forms/DiskDeviceFormRoot.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdDiskDevice } from "types/device";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import ConfigurationTable from "components/ConfigurationTable";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
 import { getConfigurationRowBase } from "components/ConfigurationRow";
@@ -49,7 +49,7 @@ const DiskDeviceFormRoot: FC<Props> = ({
   const isVirtualMachine =
     formik.values.entityType === "instance" &&
     formik.values.instanceType === "virtual-machine";
-  const defaultSize = isVirtualMachine ? "10GiB" : "unlimited";
+  const defaultSize = isVirtualMachine ? "10GiB" : "not specified";
 
   const rootStoragePool = pools.find(
     (item) => item.name === formRootDevice?.pool,

--- a/src/components/forms/GPUDeviceForm.tsx
+++ b/src/components/forms/GPUDeviceForm.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import type { LxdGPUDevice } from "types/device";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { getInheritedGPUs } from "util/configInheritance";
 import AttachGPUBtn from "components/forms/SelectGPUBtn";
 import type { GpuCard } from "types/resources";

--- a/src/components/forms/InstanceSnapshotsForm.tsx
+++ b/src/components/forms/InstanceSnapshotsForm.tsx
@@ -1,7 +1,7 @@
 import type { FC, ReactNode } from "react";
 import { Input, Notification, Select } from "@canonical/react-components";
 import { optionYesNo } from "util/instanceOptions";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import type { SnapshotFormValues } from "types/forms/instanceAndProfile";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";

--- a/src/components/forms/MemoryLimitSelector.tsx
+++ b/src/components/forms/MemoryLimitSelector.tsx
@@ -3,7 +3,7 @@ import { Input, RadioInput, Select } from "@canonical/react-components";
 import type { MemoryLimit } from "types/limits";
 import { BYTES_UNITS, MEM_LIMIT_TYPE } from "types/limits";
 import MemoryLimitAvailable from "components/forms/MemoryLimitAvailable";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;

--- a/src/components/forms/MigrationForm.tsx
+++ b/src/components/forms/MigrationForm.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Select } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import type { MigrationFormValues } from "types/forms/instanceAndProfile";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";

--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -11,7 +11,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import type { LxdDeviceValue } from "types/device";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { fetchConfigOptions } from "api/server";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { toConfigFields } from "util/config";

--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -9,7 +9,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import type { LxdProxyDevice } from "types/device";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { getInheritedProxies } from "util/configInheritance";
 import ScrollableForm from "components/ScrollableForm";
 import RenameDeviceInput from "components/forms/RenameDeviceInput";

--- a/src/components/forms/ResourceLimitsForm.tsx
+++ b/src/components/forms/ResourceLimitsForm.tsx
@@ -9,7 +9,7 @@ import CpuLimitSelector from "./CpuLimitSelector";
 import type { CpuLimit, MemoryLimit } from "types/limits";
 import { cpuLimitToPayload, memoryLimitToPayload } from "util/limits";
 import { optionAllowDeny, diskPriorities } from "util/instanceOptions";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { DEFAULT_CPU_LIMIT, DEFAULT_MEM_LIMIT } from "util/defaults";
 import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";

--- a/src/components/forms/SecurityPoliciesForm.tsx
+++ b/src/components/forms/SecurityPoliciesForm.tsx
@@ -10,7 +10,7 @@ import {
   optionTrueFalse,
   optionYesNo,
 } from "util/instanceOptions";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 
 import {
   getConfigurationRow,

--- a/src/components/forms/SshKeyForm.tsx
+++ b/src/components/forms/SshKeyForm.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   usePortal,
 } from "@canonical/react-components";
-import type { InstanceAndProfileFormikProps } from "../../types/forms/instanceAndProfileFormProps";
+import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import type {
   InstanceAndProfileFormValues,
   SshKeyFormValues,


### PR DESCRIPTION
## Done

- fix(instance) ensure root size copy for containers is clear
- drive-by: fix imports

Fixes WD-34782

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check instance > configuration > disk for a container and vm. for vms should specify 10GB and for containers "not specified" as default size of the root disk

## Screenshots

<img width="3846" height="1918" alt="image" src="https://github.com/user-attachments/assets/1ea8335f-3a01-4cc3-b3ae-05099e2ef79d" />
