### PR TITLE
feat(edit cluster member): Add roles

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -49,5 +49,6 @@ export const useSupportedFeatures = () => {
     hasInstanceBootMode: apiExtensions.has("instance_boot_mode"),
     hasProjectDeleteOperation: apiExtensions.has("project_delete_operation"),
     hasRemoteDropSource: apiExtensions.has("storage_remote_drop_source"),
+    hasClusteringControlPlane: apiExtensions.has("clustering_control_plane"),
   };
 };

--- a/src/pages/cluster/ClusterMemberOverview.tsx
+++ b/src/pages/cluster/ClusterMemberOverview.tsx
@@ -4,12 +4,17 @@ import ResourceLink from "components/ResourceLink";
 import type { LxdClusterMember } from "types/cluster";
 import ClusterMemberStatus from "pages/cluster/ClusterMemberStatus";
 import { ROOT_PATH } from "util/rootPath";
+import { getClusterMemberRolesList } from "util/clusterMember";
 
 interface Props {
   member: LxdClusterMember;
 }
 
 const ClusterMemberOverview: FC<Props> = ({ member }) => {
+  const { automaticRoles, customRoles } = getClusterMemberRolesList(
+    member.roles,
+  );
+
   return (
     <Row className="general">
       <Col size={3}>
@@ -37,12 +42,16 @@ const ClusterMemberOverview: FC<Props> = ({ member }) => {
               <td>{member.message}</td>
             </tr>
             <tr>
-              <th className="u-text--muted">Url</th>
+              <th className="u-text--muted">URL</th>
               <td>{member.url}</td>
             </tr>
             <tr>
-              <th className="u-text--muted">Roles</th>
-              <td>{member.roles.join(", ")}</td>
+              <th className="u-text--muted">Automatic roles</th>
+              <td>{automaticRoles}</td>
+            </tr>
+            <tr>
+              <th className="u-text--muted">Custom roles</th>
+              <td>{customRoles}</td>
             </tr>
             <tr>
               <th className="u-text--muted">Groups</th>

--- a/src/pages/cluster/ClusterMemberRichTooltip.tsx
+++ b/src/pages/cluster/ClusterMemberRichTooltip.tsx
@@ -13,6 +13,7 @@ import { queryKeys } from "util/queryKeys";
 import { formatSeconds } from "util/seconds";
 import ResourceLabel from "components/ResourceLabel";
 import { ROOT_PATH } from "util/rootPath";
+import { getClusterMemberRolesList } from "util/clusterMember";
 
 interface Props {
   clusterMember: string;
@@ -41,6 +42,10 @@ const ClusterMemberRichTooltip: FC<Props> = ({ clusterMember }) => {
       </>
     );
   }
+
+  const { automaticRoles, customRoles } = getClusterMemberRolesList(
+    member?.roles,
+  );
 
   const rows: TooltipRow[] = [
     {
@@ -81,9 +86,14 @@ const ClusterMemberRichTooltip: FC<Props> = ({ clusterMember }) => {
       valueTitle: member?.url || "",
     },
     {
-      title: "Roles",
-      value: member ? member.roles.join(", ") : "-",
-      valueTitle: member ? member.roles.join(", ") : "",
+      title: "Automatic roles",
+      value: automaticRoles,
+      valueTitle: automaticRoles,
+    },
+    {
+      title: "Custom roles",
+      value: customRoles,
+      valueTitle: customRoles,
     },
     {
       title: "Uptime",

--- a/src/pages/cluster/panels/ClusterMemberRolesSelector.tsx
+++ b/src/pages/cluster/panels/ClusterMemberRolesSelector.tsx
@@ -1,0 +1,67 @@
+import type { FC, ReactNode } from "react";
+import { MultiSelect } from "@canonical/react-components";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { classifyClusterMemberRoles } from "util/clusterMember";
+
+interface Props {
+  setSelectedRoles: (roles: string[]) => void;
+  selectedRoles: string[];
+  id?: string;
+  help?: ReactNode;
+  label?: string;
+}
+
+const ClusterMemberRolesSelector: FC<Props> = ({
+  setSelectedRoles,
+  selectedRoles,
+  id = "cluster-member-roles-selector",
+  help,
+  label = "Custom roles",
+}) => {
+  const { hasClusteringControlPlane } = useSupportedFeatures();
+
+  const ROLES = [
+    hasClusteringControlPlane ? "control-plane" : "event-hub",
+    "ovn-chassis",
+  ];
+
+  const {
+    automaticRoles: selectedAutomaticRoles,
+    customRoles: selectedCustomRoles,
+  } = classifyClusterMemberRoles(selectedRoles);
+
+  return (
+    <>
+      {label && <label htmlFor={id}>{label}</label>}
+      <MultiSelect
+        label={label}
+        items={ROLES.map((item) => {
+          return {
+            label: item,
+            value: item,
+          };
+        })}
+        selectedItems={selectedCustomRoles.map((item) => {
+          return {
+            label: item,
+            value: item,
+          };
+        })}
+        variant="condensed"
+        placeholder="Select custom roles"
+        onItemsUpdate={(items) => {
+          setSelectedRoles([
+            ...selectedAutomaticRoles,
+            ...items.map((item) => item.value as string),
+          ]);
+        }}
+        showDropdownFooter={false}
+        id={id}
+        help={help}
+        isSortedAlphabetically={false}
+      />
+    </>
+  );
+};
+
+export default ClusterMemberRolesSelector;

--- a/src/pages/cluster/panels/EditClusterMemberPanel.tsx
+++ b/src/pages/cluster/panels/EditClusterMemberPanel.tsx
@@ -20,12 +20,15 @@ import type { LxdClusterMember } from "types/cluster";
 import GroupSelection from "pages/permissions/panels/GroupSelection";
 import { useClusterGroups } from "context/useClusterGroups";
 import ClusterMemberRichChip from "../ClusterMemberRichChip";
+import ClusterMemberRolesSelector from "./ClusterMemberRolesSelector";
+import DocLink from "components/DocLink";
 
 export interface EditClusterMemberForm {
   name: string;
   description: string;
   failureDomain: string;
   groups: string[];
+  roles: string[];
 }
 
 interface Props {
@@ -52,6 +55,7 @@ const EditClusterMemberPanel: FC<Props> = ({ onClose }) => {
       description: member?.description ?? "",
       failureDomain: member?.failure_domain ?? "",
       groups: member?.groups ?? [],
+      roles: member?.roles ?? [],
     },
     enableReinitialize: true,
     onSubmit: (values) => {
@@ -60,7 +64,7 @@ const EditClusterMemberPanel: FC<Props> = ({ onClose }) => {
         description: values.description,
         failure_domain: values.failureDomain,
         groups: values.groups,
-        roles: member?.roles,
+        roles: values?.roles,
       } as LxdClusterMember;
 
       updateClusterMember(payload)
@@ -123,6 +127,17 @@ const EditClusterMemberPanel: FC<Props> = ({ onClose }) => {
               type="text"
               label="Failure domain"
               placeholder="Enter failure domain"
+            />
+            <ClusterMemberRolesSelector
+              selectedRoles={formik.values.roles}
+              setSelectedRoles={(roles) => {
+                formik.setFieldValue("roles", roles);
+              }}
+              help={
+                <DocLink docPath="/explanation/clusters/#member-roles">
+                  Learn more about cluster member roles
+                </DocLink>
+              }
             />
             <p className="u-sv-1">Cluster groups</p>
             <GroupSelection

--- a/src/util/clusterMember.ts
+++ b/src/util/clusterMember.ts
@@ -1,0 +1,34 @@
+export const isClusterMemberRoleAutomatic = (role: string) => {
+  return role.startsWith("database");
+};
+
+export const classifyClusterMemberRoles = (roles?: string[]) => {
+  if (!roles || roles.length === 0) {
+    return {
+      automaticRoles: [],
+      customRoles: [],
+    };
+  }
+
+  const automaticRoles = roles.filter((role) =>
+    isClusterMemberRoleAutomatic(role),
+  );
+  const customRoles = roles.filter(
+    (role) => !isClusterMemberRoleAutomatic(role),
+  );
+
+  return {
+    automaticRoles,
+    customRoles,
+  };
+};
+
+export const getClusterMemberRolesList = (roles?: string[]) => {
+  const { automaticRoles: automatic, customRoles: custom } =
+    classifyClusterMemberRoles(roles);
+
+  return {
+    automaticRoles: automatic.length > 0 ? automatic.join(", ") : "-",
+    customRoles: custom.length > 0 ? custom.join(", ") : "-",
+  };
+};


### PR DESCRIPTION
## Done

- Add cluster member role in EditClusterMemberPanel

Fixes #1859

## QA

### 🛠 Prerequisites
*Ensure your environment matches the following before testing:*

- [ ] **Environment:** Use the demo server (after we enable clustering) or a [local development build](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
- [ ] **Clustering:** Must be enabled. (To enable clustering in the UI, navigate to `Server` > `Clustering` -> `Enable clustering`).
- [ ] **Data State:** Ensure at least one cluster member is present and editable.

### 📝 QA steps
| Step | Action | Expected result |
| :--- | :--- | :--- |
| 1 | Open the **Edit cluster member** side panel. | The `Roles` section is now visible. |
| 2 | Check role state. | Current member roles are correctly pre-selected. |
| 3 | Attempt to toggle `database-*` roles. | `voter`, `leader`, and `standby` are **read-only/disabled**. |
| 4 | Toggle `control-plane` or `ovn-chassis`. | The checkboxes are interactive and hold their state. |
| 5 | Click **Save changes**. | Panel closes and changes are persisted (verify by re-opening). |

## 📸 Screenshots

### BEFORE
*Member roles are missing from the side panel.*
<img width="667" height="1045" alt="image" src="https://github.com/user-attachments/assets/2b6902e7-d884-401b-8e04-76f9f30a3c80" />

### AFTER
*Roles visible; read-only logic applied to database roles.*
<img width="667" height="1045" alt="image" src="https://github.com/user-attachments/assets/c0070d28-6833-49a9-b647-ab000a346197" />
<img width="667" height="1045" alt="image" src="https://github.com/user-attachments/assets/47be5485-5510-4dc6-9c26-bbe0dc428f8d" />

