### PR TITLE
WD-35455: networks and acls operations

### DIFF
--- a/src/api/network-acls.tsx
+++ b/src/api/network-acls.tsx
@@ -5,6 +5,7 @@ import {
 } from "util/helpers";
 import type { LxdNetworkAcl } from "types/network";
 import type { LxdApiResponse } from "types/apiResponse";
+import type { LxdOperationResponse } from "types/operation";
 import { addEntitlements } from "util/entitlements/api";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -64,28 +65,32 @@ export const fetchNetworkAclLog = async (
 export const createNetworkAcl = async (
   networkAcl: LxdNetworkAcl,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(`${ROOT_PATH}/1.0/network-acls?${params.toString()}`, {
+  return fetch(`${ROOT_PATH}/1.0/network-acls?${params.toString()}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(networkAcl),
-  }).then(handleResponse);
+  })
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const renameNetworkAcl = async (
   oldName: string,
   newName: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return await fetch(
     `${ROOT_PATH}/1.0/network-acls/${encodeURIComponent(oldName)}?${params.toString()}`,
     {
       method: "POST",
@@ -96,17 +101,21 @@ export const renameNetworkAcl = async (
         name: newName,
       }),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const updateNetworkAcl = async (
   networkAcl: LxdNetworkAcl,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return await fetch(
     `${ROOT_PATH}/1.0/network-acls/${encodeURIComponent(networkAcl.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -116,20 +125,28 @@ export const updateNetworkAcl = async (
         "If-Match": networkAcl.etag ?? "",
       },
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteNetworkAcl = async (
   name: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return await fetch(
     `${ROOT_PATH}/1.0/network-acls/${encodeURIComponent(name)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/api/networks.tsx
+++ b/src/api/networks.tsx
@@ -17,6 +17,8 @@ import type { LxdClusterMember } from "types/cluster";
 import { addEntitlements } from "util/entitlements/api";
 import { addTarget } from "util/target";
 import { ROOT_PATH } from "util/rootPath";
+import type { LxdOperationResponse } from "types/operation";
+import { waitForOperation } from "api/operations";
 
 const networkEntitlements = ["can_edit", "can_delete"];
 
@@ -159,92 +161,123 @@ export const createClusterNetwork = async (
   network: Partial<LxdNetwork>,
   project: string,
   clusterMembers: LxdClusterMember[],
+  hasStorageAndNetworkOperations: boolean,
   parentsPerClusterMember?: ClusterSpecificValues,
   bridgeExternalInterfacesPerClusterMember?: ClusterSpecificValues,
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    Promise.allSettled(
-      clusterMembers.map(async (member) => {
-        const memberNetwork = {
-          name: network.name,
-          type: network.type,
-          config: {
-            parent: parentsPerClusterMember?.[member.server_name],
-            "bridge.external_interfaces":
-              bridgeExternalInterfacesPerClusterMember?.[member.server_name],
-          },
-        };
-        return createNetwork(memberNetwork, project, member.server_name);
-      }),
-    )
-      .then((results) => {
-        const error = results.find((res) => res.status === "rejected")
-          ?.reason as Error | undefined;
+): Promise<LxdOperationResponse> => {
+  const operations = await Promise.allSettled(
+    clusterMembers.map(async (member) => {
+      const memberNetwork = {
+        name: network.name,
+        type: network.type,
+        config: {
+          parent: parentsPerClusterMember?.[member.server_name],
+          "bridge.external_interfaces":
+            bridgeExternalInterfacesPerClusterMember?.[member.server_name],
+        },
+      };
 
-        if (error) {
-          reject(error);
-          return;
-        }
+      const operation = await createNetwork(
+        memberNetwork,
+        project,
+        member.server_name,
+      );
+      return { operation, member: member.server_name };
+    }),
+  );
 
-        // The network parent is cluster member specific, so we omit it on the cluster wide network configuration.
-        delete network.config?.parent;
-        createNetwork(network, project).then(resolve).catch(reject);
-      })
-      .catch(reject);
+  const pendingOperations = operations.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
   });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation, member }) => {
+        await waitForOperation(operation.metadata.id, member);
+      }),
+    );
+  }
+
+  // The network parent is cluster member specific, so we omit it on the cluster wide network configuration.
+  delete network.config?.parent;
+  return createNetwork(network, project);
 };
 
 export const createNetwork = async (
   network: Partial<LxdNetwork>,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  return new Promise((resolve, reject) => {
-    fetch(`${ROOT_PATH}/1.0/networks?${params.toString()}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+  try {
+    const response = await fetch(
+      `${ROOT_PATH}/1.0/networks?${params.toString()}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(network),
       },
-      body: JSON.stringify(network),
-    })
-      .then(handleResponse)
-      .then(resolve)
-      .catch(async (e: Error) => {
-        // when creating a network on localhost the request can get canceled
-        // check manually if creation was successful
-        // wait for 1 second for network creation to complete.
-        await new Promise((r) => setTimeout(r, 1000));
-        if (e.message === "Failed to fetch") {
-          const newNetwork = await fetchNetwork(
-            network.name ?? "",
-            project,
-            false,
-            target,
-          );
-          if (newNetwork) {
-            resolve();
-          }
-        }
-        reject(e);
-      });
-  });
+    );
+
+    return (await handleResponse(response)) as LxdOperationResponse;
+  } catch (e: unknown) {
+    // when creating a network on localhost the request can get canceled
+    // check manually if creation was successful
+    // wait for 1 second for network creation to complete.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    if (e instanceof Error && e.message === "Failed to fetch") {
+      const newNetwork = await fetchNetwork(
+        network.name ?? "",
+        project,
+        false,
+        target,
+      );
+
+      if (newNetwork) {
+        // Return a manual success response instead of resolving a void expression
+        return {
+          operation: "",
+          metadata: {
+            class: "network",
+            created_at: new Date().toISOString(),
+            description: "Network created",
+            err: "",
+            id: "",
+            location: "",
+            may_cancel: false,
+            status: "Success",
+            status_code: 200,
+            updated_at: new Date().toISOString(),
+          },
+        } as LxdOperationResponse;
+      }
+    }
+
+    // Re-throw the error so the caller can catch it
+    throw e;
+  }
 };
 
 export const updateNetwork = async (
   network: LxdNetwork,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  return new Promise((resolve, reject) => {
-    fetch(
+  try {
+    const response = await fetch(
       `${ROOT_PATH}/1.0/networks/${encodeURIComponent(network.name)}?${params.toString()}`,
       {
         method: "PUT",
@@ -254,28 +287,46 @@ export const updateNetwork = async (
           "If-Match": network.etag ?? "",
         },
       },
-    )
-      .then(handleResponse)
-      .then(resolve)
-      .catch(async (e: Error) => {
-        // when updating a network on localhost the request can get canceled
-        // check manually if the edit was successful
-        // wait for 1 second for network update to complete.
-        await new Promise((r) => setTimeout(r, 1000));
-        if (e.message === "Failed to fetch") {
-          const newNetwork = await fetchNetwork(
-            network.name ?? "",
-            project,
-            false,
-            target,
-          );
-          if (areNetworksEqual(network, newNetwork)) {
-            resolve();
-          }
-        }
-        reject(e);
-      });
-  });
+    );
+
+    return (await handleResponse(response)) as LxdOperationResponse;
+  } catch (e: unknown) {
+    // when updating a network on localhost the request can get canceled
+    // check manually if the edit was successful
+    // wait for 1 second for network update to complete.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    if (e instanceof Error && e.message === "Failed to fetch") {
+      const updatedNetwork = await fetchNetwork(
+        network.name,
+        project,
+        false,
+        target,
+      );
+
+      if (areNetworksEqual(network, updatedNetwork)) {
+        // Return a manual success response to satisfy the return type
+        return {
+          operation: "",
+          metadata: {
+            class: "network",
+            created_at: new Date().toISOString(),
+            description: "Network updated (fallback verification)",
+            err: "",
+            id: "",
+            location: "",
+            may_cancel: false,
+            status: "Success",
+            status_code: 200,
+            updated_at: new Date().toISOString(),
+          },
+        } as LxdOperationResponse;
+      }
+    }
+
+    // Re-throw the error so the caller handles the failure
+    throw e;
+  }
 };
 
 export const updateClusterNetwork = async (
@@ -283,55 +334,63 @@ export const updateClusterNetwork = async (
   project: string,
   clusterMembers: LxdClusterMember[],
   parentsPerClusterMember: ClusterSpecificValues,
+  hasStorageAndNetworkOperations: boolean,
   bridgeExternalInterfacesPerClusterMember?: ClusterSpecificValues,
   oldConfig?: LxdNetworkConfig,
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    Promise.allSettled(
-      clusterMembers.map(async (member) => {
-        const memberName = member.server_name;
-        const config: LxdNetworkConfig = { ...oldConfig };
-        if (parentsPerClusterMember?.[memberName]) {
-          config.parent = parentsPerClusterMember[memberName];
-        }
-        if (bridgeExternalInterfacesPerClusterMember?.[memberName]) {
-          config["bridge.external_interfaces"] =
-            bridgeExternalInterfacesPerClusterMember[memberName];
-        }
-        const memberNetwork = {
-          name: network.name,
-          type: network.type,
-          config,
-        };
-        return updateNetwork(memberNetwork, project, memberName);
-      }),
-    )
-      .then((results) => {
-        const error = results.find((res) => res.status === "rejected")
-          ?.reason as Error | undefined;
+): Promise<LxdOperationResponse> => {
+  const results = await Promise.allSettled(
+    clusterMembers.map(async (member) => {
+      const memberName = member.server_name;
+      const config: LxdNetworkConfig = { ...oldConfig };
 
-        if (error) {
-          reject(error);
-          return;
-        }
-        updateNetwork({ ...network, etag: "" }, project)
-          .then(resolve)
-          .catch(reject);
-      })
-      .catch(reject);
+      if (parentsPerClusterMember?.[memberName]) {
+        config.parent = parentsPerClusterMember[memberName];
+      }
+
+      if (bridgeExternalInterfacesPerClusterMember?.[memberName]) {
+        config["bridge.external_interfaces"] =
+          bridgeExternalInterfacesPerClusterMember[memberName];
+      }
+
+      const memberNetwork = {
+        name: network.name,
+        type: network.type,
+        config,
+      };
+
+      const operation = await updateNetwork(memberNetwork, project, memberName);
+      return { operation, member: memberName };
+    }),
+  );
+
+  const pendingOperations = results.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
   });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation, member }) => {
+        await waitForOperation(operation.metadata.id, member);
+      }),
+    );
+  }
+
+  return updateNetwork({ ...network, etag: "" }, project);
 };
 
 export const renameNetwork = async (
   oldName: string,
   newName: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  return new Promise((resolve, reject) => {
-    fetch(
+  try {
+    const response = await fetch(
       `${ROOT_PATH}/1.0/networks/${encodeURIComponent(oldName)}?${params.toString()}`,
       {
         method: "POST",
@@ -342,57 +401,93 @@ export const renameNetwork = async (
           name: newName,
         }),
       },
-    )
-      .then(handleResponse)
-      .then(resolve)
-      .catch(async (e: Error) => {
-        // when renaming a network on localhost the request can get canceled
-        // check manually if renaming was successful
-        // wait for 1 second for network rename to complete.
-        await new Promise((r) => setTimeout(r, 1000));
-        if (e.message === "Failed to fetch") {
-          const renamedNetwork = await fetchNetwork(newName, project, false);
-          if (renamedNetwork) {
-            resolve();
-          }
-        }
-        reject(e);
-      });
-  });
+    );
+
+    return (await handleResponse(response)) as LxdOperationResponse;
+  } catch (e: unknown) {
+    // when renaming a network on localhost the request can get canceled
+    // check manually if renaming was successful
+    // wait for 1 second for network rename to complete.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    if (e instanceof Error && e.message === "Failed to fetch") {
+      const renamedNetwork = await fetchNetwork(newName, project, false);
+
+      if (renamedNetwork) {
+        // Return a manual success response to satisfy the return type
+        return {
+          operation: "",
+          metadata: {
+            class: "network",
+            created_at: new Date().toISOString(),
+            description: `Network renamed from ${oldName} to ${newName} (fallback verification)`,
+            err: "",
+            id: "",
+            location: "",
+            may_cancel: false,
+            status: "Success",
+            status_code: 200,
+            updated_at: new Date().toISOString(),
+          },
+        } as LxdOperationResponse;
+      }
+    }
+
+    // Re-throw the error so the caller handles the failure
+    throw e;
+  }
 };
 
 export const deleteNetwork = async (
   name: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  return new Promise((resolve, reject) => {
-    fetch(
+  try {
+    const response = await fetch(
       `${ROOT_PATH}/1.0/networks/${encodeURIComponent(name)}?${params.toString()}`,
       {
         method: "DELETE",
       },
-    )
-      .then(handleResponse)
-      .then(resolve)
-      .catch(async (e: Error) => {
-        // when deleting a network on localhost the request can get canceled
-        // check manually if deletion was successful
-        // wait for 1 second for network delete to complete.
-        await new Promise((r) => setTimeout(r, 1000));
-        if (e.message === "Failed to fetch") {
-          const response = await fetch(
-            `${ROOT_PATH}/1.0/networks/${encodeURIComponent(name)}?project=${encodeURIComponent(project)}`,
-          );
-          if (response.status === 404) {
-            resolve();
-          }
-        }
-        reject(e);
-      });
-  });
+    );
+
+    return (await handleResponse(response)) as LxdOperationResponse;
+  } catch (e: unknown) {
+    // when deleting a network on localhost the request can get canceled
+    // check manually if deletion was successful
+    // wait for 1 second for network delete to complete.
+    await new Promise((r) => setTimeout(r, 1000));
+
+    if (e instanceof Error && e.message === "Failed to fetch") {
+      const checkResponse = await fetch(
+        `${ROOT_PATH}/1.0/networks/${encodeURIComponent(name)}?project=${encodeURIComponent(project)}`,
+      );
+
+      // If the resource is gone (404), the deletion actually succeeded
+      if (checkResponse.status === 404) {
+        return {
+          operation: "",
+          metadata: {
+            class: "network",
+            created_at: new Date().toISOString(),
+            description: `Network ${name} deleted (fallback verification)`,
+            err: "",
+            id: "",
+            location: "",
+            may_cancel: false,
+            status: "Success",
+            status_code: 200,
+            updated_at: new Date().toISOString(),
+          },
+        } as LxdOperationResponse;
+      }
+    }
+
+    // Re-throw the error so the caller handles the actual failure
+    throw e;
+  }
 };
 
 export const fetchNetworkAllocations = async (

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -38,11 +38,14 @@ import {
 import { slugify } from "util/slugify";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import YamlSwitch from "components/forms/YamlSwitch";
+import { bridgeType, ovnType } from "util/networks";
 import { scrollToElement } from "util/scroll";
 import { useClusterMembers } from "context/useClusterMembers";
-import { bridgeType, ovnType } from "util/networks";
 import { useAuth } from "context/auth";
-import NetworkRichChip from "./NetworkRichChip";
+import { useEventQueue } from "context/eventQueue";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import NetworkRichChip from "pages/networks/NetworkRichChip";
+import ResourceLabel from "components/ResourceLabel";
 
 const CreateNetwork: FC = () => {
   const { isFineGrained } = useAuth();
@@ -57,6 +60,8 @@ const CreateNetwork: FC = () => {
   const isClustered = isClusteredServer(settings);
   const hasOvn = supportsOvnNetwork(settings);
   const { data: clusterMembers = [] } = useClusterMembers();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   if (!project) {
     return <>Missing project</>;
@@ -76,6 +81,60 @@ const CreateNetwork: FC = () => {
       )
       .required("Network name is required"),
   });
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.projects, project, queryKeys.networks],
+    });
+  };
+
+  const onSuccess = (networkName: string) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    toastNotify.success(
+      <>
+        Network{" "}
+        <NetworkRichChip networkName={networkName} projectName={project} />{" "}
+        created.
+      </>,
+    );
+  };
+
+  const onFailure = (networkName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of network ${networkName} failed`, e);
+
+    // load the network that we just created
+    fetchNetwork(networkName, project, isFineGrained)
+      .then((network) => {
+        // if the network was created in errored state, delete it
+        if (network.status === "Errored") {
+          deleteNetwork(networkName, project).catch(() => {
+            // deleting the errored network failed, forward to network list page and show the creation failure
+            navigate(
+              `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks`,
+            );
+            toastNotify.failure(
+              "Error during network creation",
+              e,
+              <>
+                Network{" "}
+                <NetworkRichChip
+                  networkName={networkName}
+                  projectName={project}
+                />{" "}
+                created with error status.
+              </>,
+            );
+          });
+        }
+      })
+      .catch(() => {
+        // network was not created, keep user on creation form so they can submit it again.
+      });
+    // todo: why the duplicate network fetch requests in the network tab?
+  };
 
   const formik = useFormik<NetworkFormValues>({
     initialValues: {
@@ -101,63 +160,42 @@ const CreateNetwork: FC = () => {
                 network,
                 project,
                 clusterMembers,
+                hasStorageAndNetworkOperations,
                 values.parentPerClusterMember,
                 values.bridge_external_interfaces_per_member,
               )
           : async () => createNetwork(network, project);
 
       mutation()
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [queryKeys.projects, project, queryKeys.networks],
-          });
+        .then((operation) => {
           navigate(
             `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks`,
           );
-          toastNotify.success(
-            <>
-              Network{" "}
-              <NetworkRichChip
-                networkName={values.name}
-                projectName={project}
-              />{" "}
-              created.
-            </>,
-          );
+
+          if (hasStorageAndNetworkOperations && operation.metadata.id) {
+            toastNotify.info(
+              <>
+                Creation of network{" "}
+                <ResourceLabel bold type="network" value={values.name} /> has
+                started.
+              </>,
+            );
+
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure("Network creation failed", e);
-
-          // load the network that we just created
-          fetchNetwork(values.name, project, isFineGrained)
-            .then((network) => {
-              // if the network was created in errored state, delete it
-              if (network.status === "Errored") {
-                deleteNetwork(values.name, project).catch(() => {
-                  // deleting the errored network failed, forward to network list page and show the creation failure
-                  navigate(
-                    `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks`,
-                  );
-                  toastNotify.failure(
-                    "Error during network creation",
-                    e,
-                    <>
-                      Network{" "}
-                      <NetworkRichChip
-                        networkName={values.name}
-                        projectName={project}
-                      />{" "}
-                      created with error status.
-                    </>,
-                  );
-                });
-              }
-            })
-            .catch(() => {
-              // network was not created, keep user on creation form so they can submit it again.
-            });
-          // todo: why the duplicate network fetch requests in the network tab?
+          onFailure(values.name, e);
         });
     },
   });

--- a/src/pages/networks/CreateNetworkAcl.tsx
+++ b/src/pages/networks/CreateNetworkAcl.tsx
@@ -31,6 +31,9 @@ import NetworkAclForm, {
 } from "pages/networks/forms/NetworkAclForm";
 import { createNetworkAcl } from "api/network-acls";
 import type { LxdNetworkAcl } from "types/network";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
+import ResourceLabel from "components/ResourceLabel";
 
 const CreateNetworkAcl: FC = () => {
   const navigate = useNavigate();
@@ -40,6 +43,8 @@ const CreateNetworkAcl: FC = () => {
   const { project } = useParams<{ project: string }>();
   const [section, setSection] = useState(slugify(GENERAL));
   const controllerState = useState<AbortController | null>(null);
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   if (!project) {
     return <>Missing project</>;
@@ -55,6 +60,36 @@ const CreateNetworkAcl: FC = () => {
       )
       .required("ACL name is required"),
   });
+
+  const getAclUrl = (aclName: string) =>
+    `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(aclName)}`;
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.projects, project, queryKeys.networkAcls],
+    });
+  };
+
+  const onSuccess = (aclName: string) => {
+    invalidateCache();
+    toastNotify.success(
+      <>
+        Network ACL{" "}
+        <ResourceLink
+          type="network-acl"
+          value={aclName}
+          to={getAclUrl(aclName)}
+        />{" "}
+        created.
+      </>,
+    );
+  };
+
+  const onFailure = (networkAclName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of network ACL ${networkAclName} failed`, e);
+  };
 
   const formik = useFormik<NetworkAclFormValues>({
     initialValues: {
@@ -72,28 +107,38 @@ const CreateNetworkAcl: FC = () => {
         : toNetworkAcl(formik.values);
 
       createNetworkAcl(networkAcl, project)
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [queryKeys.projects, project, queryKeys.networkAcls],
-          });
+        .then((operation) => {
           navigate(
             `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acls`,
           );
-          toastNotify.success(
-            <>
-              Network ACL{" "}
-              <ResourceLink
-                type="network-acl"
-                value={values.name}
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(values.name)}`}
-              />{" "}
-              created.
-            </>,
-          );
+
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of Network ACL{" "}
+                <ResourceLabel
+                  bold
+                  type="network-acl"
+                  value={networkAcl.name}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(networkAcl.name);
+              },
+              (msg) => {
+                onFailure(networkAcl.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(networkAcl.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure("Network ACL creation failed", e);
+          onFailure(networkAcl.name, e);
         });
     },
   });

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -30,9 +30,11 @@ import {
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import YamlSwitch from "components/forms/YamlSwitch";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
+import { useNetworkEntitlements } from "util/entitlements/networks";
 import { scrollToElement } from "util/scroll";
 import { useClusterMembers } from "context/useClusterMembers";
-import { useNetworkEntitlements } from "util/entitlements/networks";
+import { useEventQueue } from "context/eventQueue";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useNetworkFromClusterMembers } from "context/useNetworks";
 import {
   clusteredTypes,
@@ -68,6 +70,8 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
     project,
     shouldLoadMemberSpecificSettings,
   );
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   useEffect(() => {
     if (error) {
@@ -103,6 +107,44 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
     ? undefined
     : "You do not have permission to edit this network";
 
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.projects, project, queryKeys.networks, network.name],
+    });
+
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        network.name,
+        queryKeys.cluster,
+      ],
+    });
+  };
+
+  const onSuccess = (yamlNetwork: LxdNetwork) => {
+    formik.resetForm({
+      values: toNetworkFormValues(yamlNetwork, networkOnMembersFulfilled),
+    });
+    invalidateCache();
+    toastNotify.success(
+      <>
+        Network{""}
+        <NetworkRichChip
+          networkName={network.name}
+          projectName={project}
+        />{" "}
+        updated.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    notify.failure(`Update of network ${network.name} failed`, e);
+  };
+
   const formik = useFormik<NetworkFormValues>({
     initialValues: toNetworkFormValues(
       network,
@@ -126,6 +168,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
             project,
             clusterMembers,
             values.parentPerClusterMember,
+            hasStorageAndNetworkOperations,
             values.bridge_external_interfaces_per_member,
             network.config,
           );
@@ -135,43 +178,34 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
       };
 
       mutation(values)
-        .then(() => {
-          formik.resetForm({
-            values: toNetworkFormValues(yamlNetwork, networkOnMembersFulfilled),
-          });
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations && operation.metadata.id) {
+            toastNotify.info(
+              <>
+                Update of network{" "}
+                <NetworkRichChip
+                  networkName={network.name}
+                  projectName={project}
+                />{" "}
+                has started.
+              </>,
+            );
 
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              network.name,
-            ],
-          });
-
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              network.name,
-              queryKeys.cluster,
-            ],
-          });
-
-          toastNotify.success(
-            <>
-              Network{""}
-              <NetworkRichChip
-                networkName={network.name}
-                projectName={project}
-              />{" "}
-              updated.
-            </>,
-          );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(yamlNetwork);
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(yamlNetwork);
+          }
         })
         .catch((e) => {
-          notify.failure("Network update failed", e);
+          onFailure(e);
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/networks/NetworkAclDetailHeader.tsx
+++ b/src/pages/networks/NetworkAclDetailHeader.tsx
@@ -14,6 +14,8 @@ import DeleteNetworkAclBtn from "pages/networks/actions/DeleteNetworkAclBtn";
 import { useNetworkAclEntitlements } from "util/entitlements/network-acls";
 import { renameNetworkAcl } from "api/network-acls";
 import DownloadNetworkAclLogsBtn from "pages/networks/actions/DownloadNetworkAclLogsBtn";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   name: string;
@@ -27,6 +29,8 @@ const NetworkAclDetailHeader: FC<Props> = ({ name, networkAcl, project }) => {
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
   const { canEditNetworkAcl } = useNetworkAclEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
@@ -39,6 +43,21 @@ const NetworkAclDetailHeader: FC<Props> = ({ name, networkAcl, project }) => {
       )
       .required("ACL name is required"),
   });
+
+  const onSuccess = (aclName: string, url: string) => {
+    navigate(url);
+    toastNotify.success(
+      <>
+        Network ACL <strong>{name}</strong> renamed to{" "}
+        <ResourceLink type="network-acl" value={aclName} to={url} />.
+      </>,
+    );
+    formik.setFieldValue("isRenaming", false);
+  };
+
+  const onFailure = (aclName: string, e: unknown) => {
+    notify.failure(`Renaming of network ACL ${aclName} failed`, e);
+  };
 
   const formik = useFormik<RenameHeaderValues>({
     initialValues: {
@@ -53,19 +72,31 @@ const NetworkAclDetailHeader: FC<Props> = ({ name, networkAcl, project }) => {
         return;
       }
       renameNetworkAcl(name, values.name, project)
-        .then(() => {
+        .then((operation) => {
           const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(values.name)}`;
-          navigate(url);
-          toastNotify.success(
-            <>
-              Network ACL <strong>{name}</strong> renamed to{" "}
-              <ResourceLink type="network-acl" value={values.name} to={url} />.
-            </>,
-          );
-          formik.setFieldValue("isRenaming", false);
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Renaming of Network ACL <strong>{name}</strong> to{" "}
+                <ResourceLink type="network-acl" value={values.name} to={url} />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name, url);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name, url);
+          }
         })
         .catch((e) => {
-          notify.failure("Renaming failed", e);
+          onFailure(values.name, e);
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/networks/NetworkDetailHeader.tsx
+++ b/src/pages/networks/NetworkDetailHeader.tsx
@@ -12,6 +12,8 @@ import { renameNetwork } from "api/networks";
 import DeleteNetworkBtn from "pages/networks/actions/DeleteNetworkBtn";
 import { useNotify, useToastNotification } from "@canonical/react-components";
 import { useNetworkEntitlements } from "util/entitlements/networks";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 import NetworkRichChip from "./NetworkRichChip";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
 
@@ -28,6 +30,8 @@ const NetworkDetailHeader: FC<Props> = ({ name, network, project }) => {
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
   const { canEditNetwork } = useNetworkEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
@@ -40,6 +44,22 @@ const NetworkDetailHeader: FC<Props> = ({ name, network, project }) => {
       )
       .required("Network name is required"),
   });
+
+  const onSuccess = (networkName: string) => {
+    const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(networkName)}`;
+    navigate(url);
+    toastNotify.success(
+      <>
+        Network <strong>{name}</strong> renamed to{" "}
+        <NetworkRichChip networkName={networkName} projectName={project} />
+      </>,
+    );
+    formik.setFieldValue("isRenaming", false);
+  };
+
+  const onFailure = (networkName: string, e: unknown) => {
+    notify.failure(`Renaming of network ${networkName} failed`, e);
+  };
 
   const formik = useFormik<RenameHeaderValues>({
     initialValues: {
@@ -54,22 +74,33 @@ const NetworkDetailHeader: FC<Props> = ({ name, network, project }) => {
         return;
       }
       renameNetwork(name, values.name, project)
-        .then(() => {
-          const url = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(values.name)}`;
-          navigate(url);
-          toastNotify.success(
-            <>
-              Network <strong>{name}</strong> renamed to{" "}
-              <NetworkRichChip
-                networkName={values.name}
-                projectName={project}
-              />
-            </>,
-          );
-          formik.setFieldValue("isRenaming", false);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Renaming of network{" "}
+                <NetworkRichChip
+                  networkName={values.name}
+                  projectName={project}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          notify.failure("Renaming failed", e);
+          onFailure(values.name, e);
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkAclBtn.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import type { LxdNetworkAcl } from "types/network";
 import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -16,6 +16,8 @@ import classnames from "classnames";
 import { useNetworkAclEntitlements } from "util/entitlements/network-acls";
 import { deleteNetworkAcl } from "api/network-acls";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   networkAcl: LxdNetworkAcl;
@@ -28,33 +30,74 @@ const DeleteNetworkAclBtn: FC<Props> = ({ networkAcl, project }) => {
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const isSmallScreen = useIsScreenBelow();
   const { canDeleteNetworkAcl } = useNetworkAclEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[0] === queryKeys.projects &&
+        query.queryKey[1] === project &&
+        query.queryKey[2] === queryKeys.networkAcls,
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+
+    // Only navigate to the network ACLs list if we are still on the deleted ACL's detail page
+    const aclDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(networkAcl.name)}`;
+    if (location.pathname.startsWith(aclDetailPath)) {
+      navigate(
+        `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acls`,
+      );
+    }
+
+    toastNotify.success(
+      <>
+        Network ACL{" "}
+        <ResourceLabel bold type="network-acl" value={networkAcl.name} />{" "}
+        deleted.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(`Deletion of network ACL ${networkAcl.name} failed`, e);
+  };
 
   const handleDelete = () => {
     setLoading(true);
     deleteNetworkAcl(networkAcl.name, project)
-      .then(() => {
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === queryKeys.projects &&
-            query.queryKey[1] === project &&
-            query.queryKey[2] === queryKeys.networkAcls,
-        });
-        navigate(
-          `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acls`,
-        );
-        toastNotify.success(
-          <>
-            Network ACL{" "}
-            <ResourceLabel bold type="network-acl" value={networkAcl.name} />{" "}
-            deleted.
-          </>,
-        );
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of Network ACL{" "}
+              <ResourceLabel bold type="network-acl" value={networkAcl.name} />{" "}
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
       .catch((e) => {
-        setLoading(false);
-        notify.failure("ACL deletion failed", e);
+        onFailure(e);
       });
   };
 

--- a/src/pages/networks/actions/DeleteNetworkBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkBtn.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import type { LxdNetwork } from "types/network";
 import { deleteNetwork } from "api/networks";
 import { queryKeys } from "util/queryKeys";
@@ -17,6 +17,8 @@ import classnames from "classnames";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import NetworkRichChip from "../NetworkRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   network: LxdNetwork;
@@ -29,32 +31,78 @@ const DeleteNetworkBtn: FC<Props> = ({ network, project }) => {
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const isSmallScreen = useIsScreenBelow();
   const { canDeleteNetwork } = useNetworkEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[0] === queryKeys.projects &&
+        query.queryKey[1] === project &&
+        query.queryKey[2] === queryKeys.networks,
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+
+    // Only navigate to the networks list if we are still on the deleted network's detail page
+    const networkDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}`;
+    if (location.pathname.startsWith(networkDetailPath)) {
+      navigate(
+        `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks`,
+      );
+    }
+
+    setLoading(false);
+    toastNotify.success(
+      <>
+        Network <ResourceLabel bold type="network" value={network.name} />{" "}
+        deleted.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(`Deleting network ${network.name} failed`, e);
+  };
 
   const handleDelete = () => {
     setLoading(true);
     deleteNetwork(network.name, project)
-      .then(() => {
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === queryKeys.projects &&
-            query.queryKey[1] === project &&
-            query.queryKey[2] === queryKeys.networks,
-        });
-        navigate(
-          `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks`,
-        );
-        toastNotify.success(
-          <>
-            Network <ResourceLabel bold type="network" value={network.name} />{" "}
-            deleted.
-          </>,
-        );
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of network{" "}
+              <NetworkRichChip
+                networkName={network.name}
+                projectName={project}
+              />{" "}
+              has started.
+            </>,
+          );
+
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
       .catch((e) => {
-        setLoading(false);
-        notify.failure("Network deletion failed", e);
+        onFailure(e);
       });
   };
 

--- a/src/pages/networks/forms/EditNetworkAcl.tsx
+++ b/src/pages/networks/forms/EditNetworkAcl.tsx
@@ -27,6 +27,8 @@ import { updateNetworkAcl } from "api/network-acls";
 import { objectToYaml, yamlToObject } from "util/yaml";
 import { useNetworkAclEntitlements } from "util/entitlements/network-acls";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   networkAcl: LxdNetworkAcl;
@@ -39,6 +41,8 @@ const EditNetworkAcl: FC<Props> = ({ networkAcl, project }) => {
   const toastNotify = useToastNotification();
   const [section, updateSection] = useState<string>(slugify(GENERAL));
   const { canEditNetworkAcl } = useNetworkAclEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const queryClient = useQueryClient();
 
@@ -56,6 +60,35 @@ const EditNetworkAcl: FC<Props> = ({ networkAcl, project }) => {
       : "You do not have permission to edit this ACL",
   };
 
+  const baseUrl = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(networkAcl.name)}`;
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networkAcls,
+        networkAcl.name,
+      ],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+    toastNotify.success(
+      <>
+        Network ACL{" "}
+        <ResourceLink type="network-acl" value={networkAcl.name} to={baseUrl} />{" "}
+        updated.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    notify.failure(`Update of network ACL ${networkAcl.name} failed`, e);
+  };
+
   const formik = useFormik<NetworkAclFormValues>({
     initialValues,
     enableReinitialize: true,
@@ -65,38 +98,40 @@ const EditNetworkAcl: FC<Props> = ({ networkAcl, project }) => {
         : toNetworkAcl(formik.values, networkAcl);
 
       updateNetworkAcl(saveObject, project)
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networkAcls,
-              networkAcl.name,
-            ],
-          });
-
-          toastNotify.success(
-            <>
-              Network ACL{" "}
-              <ResourceLink
-                type="network-acl"
-                value={networkAcl.name}
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(networkAcl.name)}`}
-              />{" "}
-              updated.
-            </>,
-          );
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of Network ACL{" "}
+                <ResourceLink
+                  type="network-acl"
+                  value={networkAcl.name}
+                  to={baseUrl}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess();
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess();
+          }
         })
         .catch((e) => {
-          notify.failure("ACL update failed", e);
+          onFailure(e);
         })
         .finally(() => {
           formik.setSubmitting(false);
         });
     },
   });
-
-  const baseUrl = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network-acl/${encodeURIComponent(networkAcl.name)}`;
 
   const setSection = (newSection: string) => {
     if (newSection === GENERAL) {

--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -34,6 +34,7 @@ import StoragePoolRichChip from "./StoragePoolRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useEventQueue } from "context/eventQueue";
+import ResourceLabel from "components/ResourceLabel";
 
 const CreateStoragePool: FC = () => {
   const navigate = useNavigate();
@@ -66,9 +67,6 @@ const CreateStoragePool: FC = () => {
 
   const onSuccess = (storagePoolName: string) => {
     invalidateCache();
-    navigate(
-      `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
-    );
     formik.setSubmitting(false);
     toastNotify.success(
       <>
@@ -117,15 +115,16 @@ const CreateStoragePool: FC = () => {
 
       mutation()
         .then((operation) => {
+          navigate(
+            `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
+          );
+
           if (hasStorageAndNetworkOperations) {
             toastNotify.info(
               <>
                 Creation of storage pool{" "}
-                <StoragePoolRichChip
-                  poolName={storagePool.name}
-                  projectName={project}
-                />{" "}
-                has started.
+                <ResourceLabel bold type="pool" value={storagePool.name} /> has
+                started.
               </>,
             );
             eventQueue.set(

--- a/src/pages/storage/StoragePoolHeader.tsx
+++ b/src/pages/storage/StoragePoolHeader.tsx
@@ -45,6 +45,10 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
     );
   };
 
+  const onFailure = (storagePoolName: string, e: unknown) => {
+    notify.failure(`Renaming of storage pool ${storagePoolName} failed`, e);
+  };
+
   const formik = useFormik<RenameHeaderValues>({
     initialValues: {
       name,
@@ -75,12 +79,9 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
               () => {
                 onSuccess(values.name);
               },
-              (msg) =>
-                toastNotify.failure(
-                  `Renaming of storage pool ${values.name} failed`,
-
-                  new Error(msg),
-                ),
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
             );
           } else {
             onSuccess(values.name);
@@ -89,7 +90,7 @@ const StoragePoolHeader: FC<Props> = ({ name, pool, project }) => {
           formik.setFieldValue("isRenaming", false);
         })
         .catch((e) => {
-          notify.failure("Renaming failed", e);
+          onFailure(values.name, e);
         })
         .finally(() => {
           formik.setSubmitting(false);

--- a/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
+++ b/src/pages/storage/actions/DeleteStoragePoolBtn.tsx
@@ -10,7 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { deleteStoragePool } from "api/storage-pools";
 import classnames from "classnames";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import type { LxdStoragePool } from "types/storage";
 import { queryKeys } from "util/queryKeys";
 import ResourceLabel from "components/ResourceLabel";
@@ -33,6 +33,7 @@ const DeleteStoragePoolBtn: FC<Props> = ({
 }) => {
   const isSmallScreen = useIsScreenBelow();
   const navigate = useNavigate();
+  const location = useLocation();
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
@@ -58,9 +59,15 @@ const DeleteStoragePoolBtn: FC<Props> = ({
 
   const onSuccess = () => {
     invalidateCache();
-    navigate(
-      `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
-    );
+
+    // Only navigate to the storage pools list if we are still on the deleted pool's detail page
+    const poolDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pool/${encodeURIComponent(pool.name)}`;
+    if (location.pathname.startsWith(poolDetailPath)) {
+      navigate(
+        `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/storage/pools`,
+      );
+    }
+
     notifySuccess(pool.name);
   };
 


### PR DESCRIPTION
## Done

- Network ACLs: rely on operation when api extension `hasStorageAndNetworkOperations` is present
- Networks: rely on operation when api extension `hasStorageAndNetworkOperations` is present

Fixes https://github.com/canonical/lxd/pull/17978

Testing done on latest edge cluster and 5.21 cluster

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create, rename, update and delete a network ACL in a clustered and unclustered environment
    - Create, rename, update and delete a network in a clustered and unclustered environment. Note that renaming a network in a clustered environment is not allowed.

## Screenshots

<img width="1561" height="1054" alt="acl-create" src="https://github.com/user-attachments/assets/ddb55859-0120-423b-ba84-f5f1a2d90d79" />
<img width="1562" height="1055" alt="acl-rename" src="https://github.com/user-attachments/assets/410148ba-4ec0-420c-8fc4-be1ef3ec64e9" />
<img width="1562" height="1055" alt="acl-update" src="https://github.com/user-attachments/assets/45d45449-1fb2-4a68-bdeb-a035057f21c3" />
<img width="1562" height="1055" alt="acl-delete" src="https://github.com/user-attachments/assets/0a599abc-b0ca-4298-81ad-afd3a7a9d52e" />

<img width="1562" height="1055" alt="network-create" src="https://github.com/user-attachments/assets/fc8c3699-5912-431f-a8d4-4d8338fa8218" />
<img width="1562" height="1055" alt="network-rename-cluster-not-supported" src="https://github.com/user-attachments/assets/322d7462-bcfc-4328-adeb-0acbb96965a2" />
<img width="1562" height="1055" alt="network-update" src="https://github.com/user-attachments/assets/0ddaf2e5-571d-4966-8935-d25277059c1c" />
<img width="1562" height="1055" alt="network-delete" src="https://github.com/user-attachments/assets/f101f261-0e6e-4b14-bcef-0ba9c618416e" />
