### PR TITLE
fix(PermissionGroups): do not send updateGroup if group was not modified

### DIFF
--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -56,8 +56,10 @@ const PermissionGroups: FC = () => {
   useEffect(() => {
     if (panelParams.group) {
       setSelectedGroupNames([panelParams.group]);
+    } else if (panelParams.panel === null) {
+      setSelectedGroupNames([]);
     }
-  }, [panelParams.group, groups]);
+  }, [panelParams.group, panelParams.panel, groups]);
 
   const headers = [
     { content: "Name", className: "name", sortKey: "name" },

--- a/src/pages/permissions/actions/GroupActions.tsx
+++ b/src/pages/permissions/actions/GroupActions.tsx
@@ -32,7 +32,7 @@ const GroupActions: FC<Props> = ({ group }) => {
             title={
               canEditGroup(group)
                 ? "Edit group"
-                : "Edit group - You do not have permission to edit this group"
+                : "You do not have permission to edit this group"
             }
             disabled={!canEditGroup(group)}
           >

--- a/src/pages/permissions/forms/GroupForm.tsx
+++ b/src/pages/permissions/forms/GroupForm.tsx
@@ -50,6 +50,7 @@ const GroupForm: FC<Props> = ({
 
   const isNameInvalid = !formik.values.name || !!formik.errors.name;
   const isFieldDisabled = !!groupEditRestriction || isNameInvalid;
+  const isPermissionDisabled = isNameInvalid;
 
   const getDisableReason = () => {
     if (groupEditRestriction) {
@@ -63,6 +64,16 @@ const GroupForm: FC<Props> = ({
     return undefined;
   };
   const disableReason = getDisableReason();
+
+  const getPermissionsTitle = () => {
+    if (group && !canEditGroup(group)) {
+      return "View ";
+    }
+    if (isEditing) {
+      return "Edit ";
+    }
+    return "Add ";
+  };
 
   return (
     <Form onSubmit={formik.handleSubmit}>
@@ -99,7 +110,7 @@ const GroupForm: FC<Props> = ({
         onHoverText={disableReason}
       />
       <FormLink
-        title={(isEditing ? "Edit " : "Add ") + pluralize("permission", 2)}
+        title={getPermissionsTitle() + pluralize("permission", 2)}
         icon="lock-locked"
         onClick={() => {
           setSubForm("permission");
@@ -110,7 +121,7 @@ const GroupForm: FC<Props> = ({
             ? `No ${pluralize("permission", 2)}`
             : `${permissionCount} ${pluralize("permission", permissionCount)}`
         }
-        disabled={isFieldDisabled}
+        disabled={isPermissionDisabled}
         onHoverText={disableReason}
       />
     </Form>

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -134,7 +134,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
       .required("Group name is required"),
   });
 
-  const saveIdentities = async () => {
+  const saveIdentities = async (originalGroupName: string) => {
     const added = identities.filter((id) => id.isAdded);
     const removed = identities.filter((id) => id.isRemoved);
 
@@ -147,6 +147,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
     added.map((identity) => {
       identityPayload.push({
         ...identity,
+        // Use the new name from formik for additions
         groups: [...(identity.groups || []), formik.values.name],
       });
     });
@@ -154,8 +155,9 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
     removed.map((identity) => {
       identityPayload.push({
         ...identity,
+        // Use the ORIGINAL name to filter out the group membership
         groups: [
-          ...(identity.groups || []).filter((g) => g !== formik.values.name),
+          ...(identity.groups || []).filter((g) => g !== originalGroupName),
         ],
       });
     });
@@ -165,6 +167,7 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
 
   const saveGroup = (values: PermissionGroupFormValues) => {
     const isNameChanged = values.name !== group?.name;
+    const originalGroupName = group?.name ?? "";
     const groupPayload = {
       ...group,
       name: values.name,
@@ -174,14 +177,16 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
 
     const mutation = async () => {
       if (!canEditGroup(group)) {
-        return saveIdentities();
+        return saveIdentities(originalGroupName);
       }
 
       return isNameChanged
-        ? renameGroup(group?.name ?? "", values.name)
+        ? renameGroup(originalGroupName, values.name)
             .then(async () => updateGroup(groupPayload))
-            .then(saveIdentities)
-        : updateGroup(groupPayload).then(saveIdentities);
+            .then(async () => saveIdentities(originalGroupName))
+        : updateGroup(groupPayload).then(async () =>
+            saveIdentities(originalGroupName),
+          );
     };
 
     mutation()

--- a/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
+++ b/src/pages/permissions/panels/EditGroupPermissionsForm.tsx
@@ -174,7 +174,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
                   title="Restore permission"
                   className="u-no-margin--right"
                 >
-                  <Icon name="restart" className="u-no-margin--right" />
+                  <Icon name="restart" />
                 </Button>
               ) : (
                 <Button
@@ -190,7 +190,7 @@ const EditGroupPermissionsForm: FC<Props> = ({
                   className="u-no-margin--right"
                   disabled={!!getEditRestriction()}
                 >
-                  <Icon name="delete" className="u-no-margin--right" />
+                  <Icon name="delete" />
                 </Button>
               )}
               <Icon

--- a/src/pages/permissions/panels/PermissionSelector.tsx
+++ b/src/pages/permissions/panels/PermissionSelector.tsx
@@ -187,7 +187,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission, disableReason }) => {
       <CustomSelect
         id="resourceType"
         name="resourceType"
-        label={<strong>Resource Type</strong>}
+        label={<strong>Resource type</strong>}
         options={getResourceTypeOptions(metadata)}
         toggleClassName="u-no-margin--bottom"
         aria-label="Resource type"

--- a/src/sass/_permission_groups.scss
+++ b/src/sass/_permission_groups.scss
@@ -107,6 +107,21 @@
     .p-form__group {
       flex-shrink: 0; // avoid flex items from dynamic width adjustments
       width: 26%;
+
+      &:has(button.is-disabled) {
+        .p-form__label,
+        .is-disabled {
+          cursor: not-allowed;
+        }
+
+        .p-form__label {
+          color: var(--vf-color-text-muted);
+        }
+
+        .p-custom-select__wrapper .p-custom-select__toggle:focus {
+          box-shadow: none;
+        }
+      }
     }
 
     .add-entitlement {

--- a/tests/helpers/permission-groups.ts
+++ b/tests/helpers/permission-groups.ts
@@ -53,7 +53,7 @@ export const addPermission = async (
   resource: string,
   entitlement: string,
 ) => {
-  await selectOption(page, "Resource Type", resourceType);
+  await selectOption(page, "Resource type", resourceType);
   if (resource !== "server") {
     await selectOption(page, "Resource", resource);
   }


### PR DESCRIPTION
## Done

- fix(PermissionGroups): do not send `updateGroup` if group was not modified
- side quest: fix buttons on hover in Edit permissions

Fixes https://github.com/canonical/lxd/issues/17986

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions > Groups
    - Select a group
    - Add or remove identities but do not modify anything else
    - Save, make sure no error is thrown, that the identities are updated correctly, that the group is unchanged otherwise, that the side panel closes and that the group is now unselected.
    - Make sure you still can update a group (name, description and permissions) without any error.

## Screenshots

https://github.com/user-attachments/assets/9e3d1d2f-8e1e-4361-a518-b7ceb4547f14


Side quest:
BEFORE
<img width="853" height="140" alt="Screenshot from 2026-03-31 10-09-57" src="https://github.com/user-attachments/assets/1007f1d6-87ec-4b2d-b5d5-d5ebc982cfaa" />
<img width="853" height="140" alt="Screenshot from 2026-03-31 10-14-13" src="https://github.com/user-attachments/assets/529a9fbf-806c-4dab-aa25-b439d268cc7e" />


AFTER
<img width="853" height="140" alt="Screenshot from 2026-03-31 10-14-55" src="https://github.com/user-attachments/assets/62c2bb0f-c9a0-4a15-a205-66663240a91d" />
<img width="853" height="140" alt="Screenshot from 2026-03-31 10-14-25" src="https://github.com/user-attachments/assets/002021ae-a980-49f8-8ddd-10076e2c817b" />
