### PR TITLE
chore(test) fix test suite for lxc-ci

### DIFF
--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -21,7 +21,7 @@ export const restoreCertificateTrust = () => {
   runCommand("lxc config trust add keys/lxd-ui.crt");
 };
 
-const initAccessLink = () => {
+const initAccessLink = (baseUrl: string) => {
   const output = runCommand("lxd init --ui-initial-access-link");
   const urlMatch = output.match(/https?:\/\/[^\s]+/);
 
@@ -30,13 +30,11 @@ const initAccessLink = () => {
   }
 
   const originalUrl = new URL(urlMatch[0]);
-  // Replace the LXD direct port with your HAProxy dev port
-  const initialAccessLink = `https://localhost:8407/${originalUrl.search}`;
 
-  return initialAccessLink;
+  return `${baseUrl}${originalUrl.search}`;
 };
 
-export const visitInitialAccessLink = async (page: Page) => {
-  const initialAccessLink = initAccessLink();
+export const visitInitialAccessLink = async (page: Page, baseURL: string) => {
+  const initialAccessLink = initAccessLink(baseURL);
   await gotoURLWithNetworkIdle(page, initialAccessLink);
 };

--- a/tests/initial-access.spec.ts
+++ b/tests/initial-access.spec.ts
@@ -33,11 +33,17 @@ test.describe("Initial access with bearer token", () => {
 
   test("Should authenticate with bearer token and setup TLS", async ({
     page,
+    baseURL,
     lxdVersion,
   }) => {
     skipIfNotSupported(lxdVersion);
 
-    await visitInitialAccessLink(page);
+    if (!baseURL) {
+      test.fail(true, "Missing baseUrl from configuration");
+      return;
+    }
+
+    await visitInitialAccessLink(page, baseURL);
 
     await expect(page).toHaveURL(/\/ui\/project\/.*\/instances/);
     await expect(page.getByText("Initial access expires in")).toBeVisible();


### PR DESCRIPTION
## Done

- fix test suite for lxc-ci
- It uses the UI directly served via snap and not served as dev server

See https://github.com/canonical/lxd-ci/blob/f952fba72048ad187a84f94fd0f5a945f8a45106/tests/ui#L68 and https://github.com/canonical/lxd-ci/actions/runs/23477081907/job/68312050044