### PR TITLE
fix(permission-groups): select group before managing identities

### DIFF
--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -56,10 +56,8 @@ const PermissionGroups: FC = () => {
   useEffect(() => {
     if (panelParams.group) {
       setSelectedGroupNames([panelParams.group]);
-    } else if (panelParams.panel === null) {
-      setSelectedGroupNames([]);
     }
-  }, [panelParams.group, panelParams.panel, groups]);
+  }, [panelParams.group, groups]);
 
   const headers = [
     { content: "Name", className: "name", sortKey: "name" },


### PR DESCRIPTION
## Done

- fix(permission-groups): select group before clicking on `Manage identities` (previously the groups stay selected after panel closes)


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI

## Screenshots
<img width="1340" height="748" alt="image" src="https://github.com/user-attachments/assets/df4ce58a-44e8-4865-90f7-f9c77d0057c1" />
