### PR TITLE
chore: follow up update circular deps check to 5 WD-36167

### DIFF
--- a/src/pages/instances/ImageLink.tsx
+++ b/src/pages/instances/ImageLink.tsx
@@ -1,0 +1,33 @@
+import type { FC } from "react";
+import type { LxdInstance } from "types/instance";
+import { useImagesInProject } from "context/useImages";
+import ResourceLink from "components/ResourceLink";
+import ResourceLabel from "components/ResourceLabel";
+import { ROOT_PATH } from "util/rootPath";
+
+interface Props {
+  instance: LxdInstance;
+}
+export const ImageLink: FC<Props> = ({ instance }) => {
+  const { data: images = [] } = useImagesInProject(instance.project);
+  const imageDescription = instance.config["image.description"];
+  const imageFound = images?.some(
+    (image) => image.properties?.description === imageDescription,
+  );
+
+  if (!imageDescription) {
+    return "-";
+  }
+
+  if (!imageFound) {
+    return <ResourceLabel type="image" value={imageDescription} />;
+  }
+
+  return (
+    <ResourceLink
+      type="image"
+      value={imageDescription}
+      to={`${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/images`}
+    />
+  );
+};

--- a/src/pages/instances/InstanceDetailPanelContent.tsx
+++ b/src/pages/instances/InstanceDetailPanelContent.tsx
@@ -14,7 +14,7 @@ import { useIsClustered } from "context/useIsClustered";
 import InstanceMACAddresses from "pages/instances/InstanceMACAddresses";
 import ResourceLink from "components/ResourceLink";
 import { getInstanceType } from "util/instances";
-import { getImageLink } from "util/instanceImage";
+import { ImageLink } from "pages/instances/ImageLink";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
 import DevicesSummaryList from "components/DevicesSummaryList";
 import type { LxdDevices } from "types/device";
@@ -61,7 +61,7 @@ const InstanceDetailPanelContent: FC<Props> = ({ instance }) => {
               className="u-truncate base-image"
               title={instance.config["image.description"]}
             >
-              {getImageLink(instance)}
+              <ImageLink instance={instance} />
             </div>
           </td>
         </tr>

--- a/src/pages/instances/InstanceOverview.tsx
+++ b/src/pages/instances/InstanceOverview.tsx
@@ -16,7 +16,7 @@ import type { LxdDevices } from "types/device";
 import ResourceLink from "components/ResourceLink";
 import { getIpAddresses } from "util/networks";
 import { getInstanceType } from "util/instances";
-import { getImageLink } from "util/instanceImage";
+import { ImageLink } from "pages/instances/ImageLink";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
 
 interface Props {
@@ -52,7 +52,9 @@ const InstanceOverview: FC<Props> = ({ instance }) => {
             <tbody>
               <tr>
                 <th className="u-text--muted">Base image</th>
-                <td>{getImageLink(instance)}</td>
+                <td>
+                  <ImageLink instance={instance} />
+                </td>
               </tr>
               <tr>
                 <th className="u-text--muted">Description</th>


### PR DESCRIPTION
## Done

-follow up update circular deps check to 5 and move getImageLink into a React component.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure circular deps check passes