### PR TITLE
fix(doc-links test): improve test to get list of broken links

### DIFF
--- a/tests/doc-links.spec.ts
+++ b/tests/doc-links.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./fixtures/lxd-test";
+import { expect, test } from "./fixtures/lxd-test";
 import {
   createInstance,
   deleteInstance,
@@ -234,19 +234,28 @@ test("DocLink validation: collect all doc paths and verify they exist", async ({
     console.log(`- ${path}`);
   });
 
-  test.fail(
-    allDocPaths.size < 10,
-    "Expected at least 10 DocLink components in the codebase",
-  );
+  expect(
+    allDocPaths.size,
+    "Expected at least 10 DocLink components",
+  ).toBeGreaterThanOrEqual(10); // 10 is a random number chosen to ensure we are collecting a reasonable number of doc paths
 
   const sortedPaths = Array.from(allDocPaths).sort();
+  const failedLinks: string[] = [];
+
   for (const docPath of sortedPaths) {
     const result = await checkDocumentationExists(page, docPath);
-    test.fail(
-      !result.exists,
-      `✗ ${docPath} - NOT FOUND (${result.status || "Error"})`,
-    );
+
+    if (!result.exists) {
+      const errorMsg = `[${result.status || "ERROR"}] ${docPath}`;
+      failedLinks.push(errorMsg);
+      console.error(`✗ ${errorMsg}`);
+    }
   }
 
-  console.log(`✓ All ${sortedPaths.length} links validated successfully.`);
+  expect(
+    failedLinks,
+    `Found ${failedLinks.length} broken documentation links:\n${failedLinks.join("\n")}`,
+  ).toHaveLength(0);
+
+  console.log(`\n✓ All ${sortedPaths.length} links validated successfully.`);
 });


### PR DESCRIPTION
## Done

- fix(doc-links): improve the test that checks in all documentation links exist and are healthy

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - At the of opening this PR, the docs seem broken in LXD latest edge so the test should fail and log the full list of broken links with their status
    
 ```
     Error: Found 26 broken documentation links:
    [501] /explanation/authorization
    [501] /explanation/authorization/#use-groups-defined-by-the-identity-provider
    [501] /explanation/clustering/
    [501] /explanation/clusters/#member-roles
    [501] /explanation/networks/
    [501] /explanation/storage/
    [501] /explanation/storage/#storage-buckets
    [501] /explanation/storage/#storage-pools
    [501] /explanation/storage/#storage-volumes
    [501] /howto/cluster_placement_groups/
    [501] /howto/container_gpu_passthrough_with_docker/#container-gpu-passthrough-with-docker
    [501] /howto/instances_create/
    [501] /howto/instances_create/#instances-create-iso
    [501] /howto/network_acls/
    [501] /howto/network_forwards/
    [501] /howto/network_ipam/
    [501] /howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks
    [501] /howto/network_ovn_setup/#set-up-a-lxd-cluster-on-ovn
    [501] /howto/oidc
    [501] /howto/oidc/
    [501] /howto/storage_backup_volume/#storage-backup-snapshots
    [501] /howto/storage_buckets/#manage-storage-bucket-keys
    [501] /reference/devices_gpu/#devices-gpu
    [501] /reference/instance_options/#instance-options-snapshots-names
    [501] /reference/storage_btrfs/#quotas
    [501] /reference/storage_dir/#quotas
 ```