### PR TITLE
feat: [WD-34915] Make Admin groups immutable

### DIFF
--- a/src/pages/permissions/actions/GroupActions.tsx
+++ b/src/pages/permissions/actions/GroupActions.tsx
@@ -4,6 +4,7 @@ import type { LxdAuthGroup } from "types/permissions";
 import usePanelParams from "util/usePanelParams";
 import DeleteGroupModal from "./DeleteGroupModal";
 import { useGroupEntitlements } from "util/entitlements/groups";
+import { isAdminGroup } from "util/permissionGroups";
 
 interface Props {
   group: LxdAuthGroup;
@@ -13,6 +14,16 @@ const GroupActions: FC<Props> = ({ group }) => {
   const panelParams = usePanelParams();
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const { canDeleteGroup, canEditGroup } = useGroupEntitlements();
+
+  const getTitle = () => {
+    if (isAdminGroup(group)) {
+      return "Admins group cannot be deleted";
+    }
+    if (canDeleteGroup(group)) {
+      return "Delete group";
+    }
+    return "Delete group - You do not have permission to delete this group";
+  };
 
   return (
     <>
@@ -45,12 +56,8 @@ const GroupActions: FC<Props> = ({ group }) => {
             hasIcon
             onClick={openPortal}
             type="button"
-            title={
-              canDeleteGroup(group)
-                ? "Delete group"
-                : "Delete group - You do not have permission to delete this group"
-            }
-            disabled={!canDeleteGroup(group)}
+            title={getTitle()}
+            disabled={isAdminGroup(group) || !canDeleteGroup(group)}
           >
             <Icon name="delete" />
           </Button>,

--- a/src/pages/permissions/forms/GroupForm.tsx
+++ b/src/pages/permissions/forms/GroupForm.tsx
@@ -8,6 +8,7 @@ import { pluralize } from "util/instanceBulkActions";
 import type { LxdAuthGroup } from "types/permissions";
 import { useGroupEntitlements } from "util/entitlements/groups";
 import type { PermissionGroupFormValues } from "types/forms/permissionGroup";
+import { isAdminGroup } from "util/permissionGroups";
 
 interface Props {
   formik: FormikProps<PermissionGroupFormValues>;
@@ -57,12 +58,17 @@ const GroupForm: FC<Props> = ({
       return groupEditRestriction;
     }
 
+    if (group && isAdminGroup(group)) {
+      return "Admins group cannot be modified";
+    }
+
     if (isNameInvalid) {
       return "Enter a valid group name first";
     }
 
     return undefined;
   };
+
   const disableReason = getDisableReason();
 
   const getPermissionsTitle = () => {
@@ -85,13 +91,13 @@ const GroupForm: FC<Props> = ({
         label="Name"
         required
         autoFocus
-        disabled={!!groupEditRestriction}
-        title={groupEditRestriction}
+        disabled={!!groupEditRestriction || isAdminGroup(group)}
+        title={groupEditRestriction || disableReason}
       />
       <AutoExpandingTextArea
         {...getFormProps("description")}
         label="Description"
-        disabled={isFieldDisabled}
+        disabled={isFieldDisabled || isAdminGroup(group)}
         title={disableReason}
       />
       <FormLink

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -17,7 +17,7 @@ import type { PermissionGroupFormValues } from "types/forms/permissionGroup";
 import GroupForm from "../forms/GroupForm";
 import { renameGroup, updateGroup } from "api/auth-groups";
 import { queryKeys } from "util/queryKeys";
-import { testDuplicateGroupName } from "util/permissionGroups";
+import { isAdminGroup, testDuplicateGroupName } from "util/permissionGroups";
 import NotificationRow from "components/NotificationRow";
 import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
 import classnames from "classnames";
@@ -176,7 +176,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
     };
 
     const mutation = async () => {
-      if (!canEditGroup(group)) {
+      if (!canEditGroup(group) || isAdminGroup(group)) {
         return saveIdentities(originalGroupName);
       }
 

--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -21,6 +21,7 @@ import type { LxdAuthGroup } from "types/permissions";
 import { useServerEntitlements } from "util/entitlements/server";
 import { useGroupEntitlements } from "util/entitlements/groups";
 import type { FormPermission } from "types/forms/permissionGroup";
+import { isAdminGroup } from "util/permissionGroups";
 
 interface Props {
   permissions: FormPermission[];
@@ -45,6 +46,10 @@ const EditGroupPermissionsForm: FC<Props> = ({
 
     if (!canViewPermissions()) {
       return "You are not allowed to view permissions";
+    }
+
+    if (isAdminGroup(group)) {
+      return "Permissions for this group cannot be modified";
     }
 
     return "";

--- a/src/pages/permissions/panels/PermissionSelector.tsx
+++ b/src/pages/permissions/panels/PermissionSelector.tsx
@@ -22,6 +22,7 @@ import type { LxdPermission } from "types/permissions";
 import type { SelectRef } from "@canonical/react-components/dist/components/CustomSelect/CustomSelect";
 import { useImagesInAllProjects } from "context/useImages";
 import { useIdentities } from "context/useIdentities";
+import classNames from "classnames";
 
 interface Props {
   onAddPermission: (permission: FormPermission) => void;
@@ -179,7 +180,9 @@ const PermissionSelector: FC<Props> = ({ onAddPermission, disableReason }) => {
 
   return (
     <div
-      className="permission-selector"
+      className={classNames("permission-selector", {
+        "dropdown-disabled": !!disableReason,
+      })}
       tabIndex={0}
       ref={permissionSelectorRef}
       title={disableReason}

--- a/src/sass/_permission_groups.scss
+++ b/src/sass/_permission_groups.scss
@@ -90,6 +90,10 @@
     gap: 1rem;
     justify-content: space-evenly;
 
+    .dropdown-disabled * {
+      cursor: not-allowed;
+    }
+
     // wrap the permission input to columnar on small screens
     @media screen and (width < 730px) {
       align-items: inherit;

--- a/src/util/permissionGroups.tsx
+++ b/src/util/permissionGroups.tsx
@@ -5,6 +5,8 @@ import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
 import type { ChangeSummary } from "./permissionIdentities";
 import { getIdentityName } from "./permissionIdentities";
 
+export const isAdminGroup = (group?: LxdAuthGroup) => group?.name === "admins";
+
 export const testDuplicateGroupName = (
   controllerState: AbortControllerState,
   excludeName?: string,


### PR DESCRIPTION
## Done

- Make admin groups immutable
- [x] Disable deletion of admins row, with explanatory hover text.
- [x] Disable selection of new permissions
- [x] ~~Split Group + Edit Identity API calls so that you can still edit the admins inside the admins group.~~ @kimanhou made aseaparate PR to address this.

Note, my admin group is called "admins". Confirm whether this is the default group name or if I have a custom one.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to Permissions > Groups
    - Observe that the above checkbox interactions behave as expected.

## Screenshots

<img width="810" height="270" alt="image" src="https://github.com/user-attachments/assets/9b0c4e83-db33-4912-94ee-589f110b526f" />


Fixes https://github.com/canonical/lxd/issues/17986