### PR TITLE
feat: relocate images page WD-34373

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ const CreateStoragePool = lazy(
 const EditNetworkForward = lazy(
   async () => import("pages/networks/EditNetworkForward"),
 );
-const ImageList = lazy(async () => import("pages/images/ImageList"));
+const LocalImageList = lazy(async () => import("pages/images/LocalImageList"));
 const InstanceDetail = lazy(
   async () => import("pages/instances/InstanceDetail"),
 );
@@ -506,8 +506,8 @@ const App: FC = () => {
           element={<ProtectedRoute outlet={<StorageBucketDetail />} />}
         />
         <Route
-          path={`${ROOT_PATH}/ui/project/:project/images`}
-          element={<ProtectedRoute outlet={<ImageList />} />}
+          path={`${ROOT_PATH}/ui/project/:project/local-images`}
+          element={<ProtectedRoute outlet={<LocalImageList />} />}
         />
         <Route
           path={`${ROOT_PATH}/ui/server`}

--- a/src/api/images.tsx
+++ b/src/api/images.tsx
@@ -13,7 +13,7 @@ import { ROOT_PATH } from "util/rootPath";
 
 const imageEntitlements = ["can_delete"];
 
-export const fetchImagesInProject = async (
+export const fetchLocalImagesInProject = async (
   project: string,
   isFineGrained: boolean | null,
 ): Promise<LxdImage[]> => {

--- a/src/components/NavAccordion.tsx
+++ b/src/components/NavAccordion.tsx
@@ -7,7 +7,8 @@ export type AccordionNavMenu =
   | "permissions"
   | "storage"
   | "networking"
-  | "clustering";
+  | "clustering"
+  | "images";
 
 interface Props {
   baseUrls: string[];

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -457,18 +457,30 @@ const Navigation: FC = () => {
                         </NavAccordion>
                       </SideNavigationItem>
                       <SideNavigationItem>
-                        <NavLink
-                          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/images`}
-                          title={getNavTitle("images")}
+                        <NavAccordion
+                          baseUrls={[
+                            `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/image`,
+                          ]}
+                          title={getNavTitle("image")}
                           disabled={isAllProjects}
-                          onClick={softToggleMenu}
+                          iconName="image"
+                          label="Images"
+                          onOpen={() => {
+                            toggleAccordionNav("images");
+                          }}
+                          open={
+                            openNavMenus.includes("images") && !menuCollapsed
+                          }
                         >
-                          <Icon
-                            className="is-light p-side-navigation__icon"
-                            name="image"
-                          />{" "}
-                          Images
-                        </NavLink>
+                          <NavLink
+                            to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/local-images`}
+                            title={getNavTitle("local images")}
+                            disabled={isAllProjects}
+                            onClick={softToggleMenu}
+                          >
+                            Local images
+                          </NavLink>
+                        </NavAccordion>
                       </SideNavigationItem>
                       <SideNavigationItem>
                         <NavLink

--- a/src/components/UsedByItem.tsx
+++ b/src/components/UsedByItem.tsx
@@ -2,7 +2,7 @@ import type { FC } from "react";
 import ResourceLink from "./ResourceLink";
 import type { LxdUsedBy } from "util/usedBy";
 import type { ResourceIconType } from "./ResourceIcon";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import { linkForVolumeDetail } from "util/storageVolume";
 import type { LxdStorageVolume } from "types/storage";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
@@ -26,7 +26,7 @@ const UsedByItem: FC<Props> = ({
   projectLinkDetailPage = "instances",
 }) => {
   const isImageQueryEnabled = type === "image";
-  const { data: images = [] } = useImagesInProject(
+  const { data: images = [] } = useLocalImagesInProject(
     item.project || activeProject,
     isImageQueryEnabled,
   );

--- a/src/context/useImages.tsx
+++ b/src/context/useImages.tsx
@@ -2,17 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useAuth } from "./auth";
-import { fetchImagesInAllProjects, fetchImagesInProject } from "api/images";
+import {
+  fetchImagesInAllProjects,
+  fetchLocalImagesInProject,
+} from "api/images";
 import type { LxdImage } from "types/image";
 
-export const useImagesInProject = (
+export const useLocalImagesInProject = (
   project: string,
   enabled?: boolean,
 ): UseQueryResult<LxdImage[]> => {
   const { isFineGrained } = useAuth();
   return useQuery({
     queryKey: [queryKeys.images, project],
-    queryFn: async () => fetchImagesInProject(project, isFineGrained),
+    queryFn: async () => fetchLocalImagesInProject(project, isFineGrained),
     enabled: (enabled ?? true) && isFineGrained !== null,
   });
 };

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -30,7 +30,7 @@ import { getArchitectureAliases } from "util/architectures";
 import { instanceCreationTypes } from "util/instanceOptions";
 import { useSettings } from "context/useSettings";
 import { useParams } from "react-router-dom";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 
 interface Props {
   onSelect: (image: RemoteImage, type?: LxdImageType) => void;
@@ -103,7 +103,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     });
 
   const { data: localImages = [], isLoading: isLocalImageLoading } =
-    useImagesInProject(project ?? "default");
+    useLocalImagesInProject(project ?? "default");
 
   const isRemoteImagesLoading =
     !hideRemote && (isCiLoading || isMinimalLoading || isImagesLxdLoading);

--- a/src/pages/images/LocalImageList.tsx
+++ b/src/pages/images/LocalImageList.tsx
@@ -31,10 +31,10 @@ import PageHeader from "components/PageHeader";
 import CustomIsoBtn from "pages/storage/actions/CustomIsoBtn";
 import DownloadImageBtn from "./actions/DownloadImageBtn";
 import UploadImageBtn from "pages/images/actions/UploadImageBtn";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import { useImageEntitlements } from "util/entitlements/images";
 
-const ImageList: FC = () => {
+const LocalImageList: FC = () => {
   const notify = useNotify();
   const { project } = useParams<{ project: string }>();
   const [query, setQuery] = useState<string>("");
@@ -46,7 +46,11 @@ const ImageList: FC = () => {
     return <>Missing project</>;
   }
 
-  const { data: images = [], error, isLoading } = useImagesInProject(project);
+  const {
+    data: images = [],
+    error,
+    isLoading,
+  } = useLocalImagesInProject(project);
 
   if (error) {
     notify.failure("Loading images failed", error);
@@ -206,9 +210,9 @@ const ImageList: FC = () => {
             <PageHeader.Title>
               <HelpLink
                 docPath="/image-handling/"
-                title="Learn more about images"
+                title="Learn more about local images"
               >
-                Images
+                Local images
               </HelpLink>
             </PageHeader.Title>
             {selectedNames.length === 0 && images.length > 0 && (
@@ -252,10 +256,11 @@ const ImageList: FC = () => {
           <EmptyState
             className="empty-state"
             image={<Icon name="image" className="empty-state-icon" />}
-            title="No images found in this project"
+            title="No local images found in this project"
           >
             <p>
-              Images will appear here, when launching an instance from a remote.
+              Local images will appear here, when launching an instance from a
+              remote.
             </p>
           </EmptyState>
         )}
@@ -308,4 +313,4 @@ const ImageList: FC = () => {
   );
 };
 
-export default ImageList;
+export default LocalImageList;

--- a/src/pages/instances/ImageLink.tsx
+++ b/src/pages/instances/ImageLink.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import type { LxdInstance } from "types/instance";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
 import { ROOT_PATH } from "util/rootPath";
@@ -9,7 +9,7 @@ interface Props {
   instance: LxdInstance;
 }
 export const ImageLink: FC<Props> = ({ instance }) => {
-  const { data: images = [] } = useImagesInProject(instance.project);
+  const { data: images = [] } = useLocalImagesInProject(instance.project);
   const imageDescription = instance.config["image.description"];
   const imageFound = images?.some(
     (image) => image.properties?.description === imageDescription,

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -5,7 +5,7 @@ import type { LxdStorageVolume } from "types/storage";
 import classnames from "classnames";
 import { linkForVolumeDetail, hasVolumeDetailPage } from "util/storageVolume";
 import { useInstances } from "context/useInstances";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import { getImageAlias, getImageName } from "util/images";
 
 interface Props {
@@ -29,7 +29,7 @@ const StorageVolumeNameLink: FC<Props> = ({
     isInstance && instances.find((instance) => instance.name === volume.name);
 
   const isImage = volume.type === "image";
-  const { data: images = [] } = useImagesInProject(volume.project);
+  const { data: images = [] } = useLocalImagesInProject(volume.project);
   const image =
     isImage && images.find((image) => image.fingerprint === volume.name);
 

--- a/src/pages/storage/StorageVolumeSize.tsx
+++ b/src/pages/storage/StorageVolumeSize.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import type { LxdStorageVolume } from "types/storage";
 import { humanFileSize } from "util/helpers";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import { fetchStorageVolumeState } from "api/storage-volumes";
 
 interface Props {
@@ -32,7 +32,7 @@ const StorageVolumeSize: FC<Props> = ({ volume }) => {
   });
 
   const imageQueryEnabled = volume.type === "image";
-  const { data: images = [] } = useImagesInProject(
+  const { data: images = [] } = useLocalImagesInProject(
     volume.project,
     imageQueryEnabled,
   );

--- a/src/util/instanceImage.tsx
+++ b/src/util/instanceImage.tsx
@@ -1,11 +1,11 @@
 import type { LxdInstance } from "types/instance";
-import { useImagesInProject } from "context/useImages";
+import { useLocalImagesInProject } from "context/useImages";
 import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
 import { ROOT_PATH } from "util/rootPath";
 
 export const getImageLink = (instance: LxdInstance) => {
-  const { data: images = [] } = useImagesInProject(instance.project);
+  const { data: images = [] } = useLocalImagesInProject(instance.project);
   const imageDescription = instance.config["image.description"];
   const imageFound = images?.some(
     (image) => image.properties?.description === imageDescription,

--- a/tests/helpers/images.ts
+++ b/tests/helpers/images.ts
@@ -2,13 +2,13 @@ import { expect } from "../fixtures/lxd-test";
 import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
 
-export const visitImages = async (page: Page, project: string) => {
-  await gotoURL(page, `/ui/project/${project}/images`);
+export const visitLocalImages = async (page: Page, project: string) => {
+  await gotoURL(page, `/ui/project/${project}/local-images`);
   await expect(page.getByText("Upload image")).toBeVisible();
 };
 
 export const deleteAllImages = async (page: Page, project = "default") => {
-  await visitImages(page, project);
+  await visitLocalImages(page, project);
   await page
     .getByRole("columnheader", { name: "select" })
     .locator("label:has-text('Select all')")
@@ -24,7 +24,7 @@ export const deleteAllImages = async (page: Page, project = "default") => {
 };
 
 export const deleteImage = async (page: Page, imageIdentifier: string) => {
-  await visitImages(page, "default");
+  await visitLocalImages(page, "default");
 
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(imageIdentifier);

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
 import { gotoURL } from "./navigate";
 import { expect } from "../fixtures/lxd-test";
-import { visitImages } from "./images";
+import { visitLocalImages } from "./images";
 import { searchEntityListPage } from "./search";
 
 const DEFAULT_IMAGE = "alpine/3.23/cloud";
@@ -196,7 +196,7 @@ export const createImageFromInstance = async (
 export const removeCustomImages = async (page: Page) => {
   // remove all custom images created during previous runs
   // to avoid failures on retries due to fingerprint conflicts
-  await visitImages(page, "default");
+  await visitLocalImages(page, "default");
   const rows = await page.locator("#image-table tbody tr").all();
   for (const row of rows) {
     const cachedContent = await row.getByLabel("Cached").innerText();

--- a/tests/images.spec.ts
+++ b/tests/images.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./fixtures/lxd-test";
-import { deleteImage, visitImages } from "./helpers/images";
+import { deleteImage, visitLocalImages } from "./helpers/images";
 import {
   createImageFromInstance,
   createInstance,
@@ -20,13 +20,13 @@ test("search for custom image and create an instance from it", async ({
   await createImageFromInstance(page, instance, imageAlias);
   await deleteInstance(page, instance);
 
-  await visitImages(page, "default");
+  await visitLocalImages(page, "default");
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(imageAlias);
   await page.getByRole("button", { name: "Create instance" }).first().click();
   await page.getByLabel("Instance name").fill(customInstance);
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForSelector(`text=Created instance ${customInstance}.`);
+  await page.getByText(`Created instance ${customInstance}.`).waitFor();
 
   await deleteInstance(page, customInstance);
   await deleteImage(page, imageAlias);
@@ -43,23 +43,24 @@ test("Export and Upload an image", async ({ page }) => {
   await createImageFromInstance(page, instance, imageAlias);
   const downloadPromise = page.waitForEvent("download");
 
-  await page.getByRole("link", { name: "Images", exact: true }).click();
+  await page.getByRole("button", { name: "Images" }).click();
+  await page.getByRole("link", { name: "Local images", exact: true }).click();
   await page.getByPlaceholder("Search").click();
   await page.getByPlaceholder("Search").fill(imageAlias);
 
   await expect(page.getByText(imageAlias)).toBeVisible();
   await page.getByLabel("export image").click();
   const download = await downloadPromise;
-  await page.waitForSelector(
-    `text=download started. Please check your downloads folder.`,
-  );
+  await page
+    .getByText(`Download started. Please check your downloads folder.`)
+    .waitFor();
   const IMAGE_FILE = "tests/fixtures/image.tar.gz";
   await download.saveAs(IMAGE_FILE);
   await deleteImage(page, imageAlias);
 
   //Upload an image
   await gotoURL(page, "/ui/");
-  await page.getByRole("link", { name: "Images", exact: true }).click();
+  await visitLocalImages(page, "default");
 
   await page.getByRole("button", { name: "Upload image" }).click();
   await page.getByLabel("Image backup file").setInputFiles(IMAGE_FILE);
@@ -69,7 +70,7 @@ test("Export and Upload an image", async ({ page }) => {
     .getByRole("button", { name: "Upload image" })
     .click();
   await expect(page.getByText(imageAlias)).toBeVisible();
-  await page.waitForSelector(`text=Image uploaded.`);
+  await page.getByText(`Image uploaded.`).waitFor();
 
   await deleteImage(page, imageAlias);
   await deleteInstance(page, instance);

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -370,7 +370,8 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     skipIfNotSupported(lxdVersion);
 
     await gotoURL(page, "/ui/");
-    await page.getByText("Images", { exact: true }).click();
+    await page.getByRole("button", { name: "Images", exact: true }).click();
+    await page.getByRole("link", { name: "Local images", exact: true }).click();
     await expect(
       page.getByRole("button", { name: "Upload image" }),
     ).toBeDisabled();


### PR DESCRIPTION
## Done

- Rename Images page to Local images and move it under Images navigation section.


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Images -> Local images
    - Ensure the page path and name are correct.

## Screenshots

<img width="1898" height="960" alt="image" src="https://github.com/user-attachments/assets/f3847b51-4541-4c66-bfea-a5ac8c8441cd" />