### PR TITLE
feat(instance terminal and console): add icons for fullscreen and iso

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -10,7 +10,7 @@ const Title: FC<PropsWithChildren> = ({ children }) => {
 
 const Search: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="page-header__search margin-right u-no-margin--bottom">
+    <div className="page-header__search margin-right--large u-no-margin--bottom">
       {children}
     </div>
   );

--- a/src/components/forms/GPUDeviceInput.tsx
+++ b/src/components/forms/GPUDeviceInput.tsx
@@ -19,7 +19,7 @@ const GpuDeviceInput: FC<Props> = ({ device, onChange, disableReason }) => {
       <div className="u-sv1">
         <RadioInput
           inline
-          labelClassName="margin-right"
+          labelClassName="margin-right--large"
           label="ID"
           checked={!isPci}
           onClick={() => {

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -118,7 +118,9 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
                 onClick={() => {
                   handleFullScreen();
                 }}
+                hasIcon
               >
+                <Icon name="fullscreen" />
                 <span>Fullscreen</span>
               </Button>
               <InstanceConsoleShortcuts disabled={!isRunning} />

--- a/src/pages/instances/InstanceSnapshots.tsx
+++ b/src/pages/instances/InstanceSnapshots.tsx
@@ -205,7 +205,7 @@ const InstanceSnapshots = (props: Props) => {
               <div className="search-box-wrapper">
                 <SearchBox
                   name="search-snapshot"
-                  className="search-box margin-right"
+                  className="search-box margin-right--large"
                   type="text"
                   onChange={(value) => {
                     setQuery(value);

--- a/src/pages/instances/InstanceTerminal.tsx
+++ b/src/pages/instances/InstanceTerminal.tsx
@@ -265,8 +265,10 @@ const InstanceTerminal: FC<Props> = ({ instance, refreshInstance }) => {
               className="u-no-margin--bottom"
               onClick={handleFullscreen}
               disabled={isLoading || !controlWs}
+              hasIcon
             >
-              Fullscreen
+              <Icon name="fullscreen" />
+              <span>Fullscreen</span>
             </Button>
             <ReconnectTerminalBtn
               reconnect={setPayload}

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -177,7 +177,7 @@ const TerminalPayloadForm: FC<Props> = ({
           onDismiss={() => {
             setNotification(null);
           }}
-          className="margin-right"
+          className="margin-right--large"
         >
           {notification.message}
         </Notification>

--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -7,6 +7,7 @@ import {
   ActionButton,
   useToastNotification,
   usePortal,
+  Icon,
 } from "@canonical/react-components";
 import { getInstanceEditValues, getInstancePayload } from "util/instanceEdit";
 import { useQueryClient } from "@tanstack/react-query";
@@ -145,7 +146,7 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
 
   return attachedIso ? (
     <>
-      <span className="u-text--muted margin-right">
+      <span className="u-text--muted margin-right--large">
         {attachedIso?.bare?.source}
       </span>
       <ActionButton
@@ -155,7 +156,8 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
         disabled={!!disabledReason || isLoading}
         title={disabledReason}
       >
-        Detach ISO
+        <Icon name="iso" className="iso-icon margin-right--small" />
+        <span>Detach ISO</span>
       </ActionButton>
     </>
   ) : (
@@ -167,7 +169,8 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
         disabled={!!disabledReason || isLoading}
         title={disabledReason}
       >
-        Attach ISO
+        <Icon name="iso" className="iso-icon margin-right--small" />
+        <span>Attach ISO</span>
       </ActionButton>
       {isOpen && (
         <Portal>

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -156,7 +156,7 @@ const OperationList: FC = () => {
               {operations.length > 0 && (
                 <PageHeader.Search>
                   <SearchBox
-                    className="search-box margin-right u-no-margin--bottom"
+                    className="search-box margin-right--large u-no-margin--bottom"
                     name="search-operations"
                     onChange={setQuery}
                     placeholder="Search"

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -191,7 +191,7 @@ const ProfileList: FC = () => {
               {profiles.length > 0 && (
                 <PageHeader.Search>
                   <SearchBox
-                    className="search-box margin-right u-no-margin--bottom"
+                    className="search-box margin-right--large u-no-margin--bottom"
                     name="search-profile"
                     type="text"
                     onChange={(value) => {

--- a/src/pages/storage/CustomIsoList.tsx
+++ b/src/pages/storage/CustomIsoList.tsx
@@ -220,7 +220,7 @@ const CustomIsoList: FC = () => {
                 <div className="search-box-wrapper">
                   <SearchBox
                     name="search-snapshot"
-                    className="search-box margin-right u-no-margin--bottom"
+                    className="search-box margin-right--large u-no-margin--bottom"
                     type="text"
                     onChange={(value) => {
                       setQuery(value);

--- a/src/pages/storage/StorageBucketKeys.tsx
+++ b/src/pages/storage/StorageBucketKeys.tsx
@@ -160,7 +160,7 @@ const StorageBucketKeys: FC<Props> = ({ bucket }) => {
               <div className="search-box-wrapper">
                 <SearchBox
                   name="search-snapshot"
-                  className="search-box margin-right"
+                  className="search-box margin-right--large"
                   type="text"
                   onChange={(value) => {
                     setQuery(value);

--- a/src/pages/storage/StorageBucketsFilter.tsx
+++ b/src/pages/storage/StorageBucketsFilter.tsx
@@ -54,7 +54,7 @@ const StorageBucketsFilter: FC<Props> = ({ buckets }) => {
   };
 
   return (
-    <div className="search-wrapper margin-right">
+    <div className="search-wrapper margin-right--large">
       <h2 className="u-off-screen">Search and filter</h2>
       <SearchAndFilter
         existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}

--- a/src/pages/storage/StorageVolumeSnapshots.tsx
+++ b/src/pages/storage/StorageVolumeSnapshots.tsx
@@ -203,7 +203,7 @@ const StorageVolumeSnapshots: FC<Props> = ({ volume }) => {
               <div className="search-box-wrapper">
                 <SearchBox
                   name="search-snapshot"
-                  className="search-box margin-right"
+                  className="search-box margin-right--large"
                   type="text"
                   onChange={(value) => {
                     setQuery(value);

--- a/src/pages/storage/StorageVolumesFilter.tsx
+++ b/src/pages/storage/StorageVolumesFilter.tsx
@@ -99,7 +99,7 @@ const StorageVolumesFilter: FC<Props> = ({ volumes }) => {
   };
 
   return (
-    <div className="search-wrapper margin-right">
+    <div className="search-wrapper margin-right--large">
       <h2 className="u-off-screen">Search and filter</h2>
       <SearchAndFilter
         existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}

--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -13,6 +13,12 @@
         margin-right: $sph--x-large;
       }
     }
+
+    .p-action-button.p-button {
+      > .iso-icon {
+        margin-left: calc(-1 * $sph--small);
+      }
+    }
   }
 
   .spice-wrapper {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -352,8 +352,12 @@ body.is-dark .lxd-icon {
   text-decoration: line-through;
 }
 
-.margin-right {
+.margin-right--large {
   margin-right: $sph--large;
+}
+
+.margin-right--small {
+  margin-right: $sph--small;
 }
 
 .help-link {


### PR DESCRIPTION
## Done

- Add icons for fullscreen buttons and attach/detach iso buttons in instance terminal and instance console

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a running instance
    - Go to terminal tab, admire beautiful icons for Fullscreen button.
    - Go to console tab, admire beautiful icons for Fullscreen button and Attach/Detach ISO button. Attach and detach ISO to get both buttons.

## Screenshots

<img width="1562" height="1049" alt="Screenshot from 2026-03-27 10-22-42" src="https://github.com/user-attachments/assets/41fddb06-c9e5-46cd-92d7-21c6372a6657" />
<img width="1562" height="1049" alt="Screenshot from 2026-03-27 10-22-56" src="https://github.com/user-attachments/assets/70393fbb-05cb-4da0-add1-61402cc7bff0" />
<img width="1562" height="1049" alt="Screenshot from 2026-03-27 10-22-37" src="https://github.com/user-attachments/assets/26d58587-6293-4e9c-ac53-471a303894e1" />
