### PR TITLE
fix(form) spacing for overflowing checkbox highlight.

### DIFF
--- a/src/components/forms/ClusteredDiskSizeSelector.tsx
+++ b/src/components/forms/ClusteredDiskSizeSelector.tsx
@@ -53,19 +53,17 @@ const ClusteredDiskSizeSelector: FC<Props> = ({
   return (
     <div className="u-sv3">
       <Label forId="sizePerClusterMember">Size</Label>
-      {
-        <CheckboxInput
-          id={`${id}-same-for-all-toggle`}
-          label="Same for all cluster members"
-          checked={!isSpecific}
-          onChange={() => {
-            setValueForAllMembers(firstValue);
-            setIsSpecific((val) => !val);
-          }}
-          disabled={!!disabledReason}
-          title={disabledReason}
-        />
-      }
+      <CheckboxInput
+        id={`${id}-same-for-all-toggle`}
+        label="Same for all cluster members"
+        checked={!isSpecific}
+        onChange={() => {
+          setValueForAllMembers(firstValue);
+          setIsSpecific((val) => !val);
+        }}
+        disabled={!!disabledReason}
+        title={disabledReason}
+      />
       {isSpecific && (
         <div className="cluster-specific-input">
           {memberNames.map((item) => {

--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -180,18 +180,20 @@ const ProfileSelector: FC<Props> = ({
         </div>
       ))}
       {!readOnly && (
-        <Button
-          id="addProfileButton"
-          disabled={!!disabledReason || unselected.length === 0}
-          className="profile-add-btn"
-          onClick={addProfile}
-          type="button"
-          title={disabledReason}
-          hasIcon
-        >
-          <Icon name="plus" />
-          <span>Add profile</span>
-        </Button>
+        <div>
+          <Button
+            id="addProfileButton"
+            disabled={!!disabledReason || unselected.length === 0}
+            className="profile-add-btn"
+            onClick={addProfile}
+            type="button"
+            title={disabledReason}
+            hasIcon
+          >
+            <Icon name="plus" />
+            <span>Add profile</span>
+          </Button>
+        </div>
       )}
     </>
   );

--- a/src/pages/storage/CustomVolumeSelectModal.tsx
+++ b/src/pages/storage/CustomVolumeSelectModal.tsx
@@ -187,7 +187,10 @@ const CustomVolumeSelectModal: FC<Props> = ({
         />
       </ScrollableTable>
       {!isLoading && (
-        <footer className="p-modal__footer" id="modal-footer">
+        <footer
+          className="p-modal__footer create-volume-modal-footer"
+          id="modal-footer"
+        >
           <Button
             className="u-no-margin--bottom"
             onClick={onCancel}

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -168,31 +168,33 @@ const StorageVolumeFormMain: FC<Props> = ({
         </Col>
       </Row>
       {formik.values.content_type === "filesystem" && (
-        <ConfigurationTable
-          rows={[
-            getConfigurationRow({
-              formik,
-              label: "Security shifted",
-              name: "security_shifted",
-              defaultValue: "",
-              disabled: formik.values.security_unmapped === "true",
-              disabledReason:
-                "This setting can't be changed while security unmapped is set to true",
-              children: <Select options={optionTrueFalse} />,
-            }),
+        <div>
+          <ConfigurationTable
+            rows={[
+              getConfigurationRow({
+                formik,
+                label: "Security shifted",
+                name: "security_shifted",
+                defaultValue: "",
+                disabled: formik.values.security_unmapped === "true",
+                disabledReason:
+                  "This setting can't be changed while security unmapped is set to true",
+                children: <Select options={optionTrueFalse} />,
+              }),
 
-            getConfigurationRow({
-              formik,
-              label: "Security unmapped",
-              name: "security_unmapped",
-              defaultValue: "",
-              disabled: formik.values.security_shifted === "true",
-              disabledReason:
-                "This setting can't be changed while security shifted is set to true",
-              children: <Select options={optionTrueFalse} />,
-            }),
-          ]}
-        />
+              getConfigurationRow({
+                formik,
+                label: "Security unmapped",
+                name: "security_unmapped",
+                defaultValue: "",
+                disabled: formik.values.security_shifted === "true",
+                disabledReason:
+                  "This setting can't be changed while security shifted is set to true",
+                children: <Select options={optionTrueFalse} />,
+              }),
+            ]}
+          />
+        </div>
       )}
     </ScrollableForm>
   );

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -383,6 +383,18 @@
   }
 }
 
+.form-contents:has(.content-details > .row) {
+  padding-left: 0;
+
+  .content-details {
+    max-width: 56.5rem;
+
+    > * {
+      padding-left: 2.5rem;
+    }
+  }
+}
+
 .edit-instance {
   .form-footer {
     .bottom-btns {

--- a/src/sass/_storage_volume_form.scss
+++ b/src/sass/_storage_volume_form.scss
@@ -21,4 +21,8 @@
     min-height: 100%;
     padding-bottom: 0;
   }
+
+  .create-volume-modal-footer {
+    padding-bottom: 1rem;
+  }
 }


### PR DESCRIPTION
## Done

-  fix spacing for overflowing checkbox highlight.
-  fix spacing for footer in volume creation in modal during instance edit/create.


Fixes #1862

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create/edit an instance/profile/network/storage pool/storage volume and ensure the spacing in the configuration form is correct
    - Start a storage pool creation in a clustered environment. Ensure the outline of the "cluster member specific" input checkbox is not cut off on the left side
    - Start to edit/create and instance/profile and go to "devices" > "disk" > "attach a disk device" > "custom volume". Ensure the "create a volume" button has correct bottom padding.

## Screenshots

Before:

<img width="3110" height="1898" alt="image" src="https://github.com/user-attachments/assets/f48d3812-eae5-4169-bfa4-1d1e5e401888" />


After:

<img width="3110" height="1898" alt="image" src="https://github.com/user-attachments/assets/c7aeaab9-6300-4f05-bf1b-f1beb29d7dfe" />

Before:

<img width="3850" height="1896" alt="image" src="https://github.com/user-attachments/assets/d9b1e117-7ac1-49ab-96e7-31b3a8d53b6b" />

After:

<img width="3850" height="1896" alt="image" src="https://github.com/user-attachments/assets/bc5f0675-f8db-4d2e-8beb-6f165318d737" />
