### PR TITLE
feat(ProfileSelector): Move helptext in Tooltip

### DIFF
--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -7,6 +7,7 @@ import {
   Select,
   useNotify,
   Spinner,
+  Tooltip,
 } from "@canonical/react-components";
 import { defaultFirst } from "util/helpers";
 import { useProfiles } from "context/useProfiles";
@@ -69,34 +70,30 @@ const ProfileSelector: FC<Props> = ({
     }
   };
 
-  const getHelp = (index: number) => {
-    const profileIntro =
-      "Profiles store a set of configuration options, such as instance and device options.";
-
-    if (index > 0 && index === selected.length - 1) {
-      return (
-        <>
-          {profileIntro}
-          <br />
-          Each profile overrides the settings specified in previous profiles.
-        </>
-      );
-    }
-    if (selected.length === 1) {
-      return profileIntro;
-    }
-  };
-
   return (
     <>
-      <Label forId="profile-0">Profiles</Label>
+      <Label forId="profile-0">
+        Profiles{" "}
+        <Tooltip
+          message={
+            <>
+              A profile stores a set of configuration, such as instance and
+              device options.
+              <br />
+              Each profile overrides the configuration specified in previous
+              profiles.
+            </>
+          }
+        >
+          <Icon name="information" />
+        </Tooltip>
+      </Label>
       {selected.map((value, index) => (
         <div className="profile-select" key={value}>
           <div>
             <Select
               id={`profile-${index}`}
               aria-label="Select a profile"
-              help={getHelp(index)}
               onChange={(e) => {
                 const newValues = [...selected];
                 newValues[index] = e.target.value;


### PR DESCRIPTION
## Done

- When creating/editing an instance, in the Profiles section: move helptext from under the dropdown list to an icon next to the label

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an instance
    - Make sure the Profiles label has an info icon (similar to Target and SSH keys). When hover on the icon, a help text should appear: `Profiles store a set of configuration options, such as instance and device options.`
    - Select more than one profile, make sure the helptext is updated correctly to:
    ```
    Profiles store a set of configuration options, such as instance and device options.
    Each profile overrides the settings specified in previous profiles.
    ```

## Screenshots

<img width="1562" height="1049" alt="Screenshot from 2026-03-27 13-16-16" src="https://github.com/user-attachments/assets/b6c87368-d38e-4d8b-90d4-c1b0d761dc1c" />
<img width="1562" height="1049" alt="Screenshot from 2026-03-27 13-16-26" src="https://github.com/user-attachments/assets/6ba74410-6b63-403b-af04-df2204a6850c" />
