### PR TITLE
feat: image registries list page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,10 @@ const StoragePoolDetail = lazy(
 const CreateStorageVolume = lazy(
   async () => import("pages/storage/forms/CreateStorageVolume"),
 );
+const ImageRegistriesList = lazy(
+  async () => import("pages/images/ImageRegistriesList"),
+);
+
 const StorageVolumeDetail = lazy(
   async () => import("pages/storage/StorageVolumeDetail"),
 );
@@ -508,6 +512,10 @@ const App: FC = () => {
         <Route
           path={`${ROOT_PATH}/ui/project/:project/local-images`}
           element={<ProtectedRoute outlet={<LocalImageList />} />}
+        />
+        <Route
+          path={`${ROOT_PATH}/ui/image-registries`}
+          element={<ProtectedRoute outlet={<ImageRegistriesList />} />}
         />
         <Route
           path={`${ROOT_PATH}/ui/server`}

--- a/src/api/image-registries.tsx
+++ b/src/api/image-registries.tsx
@@ -1,0 +1,36 @@
+import { handleResponse } from "util/helpers";
+import type { LxdImageRegistry } from "types/image";
+import type { LxdApiResponse } from "types/apiResponse";
+import { addEntitlements } from "util/entitlements/api";
+import { ROOT_PATH } from "util/rootPath";
+
+const imageRegistryEntitlements = ["can_edit", "can_delete"];
+
+export const fetchImageRegistries = async (
+  isFineGrained: boolean | null,
+): Promise<LxdImageRegistry[]> => {
+  const params = new URLSearchParams();
+  params.set("recursion", "1");
+  addEntitlements(params, isFineGrained, imageRegistryEntitlements);
+  return fetch(`${ROOT_PATH}/1.0/image-registries?${params.toString()}`)
+    .then(handleResponse)
+    .then((data: LxdApiResponse<LxdImageRegistry[]>) => {
+      return data.metadata;
+    });
+};
+
+export const fetchImageRegistry = async (
+  name: string,
+  isFineGrained: boolean | null,
+): Promise<LxdImageRegistry> => {
+  const params = new URLSearchParams();
+  params.set("recursion", "1");
+  addEntitlements(params, isFineGrained, imageRegistryEntitlements);
+  return fetch(
+    `${ROOT_PATH}/1.0/image-registries/${encodeURIComponent(name)}?${params.toString()}`,
+  )
+    .then(handleResponse)
+    .then((data: LxdApiResponse<LxdImageRegistry>) => {
+      return data.metadata;
+    });
+};

--- a/src/components/BulkDeleteButton.tsx
+++ b/src/components/BulkDeleteButton.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from "react";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { ConfirmationButtonProps } from "@canonical/react-components";
 import { ConfirmationButton, Icon } from "@canonical/react-components";
 import classnames from "classnames";

--- a/src/components/DevicesSummaryList.tsx
+++ b/src/components/DevicesSummaryList.tsx
@@ -11,7 +11,7 @@ import {
   isVolumeDevice,
 } from "util/devices";
 import type { FormDevice } from "types/formDevice";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import classnames from "classnames";
 
 interface Props {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,6 +44,10 @@ const initialiseOpenNavMenus = (location: Location) => {
   const openCluster =
     location.pathname.includes("/cluster/") ||
     location.pathname.includes("/placement-groups");
+  const openImages =
+    location.pathname.includes("/image-registries") ||
+    location.pathname.includes("/local-images");
+
   const initialOpenMenus: AccordionNavMenu[] = [];
   if (openPermissions) {
     initialOpenMenus.push("permissions");
@@ -59,6 +63,10 @@ const initialiseOpenNavMenus = (location: Location) => {
 
   if (openCluster) {
     initialOpenMenus.push("clustering");
+  }
+
+  if (openImages) {
+    initialOpenMenus.push("images");
   }
 
   return initialOpenMenus;
@@ -97,7 +105,8 @@ const Navigation: FC = () => {
     initializeProjectName(isAllProjectsFromUrl, isLoading, project),
   );
   const isAllProjects = projectName === ALL_PROJECTS;
-  const { hasCustomVolumeIso, hasAccessManagement } = useSupportedFeatures();
+  const { hasCustomVolumeIso, hasAccessManagement, hasImageRegistries } =
+    useSupportedFeatures();
   const { loggedInUserName, loggedInUserID } = useLoggedInUser();
   const [scroll, setScroll] = useState(false);
   const location = useLocation();
@@ -459,10 +468,10 @@ const Navigation: FC = () => {
                       <SideNavigationItem>
                         <NavAccordion
                           baseUrls={[
-                            `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/image`,
+                            `${ROOT_PATH}/ui/image-registries`,
+                            `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/local-images`,
                           ]}
                           title={getNavTitle("image")}
-                          disabled={isAllProjects}
                           iconName="image"
                           label="Images"
                           onOpen={() => {
@@ -480,6 +489,15 @@ const Navigation: FC = () => {
                           >
                             Local images
                           </NavLink>
+                          {hasImageRegistries && (
+                            <NavLink
+                              to={`${ROOT_PATH}/ui/image-registries`}
+                              title={getNavTitle("image registries")}
+                              onClick={softToggleMenu}
+                            >
+                              Image registries
+                            </NavLink>
+                          )}
                         </NavAccordion>
                       </SideNavigationItem>
                       <SideNavigationItem>

--- a/src/components/OperationStatus.tsx
+++ b/src/components/OperationStatus.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@canonical/react-components";
 import { useOperations } from "context/operationsProvider";
 import { Link } from "react-router-dom";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import { ROOT_PATH } from "util/rootPath";
 

--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -12,7 +12,7 @@ import {
   useListener,
 } from "@canonical/react-components";
 import classnames from "classnames";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 
 interface SelectableMainTableProps {
   filteredNames: string[];

--- a/src/components/SelectedTableNotification.tsx
+++ b/src/components/SelectedTableNotification.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Button } from "@canonical/react-components";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 
 interface Props {
   totalCount: number;

--- a/src/components/UsedByRow.tsx
+++ b/src/components/UsedByRow.tsx
@@ -2,7 +2,7 @@ import { type FC } from "react";
 import UsedByItem from "./UsedByItem";
 import ExpandableList from "./ExpandableList";
 import { filterUsedByType, getLinkTarget } from "util/usedBy";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { ResourceIconType } from "components/ResourceIcon";
 import { capitalizeFirstLetter } from "util/helpers";
 import ResourceIcon from "components/ResourceIcon";

--- a/src/components/forms/FormSubmitBtn.tsx
+++ b/src/components/forms/FormSubmitBtn.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { ActionButton, useListener } from "@canonical/react-components";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { ConfigurationRowFormikProps } from "types/forms/configurationRow";
 import { getFormChangeCount } from "util/formChangeCount";
 import { unstable_usePrompt as usePrompt } from "react-router";

--- a/src/components/forms/YamlNotification.tsx
+++ b/src/components/forms/YamlNotification.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { Notification } from "@canonical/react-components";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import DocLink from "components/DocLink";
 
 const loadClosed = (entity: string) => {

--- a/src/context/useImageRegistries.tsx
+++ b/src/context/useImageRegistries.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import { useAuth } from "./auth";
+import { fetchImageRegistries, fetchImageRegistry } from "api/image-registries";
+
+export const useImageRegistries = (isEnabled = true) => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [queryKeys.imageRegistries],
+    queryFn: async () => fetchImageRegistries(isFineGrained),
+    enabled: isEnabled && isFineGrained !== null,
+  });
+};
+
+export const useImageRegistry = (name: string, isEnabled = true) => {
+  const { isFineGrained } = useAuth();
+  return useQuery({
+    queryKey: [queryKeys.imageRegistries, name],
+    queryFn: async () => fetchImageRegistry(name, isFineGrained),
+    enabled: isEnabled && isFineGrained !== null,
+  });
+};

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -53,5 +53,6 @@ export const useSupportedFeatures = () => {
     hasStorageAndNetworkOperations: apiExtensions.has(
       "storage_and_network_operations",
     ),
+    hasImageRegistries: apiExtensions.has("image_registries"),
   };
 };

--- a/src/pages/images/ImageRegistriesList.tsx
+++ b/src/pages/images/ImageRegistriesList.tsx
@@ -1,0 +1,197 @@
+import { type FC } from "react";
+import {
+  Row,
+  ScrollableTable,
+  TablePagination,
+  useNotify,
+  CustomLayout,
+  Spinner,
+  MainTable,
+} from "@canonical/react-components";
+import useSortTableData from "util/useSortTableData";
+import { useImageRegistries } from "context/useImageRegistries";
+import HelpLink from "components/HelpLink";
+import NotificationRow from "components/NotificationRow";
+import PageHeader from "components/PageHeader";
+import ImageRegistriesSearchFilter, {
+  type ImageRegistryFilter,
+} from "./ImageRegistriesSearchFilter";
+import { useSearchParams } from "react-router-dom";
+import type { LxdImageRegistryProtocol } from "types/image";
+import { isRegistryPublic } from "util/image-registries";
+import { CreateImageRegistryButton } from "./actions/CreateImageRegistryButton";
+
+const ImageRegistriesList: FC = () => {
+  const notify = useNotify();
+  const [searchParams] = useSearchParams();
+  const { data: imageRegistries = [], error, isLoading } = useImageRegistries();
+
+  if (error) {
+    notify.failure("Loading image registries failed", error);
+  }
+
+  const headers = [
+    { content: "Name", sortKey: "name" },
+    { content: "Description", sortKey: "description" },
+    {
+      content: "Protocol",
+      sortKey: "protocol",
+    },
+    {
+      content: "Built-in",
+      sortKey: "builtin",
+    },
+    {
+      content: "Public",
+      sortKey: "public",
+    },
+  ];
+
+  const filters: ImageRegistryFilter = {
+    queries: searchParams.getAll("query").map((value) => value.toLowerCase()),
+    protocol: searchParams.getAll("protocol") as LxdImageRegistryProtocol[],
+    builtin: searchParams
+      .getAll("builtin")
+      .map((value) => value.toLowerCase() === "yes"),
+    public: searchParams
+      .getAll("public")
+      .map((value) => value.toLowerCase() === "yes"),
+  };
+
+  const filteredImageRegistries = imageRegistries.filter(
+    (item) =>
+      (!filters.queries.length ||
+        filters.queries.some(
+          (query) =>
+            (item?.description ?? "").toLowerCase().includes(query) ||
+            item.name.toLowerCase().includes(query),
+        )) &&
+      (!filters.protocol.length || filters.protocol.includes(item.protocol)) &&
+      (!filters.builtin.length || filters.builtin.includes(item.builtin)) &&
+      (!filters.public.length ||
+        filters.public.includes(isRegistryPublic(item))),
+  );
+
+  const rows = filteredImageRegistries.map((registry) => {
+    return {
+      key: registry.name,
+      name: registry.name,
+      columns: [
+        {
+          content: registry.name,
+          role: "rowheader",
+          "aria-label": "Name",
+          title: `Image registry ${registry.name}`,
+        },
+        {
+          content: (
+            <div className="u-truncate" title={registry.description}>
+              {registry.description}
+            </div>
+          ),
+          role: "cell",
+          "aria-label": "Description",
+        },
+        {
+          content: registry.protocol,
+          role: "cell",
+          "aria-label": "Protocol",
+        },
+        {
+          content: registry.builtin ? "Yes" : "No",
+          role: "cell",
+          "aria-label": "Built-in",
+        },
+        {
+          content: isRegistryPublic(registry) ? "Yes" : "No",
+          role: "cell",
+          "aria-label": "Public",
+        },
+      ],
+      sortData: {
+        name: registry.name.toLowerCase(),
+        description: registry.description.toLowerCase(),
+        protocol: registry.protocol.toLowerCase(),
+        builtin: registry.builtin,
+        public: isRegistryPublic(registry),
+      },
+    };
+  });
+  const { rows: sortedRows, updateSort } = useSortTableData({ rows });
+  if (isLoading) {
+    return <Spinner className="u-loader" text="Loading..." isMainComponent />;
+  }
+
+  const getTablePaginationDescription = () => {
+    // This is needed because TablePagination does not support the plural form of registry
+    if (rows.length === 0) {
+      return "Showing 0 image registries";
+    }
+    const defaultPaginationDescription =
+      rows.length > 1
+        ? `Showing all ${rows.length} image registries`
+        : `Showing 1 out of 1 image registry`;
+
+    return defaultPaginationDescription;
+  };
+
+  return (
+    <>
+      <CustomLayout
+        contentClassName="u-no-padding--bottom"
+        header={
+          <PageHeader>
+            <PageHeader.Left>
+              <PageHeader.Title>
+                <HelpLink
+                  docPath="/image-handling/"
+                  title="Learn more about image registries"
+                >
+                  Image registries
+                </HelpLink>
+              </PageHeader.Title>
+              {imageRegistries.length > 0 && (
+                <PageHeader.Search>
+                  <ImageRegistriesSearchFilter />
+                </PageHeader.Search>
+              )}
+            </PageHeader.Left>
+            <PageHeader.BaseActions>
+              <CreateImageRegistryButton />
+            </PageHeader.BaseActions>
+          </PageHeader>
+        }
+      >
+        <NotificationRow />
+        <Row>
+          <ScrollableTable
+            dependencies={[imageRegistries]}
+            tableId="image-registries-table"
+            belowIds={["status-bar"]}
+          >
+            <TablePagination
+              data={sortedRows}
+              id="pagination"
+              className="u-no-margin--top"
+              itemName="registry"
+              aria-label="Table pagination control"
+              description={getTablePaginationDescription()}
+            >
+              <MainTable
+                id="image-registries-table"
+                defaultSort="Name"
+                headers={headers}
+                rows={rows}
+                sortable
+                emptyStateMsg="No matching image registries found."
+                onUpdateSort={updateSort}
+              />
+            </TablePagination>
+          </ScrollableTable>
+        </Row>
+      </CustomLayout>
+    </>
+  );
+};
+
+export default ImageRegistriesList;

--- a/src/pages/images/ImageRegistriesSearchFilter.tsx
+++ b/src/pages/images/ImageRegistriesSearchFilter.tsx
@@ -1,0 +1,88 @@
+import type { FC } from "react";
+import { memo } from "react";
+import { SearchAndFilter } from "@canonical/react-components";
+import type {
+  SearchAndFilterChip,
+  SearchAndFilterData,
+} from "@canonical/react-components/dist/components/SearchAndFilter/types";
+import { useSearchParams } from "react-router-dom";
+import {
+  paramsFromSearchData,
+  searchParamsToChips,
+} from "util/searchAndFilter";
+import type { LxdImageRegistryProtocol } from "types/image";
+
+export interface ImageRegistryFilter {
+  queries: string[];
+  protocol: LxdImageRegistryProtocol[];
+  builtin: boolean[];
+  public: boolean[];
+}
+
+export const QUERY = "query";
+export const PROTOCOL = "protocol";
+export const BUILTIN = "builtin";
+export const PUBLIC = "public";
+
+const QUERY_PARAMS = [QUERY, PROTOCOL, BUILTIN, PUBLIC];
+
+const InstanceSearchFilter: FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const searchAndFilterData: SearchAndFilterData[] = [
+    {
+      id: 1,
+      heading: "Protocol",
+      chips: ["SimpleStreams", "LXD"].map((protocol) => {
+        return { lead: PROTOCOL, value: protocol.toLowerCase() };
+      }),
+    },
+    {
+      id: 2,
+      heading: "Built-in",
+      chips: ["Yes", "No"].map((type) => {
+        return { lead: BUILTIN, value: type };
+      }),
+    },
+    {
+      id: 3,
+      heading: "Public",
+      chips: ["Yes", "No"].map((type) => {
+        return { lead: PUBLIC, value: type };
+      }),
+    },
+  ];
+
+  const onSearchDataChange = (searchData: SearchAndFilterChip[]) => {
+    const newParams = paramsFromSearchData(
+      searchData,
+      searchParams,
+      QUERY_PARAMS,
+    );
+
+    if (newParams.toString() !== searchParams.toString()) {
+      setSearchParams(newParams);
+    }
+  };
+
+  return (
+    <>
+      <h2 className="u-off-screen">Search and filter</h2>
+      <SearchAndFilter
+        existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}
+        filterPanelData={searchAndFilterData}
+        returnSearchData={onSearchDataChange}
+        onExpandChange={() => {
+          window.dispatchEvent(
+            new CustomEvent("resize", { detail: "search-and-filter" }),
+          );
+        }}
+        onPanelToggle={() => {
+          window.dispatchEvent(new CustomEvent("sfp-toggle"));
+        }}
+      />
+    </>
+  );
+};
+
+export default memo(InstanceSearchFilter);

--- a/src/pages/images/actions/BulkDeleteImageBtn.tsx
+++ b/src/pages/images/actions/BulkDeleteImageBtn.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/promises";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import BulkDeleteButton from "components/BulkDeleteButton";
 import { useImageEntitlements } from "util/entitlements/images";
 import type { LxdImage } from "types/image";

--- a/src/pages/images/actions/CreateImageRegistryButton.tsx
+++ b/src/pages/images/actions/CreateImageRegistryButton.tsx
@@ -1,0 +1,23 @@
+import type { FC } from "react";
+import { useServerEntitlements } from "util/entitlements/server";
+import { Button, Icon } from "@canonical/react-components";
+
+export const CreateImageRegistryButton: FC = () => {
+  const { canCreateImageRegistries } = useServerEntitlements();
+  const isDisabled = !canCreateImageRegistries();
+  return (
+    <Button
+      name="Create registry"
+      disabled={isDisabled}
+      hasIcon
+      appearance="positive"
+      className="u-float-right u-no-margin--bottom"
+      title={
+        isDisabled && "You don't have permissions to create image registries"
+      }
+    >
+      <Icon name="plus" light className="u-margin--right" />
+      <span>Create registry</span>
+    </Button>
+  );
+};

--- a/src/pages/instances/actions/InstanceBulkAction.tsx
+++ b/src/pages/instances/actions/InstanceBulkAction.tsx
@@ -5,11 +5,8 @@ import type {
   LxdInstanceAction,
   LxdInstanceStatus,
 } from "types/instance";
-import {
-  instanceAction,
-  pluralize,
-  statusLabel,
-} from "util/instanceBulkActions";
+import { instanceAction, statusLabel } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { ConfirmationButton, Icon } from "@canonical/react-components";
 import { getInstanceKey } from "util/instances";
 import { useIsScreenBelow } from "context/useIsScreenBelow";

--- a/src/pages/instances/actions/InstanceBulkActions.tsx
+++ b/src/pages/instances/actions/InstanceBulkActions.tsx
@@ -5,11 +5,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import type { LxdInstance, LxdInstanceAction } from "types/instance";
-import {
-  instanceActionLabel,
-  instanceActions,
-  pluralize,
-} from "util/instanceBulkActions";
+import { instanceActionLabel, instanceActions } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import InstanceBulkAction from "pages/instances/actions/InstanceBulkAction";
 import { getPromiseSettledCounts } from "util/promises";
 import { useEventQueue } from "context/eventQueue";

--- a/src/pages/instances/actions/InstanceBulkDelete.tsx
+++ b/src/pages/instances/actions/InstanceBulkDelete.tsx
@@ -2,7 +2,7 @@ import type { FC } from "react";
 import { useState } from "react";
 import { deleteInstanceBulk } from "api/instances";
 import type { LxdInstance } from "types/instance";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { bulkDeletableStatuses } from "util/instanceDelete";

--- a/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceSnapshotBulkDelete.tsx
@@ -4,7 +4,7 @@ import type { LxdInstance } from "types/instance";
 import { deleteInstanceSnapshotBulk } from "api/instance-snapshots";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/promises";
 import { useInstanceEntitlements } from "util/entitlements/instances";

--- a/src/pages/instances/forms/ExportInstanceModal.tsx
+++ b/src/pages/instances/forms/ExportInstanceModal.tsx
@@ -18,7 +18,7 @@ import { useSettings } from "context/useSettings";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { isDiskDevice } from "util/devices";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { InstanceRichChip } from "../InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
 

--- a/src/pages/instances/forms/InstanceTargetSelect.tsx
+++ b/src/pages/instances/forms/InstanceTargetSelect.tsx
@@ -15,7 +15,7 @@ import { useCurrentProject } from "context/useCurrentProject";
 import { useServerEntitlements } from "util/entitlements/server";
 import { useClusterGroups } from "context/useClusterGroups";
 import { usePlacementGroups } from "context/usePlacementGroups";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useClusterMembers } from "context/useClusterMembers";
 import type { SelectRef } from "@canonical/react-components/dist/components/CustomSelect/CustomSelect";
 import PlacementGroupSelect from "pages/instances/forms/PlacementGroupSelect";

--- a/src/pages/instances/forms/PlacementGroupSelect.tsx
+++ b/src/pages/instances/forms/PlacementGroupSelect.tsx
@@ -3,7 +3,7 @@ import { CustomSelect } from "@canonical/react-components";
 import { usePlacementGroups } from "context/usePlacementGroups";
 import type { SelectRef } from "@canonical/react-components/dist/components/CustomSelect/CustomSelect";
 import { Link } from "react-router-dom";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { CustomSelectOption } from "@canonical/react-components/dist/components/CustomSelect/CustomSelectDropdown/CustomSelectDropdown";
 import { useProfiles } from "context/useProfiles";
 import { ROOT_PATH } from "util/rootPath";

--- a/src/pages/networks/panels/EditLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/EditLocalPeeringPanel.tsx
@@ -13,7 +13,7 @@ import { useFormik } from "formik";
 import NotificationRow from "components/NotificationRow";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { LxdNetwork, LxdNetworkPeer } from "types/network";
 import NetworkLocalPeeringForm from "../forms/NetworkLocalPeeringForm";
 import type { LocalPeeringFormValues } from "types/forms/localPeering";

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -36,7 +36,7 @@ import { isUnrestricted } from "util/helpers";
 import CreateTlsIdentityBtn from "./CreateTlsIdentityBtn";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { getIdentityName } from "util/permissionIdentities";
 import CreateTLSIdentity from "./CreateTLSIdentity";
 import ResourceLabel from "components/ResourceLabel";

--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -30,7 +30,7 @@ import { Link } from "react-router-dom";
 import { useIdpGroups } from "context/useIdpGroups";
 import { useServerEntitlements } from "util/entitlements/server";
 import { useIdpGroupEntitlements } from "util/entitlements/idp-groups";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import DocLink from "components/DocLink";
 import { ROOT_PATH } from "util/rootPath";

--- a/src/pages/permissions/actions/BulkDeleteGroupsBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteGroupsBtn.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import type { LxdAuthGroup } from "types/permissions";
 import DeleteGroupModal from "./DeleteGroupModal";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useGroupEntitlements } from "util/entitlements/groups";
 
 interface Props {

--- a/src/pages/permissions/actions/BulkDeleteIdentitiesBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteIdentitiesBtn.tsx
@@ -5,7 +5,7 @@ import type { LxdIdentity } from "types/permissions";
 import { deleteIdentities } from "api/auth-identities";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import BulkDeleteButton from "components/BulkDeleteButton";
 import LoggedInUserNotification from "pages/permissions/panels/LoggedInUserNotification";

--- a/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
+++ b/src/pages/permissions/actions/BulkDeleteIdpGroupsBtn.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import type { IdpGroup } from "types/permissions";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useDeleteIdpGroups } from "util/permissionIdpGroups";
 import BulkDeleteButton from "components/BulkDeleteButton";
 

--- a/src/pages/permissions/actions/DeleteGroupModal.tsx
+++ b/src/pages/permissions/actions/DeleteGroupModal.tsx
@@ -12,7 +12,7 @@ import type { ChangeEvent, FC } from "react";
 import { useState } from "react";
 import type { LxdAuthGroup } from "types/permissions";
 import { useGroupEntitlements } from "util/entitlements/groups";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { queryKeys } from "util/queryKeys";
 import LoggedInUserNotification from "../panels/LoggedInUserNotification";
 import { useSettings } from "context/useSettings";

--- a/src/pages/permissions/actions/EditIdentityGroupsBtn.tsx
+++ b/src/pages/permissions/actions/EditIdentityGroupsBtn.tsx
@@ -4,7 +4,7 @@ import { Button, Icon } from "@canonical/react-components";
 import type { LxdIdentity } from "types/permissions";
 import usePanelParams from "util/usePanelParams";
 import { useIdentityEntitlements } from "util/entitlements/identities";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { getIdentityName } from "util/permissionIdentities";
 
 interface Props {

--- a/src/pages/permissions/actions/GroupSelectionActions.tsx
+++ b/src/pages/permissions/actions/GroupSelectionActions.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import ModifiedStatusAction from "./ModifiedStatusAction";
 import { ActionButton, Button } from "@canonical/react-components";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 
 interface Props {
   modifiedGroups: Set<string>;

--- a/src/pages/permissions/actions/ModifiedStatusAction.tsx
+++ b/src/pages/permissions/actions/ModifiedStatusAction.tsx
@@ -1,7 +1,6 @@
 import { Button, Icon } from "@canonical/react-components";
 import type { FC } from "react";
-import { getClientOS } from "util/helpers";
-import { pluralize } from "util/instanceBulkActions";
+import { getClientOS, pluralize } from "util/helpers";
 
 interface Props {
   modifiedCount: number;

--- a/src/pages/permissions/forms/GroupForm.tsx
+++ b/src/pages/permissions/forms/GroupForm.tsx
@@ -4,7 +4,7 @@ import type { FormikProps } from "formik/dist/types";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import type { GroupSubForm } from "types/forms/permissionGroup";
 import FormLink from "components/FormLink";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { LxdAuthGroup } from "types/permissions";
 import { useGroupEntitlements } from "util/entitlements/groups";
 import type { PermissionGroupFormValues } from "types/forms/permissionGroup";

--- a/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
@@ -14,7 +14,7 @@ import SelectableMainTable from "components/SelectableMainTable";
 import { useSearchParams } from "react-router-dom";
 import useEditHistory from "util/useEditHistory";
 import ModifiedStatusAction from "../actions/ModifiedStatusAction";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { LxdAuthGroup } from "types/permissions";
 import { getCurrentIdentitiesForGroups } from "util/permissionGroups";
 import GroupIdentitiesPanelConfirmModal from "./GroupIdentitiesPanelConfirmModal";

--- a/src/pages/permissions/panels/EditGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupPanel.tsx
@@ -35,7 +35,7 @@ import {
 import { updateIdentities } from "api/auth-identities";
 import LoggedInUserNotification from "pages/permissions/panels/LoggedInUserNotification";
 import { useSettings } from "context/useSettings";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import GroupHeaderTitle from "pages/permissions/panels/GroupHeaderTitle";
 import type { GroupSubForm } from "types/forms/permissionGroup";
 import ResourceLink from "components/ResourceLink";

--- a/src/pages/permissions/panels/GroupHeaderTitle.tsx
+++ b/src/pages/permissions/panels/GroupHeaderTitle.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import type { LxdAuthGroup } from "types/permissions";
 import type { GroupSubForm } from "types/forms/permissionGroup";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import BackLink from "components/BackLink";
 
 interface Props {

--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import SelectableMainTable from "components/SelectableMainTable";
 import { Link } from "react-router-dom";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import useSortTableData from "util/useSortTableData";
 import { ROOT_PATH } from "util/rootPath";
 import classnames from "classnames";

--- a/src/pages/projects/NavigationProjectSelectorList.tsx
+++ b/src/pages/projects/NavigationProjectSelectorList.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 import type { LxdProject } from "types/project";
 import { getSubpageFromUrl } from "util/projects";
 import { filterUsedByType } from "util/usedBy";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 
 interface Props {

--- a/src/pages/storage/actions/StorageBucketBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketBulkDelete.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import BulkDeleteButton from "components/BulkDeleteButton";

--- a/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import BulkDeleteButton from "components/BulkDeleteButton";

--- a/src/pages/storage/actions/StorageVolumeBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageVolumeBulkDelete.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import BulkDeleteButton from "components/BulkDeleteButton";

--- a/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeSnapshotBulkDelete.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { deleteVolumeSnapshotBulk } from "api/volume-snapshots";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useEventQueue } from "context/eventQueue";
 import { getPromiseSettledCounts } from "util/promises";
 import type { LxdStorageVolume } from "types/storage";

--- a/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
@@ -16,7 +16,7 @@ import { updateStorageBucketKey } from "api/storage-buckets";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import type { StorageBucketKeyFormValues } from "types/forms/storageBucketKey";
 import { useBucketKey } from "context/useBuckets";
 import StorageBucketKeyForm from "../forms/StorageBucketKeyForm";

--- a/src/pages/storage/panels/EditStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketPanel.tsx
@@ -17,7 +17,7 @@ import { updateStorageBucket } from "api/storage-buckets";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket } from "types/storage";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useCurrentProject } from "context/useCurrentProject";
 import { ROOT_PATH } from "util/rootPath";
 

--- a/src/pages/warnings/actions/BulkDeleteWarningBtn.tsx
+++ b/src/pages/warnings/actions/BulkDeleteWarningBtn.tsx
@@ -8,7 +8,7 @@ import {
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteWarningBulk } from "api/warnings";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useServerEntitlements } from "util/entitlements/server";
 
 interface Props {

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -1,6 +1,7 @@
 import type { LxdStorageVolume } from "types/storage";
 
 export type LxdImageType = "container" | "virtual-machine";
+export type LxdImageRegistryProtocol = "simplestreams" | "lxd";
 
 interface LxdImageAlias {
   name: string;
@@ -19,7 +20,7 @@ export interface LxdImage {
   };
   update_source?: {
     alias: string;
-    protocol: string;
+    protocol: LxdImageRegistryProtocol;
     server: string;
   };
   architecture: string;
@@ -29,6 +30,20 @@ export interface LxdImage {
   aliases: LxdImageAlias[];
   cached: boolean;
   name?: string;
+  access_entitlements?: string[];
+}
+
+export interface LxdImageRegistry {
+  name: string;
+  description: string;
+  protocol: LxdImageRegistryProtocol;
+  builtin: boolean;
+  config?: {
+    url: string;
+    public: string;
+    cluster: string;
+    source_project: string;
+  };
   access_entitlements?: string[];
 }
 

--- a/src/util/entitlements/images.tsx
+++ b/src/util/entitlements/images.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "context/auth";
 import { hasEntitlement } from "./helpers";
-import type { LxdImage } from "types/image";
+import type { LxdImage, LxdImageRegistry } from "types/image";
 
 export const useImageEntitlements = () => {
   const { isFineGrained } = useAuth();
@@ -10,5 +10,27 @@ export const useImageEntitlements = () => {
 
   return {
     canDeleteImage,
+  };
+};
+
+export const useImageRegistriesEntitlements = () => {
+  const { isFineGrained } = useAuth();
+
+  const canDeleteImageRegistry = (imageRegistry: LxdImageRegistry) =>
+    hasEntitlement(
+      isFineGrained,
+      "can_delete",
+      imageRegistry?.access_entitlements,
+    );
+  const canEditImageRegistry = (imageRegistry: LxdImageRegistry) =>
+    hasEntitlement(
+      isFineGrained,
+      "can_edit",
+      imageRegistry?.access_entitlements,
+    );
+
+  return {
+    canDeleteImageRegistry,
+    canEditImageRegistry,
   };
 };

--- a/src/util/entitlements/server.tsx
+++ b/src/util/entitlements/server.tsx
@@ -67,10 +67,18 @@ export const useServerEntitlements = () => {
     hasEntitlement(isFineGrained, "admin", serverEntitlements) ||
     hasEntitlement(isFineGrained, "viewer", serverEntitlements);
 
+  const canCreateImageRegistries = () =>
+    hasEntitlement(
+      isFineGrained,
+      "can_create_image_registries",
+      serverEntitlements,
+    ) || hasEntitlement(isFineGrained, "admin", serverEntitlements);
+
   return {
     canCreateGroups,
     canCreateIdentities,
     canCreateIdpGroups,
+    canCreateImageRegistries,
     canCreateProjects,
     canCreateStoragePools,
     canEditServerConfiguration,

--- a/src/util/helpers.tsx
+++ b/src/util/helpers.tsx
@@ -475,3 +475,40 @@ export const isBearerAuthError = (error: Error | null) => {
 
 export const ensureArray = <T,>(data: T | T[]): T[] =>
   Array.isArray(data) ? data : [data];
+
+export const pluralize = (item: string, count: number): string => {
+  if (!item) return "";
+  if (count === 1) return item;
+
+  const itemLower = item.toLowerCase();
+
+  const exceptions: Record<string, string> = {
+    identity: "identities",
+    proxy: "proxies",
+    gpu: "gpus",
+    registry: "registries",
+  };
+
+  if (exceptions[itemLower]) {
+    const pluralForm = exceptions[itemLower];
+
+    // Special case: GPU -> GPUs, not GPUS
+    if (item === "GPU") {
+      return "GPUs";
+    }
+
+    if (item === item.toUpperCase()) {
+      return pluralForm.toUpperCase();
+    } else if (item.charAt(0) === item.charAt(0).toUpperCase()) {
+      return capitalizeFirstLetter(pluralForm);
+    } else {
+      return pluralForm;
+    }
+  }
+
+  if (item === item.toUpperCase()) {
+    return `${item}S`;
+  } else {
+    return `${item}s`;
+  }
+};

--- a/src/util/image-registries.tsx
+++ b/src/util/image-registries.tsx
@@ -1,0 +1,5 @@
+import type { LxdImageRegistry } from "types/image";
+
+export const isRegistryPublic = (registry: LxdImageRegistry): boolean => {
+  return registry.config?.public?.toLowerCase() === "true";
+};

--- a/src/util/instanceBulkActions.spec.tsx
+++ b/src/util/instanceBulkActions.spec.tsx
@@ -1,4 +1,4 @@
-import { pluralize } from "./instanceBulkActions";
+import { pluralize } from "util/helpers";
 
 describe("pluralize function", () => {
   describe("count of 1", () => {

--- a/src/util/instanceBulkActions.tsx
+++ b/src/util/instanceBulkActions.tsx
@@ -4,7 +4,6 @@ import type {
   LxdInstanceStatus,
 } from "types/instance";
 import type { InstanceBulkAction } from "api/instances";
-import { capitalizeFirstLetter } from "util/helpers";
 
 // map desired actions to pairs of instance status and performed action
 // statuses missing will be ignored
@@ -67,42 +66,6 @@ export const instanceActionLabel = (action: LxdInstanceAction): string => {
     freeze: "frozen",
     stop: "stopped",
   }[action];
-};
-
-export const pluralize = (item: string, count: number): string => {
-  if (!item) return "";
-  if (count === 1) return item;
-
-  const itemLower = item.toLowerCase();
-
-  const exceptions: Record<string, string> = {
-    identity: "identities",
-    proxy: "proxies",
-    gpu: "gpus",
-  };
-
-  if (exceptions[itemLower]) {
-    const pluralForm = exceptions[itemLower];
-
-    // Special case: GPU -> GPUs, not GPUS
-    if (item === "GPU") {
-      return "GPUs";
-    }
-
-    if (item === item.toUpperCase()) {
-      return pluralForm.toUpperCase();
-    } else if (item.charAt(0) === item.charAt(0).toUpperCase()) {
-      return capitalizeFirstLetter(pluralForm);
-    } else {
-      return pluralForm;
-    }
-  }
-
-  if (item === item.toUpperCase()) {
-    return `${item}S`;
-  } else {
-    return `${item}s`;
-  }
 };
 
 export const statusLabel = (status: LxdInstanceStatus): string | undefined => {

--- a/src/util/permissionIdpGroups.tsx
+++ b/src/util/permissionIdpGroups.tsx
@@ -6,7 +6,7 @@ import { useNotify, useToastNotification } from "@canonical/react-components";
 import { useState } from "react";
 import { useIdpGroupEntitlements } from "util/entitlements/idp-groups";
 import ResourceLabel from "components/ResourceLabel";
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 import { useQueryClient } from "@tanstack/react-query";
 import type { IdpGroup } from "types/permissions";
 import { queryKeys } from "./queryKeys";

--- a/src/util/queryKeys.tsx
+++ b/src/util/queryKeys.tsx
@@ -7,6 +7,7 @@ export const queryKeys = {
   forwards: "forwards",
   groups: "groups",
   images: "images",
+  imageRegistries: "imageRegistries",
   instances: "instances",
   customVolumes: "customVolumes",
   isoVolumes: "isoVolumes",

--- a/src/util/seconds.tsx
+++ b/src/util/seconds.tsx
@@ -1,4 +1,4 @@
-import { pluralize } from "util/instanceBulkActions";
+import { pluralize } from "util/helpers";
 
 export const formatSeconds = (seconds: number): string => {
   let result = "";

--- a/tests/helpers/image-registries.ts
+++ b/tests/helpers/image-registries.ts
@@ -1,0 +1,17 @@
+import { expect, test, type LxdVersions } from "../fixtures/lxd-test";
+import type { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
+
+export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
+  test.skip(
+    lxdVersion === "latest-edge" ||
+      lxdVersion === "5.0-edge" ||
+      lxdVersion === "5.21-edge",
+    "Image registries page are currently not available",
+  );
+};
+
+export const visitImageRegistries = async (page: Page) => {
+  await gotoURL(page, `/ui/image-registries`);
+  await expect(page.getByTitle("Create image registry")).toBeVisible();
+};

--- a/tests/image-registries.spec.ts
+++ b/tests/image-registries.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "./fixtures/lxd-test";
+import {
+  skipIfNotSupported,
+  visitImageRegistries,
+} from "./helpers/image-registries";
+import { gotoURL } from "./helpers/navigate";
+
+test("search for an image registry", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  await gotoURL(page, "/ui");
+  await page.getByRole("button", { name: "Images" }).click();
+  await page
+    .getByRole("link", { name: "Image registries", exact: true })
+    .click();
+  await expect(page.getByTitle("Create registry")).toBeVisible();
+
+  await page.getByPlaceholder("Search and filter").click();
+  await page.getByPlaceholder("Search and filter").fill("ubuntu-daily"); //builtin image registry
+  await page.getByPlaceholder("Search and filter").press("Enter");
+  await page.getByPlaceholder("Add filter").press("Escape");
+
+  await expect(
+    page.getByRole("row", { name: /ubuntu-daily/i, exact: true }),
+  ).toBeVisible();
+});
+
+test("search for built-in image registries", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  await visitImageRegistries(page);
+
+  await page.getByPlaceholder("Search and filter").click();
+  await page.getByPlaceholder("Search and filter").press("Enter");
+  await page.getByRole("button", { name: /BUILTIN Yes/i }).click();
+  await page.getByPlaceholder("Add filter").press("Escape");
+
+  await expect(page.getByText("Showing all 5 image registries")).toBeVisible();
+});


### PR DESCRIPTION
## Done

- Add a new page for listing image registries

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - This needs to run against a version lxd with image registries support. For now, you can run against lxd of the following branch https://github.com/canonical/lxd/pull/17680
    - Go to Images -> Registries
    - Registry creation is currently not available in the UI. Instead, you can run `sudo lxc image registry create ubuntu1 --protocol simplestreams url=https://ubuntu.com public=true` to create a new public registry pointing to ubuntu.com 
   
    - Explore the page, especially the following components:
       - Search and filter 
       - Table layout
       - Rows selection

## Screenshots
<img width="1844" height="1054" alt="image" src="https://github.com/user-attachments/assets/da21011c-2a50-41e6-9120-328ca278b755" />
<img width="1844" height="1054" alt="image" src="https://github.com/user-attachments/assets/3d025051-3239-4177-9ff3-7e83da63544e" />