### PR TITLE
feat: [WD-34755] Replace disabled input fields with muted text

### DIFF
--- a/src/components/OutputField.tsx
+++ b/src/components/OutputField.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+import { Field } from "@canonical/react-components";
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  help?: string;
+}
+
+const OutputField: FC<Props> = ({ id, label, value, help }) => {
+  return (
+    <Field
+      forId={id}
+      label={label}
+      help={help}
+      labelClassName="u-no-margin--bottom"
+      className="output-field"
+    >
+      <output id={id} className="mono-font u-sv2">
+        <b>{value}</b>
+      </output>
+    </Field>
+  );
+};
+
+export default OutputField;

--- a/src/pages/instances/forms/EditInstanceDetails.tsx
+++ b/src/pages/instances/forms/EditInstanceDetails.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Col, Input, Row, Select } from "@canonical/react-components";
+import { Col, Row, Select } from "@canonical/react-components";
 import ProfileSelector from "pages/profiles/ProfileSelector";
 import type { FormikProps } from "formik/dist/types";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
@@ -10,6 +10,7 @@ import SshKeyForm from "components/forms/SshKeyForm";
 import { useIsClustered } from "context/useIsClustered";
 import PlacementGroupSelect from "pages/instances/forms/PlacementGroupSelect";
 import { getInstanceField } from "util/instanceConfigFields";
+import OutputField from "components/OutputField";
 
 export const instanceEditDetailPayload = (values: EditInstanceFormValues) => {
   return {
@@ -38,18 +39,11 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
     <ScrollableForm>
       <Row>
         <Col size={12}>
-          <Input
+          <OutputField
             id="name"
-            name="name"
-            type="text"
             label="Name"
-            help="Click the instance name in the header to rename the instance"
-            placeholder="Enter name"
-            onBlur={formik.handleBlur}
-            onChange={formik.handleChange}
             value={formik.values.name}
-            error={formik.touched.name ? formik.errors.name : null}
-            disabled={true}
+            help="Click the instance name in the header to rename the instance"
           />
           <AutoExpandingTextArea
             id="description"

--- a/src/sass/_output_field.scss
+++ b/src/sass/_output_field.scss
@@ -1,0 +1,9 @@
+.output-field {
+  .p-form-help-text {
+    margin-top: -0.65rem;
+  }
+
+  .p-form__control {
+    margin-top: 0.25rem;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -126,6 +126,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "no_match";
 @import "not_found";
 @import "operation_list";
+@import "output_field";
 @import "page_header";
 @import "pattern_navigation";
 @import "pattern_terminal";


### PR DESCRIPTION
## Done

- Created a new read-only component to provide muted Name fields for entities whose names cannot be changed. This PR only covers Instances, however addition iterations should be made to cover all relevant entity types.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to the configuration page of an Instance and verify that the instance name in the config section cannot be changed and presents as displayed within the screenshot.

## Screenshots

<img width="1006" height="467" alt="image" src="https://github.com/user-attachments/assets/53325cfa-2733-4dfb-9ed2-4cb04f05a0c1" />