### PR TITLE
WD-35391: Do not display "Same for all members" checkbox if the cluster has only one node

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -93,7 +92,12 @@ jobs:
       matrix:
         lxd_channel: ["5.0/edge", "5.21/edge", "latest/edge"]
         browser: ["chromium", "firefox"]
-        deployment: ["unclustered", "clustered"]
+        deployment: ["unclustered", "clustered", "single-node-cluster"]
+        exclude:
+          - lxd_channel: "5.0/edge"
+            deployment: "clustered"
+          - lxd_channel: "5.0/edge"
+            deployment: "single-node-cluster"
     outputs:
       job_status: ${{job.status}}
     env:
@@ -115,24 +119,19 @@ jobs:
 
       - name: Install LXD-UI dependencies
         run: |
-          set -x
           sudo chmod 0777 ../lxd-ui
           dotrun install
+
+      - name: Generate SSL keys for HAProxy
+        run: |
+          mkdir -p keys
+          openssl req -x509 -newkey rsa:4096 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -days 365 -nodes -subj "/CN=localhost"
+          cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
 
       - name: OVN dependencies
         run: |
           sudo snap refresh snapd --channel latest/beta || sudo snap install snapd --channel latest/beta
           sudo snap refresh core26 --channel latest/edge || sudo snap install core26 --channel latest/edge
-
-      - name: Run LXD-UI
-        env:
-          ENVIRONMENT: devel
-          PORT: 8407
-          LXD_UI_BACKEND_IP: 172.17.0.1
-          VITE_PORT: 3000
-        run: |
-          dotrun &
-          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
       - name: Setup Ceph
         if: ${{ matrix.lxd_channel != '5.0/edge' }}
@@ -146,15 +145,168 @@ jobs:
         uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
         with:
           channel: ${{ matrix.lxd_channel }}
-          group: lxd
 
-      - name: Setup LXD
+      - name: Setup LXD (Clustered in VMs)
+        if: ${{ matrix.deployment == 'clustered' }}
+        shell: bash
+        run: |
+          set -x
+          sudo lxd init --auto
+          sudo lxc launch ubuntu:24.04 vm1 --vm
+          until sudo lxc exec vm1 -- true 2>/dev/null; do
+            sleep 1
+          done
+          sudo lxc exec vm1 -- cloud-init status --wait
+          sudo lxc launch ubuntu:24.04 vm2 --vm
+          until sudo lxc exec vm2 -- true 2>/dev/null; do
+            sleep 1
+          done
+          sudo lxc exec vm2 -- cloud-init status --wait
+
+          sudo lxc exec vm1 -- snap install lxd --channel=${{ matrix.lxd_channel }}
+          sudo lxc exec vm2 -- snap install lxd --channel=${{ matrix.lxd_channel }}
+
+          VM1_IP=$(sudo lxc list vm1 --format csv -c 4 | cut -d' ' -f1 | cut -d',' -f1)
+          VM2_IP=$(sudo lxc list vm2 --format csv -c 4 | cut -d' ' -f1 | cut -d',' -f1)
+
+          # Bootstrap VM1
+          cat <<EOF | sudo lxc exec vm1 -- lxd init --preseed
+          config:
+            core.https_address: ${VM1_IP}:8443
+          cluster:
+            enabled: true
+            server_name: vm1
+          networks:
+          - name: lxdbr0
+            type: bridge
+            config:
+              ipv4.address: auto
+              ipv6.address: auto
+          storage_pools:
+          - name: default
+            driver: dir
+            config: {}
+          profiles:
+          - name: default
+            devices:
+              root:
+                path: /
+                pool: default
+                type: disk
+          EOF
+
+          TOKEN=$(sudo lxc exec vm1 -- lxc cluster add vm2 | grep -oE 'ey[A-Za-z0-9._=-]+')
+
+          # Join VM2
+          cat <<EOF | sudo lxc exec vm2 -- lxd init --preseed
+          cluster:
+            enabled: true
+            server_name: vm2
+            server_address: ${VM2_IP}:8443
+            cluster_token: ${TOKEN}
+          EOF
+
+          cat keys/lxd-ui.crt | sudo lxc exec vm1 -- lxc config trust add - || true
+
+          echo "LXD_UI_BACKEND_IP=$VM1_IP" > .env.local
+
+          sudo lxc exec vm1 -- sudo snap install snapd --channel=latest/beta
+          sudo lxc exec vm1 -- sudo snap install core26 --channel latest/edge
+          sudo lxc exec vm1 -- sudo snap install microovn --channel latest/edge
+          sudo lxc exec vm1 -- sudo microovn waitready
+          sudo lxc exec vm1 -- sudo microovn cluster bootstrap
+          sudo lxc exec vm1 -- sudo microovn status
+          OVN_TOKEN=$(sudo lxc exec vm1 -- sudo microovn cluster add vm2)
+
+          sudo lxc exec vm2 -- sudo snap install snapd --channel=latest/beta
+          sudo lxc exec vm2 -- sudo snap install core26 --channel latest/edge
+          sudo lxc exec vm2 -- sudo snap install microovn --channel latest/edge
+          sudo lxc exec vm2 -- sudo microovn waitready
+          sudo lxc exec vm2 -- sudo microovn cluster join "$OVN_TOKEN"
+          sudo lxc exec vm2 -- sudo microovn status
+
+          sudo lxc exec vm1 -- lxc config set network.ovn.northbound_connection "ssl:$VM1_IP:6641,ssl:$VM2_IP:6641"
+
+          # Wait for OVN chassis to be fully registered
+          echo "Waiting for OVN chassis registration..."
+          sleep 15
+
+          # Verify chassis are registered
+          echo "Checking chassis status..."
+          sudo lxc exec vm1 -- sudo ovn-sbctl show
+
+          # Wait for ovn-controller to be ready on both nodes
+          for vm in vm1 vm2; do
+            echo "Checking ovn-controller on $vm..."
+            sudo lxc exec $vm -- sudo systemctl is-active ovn-controller || true
+            sudo lxc exec $vm -- sudo ovn-sbctl list chassis || true
+          done
+
+      - name: Setup LXD (Unclustered on host)
+        if: ${{ matrix.deployment == 'unclustered' }}
         shell: bash
         run: |
           set -x
           sudo lxc config set core.https_address "[::]:8443"
           sudo lxc config trust add keys/lxd-ui.crt
-          sudo lxc config set cluster.https_address "127.0.0.1"
+
+      - name: Setup LXD (Single-node cluster)
+        if: ${{ matrix.deployment == 'single-node-cluster' }}
+        shell: bash
+        run: |
+          set -x
+          HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7; exit}')
+          sudo lxc config trust add keys/lxd-ui.crt
+          cat <<EOF | sudo lxd init --preseed
+          config:
+            core.https_address: ${HOST_IP}:8443
+          networks:
+          - name: lxdbr0
+            type: bridge
+            config:
+              ipv4.address: auto
+              ipv6.address: auto
+          storage_pools:
+          - name: default
+            driver: dir
+            config: {}
+          profiles:
+          - name: default
+            devices:
+              root:
+                path: /
+                pool: default
+                type: disk
+          EOF
+          echo "LXD_UI_BACKEND_IP=${HOST_IP}" > .env.local
+
+      - name: Setup for tests
+        if: ${{ matrix.lxd_channel != '5.0/edge' }}
+        shell: bash
+        env:
+          DEPLOYMENT: ${{ matrix.deployment }}
+          LXD_OIDC_ISSUER: ${{ env.LXD_OIDC_ISSUER }}
+          LXD_OIDC_CLIENT_ID: ${{ env.LXD_OIDC_CLIENT_ID }}
+          LXD_OIDC_CLIENT_SECRET: ${{ env.LXD_OIDC_CLIENT_SECRET }}
+          LXD_OIDC_AUDIENCE: ${{ env.LXD_OIDC_AUDIENCE }}
+          LXD_OIDC_GROUPS_CLAIM: ${{ env.LXD_OIDC_GROUPS_CLAIM }}
+        run: sudo -E ./tests/scripts/setup_test
+
+      - name: Run LXD-UI
+        env:
+          ENVIRONMENT: devel
+          PORT: 8407
+          VITE_PORT: 3000
+        run: |
+          echo "Backend configuration:"
+          if [ -f .env.local ]; then
+            cat .env.local
+          else
+            echo "Using default backend configuration"
+          fi
+          dotrun &
+          sleep 10
+          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -163,25 +315,14 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps ${{ matrix.browser }}
 
-      - name: Set lxd channel env variable
-        id: lxd-env
-        run: |
-          # need to change / to - in lxd channel string for report naming
-          LXD_CHANNEL=$(echo '${{ matrix.lxd_channel }}' | sed 's#/#-#g')
-          echo "LXD_CHANNEL=$LXD_CHANNEL" >> $GITHUB_OUTPUT
-
-      - name: Setup for tests
-        if: ${{ matrix.lxd_channel != '5.0/edge' }}
-        shell: bash
-        run: sudo -E ./tests/scripts/setup_test
-
       - name: Run Playwright tests
         env:
           BROWSER: ${{ matrix.browser }}
           DEPLOYMENT: ${{ matrix.deployment }}
-          LXD_CHANNEL: ${{ steps.lxd-env.outputs.LXD_CHANNEL }}
+          LXD_CHANNEL: ${{ matrix.lxd_channel }}
         run: |
-          npx playwright test --project "${BROWSER}:lxd-${LXD_CHANNEL}:${DEPLOYMENT}"
+          PLAYWRIGHT_CHANNEL=$(echo "${LXD_CHANNEL}" | sed 's#/#-#g')
+          npx playwright test --project "${BROWSER}:lxd-${PLAYWRIGHT_CHANNEL}:${DEPLOYMENT}"
 
       - name: Rename Playwright report and artifacts folder
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,18 +66,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
       testMatch: "login.spec.ts",
     },
     {
-      name: "enable-clustering-chrome",
-      // enable clustering for subsequent tests
-      use: { ...devices["Desktop Chrome"] },
-      testMatch: "enable-clustering.spec.ts",
-    },
-    {
-      name: "enable-clustering-firefox",
-      // enable clustering for subsequent tests
-      use: { ...devices["Desktop Firefox"] },
-      testMatch: "enable-clustering.spec.ts",
-    },
-    {
       name: "chromium:lxd-5.0-edge:unclustered",
       use: {
         ...devices["Desktop Chrome"],
@@ -123,24 +111,41 @@ const config: PlaywrightTestConfig<TestOptions> = {
       },
       dependencies: ["login-firefox"],
     },
-    // Clustered tests
     {
-      name: "chromium:lxd-5.0-edge:clustered",
+      name: "chromium:lxd-5.21-edge:single-node-cluster",
       use: {
         ...devices["Desktop Chrome"],
-        lxdVersion: "5.0-edge",
+        lxdVersion: "5.21-edge",
       },
-      testMatch: "*-clustered.spec.ts",
-      dependencies: ["enable-clustering-chrome"],
+      dependencies: ["login-chromium"],
+      testMatch: "enable-clustering.spec.ts",
     },
     {
-      name: "firefox:lxd-5.0-edge:clustered",
+      name: "firefox:lxd-5.21-edge:single-node-cluster",
       use: {
         ...devices["Desktop Firefox"],
-        lxdVersion: "5.0-edge",
+        lxdVersion: "5.21-edge",
       },
-      dependencies: ["enable-clustering-firefox"],
-      testMatch: "*-clustered.spec.ts",
+      dependencies: ["login-firefox"],
+      testMatch: "enable-clustering.spec.ts",
+    },
+    {
+      name: "chromium:lxd-latest-edge:single-node-cluster",
+      use: {
+        ...devices["Desktop Chrome"],
+        lxdVersion: "latest-edge",
+      },
+      dependencies: ["login-chromium"],
+      testMatch: "enable-clustering.spec.ts",
+    },
+    {
+      name: "firefox:lxd-latest-edge:single-node-cluster",
+      use: {
+        ...devices["Desktop Firefox"],
+        lxdVersion: "latest-edge",
+      },
+      dependencies: ["login-firefox"],
+      testMatch: "enable-clustering.spec.ts",
     },
     {
       name: "chromium:lxd-5.21-edge:clustered",
@@ -148,7 +153,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         ...devices["Desktop Chrome"],
         lxdVersion: "5.21-edge",
       },
-      dependencies: ["enable-clustering-chrome"],
       testMatch: "*-clustered.spec.ts",
     },
     {
@@ -157,7 +161,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         ...devices["Desktop Firefox"],
         lxdVersion: "5.21-edge",
       },
-      dependencies: ["enable-clustering-firefox"],
       testMatch: "*-clustered.spec.ts",
     },
     {
@@ -166,7 +169,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         ...devices["Desktop Chrome"],
         lxdVersion: "latest-edge",
       },
-      dependencies: ["enable-clustering-chrome"],
       testMatch: "*-clustered.spec.ts",
     },
     {
@@ -175,7 +177,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         ...devices["Desktop Firefox"],
         lxdVersion: "latest-edge",
       },
-      dependencies: ["enable-clustering-firefox"],
       testMatch: "*-clustered.spec.ts",
     },
     {
@@ -194,7 +195,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         lxdVersion: "latest-edge",
         hasCoverage: true,
       },
-      dependencies: ["enable-clustering-chrome"],
       testMatch: "*-clustered.spec.ts",
     },
     {
@@ -211,7 +211,6 @@ const config: PlaywrightTestConfig<TestOptions> = {
         ...devices["Desktop Chrome"],
         lxdVersion: "latest-edge",
       },
-      dependencies: ["enable-clustering-chrome"],
       testMatch: "docs-screenshots-clustered.spec.ts",
     },
   ],

--- a/src/components/ClusterSpecificSelect.tsx
+++ b/src/components/ClusterSpecificSelect.tsx
@@ -97,7 +97,7 @@ const ClusterSpecificSelect: FC<Props> = ({
 
   return (
     <div className={classname}>
-      {canToggleSpecific && !isReadOnly && (
+      {canToggleSpecific && !isReadOnly && options.length > 1 && (
         <CheckboxInput
           id={`${id}-same-for-all-toggle`}
           label="Same for all cluster members"

--- a/src/components/forms/ClusterSpecificInput.tsx
+++ b/src/components/forms/ClusterSpecificInput.tsx
@@ -69,7 +69,7 @@ const ClusterSpecificInput: FC<Props> = ({
 
   return (
     <div className={classname}>
-      {canToggleSpecific && !isReadOnly && (
+      {canToggleSpecific && !isReadOnly && memberNames.length > 1 && (
         <CheckboxInput
           id={`${id}-same-for-all-toggle`}
           label="Same for all cluster members"

--- a/src/components/forms/ClusteredDiskSizeSelector.tsx
+++ b/src/components/forms/ClusteredDiskSizeSelector.tsx
@@ -53,17 +53,19 @@ const ClusteredDiskSizeSelector: FC<Props> = ({
   return (
     <div className="u-sv3">
       <Label forId="sizePerClusterMember">Size</Label>
-      <CheckboxInput
-        id={`${id}-same-for-all-toggle`}
-        label="Same for all cluster members"
-        checked={!isSpecific}
-        onChange={() => {
-          setValueForAllMembers(firstValue);
-          setIsSpecific((val) => !val);
-        }}
-        disabled={!!disabledReason}
-        title={disabledReason}
-      />
+      {clusterMembers.length > 1 && (
+        <CheckboxInput
+          id={`${id}-same-for-all-toggle`}
+          label="Same for all cluster members"
+          checked={!isSpecific}
+          onChange={() => {
+            setValueForAllMembers(firstValue);
+            setIsSpecific((val) => !val);
+          }}
+          disabled={!!disabledReason}
+          title={disabledReason}
+        />
+      )}
       {isSpecific && (
         <div className="cluster-specific-input">
           {memberNames.map((item) => {

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -18,7 +18,7 @@ const openProjectCreationForm = async (page: Page) => {
   await expect(page.getByText("Loading storage pools")).not.toBeVisible();
 
   await page.getByLabel("Default instance network", { exact: true }).click();
-  await page.getByText("No network", { exact: true }).click();
+  await page.getByTitle("No network", { exact: true }).click();
 };
 
 const submitProjectCreationForm = async (page: Page, project: string) => {

--- a/tests/scripts/setup_test
+++ b/tests/scripts/setup_test
@@ -1,59 +1,46 @@
 #! /usr/bin/env bash
 set -e
 
+LXC_CMD="sudo lxc"
+LXD_CMD="sudo lxd"
+SNAP_CMD="sudo snap"
+if [ "$DEPLOYMENT" = "clustered" ]; then
+    echo "Configuring clustered environment via vm1..."
+    LXC_CMD="sudo lxc exec vm1 -- lxc"
+    LXD_CMD="sudo lxc exec vm1 -- lxd"
+    SNAP_CMD="sudo lxc exec vm1 -- snap"
+fi
+
 # hasNeededAPIExtension: check if LXD supports the needed extension.
 hasNeededAPIExtension() (
     needed_extension="${1}"
-    lxc info | grep -qxFm1 -- "- ${needed_extension}"
+    $LXC_CMD info | grep -qxFm1 -- "- ${needed_extension}"
 )
 
-# setup oidc configs
 if [ -f .env.local ]
 then
   set -o allexport; source .env.local; set +o allexport
 fi
-lxc config set oidc.issuer=${LXD_OIDC_ISSUER}
-lxc config set oidc.client.id=${LXD_OIDC_CLIENT_ID}
+
+# Apply OIDC settings
+$LXC_CMD config set oidc.issuer "${LXD_OIDC_ISSUER}"
+$LXC_CMD config set oidc.client.id "${LXD_OIDC_CLIENT_ID}"
+$LXC_CMD config set oidc.audience "${LXD_OIDC_AUDIENCE}"
+$LXC_CMD config set oidc.groups.claim "${LXD_OIDC_GROUPS_CLAIM}"
+
+# Logic for Secret (Only if the extension exists)
 if hasNeededAPIExtension "oidc_client_secret"; then
-    lxc config set oidc.client.secret=${LXD_OIDC_CLIENT_SECRET}
+    $LXC_CMD config set oidc.client.secret=${LXD_OIDC_CLIENT_SECRET}
     echo "OIDC client secret is set."
 fi
-lxc config set oidc.audience=${LXD_OIDC_AUDIENCE}
-lxc config set oidc.groups.claim=${LXD_OIDC_GROUPS_CLAIM}
 
-# create identity provider group mapping
-lxc auth group create login-admin
-lxc auth group permission add login-admin server admin
-# The name of the identity provider group should be the same as the role name assigned to the user
-lxc auth identity-provider-group create admin
-lxc auth identity-provider-group group add admin login-admin
+# Auth groups
+$LXC_CMD auth group create login-admin
+$LXC_CMD auth group permission add login-admin server admin
+$LXC_CMD auth identity-provider-group create admin
+$LXC_CMD auth identity-provider-group group add admin login-admin
 
-# create oidc user foo
-lxd sql global "
-    INSERT OR REPLACE INTO identities 
-    (id, auth_method, type, identifier, name, metadata) 
-    VALUES 
-    (
-        (SELECT id from identities WHERE name='foo'),
-        2, 
-        5, 
-        'foo@foo.com', 
-        'foo', 
-        '{}'
-    );
-"
+# SQL - Ensure we don't fail if the user already exists
+$LXD_CMD sql global "INSERT OR REPLACE INTO identities (auth_method, type, identifier, name, metadata) VALUES (2, 5, 'foo@foo.com', 'foo', '{}');"
+$LXD_CMD sql global "INSERT OR REPLACE INTO identities (auth_method, type, identifier, name, metadata) VALUES (2, 5, 'bar@bar.com', 'bar', '{}');"
 
-# create oidc user bar
-lxd sql global "
-    INSERT OR REPLACE INTO identities 
-    (id, auth_method, type, identifier, name, metadata) 
-    VALUES 
-    (
-        (SELECT id from identities WHERE name='bar'),
-        2, 
-        5, 
-        'bar@bar.com', 
-        'bar', 
-        '{}'
-    );
-"

--- a/tests/snapshots.spec.ts
+++ b/tests/snapshots.spec.ts
@@ -69,8 +69,7 @@ test("publish image from instance snapshot in custom project", async ({
   await createCustomProject(page, project);
 
   const instance = randomInstanceName();
-  const type = "container";
-  await createInstance(page, instance, type, project);
+  await createInstance(page, instance, "container", project);
 
   const snapshot = randomSnapshotName();
   await createInstanceSnapshot(page, instance, snapshot, project);


### PR DESCRIPTION
## Done

- Do not display `Same for all cluster members` checkbox if the cluster has only one node.
- Affected screens: 
    - existing storage pool > Configuration
    - Settings > core.syslog_socket
    - Settings > cluster.https_address
    - Network configuration with Parent (type=macvlan)
    - Network configuration > External interfaces
    - Create storage pool: source
    - Create storage pool > ZFS

I updated the test `create a member-specific physical network`, which was failing because `Same for all cluster members` checkbox is not displayed anymore. I created a VM and added it to the cluster, however it's offline.
The good news is that the test doesn't fail on `await page.getByText("Same for all cluster members").click();` anymore.
The less good news is that the `Create` button is disabled because the new member is offline so the test fails anyway.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Check all affected screens in a one-member cluster and ensure the `Same for all cluster members` checkbox is **not** displayed.
    - Check all affected screens in a 2-member cluster and ensure the `Same for all cluster members` checkbox is displayed.
    - Rely on CI passing

## Screenshots

Tests
<img width="1010" height="487" alt="Screenshot from 2026-04-30 15-14-33" src="https://github.com/user-attachments/assets/0fa17db4-1c22-438e-8522-4daf1fa08636" />


Affected screens
Existing storage pool > Configuration with `Same for all cluster members` checkbox
<img width="1549" height="1049" alt="Screenshot from 2026-04-01 09-59-12" src="https://github.com/user-attachments/assets/5fa3caee-1583-46b3-9ca6-42af101439f8" />

Existing storage pool > Configuration without `Same for all cluster members` checkbox
<img width="1549" height="1049" alt="Screenshot from 2026-04-01 09-58-39" src="https://github.com/user-attachments/assets/957b017d-d55e-4d4c-af32-b2f354fb8725" />

Settings > core.syslog_socket with `Same for all cluster members` checkbox
<img width="1544" height="403" alt="Screenshot from 2026-04-01 09-59-43" src="https://github.com/user-attachments/assets/164586de-a3da-4d8a-ac96-c5fdb564afe1" />

Settings > core.syslog_socket without `Same for all cluster members` checkbox
<img width="1544" height="403" alt="Screenshot from 2026-04-01 10-03-16" src="https://github.com/user-attachments/assets/af490567-9b7b-48e9-84c3-c20ddf7953cc" />

Settings > cluster.https_address with `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-14-03" src="https://github.com/user-attachments/assets/8439d8e9-0678-422e-8be4-fe5ccea4d074" />

Settings > cluster.https_address without `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-14-22" src="https://github.com/user-attachments/assets/96dc0b34-3320-4dfa-bc4e-f4a2088a954f" />

Network configuration with Parent with `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-06-22" src="https://github.com/user-attachments/assets/862e289a-e91a-44bf-8876-302587da8b3b" />

Network configuration with Parent without `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-06-41" src="https://github.com/user-attachments/assets/95f79fe7-5d40-4ece-9b27-e24d0ce60b2f" />

Network configuration > External interfaces with `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-12-11" src="https://github.com/user-attachments/assets/c9488c9b-bcd8-4344-9327-5f015d6bed53" />

Network configuration > External interfaces without `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-12-31" src="https://github.com/user-attachments/assets/2b9494b8-502c-43a3-ba8a-b93a1918389a" />

Create storage pool: source with `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-09-26" src="https://github.com/user-attachments/assets/2dbf0929-10bf-4385-a6b9-60ab63d0b089" />

Create storage pool: source without `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-10-01" src="https://github.com/user-attachments/assets/4cdfe33b-15f7-4413-901f-961a1170bf3d" />

Create storage pool > ZFS with `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-16-21" src="https://github.com/user-attachments/assets/b8037f63-fa21-4cdb-b014-087bad0c883e" />

Create storage pool > ZFS without `Same for all cluster members` checkbox
<img width="1546" height="1053" alt="Screenshot from 2026-04-01 10-16-48" src="https://github.com/user-attachments/assets/b7dc2753-ccd9-49e4-8e46-e6b9c75b42b2" />
