### PR TITLE
fix: screenshot automation workflow WD-35555

### DIFF
--- a/src/pages/networks/forms/NetworkForwardForm.tsx
+++ b/src/pages/networks/forms/NetworkForwardForm.tsx
@@ -270,21 +270,25 @@ const NetworkForwardForm: FC<Props> = ({ formik, isEdit, network }) => {
               disabled={!isListenAddressValid}
             />
             {formik.values.ports.length > 0 && (
-              <NetworkForwardFormPorts
-                formik={formik}
-                network={network}
-                targetAddressFamily={targetAddressFamily}
-              />
+              <Row>
+                <NetworkForwardFormPorts
+                  formik={formik}
+                  network={network}
+                  targetAddressFamily={targetAddressFamily}
+                />
+              </Row>
             )}
-            <Button
-              hasIcon
-              onClick={addPort}
-              type="button"
-              disabled={!isListenAddressValid}
-            >
-              <Icon name="plus" />
-              <span>Add port</span>
-            </Button>
+            <div>
+              <Button
+                hasIcon
+                onClick={addPort}
+                type="button"
+                disabled={!isListenAddressValid}
+              >
+                <Icon name="plus" />
+                <span>Add port</span>
+              </Button>
+            </div>
           </ScrollableForm>
         </Col>
       </Row>

--- a/src/sass/_network_forwards_form.scss
+++ b/src/sass/_network_forwards_form.scss
@@ -22,6 +22,10 @@
       width: 15rem;
     }
 
+    .listen-port {
+      padding-left: 0;
+    }
+
     @media screen and (width <= 1337px) {
       .listen-port,
       .protocol,

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -34,10 +34,12 @@ test("instances", async ({ page }) => {
   const pool = "other-pool";
   const volume = "CustomVolume";
   const instance = "comic-glider";
+  const network = "bridge1";
 
   await page.setViewportSize({ width: 1440, height: 800 });
   await createPool(page, pool, "dir");
   await createVolume(page, volume);
+  await createNetwork(page, network, "bridge");
   await gotoURL(page, "/ui/");
   await page.getByText("Instances", { exact: true }).click();
   await page.getByRole("button", { name: "Create instance" }).click();
@@ -90,9 +92,10 @@ test("instances", async ({ page }) => {
   });
 
   await page.getByRole("button", { name: "Attach network" }).click();
+  await expect(page.getByText("Create network device")).toBeVisible();
   await page.screenshot({
     path: "tests/screenshots/doc/images/networks/network_attach_instance.png",
-    clip: getClipPosition(490, 70, 1245, 340),
+    clip: getClipPosition(240, 0, 1600, 800),
   });
 
   await page
@@ -778,6 +781,7 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
 
   await page.getByRole("button", { name: "Update" }).click();
   await page.getByTestId("notification-close-button").click();
+  await expect(page.getByTitle("Edit network forward")).toBeVisible();
   await page.screenshot({
     path: "tests/screenshots/doc/images/UI/forward_edit_ex1.png",
     clip: getClipPosition(240, 0, 1440, 360),
@@ -789,8 +793,8 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
   });
 
   await makeNetworkOvnUplink(page, network1, {
-    CIDR: "10.0.0.2/24",
-    ovnIpv4Range: "10.0.0.2-10.0.0.50",
+    CIDR: "10.0.0.1/24",
+    ovnIpv4Range: "10.0.0.50-10.0.0.60",
     dhcpIpv4Range: "10.0.0.100-10.0.0.150",
   });
   await createNetwork(page, network2, "ovn", {
@@ -801,7 +805,7 @@ test("LXD - UI Folder - Networks", async ({ page }) => {
 
   await page.getByText("/24").getByRole("button").click();
   networkSubnet = await page.inputValue("input#ipv4_address");
-  listenAddress = networkSubnet.replace("1/24", "1");
+  listenAddress = networkSubnet.replace("1/24", "2");
   await page.getByRole("link", { name: "Forwards" }).click();
   await page.getByTitle("Create forward").click();
   await page.locator("label", { hasText: "Manually enter address" }).click();


### PR DESCRIPTION
## Done

- Fix screenshot workflow automation
- Fix layout of network forward form

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Make sure screenshot workflow automation passes in CI. Link to successful run: https://github.com/omarelkashef/lxd-ui/actions/runs/23766415978/job/69246949114
    - Start creating a network forward.
    - Make sure "Add port" button and port rows are left aligned correctly with the rest of the page

## Screenshots

Before
<img width="1857" height="955" alt="image" src="https://github.com/user-attachments/assets/864b8fd1-b4ef-4aa2-924a-089ba2da5dda" />


After

<img width="1857" height="955" alt="image" src="https://github.com/user-attachments/assets/4d1a65f6-8526-4c01-ae0d-4a4fae947787" />
