### PR TITLE
feat: [WD-34728] Storage driver custom select

### DIFF
--- a/src/components/OutputField.tsx
+++ b/src/components/OutputField.tsx
@@ -1,0 +1,27 @@
+import type { FC, ReactNode } from "react";
+import { Field } from "@canonical/react-components";
+
+interface Props {
+  id: string;
+  label: string;
+  value: string;
+  help?: ReactNode;
+}
+
+const OutputField: FC<Props> = ({ id, label, value, help }) => {
+  return (
+    <Field
+      forId={id}
+      label={label}
+      help={help}
+      labelClassName="u-no-margin--bottom"
+      className="output-field"
+    >
+      <output id={id} className="mono-font u-sv2">
+        <b>{value}</b>
+      </output>
+    </Field>
+  );
+};
+
+export default OutputField;

--- a/src/pages/storage/forms/StorageDriverSelect.tsx
+++ b/src/pages/storage/forms/StorageDriverSelect.tsx
@@ -1,0 +1,156 @@
+import type { FC } from "react";
+import { CustomSelect } from "@canonical/react-components";
+import {
+  getAlletraStoragePoolFormFields,
+  getCephObjectPoolFormFields,
+  getCephPoolFormFields,
+  getPowerflexPoolFormFields,
+  getPureStoragePoolFormFields,
+  getZfsStoragePoolFormFields,
+} from "util/storagePool";
+import {
+  zfsDriver,
+  cephDriver,
+  getStorageDriverOptions,
+  powerFlex,
+  pureStorage,
+  cephObject,
+  alletraDriver,
+  storageDriverLabels,
+} from "util/storageOptions";
+import type { FormikProps } from "formik";
+import type { StoragePoolFormValues } from "types/forms/storagePool";
+import {
+  isStoragePoolWithSize,
+  isStoragePoolWithSource,
+} from "util/storagePoolForm";
+import { useSettings } from "context/useSettings";
+import OutputField from "components/OutputField";
+import DocLink from "components/DocLink";
+
+interface Props {
+  formik: FormikProps<StoragePoolFormValues>;
+}
+
+const StorageDriverSelect: FC<Props> = ({ formik }) => {
+  const { data: settings } = useSettings();
+
+  const storageDriverOptions = getStorageDriverOptions(settings);
+
+  const cephObjectNotice = (
+    <>
+      RADOS gateway must be enabled for Ceph Object driver to work. If using
+      microcloud or microceph, run <code>microceph enable rgw --port 8080</code>
+      .
+    </>
+  );
+
+  const getDriverHelpText = (driver: string, isEditing: boolean) => {
+    return (
+      <>
+        {isEditing && <span>Driver can not be changed - </span>} This driver
+        requires a storage appliance.{" "}
+        <DocLink docPath={`/reference/${driver}/`} hasExternalIcon>
+          Learn more
+        </DocLink>
+      </>
+    );
+  };
+
+  const getHelpText = () => {
+    const isEditing = !formik.values.isCreating;
+    if (!formik.values.isCreating) {
+      return "Driver can not be changed";
+    } else if (formik.values.driver === zfsDriver) {
+      return "ZFS gives best performance and reliability";
+    } else if (formik.values.driver === powerFlex) {
+      return getDriverHelpText("storage_powerflex", isEditing);
+    } else if (formik.values.driver === alletraDriver) {
+      return getDriverHelpText("storage_alletra", isEditing);
+    } else if (formik.values.driver === pureStorage) {
+      return getDriverHelpText("storage_pure", isEditing);
+    } else if (formik.values.driver === cephObject) {
+      return cephObjectNotice;
+    }
+    return undefined;
+  };
+
+  const onChange = (val: string) => {
+    if (!val) return;
+
+    if (val !== cephDriver) {
+      const cephFields = getCephPoolFormFields();
+      for (const field of cephFields) {
+        formik.setFieldValue(field, undefined);
+      }
+    }
+    if (val !== cephObject) {
+      const cephobjectFields = getCephObjectPoolFormFields();
+      for (const field of cephobjectFields) {
+        formik.setFieldValue(field, undefined);
+      }
+    }
+    if (val !== powerFlex) {
+      const powerflexFields = getPowerflexPoolFormFields();
+      for (const field of powerflexFields) {
+        formik.setFieldValue(field, undefined);
+      }
+    }
+    if (val !== pureStorage) {
+      const pureFields = getPureStoragePoolFormFields();
+      for (const field of pureFields) {
+        formik.setFieldValue(field, undefined);
+      }
+    }
+    if (val !== zfsDriver) {
+      const zfsFields = getZfsStoragePoolFormFields();
+      for (const field of zfsFields) {
+        formik.setFieldValue(field, undefined);
+      }
+      formik.setFieldValue("zfsPoolNamePerClusterMember", "");
+    }
+    if (val !== alletraDriver) {
+      const alletraFields = getAlletraStoragePoolFormFields();
+      for (const field of alletraFields) {
+        formik.setFieldValue(field, undefined);
+      }
+    }
+    if (!isStoragePoolWithSize(val)) {
+      formik.setFieldValue("size", undefined);
+      formik.setFieldValue("sizePerClusterMember", undefined);
+    }
+    if (!isStoragePoolWithSource(val)) {
+      formik.setFieldValue("source", undefined);
+      formik.setFieldValue("sourcePerClusterMember", undefined);
+    }
+    formik.setFieldValue("driver", val);
+  };
+
+  return (
+    <>
+      {!formik.values.isCreating ? (
+        <OutputField
+          id={"driver"}
+          label={"Driver"}
+          value={storageDriverLabels[formik.values.driver]}
+          help={getHelpText()}
+        />
+      ) : (
+        <CustomSelect
+          id="driver"
+          name="driver"
+          label="Driver"
+          wrapperClassName="select-input"
+          dropdownClassName="instance-target-dropdown"
+          help={getHelpText()}
+          onChange={onChange}
+          options={storageDriverOptions}
+          value={formik.values.driver}
+          required
+        />
+      )}
+    </>
+  );
+};
+
+export default StorageDriverSelect;

--- a/src/pages/storage/forms/StoragePoolFormMain.tsx
+++ b/src/pages/storage/forms/StoragePoolFormMain.tsx
@@ -1,17 +1,8 @@
 import type { FC } from "react";
-import {
-  Row,
-  Input,
-  Select,
-  Col,
-  OutputField,
-} from "@canonical/react-components";
+import { Row, Input, Col, OutputField } from "@canonical/react-components";
 import type { FormikProps } from "formik";
 import {
-  zfsDriver,
   dirDriver,
-  cephDriver,
-  getStorageDriverOptions,
   powerFlex,
   pureStorage,
   cephObject,
@@ -20,28 +11,17 @@ import {
 import type { StoragePoolFormValues } from "types/forms/storagePool";
 import DiskSizeSelector from "components/forms/DiskSizeSelector";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
-import {
-  getAlletraStoragePoolFormFields,
-  getCephObjectPoolFormFields,
-  getCephPoolFormFields,
-  getPowerflexPoolFormFields,
-  getPureStoragePoolFormFields,
-  getZfsStoragePoolFormFields,
-  isCephDriver,
-  isCephFSDriver,
-} from "util/storagePool";
+import { isCephDriver, isCephFSDriver } from "util/storagePool";
 import { useSettings } from "context/useSettings";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ScrollableForm from "components/ScrollableForm";
 import { ensureEditMode } from "util/instanceEdit";
 import { isClusteredServer } from "util/settings";
 import ClusteredDiskSizeSelector from "components/forms/ClusteredDiskSizeSelector";
-import {
-  isStoragePoolWithSize,
-  isStoragePoolWithSource,
-} from "util/storagePoolForm";
+import { isStoragePoolWithSize } from "util/storagePoolForm";
 import StoragePoolSource from "./StoragePoolSource";
 import { getFormProps } from "util/storagePoolForm";
+import StorageDriverSelect from "./StorageDriverSelect";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -55,7 +35,6 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
   const isPowerFlexDriver = formik.values.driver === powerFlex;
   const isPureDriver = formik.values.driver === pureStorage;
   const isAlletraDriver = formik.values.driver === alletraDriver;
-  const storageDriverOptions = getStorageDriverOptions(settings);
   const isCephVariant =
     isCephDriver(formik.values) || isCephFSDriver(formik.values);
   const isCephVariantWithoutSource = isCephVariant && hasRemoteDropSource;
@@ -66,14 +45,6 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
     !isCephObjectDriver &&
     !isAlletraDriver &&
     !isCephVariantWithoutSource;
-
-  const cephObjectNotice = (
-    <>
-      Rados gateway must be enabled for Ceph Object driver to work. If using
-      microcloud or microceph, run <code>microceph enable rgw --port 8080</code>
-      .
-    </>
-  );
 
   return (
     <ScrollableForm>
@@ -104,73 +75,7 @@ const StoragePoolFormMain: FC<Props> = ({ formik }) => {
             disabled={!!formik.values.editRestriction}
             title={formik.values.editRestriction}
           />
-          <Select
-            id="driver"
-            name="driver"
-            help={
-              !formik.values.isCreating
-                ? "Driver can't be changed"
-                : formik.values.driver === zfsDriver
-                  ? "ZFS gives best performance and reliability"
-                  : formik.values.driver === cephObject
-                    ? cephObjectNotice
-                    : undefined
-            }
-            label="Driver"
-            options={storageDriverOptions}
-            onChange={(target) => {
-              const val = target.target.value;
-              if (val !== cephDriver) {
-                const cephFields = getCephPoolFormFields();
-                for (const field of cephFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-              }
-              if (val !== cephObject) {
-                const cephobjectFields = getCephObjectPoolFormFields();
-                for (const field of cephobjectFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-              }
-              if (val !== powerFlex) {
-                const powerflexFields = getPowerflexPoolFormFields();
-                for (const field of powerflexFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-              }
-              if (val !== pureStorage) {
-                const pureFields = getPureStoragePoolFormFields();
-                for (const field of pureFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-              }
-              if (val !== zfsDriver) {
-                const zfsFields = getZfsStoragePoolFormFields();
-                for (const field of zfsFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-                formik.setFieldValue("zfsPoolNamePerClusterMember", "");
-              }
-              if (val !== alletraDriver) {
-                const alletraFields = getAlletraStoragePoolFormFields();
-                for (const field of alletraFields) {
-                  formik.setFieldValue(field, undefined);
-                }
-              }
-              if (!isStoragePoolWithSize(val)) {
-                formik.setFieldValue("size", undefined);
-                formik.setFieldValue("sizePerClusterMember", undefined);
-              }
-              if (!isStoragePoolWithSource(val)) {
-                formik.setFieldValue("source", undefined);
-                formik.setFieldValue("sourcePerClusterMember", undefined);
-              }
-              formik.setFieldValue("driver", val);
-            }}
-            value={formik.values.driver}
-            required
-          />
-
+          <StorageDriverSelect formik={formik} />
           {isStoragePoolWithSize(formik.values.driver) &&
             (isClusteredServer(settings) ? (
               <ClusteredDiskSizeSelector

--- a/src/sass/_custom_dropdown.scss
+++ b/src/sass/_custom_dropdown.scss
@@ -1,5 +1,6 @@
 .network-type-label,
-.acl-action-label {
+.acl-action-label,
+.storage-driver-label {
   display: flex;
 
   .network-type-name {
@@ -7,14 +8,21 @@
     width: 5rem;
   }
 
-  .network-type-explanation {
+  .storage-driver-name {
+    margin-left: $sph--small;
+    width: 8rem;
+  }
+
+  .network-type-explanation,
+  .storage-driver-description {
     margin-left: $sph--small;
   }
 
   @media screen and (width <= 1200px) {
     flex-direction: column;
 
-    .network-type-explanation {
+    .network-type-explanation,
+    .storage-driver-description {
       white-space: break-spaces;
     }
   }

--- a/src/util/storageOptions.tsx
+++ b/src/util/storageOptions.tsx
@@ -1,4 +1,4 @@
-import type { OptionHTMLAttributes } from "react";
+import type { CustomSelectOption } from "@canonical/react-components";
 import type { LxdSettings } from "types/server";
 
 export const dirDriver = "dir";
@@ -25,6 +25,21 @@ export const storageDriverLabels: { [key: string]: string } = {
   [alletraDriver]: "HPE Alletra",
 };
 
+export const storageDriverDescriptions: { [key: string]: string } = {
+  [alletraDriver]: "HPE Alletra block storage",
+  [btrfsDriver]:
+    "Copy-on-Write filesystem with native subvolumes and snapshots",
+  [cephDriver]: "Distributed Ceph RBD block storage",
+  [cephFSDriver]: "Distributed Ceph filesystem",
+  [cephObject]: "S3-compatible Ceph object storage via RADOS gateway",
+  [dirDriver]: "Basic local directory (no native snapshots or quotas)",
+  [lvmDriver]: "Logical volume-backed block storage with thin provisioning",
+  [powerFlex]: "Dell PowerFlex software-defined block storage",
+  [pureStorage]: "Pure Storage FlashArray block storage",
+  [zfsDriver]:
+    "Advanced Copy-on-Write filesystem with datasets and zvols (recommended)",
+};
+
 const bucketCompatibleDrivers = [cephObject];
 const driversWithClusterWideSource = [cephDriver, cephFSDriver];
 
@@ -38,19 +53,35 @@ export const isClusterWideSourceDriver = (driver: string): boolean => {
 
 export const getStorageDriverOptions = (
   settings?: LxdSettings,
-): OptionHTMLAttributes<HTMLOptionElement>[] => {
+): CustomSelectOption[] => {
   const serverSupportedStorageDrivers =
     settings?.environment?.storage_supported_drivers || [];
-  const storageDriverOptions: OptionHTMLAttributes<HTMLOptionElement>[] = [];
+
+  const storageDriverOptions: CustomSelectOption[] = [];
+
   for (const driver of serverSupportedStorageDrivers) {
-    const label = storageDriverLabels[driver.Name];
-    if (label) {
-      storageDriverOptions.push({ label, value: driver.Name });
+    const text = storageDriverLabels[driver.Name];
+    const description = storageDriverDescriptions[driver.Name];
+    if (text) {
+      storageDriverOptions.push({
+        value: driver.Name,
+        text: text,
+        label: (
+          <div className="storage-driver-label">
+            <span className="storage-driver-name">{text}</span>
+            {description && (
+              <span className="storage-driver-description u-text--muted">
+                {description}
+              </span>
+            )}
+          </div>
+        ),
+      });
     }
   }
 
   return storageDriverOptions.sort((a, b) =>
-    (a.label as string).localeCompare(b.label as string),
+    (a.text as string).localeCompare(b.text as string),
   );
 };
 

--- a/tests/docs-screenshots.spec.ts
+++ b/tests/docs-screenshots.spec.ts
@@ -22,6 +22,7 @@ import { setOption } from "./helpers/configuration";
 import { getClipPosition } from "./helpers/doc-screenshots";
 import { openInstancePanel } from "./helpers/instancePanel";
 import { deleteNetworkAcl } from "./helpers/network-acls";
+import { dirDriver, storageDriverLabels } from "util/storageOptions";
 
 test.beforeEach(() => {
   test.skip(
@@ -37,7 +38,7 @@ test("instances", async ({ page }) => {
   const network = "bridge1";
 
   await page.setViewportSize({ width: 1440, height: 800 });
-  await createPool(page, pool, "dir");
+  await createPool(page, pool, storageDriverLabels[dirDriver]);
   await createVolume(page, volume);
   await createNetwork(page, network, "bridge");
   await gotoURL(page, "/ui/");

--- a/tests/helpers/storagePool.ts
+++ b/tests/helpers/storagePool.ts
@@ -2,13 +2,21 @@ import type { Page } from "@playwright/test";
 import { randomNameSuffix } from "./name";
 import { gotoURL } from "./navigate";
 import { expect } from "../fixtures/lxd-test";
-import { cephObject } from "util/storageOptions";
+import {
+  cephObject,
+  dirDriver,
+  storageDriverLabels,
+} from "util/storageOptions";
 
 export const randomPoolName = (): string => {
   return `playwright-pool-${randomNameSuffix()}`;
 };
 
-export const createPool = async (page: Page, pool: string, driver = "dir") => {
+export const createPool = async (
+  page: Page,
+  pool: string,
+  driver = storageDriverLabels[dirDriver],
+) => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Storage" }).click();
   await page.getByRole("link", { name: "Pools" }).click();
@@ -18,8 +26,9 @@ export const createPool = async (page: Page, pool: string, driver = "dir") => {
   }
   await page.getByRole("button", { name: "Create pool" }).click();
   await page.getByPlaceholder("Enter name").fill(pool);
-  await page.getByLabel("Driver").selectOption(driver);
-  if (driver === cephObject) {
+  await page.getByRole("button", { name: "Driver" }).click();
+  await page.getByRole("option", { name: driver }).click();
+  if (driver === storageDriverLabels[cephObject]) {
     await page.getByLabel("Rados gateway endpoint").fill("http://localhost");
   }
   await page.getByRole("button", { name: "Create", exact: true }).click();

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -32,7 +32,11 @@ import {
   randomBucketName,
   visitBucket,
 } from "./helpers/storageBucket";
-import { cephObject } from "util/storageOptions";
+import {
+  cephObject,
+  storageDriverLabels,
+  zfsDriver,
+} from "util/storageOptions";
 
 let volume = randomVolumeName();
 
@@ -156,7 +160,7 @@ test("storage pool with driver zfs", async ({ page, lxdVersion }) => {
   );
 
   const pool = randomPoolName();
-  await createPool(page, pool, "ZFS");
+  await createPool(page, pool, storageDriverLabels[zfsDriver]);
 
   const poolRow = page.getByRole("row").filter({ hasText: pool });
   await expect(poolRow.getByRole("link", { name: pool })).toBeVisible();
@@ -245,9 +249,9 @@ test("storage bucket create, edit, delete", async ({ page, lxdVersion }) => {
   );
 
   const bucket = randomBucketName();
-  const pool = "CephObjectPool"; //Pool explcitly named for explicit selection & deletion
+  const pool = "CephObjectPool"; //Pool named for explicit selection & deletion
 
-  await createPool(page, pool, cephObject);
+  await createPool(page, pool, storageDriverLabels[cephObject]);
   await createBucket(page, bucket);
 
   const row = page.getByRole("row").filter({ hasText: bucket });
@@ -278,9 +282,9 @@ test("storage bucket keys create, edit, delete", async ({
 
   const bucket = randomBucketName();
   const bucketkey = `${bucket}-key`;
-  const pool = "CephObjectPool"; //Pool explcitly named for explicit selection & deletion
+  const pool = "CephObjectPool"; //Pool named for explicit selection & deletion
 
-  await createPool(page, pool, cephObject);
+  await createPool(page, pool, storageDriverLabels[cephObject]);
   await createBucket(page, bucket);
   await visitBucket(page, bucket);
   await createBucketKey(page, bucket, bucketkey);


### PR DESCRIPTION
## Done

- Added a Custom select dropdown list for Storage drivers
- Descriptions open to copy adjustments.
  - [x] Copies verified and cross referenced with LXD Docs team
  - [x] Updated OutputField React Component use.
- Minor amendments to tests to suppor the new design and ensure uniformity across custom creation of pools w.r.t naming.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to Storage Pools > Create
    - Observe that the dropdown in the Storage pool creation page displays the Custom select dropdown and descriptions.
    - Verify that previous functionality to save the pool still works.

## Screenshots

<img width="924" height="527" alt="image" src="https://github.com/user-attachments/assets/c3c697ac-6c44-441d-9170-7d9b8cc60766" />

Read only output field usage:
<img width="1229" height="635" alt="image" src="https://github.com/user-attachments/assets/8f71a4f8-a699-4a01-978f-3b8142ba9dec" />

Help text specification for the storage drivers that require storage appliances:
<img width="1229" height="635" alt="image" src="https://github.com/user-attachments/assets/40ee2201-3cb7-4287-9be1-0427bc52777c" />
