### PR TITLE
feat(Instance terminal): add Ubuntu background

### DIFF
--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -29,37 +29,8 @@ import { getDefaultPayload } from "util/instanceTerminal";
 
 const XTERM_OPTIONS = {
   theme: {
-    background: "#292c2f",
+    background: "#300A24",
   },
-};
-
-const defaultPayload: TerminalConnectPayload = {
-  command: "su -l",
-  environment: [
-    {
-      key: "TERM",
-      value: "xterm-256color",
-    },
-    {
-      key: "HOME",
-      value: "/root",
-    },
-    {
-      key: "PATH",
-      value:
-        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/run/current-system/sw/bin",
-    },
-    {
-      key: "LANG",
-      value: "C.UTF-8",
-    },
-    {
-      key: "USER",
-      value: "root",
-    },
-  ],
-  user: 0,
-  group: 0,
 };
 
 interface Props {
@@ -78,8 +49,8 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
   const [dataWs, setDataWs] = useState<WebSocket | null>(null);
   const [controlWs, setControlWs] = useState<WebSocket | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [payload, setPayload] = useState(
-    getDefaultPayload(instance, defaultPayload),
+  const [payload, setPayload] = useState<TerminalConnectPayload>(() =>
+    getDefaultPayload(instance),
   );
   const [fitAddon] = useState<FitAddon>(new FitAddon());
   const [userInteracted, setUserInteracted] = useState(false);

--- a/src/sass/_pattern_terminal.scss
+++ b/src/sass/_pattern_terminal.scss
@@ -2,7 +2,7 @@
   height: calc(100dvh - 240px);
 
   .xterm .xterm-viewport {
-    background-color: #292c2f;
+    background-color: #300a24;
     overflow: hidden;
   }
 }

--- a/src/util/instanceTerminal.tsx
+++ b/src/util/instanceTerminal.tsx
@@ -1,16 +1,71 @@
 import type { LxdInstance } from "types/instance";
 import type { TerminalConnectPayload } from "types/terminal";
 
-export const getDefaultPayload = (
-  instance: LxdInstance,
-  defaultPayload: TerminalConnectPayload,
-) => {
+export const UI_TERMINAL_DEFAULT_PAYLOAD = "user.ui_terminal_default_payload";
+
+const BASH_DISTROS = ["ubuntu", "debian", "fedora"];
+
+const getCommand = (instance: LxdInstance): string => {
+  const os = instance.config["image.os"]?.toLowerCase() || "";
+
+  if (BASH_DISTROS.includes(os)) {
+    return "bash -il";
+  }
+
+  return "su -l";
+};
+
+const getEnvironment = (instance: LxdInstance) => {
+  const os = instance.config["image.os"]?.toLowerCase() || "";
+
+  const environment = [
+    {
+      key: "TERM",
+      value: "xterm-256color",
+    },
+    {
+      key: "HOME",
+      value: "/root",
+    },
+    {
+      key: "PATH",
+      value:
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/run/current-system/sw/bin",
+    },
+    {
+      key: "LANG",
+      value: "C.UTF-8",
+    },
+    {
+      key: "USER",
+      value: "root",
+    },
+  ];
+
+  if (BASH_DISTROS.includes(os)) {
+    environment.push({
+      key: "force_color_prompt",
+      value: "yes",
+    });
+  }
+
+  return environment;
+};
+
+const createDefaultPayload = (instance: LxdInstance) => {
+  return {
+    command: getCommand(instance),
+    environment: getEnvironment(instance),
+    user: 0,
+    group: 0,
+  };
+};
+
+export const getDefaultPayload = (instance: LxdInstance) => {
   const userPayload = instance.config[UI_TERMINAL_DEFAULT_PAYLOAD];
   if (userPayload) {
     return JSON.parse(userPayload) as TerminalConnectPayload;
   }
 
-  return defaultPayload;
+  return createDefaultPayload(instance);
 };
-
-export const UI_TERMINAL_DEFAULT_PAYLOAD = "user.ui_terminal_default_payload";


### PR DESCRIPTION
## Done

- Instance terminal: change background and prompt color to make the terminal more aligned with the Ubuntu terminal design
- No theming functionality was added: Ubuntu theme replaces the old theme.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a running instance > Terminal tab
    - The terminal should be Ubuntu themed.

## Screenshots

<img width="1554" height="1051" alt="image" src="https://github.com/user-attachments/assets/6d189486-5fa5-41da-b01f-03fe69fe0559" />

