### PR TITLE
feat(ISO ActionButton): improve syntax

### DIFF
--- a/src/pages/instances/actions/AttachIsoBtn.tsx
+++ b/src/pages/instances/actions/AttachIsoBtn.tsx
@@ -152,11 +152,11 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
       <ActionButton
         loading={isLoading}
         onClick={detachIso}
-        className="u-no-margin--bottom"
+        className="u-no-margin--bottom has-icon"
         disabled={!!disabledReason || isLoading}
         title={disabledReason}
       >
-        <Icon name="iso" className="iso-icon margin-right--small" />
+        <Icon name="iso" />
         <span>Detach ISO</span>
       </ActionButton>
     </>
@@ -165,11 +165,11 @@ const AttachIsoBtn: FC<Props> = ({ instance }) => {
       <ActionButton
         loading={isLoading}
         onClick={openPortal}
-        className="u-no-margin--bottom"
+        className="u-no-margin--bottom has-icon"
         disabled={!!disabledReason || isLoading}
         title={disabledReason}
       >
-        <Icon name="iso" className="iso-icon margin-right--small" />
+        <Icon name="iso" />
         <span>Attach ISO</span>
       </ActionButton>
       {isOpen && (

--- a/src/sass/_instance_detail_console.scss
+++ b/src/sass/_instance_detail_console.scss
@@ -13,12 +13,6 @@
         margin-right: $sph--x-large;
       }
     }
-
-    .p-action-button.p-button {
-      > .iso-icon {
-        margin-left: calc(-1 * $sph--small);
-      }
-    }
   }
 
   .spice-wrapper {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -356,10 +356,6 @@ body.is-dark .lxd-icon {
   margin-right: $sph--large;
 }
 
-.margin-right--small {
-  margin-right: $sph--small;
-}
-
 .help-link {
   align-items: center;
   display: inline-flex;


### PR DESCRIPTION
## Done

- Follow up of already merged PR https://github.com/canonical/lxd-ui/pull/1906
- Improve syntax by replacing custom CSS by a Vanilla classname

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Same as for previous PR
    - Go to console tab, admire beautiful icons for Attach/Detach ISO buttons. Attach and detach ISO to get both buttons. No visual change expected.

## Screenshots

<img width="1536" height="258" alt="image" src="https://github.com/user-attachments/assets/a06ed2a6-79f7-4b24-ba70-266ec03bedf9" />
