### PR TITLE
fix(doc-links): get instead of head

### DIFF
--- a/tests/helpers/doc-links.ts
+++ b/tests/helpers/doc-links.ts
@@ -42,7 +42,7 @@ export async function checkDocumentationExists(
 }> {
   try {
     const fullUrl = `/documentation${docPath}`;
-    const response = await page.request.head(fullUrl);
+    const response = await page.request.get(fullUrl);
     const status = response.status();
     const exists = status === 200;
     return { exists, status };


### PR DESCRIPTION
## Done

- fix(doc-links): Fix `DocLink validation: collect all doc paths and verify they exist` on latest edge

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI passing

## Screenshots

Locally
<img width="942" height="47" alt="image" src="https://github.com/user-attachments/assets/3c1fa2fa-8109-4b4e-8687-73e513fd5647" />

CI
<img width="1362" height="718" alt="image" src="https://github.com/user-attachments/assets/9b73a5f9-71d1-463f-b6bc-ac31929dfa8d" />

