### PR TITLE
fix(doc-link): Fix Ensure the documentation link text and link targets are present: Instance Detail > Configuration

### DIFF
--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -37,6 +37,8 @@ export const createInstance = async (
   await page.getByLabel("Instance name").click();
   await page.getByLabel("Instance name").fill(instance);
   await page.getByRole("button", { name: "Browse images" }).click();
+  const dialog = page.getByRole("dialog", { name: "Select base image" });
+  await dialog.getByRole("combobox", { name: "Type" }).selectOption(type);
   await page.getByPlaceholder("Search an image").click();
   await page.getByPlaceholder("Search an image").fill(image);
   await page
@@ -45,9 +47,6 @@ export const createInstance = async (
     .getByRole("button", { name: "Select" })
     .first()
     .click();
-  await page
-    .getByRole("combobox", { name: "Instance type" })
-    .selectOption(type);
 
   if (project !== "default") {
     await page.getByText("Disk", { exact: true }).click();


### PR DESCRIPTION
## Done

- fix(doc-link): on instance create, do not try to update instance type if dropdown is disabled

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI passing

## Screenshots

Locally
<img width="942" height="47" alt="image" src="https://github.com/user-attachments/assets/a7c0e104-7b11-4686-a30c-096564aabb85" />

CI
<img width="1362" height="718" alt="image" src="https://github.com/user-attachments/assets/838908e5-ae4d-453c-b80b-37fbe720bac5" />
