### PR TITLE
fix(storage pool): rely on operation when api extension is present

### DIFF
--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -38,3 +38,44 @@ export const cancelOperation = async (id: string): Promise<void> => {
     method: "DELETE",
   }).then(handleResponse);
 };
+
+export const waitForOperation = async (
+  id: string,
+  member?: string,
+  maxTimeoutMs = 120000,
+): Promise<void> => {
+  const endpoint = `${ROOT_PATH}/1.0/operations/${encodeURIComponent(id)}`;
+  const startTime = Date.now();
+  const memberPrefix = member ? `Member: ${member} - ` : "";
+
+  while (true) {
+    try {
+      const response = (await fetch(endpoint).then(
+        handleResponse,
+      )) as LxdApiResponse<LxdOperation>;
+      const operation = response.metadata;
+
+      if (operation.status_code === 200) {
+        return;
+      }
+
+      if (operation.status_code >= 400) {
+        throw new Error(
+          `${operation.err || `Operation ${id} failed with status ${operation.status}`}`,
+        );
+      }
+    } catch (error) {
+      // Add memberPrefix to all other errors before re-throwing
+      if (error instanceof Error) {
+        throw new Error(`${memberPrefix}${error.message}`);
+      }
+      throw new Error(`${memberPrefix}Unknown error occurred`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    if (Date.now() - startTime > maxTimeoutMs) {
+      throw new Error(`${memberPrefix}Operation timed out.`);
+    }
+  }
+};

--- a/src/api/storage-pools.tsx
+++ b/src/api/storage-pools.tsx
@@ -2,7 +2,6 @@ import {
   constructMemberError,
   handleEtagResponse,
   handleResponse,
-  handleSettledResult,
 } from "util/helpers";
 import type {
   LxdStoragePool,
@@ -12,9 +11,11 @@ import type {
 import type { LxdApiResponse } from "types/apiResponse";
 import type { LxdClusterMember } from "types/cluster";
 import type { ClusterSpecificValues } from "types/cluster";
+import type { LxdOperationResponse } from "types/operation";
 import { addEntitlements } from "util/entitlements/api";
 import { addTarget } from "util/target";
 import { ROOT_PATH } from "util/rootPath";
+import { waitForOperation } from "api/operations";
 
 export const storagePoolEntitlements = ["can_edit", "can_delete"];
 
@@ -101,17 +102,21 @@ export const fetchClusteredStoragePoolResources = async (
 export const createPool = async (
   pool: Partial<LxdStoragePool>,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   addTarget(params, target);
 
-  await fetch(`${ROOT_PATH}/1.0/storage-pools?${params.toString()}`, {
+  return fetch(`${ROOT_PATH}/1.0/storage-pools?${params.toString()}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(pool),
-  }).then(handleResponse);
+  })
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 const getClusterAndMemberPoolPayload = (pool: LxdStoragePool) => {
@@ -146,13 +151,15 @@ const getClusterAndMemberPoolPayload = (pool: LxdStoragePool) => {
 export const createClusteredPool = async (
   pool: LxdStoragePool,
   clusterMembers: LxdClusterMember[],
+  hasStorageAndNetworkOperations: boolean,
   sourcePerClusterMember?: ClusterSpecificValues,
   zfsPoolNamePerClusterMember?: ClusterSpecificValues,
   sizePerClusterMember?: ClusterSpecificValues,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const { memberPoolPayload, clusterPoolPayload } =
     getClusterAndMemberPoolPayload(pool);
-  return Promise.allSettled(
+
+  const operations = await Promise.allSettled(
     clusterMembers.map(async (item) => {
       const clusteredMemberPool = {
         ...memberPoolPayload,
@@ -163,23 +170,37 @@ export const createClusteredPool = async (
           "zfs.pool_name": zfsPoolNamePerClusterMember?.[item.server_name],
         },
       };
-      return createPool(clusteredMemberPool, item.server_name);
+      const operation = await createPool(clusteredMemberPool, item.server_name);
+      return { operation, member: item.server_name };
     }),
-  )
-    .then(handleSettledResult)
-    .then(async () => {
-      return createPool(clusterPoolPayload);
-    });
+  );
+
+  const pendingOperations = operations.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
+  });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation, member }) => {
+        await waitForOperation(operation.metadata.id, member);
+      }),
+    );
+  }
+
+  return createPool(clusterPoolPayload);
 };
 
 export const updatePool = async (
   pool: LxdStoragePool,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool.name)}?${params.toString()}`,
     {
       method: "PATCH",
@@ -188,19 +209,25 @@ export const updatePool = async (
       },
       body: JSON.stringify(pool),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const updateClusteredPool = async (
   pool: LxdStoragePool,
   clusterMembers: LxdClusterMember[],
+  hasStorageAndNetworkOperations: boolean,
   sourcePerClusterMember?: ClusterSpecificValues,
   zfsPoolNamePerClusterMember?: ClusterSpecificValues,
   sizePerClusterMember?: ClusterSpecificValues,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const { memberPoolPayload, clusterPoolPayload } =
     getClusterAndMemberPoolPayload(pool);
-  return Promise.allSettled(
+
+  const results = await Promise.allSettled(
     clusterMembers.map(async (item) => {
       const clusteredMemberPool = {
         ...memberPoolPayload,
@@ -220,32 +247,61 @@ export const updateClusteredPool = async (
         clusteredMemberPool.config["zfs.pool_name"] =
           zfsPoolNamePerClusterMember[item.server_name];
       }
-      return updatePool(clusteredMemberPool, item.server_name);
+      const operation = await updatePool(clusteredMemberPool, item.server_name);
+      return { operation, member: item.server_name };
     }),
-  )
-    .then(handleSettledResult)
-    .then(async () => updatePool(clusterPoolPayload));
+  );
+
+  const pendingOperations = results.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
+  });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation, member }) => {
+        await waitForOperation(operation.metadata.id, member);
+      }),
+    );
+  }
+
+  return updatePool(clusterPoolPayload);
 };
 
 export const renameStoragePool = async (
   oldName: string,
   newName: string,
-): Promise<void> => {
-  await fetch(`${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(oldName)}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
+): Promise<LxdOperationResponse> => {
+  return fetch(
+    `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(oldName)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: newName,
+      }),
     },
-    body: JSON.stringify({
-      name: newName,
-    }),
-  }).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
-export const deleteStoragePool = async (pool: string): Promise<void> => {
-  await fetch(`${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}`, {
+export const deleteStoragePool = async (
+  pool: string,
+): Promise<LxdOperationResponse> => {
+  return fetch(`${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}`, {
     method: "DELETE",
-  }).then(handleResponse);
+  })
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const fetchPoolFromClusterMembers = async (

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -50,5 +50,8 @@ export const useSupportedFeatures = () => {
     hasProjectDeleteOperation: apiExtensions.has("project_delete_operation"),
     hasRemoteDropSource: apiExtensions.has("storage_remote_drop_source"),
     hasClusteringControlPlane: apiExtensions.has("clustering_control_plane"),
+    hasStorageAndNetworkOperations: apiExtensions.has(
+      "storage_and_network_operations",
+    ),
   };
 };

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -33,6 +33,7 @@ import YamlSwitch from "components/forms/YamlSwitch";
 import StoragePoolRichChip from "./StoragePoolRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 const CreateStoragePool: FC = () => {
   const navigate = useNavigate();
@@ -43,7 +44,9 @@ const CreateStoragePool: FC = () => {
   const [section, setSection] = useState(slugify(MAIN_CONFIGURATION));
   const controllerState = useState<AbortController | null>(null);
   const { data: clusterMembers = [] } = useClusterMembers();
-  const { hasRemoteDropSource } = useSupportedFeatures();
+  const { hasRemoteDropSource, hasStorageAndNetworkOperations } =
+    useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   if (!project) {
     return <>Missing project</>;
@@ -54,6 +57,33 @@ const CreateStoragePool: FC = () => {
       .test(...testDuplicateStoragePoolName(project, controllerState))
       .required("This field is required"),
   });
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage],
+    });
+  };
+
+  const onSuccess = (storagePoolName: string) => {
+    invalidateCache();
+    navigate(
+      `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
+    );
+    formik.setSubmitting(false);
+    toastNotify.success(
+      <>
+        Storage pool{" "}
+        <StoragePoolRichChip poolName={storagePoolName} projectName={project} />{" "}
+        created.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure("Creation of storage pool failed", e);
+  };
 
   const formik = useFormik<StoragePoolFormValues>({
     initialValues: {
@@ -78,6 +108,7 @@ const CreateStoragePool: FC = () => {
               createClusteredPool(
                 storagePool,
                 clusterMembers,
+                hasStorageAndNetworkOperations,
                 values.sourcePerClusterMember,
                 values.zfsPoolNamePerClusterMember,
                 values.sizePerClusterMember,
@@ -85,27 +116,33 @@ const CreateStoragePool: FC = () => {
           : async () => createPool(storagePool);
 
       mutation()
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [queryKeys.storage],
-          });
-          navigate(
-            `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
-          );
-          toastNotify.success(
-            <>
-              Storage pool{" "}
-              <StoragePoolRichChip
-                poolName={storagePool.name}
-                projectName={project}
-              />{" "}
-              created.
-            </>,
-          );
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of storage pool{" "}
+                <StoragePoolRichChip
+                  poolName={storagePool.name}
+                  projectName={project}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(storagePool.name);
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(storagePool.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure("Storage pool creation failed", e);
+          onFailure(e);
         });
     },
   });

--- a/src/pages/storage/EditStoragePool.tsx
+++ b/src/pages/storage/EditStoragePool.tsx
@@ -32,6 +32,8 @@ import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import { useStoragePoolEntitlements } from "util/entitlements/storage-pools";
 import { usePoolFromClusterMembers } from "context/useStoragePools";
 import StoragePoolRichChip from "./StoragePoolRichChip";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   pool: LxdStoragePool;
@@ -51,6 +53,8 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
   const { data: clusterMembers = [] } = useClusterMembers();
   const [version, setVersion] = useState(0);
   const { canEditPool } = useStoragePoolEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   if (!project) {
     return <>Missing project</>;
@@ -82,6 +86,50 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
     ? undefined
     : "You do not have permission to edit this pool";
 
+  const invalidateCache = (values: StoragePoolFormValues) => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage],
+      predicate: (query) =>
+        query.queryKey[0] === queryKeys.volumes ||
+        query.queryKey[0] === queryKeys.storage,
+    });
+    if (pool.driver === cephDriver && values.ceph_rbd_du === "false") {
+      // Clear the storage volume sizes from the cache. The sizes are not available
+      // after disabling `ceph_rbd_du` and the volume state queries will fail. So we
+      // remove the queries to avoid serving the size from a stale cache.
+      queryClient.removeQueries({
+        predicate: (query) =>
+          query.queryKey[0] === queryKeys.storage &&
+          query.queryKey[1] === pool.name,
+      });
+    }
+  };
+
+  const onSuccess = (
+    storagePoolName: string,
+    values: StoragePoolFormValues,
+  ) => {
+    invalidateCache(values);
+    formik.setSubmitting(false);
+    toastNotify.success(
+      <>
+        Storage pool{" "}
+        <StoragePoolRichChip poolName={storagePoolName} projectName={project} />{" "}
+        updated.
+      </>,
+    );
+  };
+
+  const onFailure = (
+    values: StoragePoolFormValues,
+    storagePoolName: string,
+    e: unknown,
+  ) => {
+    invalidateCache(values);
+    formik.setSubmitting(false);
+    toastNotify.failure(`Update of storage pool ${storagePoolName} failed`, e);
+  };
+
   const formik = useFormik<StoragePoolFormValues>({
     initialValues: toStoragePoolFormValues(
       pool,
@@ -101,6 +149,7 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
               updateClusteredPool(
                 savedPool,
                 clusterMembers,
+                hasStorageAndNetworkOperations,
                 values.sourcePerClusterMember,
                 values.zfsPoolNamePerClusterMember,
                 values.sizePerClusterMember,
@@ -108,39 +157,33 @@ const EditStoragePool: FC<Props> = ({ pool }) => {
           : async () => updatePool(savedPool);
 
       mutation()
-        .then(() => {
-          toastNotify.success(
-            <>
-              Storage pool{" "}
-              <StoragePoolRichChip
-                poolName={savedPool.name}
-                projectName={project}
-              />{" "}
-              updated.
-            </>,
-          );
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of storage pool{" "}
+                <StoragePoolRichChip
+                  poolName={savedPool.name}
+                  projectName={project}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(savedPool.name, values);
+              },
+              (msg) => {
+                onFailure(values, savedPool.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(savedPool.name, values);
+          }
         })
         .catch((e) => {
-          notify.failure("Storage pool update failed", e);
-        })
-        .finally(() => {
-          formik.setSubmitting(false);
-          queryClient.invalidateQueries({
-            queryKey: [queryKeys.storage],
-            predicate: (query) =>
-              query.queryKey[0] === queryKeys.volumes ||
-              query.queryKey[0] === queryKeys.storage,
-          });
-          if (pool.driver === cephDriver && values.ceph_rbd_du === "false") {
-            // Clear the storage volume sizes from the cache. The sizes are not available
-            // after disabling `ceph_rbd_du` and the volume state queries will fail. So we
-            // remove the queries to avoid serving the size from a stale cache.
-            queryClient.removeQueries({
-              predicate: (query) =>
-                query.queryKey[0] === queryKeys.storage &&
-                query.queryKey[1] === pool.name,
-            });
-          }
+          onFailure(values, savedPool.name, e);
         });
     },
   });

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -11,6 +11,8 @@ import { useFormik } from "formik";
 import { renameStoragePool } from "api/storage-pools";
 import { ROOT_PATH } from "util/rootPath";
 import StoragePoolRichChip from "./StoragePoolRichChip";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   name: string;
@@ -23,12 +25,25 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
       .test(...testDuplicateStoragePoolName(project, controllerState))
       .required("This field is required"),
   });
+
+  const onSuccess = (poolName: string) => {
+    const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(poolName)}`;
+    navigate(url);
+    toastNotify.success(
+      <>
+        Storage pool <strong>{name}</strong> renamed to{" "}
+        <StoragePoolRichChip poolName={poolName} projectName={project} />
+      </>,
+    );
+  };
 
   const formik = useFormik<RenameHeaderValues>({
     initialValues: {
@@ -43,18 +58,34 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
         return;
       }
       renameStoragePool(name, values.name)
-        .then(() => {
-          const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(values.name)}`;
-          navigate(url);
-          toastNotify.success(
-            <>
-              Storage pool <strong>{name}</strong> renamed to{" "}
-              <StoragePoolRichChip
-                poolName={values.name}
-                projectName={project}
-              />
-            </>,
-          );
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Renaming of storage pool{" "}
+                <StoragePoolRichChip
+                  poolName={values.name}
+                  projectName={project}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) =>
+                toastNotify.failure(
+                  `Renaming of storage pool ${values.name} failed`,
+
+                  new Error(msg),
+                ),
+            );
+          } else {
+            onSuccess(values.name);
+          }
+
           formik.setFieldValue("isRenaming", false);
         })
         .catch((e) => {
@@ -85,7 +116,8 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
           shouldExpand
         />,
       ]}
-      isLoaded
+      isLoaded={Boolean(pool)}
+      formik={formik}
       renameDisabledReason="Cannot rename storage pools"
     />
   );

--- a/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
+++ b/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
@@ -16,6 +16,9 @@ import { queryKeys } from "util/queryKeys";
 import ResourceLabel from "components/ResourceLabel";
 import { useStoragePoolEntitlements } from "util/entitlements/storage-pools";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
+import StoragePoolRichChip from "../StoragePoolRichChip";
 
 interface Props {
   pool: LxdStoragePool;
@@ -35,27 +38,66 @@ const DeleteStoragePoolBtn: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
   const { canDeletePool } = useStoragePoolEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
+  const notifySuccess = (poolName: string) => {
+    toastNotify.success(
+      <>
+        Storage pool <ResourceLabel bold type="pool" value={poolName} />{" "}
+        deleted.
+      </>,
+    );
+  };
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+    navigate(
+      `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
+    );
+    notifySuccess(pool.name);
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(`Deleting storage pool ${pool.name} failed`, e);
+  };
 
   const handleDelete = () => {
     setLoading(true);
     deleteStoragePool(pool.name)
-      .then(() => {
-        queryClient.invalidateQueries({
-          queryKey: [queryKeys.storage],
-        });
-        navigate(
-          `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
-        );
-        toastNotify.success(
-          <>
-            Storage pool <ResourceLabel bold type="pool" value={pool.name} />{" "}
-            deleted.
-          </>,
-        );
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of storage pool{" "}
+              <StoragePoolRichChip poolName={pool.name} projectName={project} />{" "}
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              setLoading(false);
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
       .catch((e) => {
-        setLoading(false);
-        notify.failure("Storage pool deletion failed", e);
+        onFailure(e);
       });
   };
 

--- a/src/types/operation.d.ts
+++ b/src/types/operation.d.ts
@@ -21,7 +21,7 @@ export interface LxdOperation {
     storage_volume_snapshots?: string[];
   };
   status: LxdOperationStatus;
-  status_code: string;
+  status_code: number;
   updated_at: string;
 }
 


### PR DESCRIPTION
## Done

- fix(storage pool): rely on operation when api extension `storage_and_network_operations` is present
- Affected methods:  `createPool`, `createClusteredPool`, `updatePool`, `updateClusteredPool`, `renameStoragePool` and `deleteStoragePool`.

Follow up of https://github.com/canonical/lxd/pull/17955

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps and for each step, make sure the action is performed successfully and that 2 notifications (started and success) are displayed correctly:
    - Create pool
    - Create pool in a cluster
    - Update pool
    - Update clustered pool
    - Rename pool
    - Delete pool
_Note: QA cannot be performed on the demo server, as the demo server doesn't have clustering enabled. Reviewers have to check out the branch locally._

## Screenshots
<img width="1559" height="1050" alt="image" src="https://github.com/user-attachments/assets/ca65b9d7-fe34-4674-8f01-3dc47fd08cd1" />
