### PR TITLE
WD-34375 create image registry

### DIFF
--- a/src/api/image-registries.tsx
+++ b/src/api/image-registries.tsx
@@ -50,3 +50,13 @@ export const fetchRegistryImages = async (
       return data.metadata;
     });
 };
+
+export const createImageRegistry = async (body: string): Promise<void> => {
+  await fetch(`${ROOT_PATH}/1.0/image-registries`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: body,
+  }).then(handleResponse);
+};

--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -49,7 +49,7 @@ const resourceIcons: Record<ResourceIconType, string> = {
   volume: "storage-volume",
   "iso-volume": "iso",
   image: "image",
-  "image-registry": "image-registry",
+  "image-registry": "image",
   "oidc-identity": "user",
   certificate: "certificate",
   "auth-group": "user-group",

--- a/src/pages/images/ClusterLinkSelector.tsx
+++ b/src/pages/images/ClusterLinkSelector.tsx
@@ -1,0 +1,66 @@
+import type { FC } from "react";
+import { CustomSelect } from "@canonical/react-components";
+import { useClusterLinks } from "context/useClusterLinks";
+import type { FormikProps } from "formik";
+import type { ImageRegistryFormValues } from "types/forms/image";
+import { useNotify } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { ROOT_PATH } from "util/rootPath";
+
+interface Props {
+  formik: FormikProps<ImageRegistryFormValues>;
+}
+
+export const ClusterLinkSelector: FC<Props> = ({ formik }) => {
+  const { data: links = [], error } = useClusterLinks();
+  const notify = useNotify();
+  const hasNoLinks = links.length === 0;
+
+  if (error) {
+    notify.failure("Loading cluster links failed", error);
+  }
+
+  const options = links.map((link) => ({
+    value: link.name,
+    text: link.name,
+    label: (
+      <div className="cluster-link-label">
+        <span className="cluster-link-name">{link.name}</span>
+        <span className="cluster-link-description u-text--muted">
+          {link.type === "bidirectional"
+            ? "public and private images"
+            : "public images only"}
+        </span>
+      </div>
+    ),
+  }));
+
+  const helpText = hasNoLinks ? (
+    <>
+      Cluster containing the images. Create your first{" "}
+      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
+    </>
+  ) : (
+    <>
+      Cluster containing the images. Manage your{" "}
+      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>.
+    </>
+  );
+
+  return (
+    <CustomSelect
+      {...formik.getFieldProps("cluster")}
+      label="Cluster"
+      options={
+        hasNoLinks
+          ? [{ value: "", label: "No cluster links available." }]
+          : [{ value: "", label: "Select a cluster" }, ...options]
+      }
+      value={formik.values.cluster ?? ""}
+      help={helpText}
+      onChange={(value) => {
+        formik.setFieldValue("cluster", value);
+      }}
+    />
+  );
+};

--- a/src/pages/images/ImageRegistriesList.tsx
+++ b/src/pages/images/ImageRegistriesList.tsx
@@ -20,10 +20,14 @@ import { useSearchParams } from "react-router-dom";
 import type { LxdImageRegistryProtocol } from "types/image";
 import { isImageRegistryPublic } from "util/image-registries";
 import { CreateImageRegistryButton } from "./actions/CreateImageRegistryButton";
+import usePanelParams, { panels } from "util/usePanelParams";
+import { CreateImageRegistryPanel } from "./panels/CreateImageRegistryPanel";
 
 const ImageRegistriesList: FC = () => {
   const notify = useNotify();
   const [searchParams] = useSearchParams();
+  const panelParams = usePanelParams();
+
   const { data: imageRegistries = [], error, isLoading } = useImageRegistries();
 
   if (error) {
@@ -162,7 +166,7 @@ const ImageRegistriesList: FC = () => {
           </PageHeader>
         }
       >
-        <NotificationRow />
+        {!panelParams.panel && <NotificationRow />}
         <Row>
           <ScrollableTable
             dependencies={[imageRegistries]}
@@ -190,6 +194,10 @@ const ImageRegistriesList: FC = () => {
           </ScrollableTable>
         </Row>
       </CustomLayout>
+
+      {panelParams.panel === panels.createImageRegistry && (
+        <CreateImageRegistryPanel />
+      )}
     </>
   );
 };

--- a/src/pages/images/ImageRegistryForm.tsx
+++ b/src/pages/images/ImageRegistryForm.tsx
@@ -1,0 +1,81 @@
+import { Form, Input, PrefixedInput } from "@canonical/react-components";
+import type { FC } from "react";
+import type { FormikProps } from "formik/dist/types";
+import type { ImageRegistryFormValues } from "types/forms/image";
+import { ClusterLinkSelector } from "./ClusterLinkSelector";
+import { ImageRegistryProtocolSelector } from "./ImageRegistryProtocolSelector";
+
+interface Props {
+  formik: FormikProps<ImageRegistryFormValues>;
+  isEdit?: boolean;
+}
+
+export const ImageRegistryForm: FC<Props> = ({ formik, isEdit = false }) => {
+  const isSimpleStreams = formik.values.protocol === "simplestreams";
+  const stripProtocol = (value: string) => value.replace(/^https?:\/\//i, "");
+
+  const getFieldError = (fieldName: keyof ImageRegistryFormValues) => {
+    return formik.touched[fieldName] ? formik.errors[fieldName] : undefined;
+  };
+
+  return (
+    <Form onSubmit={formik.handleSubmit}>
+      {/* hidden submit to enable enter key in inputs */}
+      <Input type="submit" hidden value="Hidden input" />
+      <Input
+        {...formik.getFieldProps("name")}
+        type="text"
+        autoFocus={!isEdit}
+        label="Name"
+        required
+        error={getFieldError("name")}
+        placeholder="Enter name"
+      />
+      <Input
+        {...formik.getFieldProps("description")}
+        type="text"
+        autoFocus={isEdit}
+        label="Description"
+        placeholder="Enter description"
+        error={getFieldError("description")}
+      />
+      <ImageRegistryProtocolSelector formik={formik} />
+      {isSimpleStreams && (
+        <PrefixedInput
+          {...formik.getFieldProps("url")}
+          immutableText="https://"
+          value={formik.values.url ? stripProtocol(formik.values.url) : ""}
+          label="Server"
+          placeholder="example.org/releases"
+          error={getFieldError("url")}
+          onChange={(e) => {
+            const normalizedUrl = stripProtocol(e.target.value);
+            formik.setFieldValue(
+              "url",
+              normalizedUrl ? `https://${normalizedUrl}` : "",
+            );
+          }}
+          help={
+            <>
+              Enter the base folder for <code>streams/v1</code>, such as{" "}
+              https://cloud-images.ubuntu.com/releases/
+            </>
+          }
+        />
+      )}
+      {!isSimpleStreams && (
+        <>
+          <ClusterLinkSelector formik={formik} />
+          <Input
+            {...formik.getFieldProps("sourceProject")}
+            type="text"
+            label="Source Project"
+            placeholder="Enter source project"
+            error={getFieldError("sourceProject")}
+            help="Project with images on the remote cluster."
+          />
+        </>
+      )}
+    </Form>
+  );
+};

--- a/src/pages/images/ImageRegistryProtocolSelector.tsx
+++ b/src/pages/images/ImageRegistryProtocolSelector.tsx
@@ -1,0 +1,48 @@
+import { type FC } from "react";
+import { RadioInput, Icon } from "@canonical/react-components";
+import type { FormikProps } from "formik";
+import type { ImageRegistryFormValues } from "types/forms/image";
+import { Link } from "react-router-dom";
+
+interface Props {
+  formik: FormikProps<ImageRegistryFormValues>;
+}
+export const ImageRegistryProtocolSelector: FC<Props> = ({ formik }) => {
+  return (
+    <div className="image-registry-protocol-selector">
+      <div>
+        <label htmlFor="protocol">Protocol</label>
+        <Link
+          to="https://documentation.ubuntu.com/lxd/v5/reference/remote_image_servers/#remote-server-types"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="help-text help-link"
+          title="Learn more about remote server types."
+        >
+          <Icon name="help" className="help-link-icon" />
+        </Link>
+      </div>
+      <div id="protocol">
+        <RadioInput
+          inline
+          aria-label="LXD"
+          labelClassName="lxd-protocol-input"
+          label="LXD"
+          checked={formik.values.protocol === "lxd"}
+          onChange={() => {
+            formik.setFieldValue("protocol", "lxd");
+          }}
+        />
+        <RadioInput
+          inline
+          aria-label="SimpleStreams"
+          label="SimpleStreams"
+          checked={formik.values.protocol === "simplestreams"}
+          onChange={() => {
+            formik.setFieldValue("protocol", "simplestreams");
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/pages/images/actions/CreateImageRegistryButton.tsx
+++ b/src/pages/images/actions/CreateImageRegistryButton.tsx
@@ -1,10 +1,13 @@
 import type { FC } from "react";
 import { useServerEntitlements } from "util/entitlements/server";
 import { Button, Icon } from "@canonical/react-components";
+import usePanelParams from "util/usePanelParams";
 
 export const CreateImageRegistryButton: FC = () => {
   const { canCreateImageRegistries } = useServerEntitlements();
   const isDisabled = !canCreateImageRegistries();
+  const { openCreateImageRegistry } = usePanelParams();
+
   return (
     <Button
       name="Create registry"
@@ -15,6 +18,7 @@ export const CreateImageRegistryButton: FC = () => {
       title={
         isDisabled && "You don't have permissions to create image registries"
       }
+      onClick={openCreateImageRegistry}
     >
       <Icon name="plus" light className="u-margin--right" />
       <span>Create registry</span>

--- a/src/pages/images/panels/CreateImageRegistryPanel.tsx
+++ b/src/pages/images/panels/CreateImageRegistryPanel.tsx
@@ -1,0 +1,145 @@
+import {
+  ActionButton,
+  Button,
+  ScrollableContainer,
+  SidePanel,
+  useNotify,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useState, type FC } from "react";
+import usePanelParams from "util/usePanelParams";
+import * as Yup from "yup";
+import { useFormik } from "formik";
+import NotificationRow from "components/NotificationRow";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "util/queryKeys";
+import type { ImageRegistryFormValues } from "types/forms/image";
+import { createImageRegistry } from "api/image-registries";
+import { ImageRegistryForm } from "../ImageRegistryForm";
+import { checkDuplicateName } from "util/helpers";
+import ImageRegistryRichChip from "../ImageRegistryRichChip";
+import type { LxdImageRegistry, LxdImageRegistryConfig } from "types/image";
+
+export const CreateImageRegistryPanel: FC = () => {
+  const panelParams = usePanelParams();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const controllerState = useState<AbortController | null>(null);
+
+  const closePanel = () => {
+    panelParams.clear();
+    notify.clear();
+  };
+
+  const schema = Yup.object().shape({
+    name: Yup.string()
+      .test(
+        "deduplicate",
+        "An image registry with this name already exists.",
+        async (value) =>
+          checkDuplicateName(value, "", controllerState, "image-registries"),
+      )
+      .matches(/^[A-Za-z0-9/\-:_.]+$/, {
+        message:
+          "Name can only contain alphanumeric, forward slash, hyphen, colon, underscore and full stop characters.",
+      })
+      .required("Image registry name is required."),
+  });
+
+  const getPayload = () => {
+    const isSimpleStreams = formik.values.protocol === "simplestreams";
+    const isPublic = isSimpleStreams || formik.values.cluster === "";
+    const config: LxdImageRegistryConfig = {
+      public: isPublic ? "true" : "false",
+    };
+    const payload = {
+      name: formik.values.name,
+      description: formik.values.description,
+      protocol: formik.values.protocol,
+    } as Partial<LxdImageRegistry>;
+
+    if (isSimpleStreams) {
+      config.url = formik.values.url;
+    } else {
+      config.cluster = formik.values.cluster;
+      config.source_project = formik.values.sourceProject;
+      config.url = formik.values.url;
+    }
+    payload.config = config;
+    return payload;
+  };
+
+  const formik = useFormik<ImageRegistryFormValues>({
+    initialValues: {
+      name: "",
+      description: "",
+      sourceProject: "default",
+      cluster: "",
+      protocol: "lxd",
+    },
+    validationSchema: schema,
+    onSubmit: () => {
+      createImageRegistry(JSON.stringify(getPayload()))
+        .then(() => {
+          toastNotify.success(
+            <>
+              Image registry{" "}
+              <ImageRegistryRichChip
+                imageRegistryName={formik.values.name ?? ""}
+              />{" "}
+              created.
+            </>,
+          );
+
+          queryClient.invalidateQueries({
+            queryKey: [queryKeys.imageRegistries],
+          });
+          closePanel();
+        })
+        .catch((e) => {
+          notify.failure("Image registry creation failed", e);
+          formik.setSubmitting(false);
+        });
+    },
+  });
+
+  return (
+    <>
+      <SidePanel>
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Create image registry</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <NotificationRow className="u-no-padding" />
+        <SidePanel.Content className="u-no-padding">
+          <ScrollableContainer
+            dependencies={[notify.notification]}
+            belowIds={["panel-footer"]}
+          >
+            <ImageRegistryForm formik={formik} />
+          </ScrollableContainer>
+        </SidePanel.Content>
+        <SidePanel.Footer className="u-align--right">
+          <Button
+            appearance="base"
+            onClick={closePanel}
+            className="u-no-margin--bottom"
+          >
+            Cancel
+          </Button>
+          <ActionButton
+            appearance="positive"
+            onClick={() => void formik.submitForm()}
+            className="u-no-margin--bottom"
+            disabled={
+              !formik.isValid || formik.isSubmitting || !formik.values.name
+            }
+            loading={formik.isSubmitting}
+          >
+            Create
+          </ActionButton>
+        </SidePanel.Footer>
+      </SidePanel>
+    </>
+  );
+};

--- a/src/sass/_custom_dropdown.scss
+++ b/src/sass/_custom_dropdown.scss
@@ -1,6 +1,7 @@
 .network-type-label,
 .acl-action-label,
-.storage-driver-label {
+.storage-driver-label,
+.cluster-link-label {
   display: flex;
 
   .network-type-name {
@@ -13,8 +14,14 @@
     width: 8rem;
   }
 
+  .cluster-link-name {
+    margin-left: $sph--small;
+    width: 8rem;
+  }
+
   .network-type-explanation,
-  .storage-driver-description {
+  .storage-driver-description,
+  .cluster-link-description {
     margin-left: $sph--small;
   }
 
@@ -22,7 +29,8 @@
     flex-direction: column;
 
     .network-type-explanation,
-    .storage-driver-description {
+    .storage-driver-description,
+    .cluster-link-description {
       white-space: break-spaces;
     }
   }

--- a/src/sass/_image_registry_protocol_selector.scss
+++ b/src/sass/_image_registry_protocol_selector.scss
@@ -1,0 +1,8 @@
+.image-registry-protocol-selector {
+  margin-bottom: $spv--medium;
+
+  .lxd-protocol-input {
+    margin-left: $sph--x-small;
+    margin-right: $sph--large;
+  }
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -110,6 +110,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "instance_list";
 @import "instance_rich_tooltip";
 @import "instance_target_selector";
+@import "image_registry_protocol_selector";
 @import "image_registry_rich_tooltip";
 @import "ip_address";
 @import "login";

--- a/src/types/forms/image.d.ts
+++ b/src/types/forms/image.d.ts
@@ -1,0 +1,9 @@
+import type { LxdImageRegistryProtocol } from "../image";
+export interface ImageRegistryFormValues {
+  name: string;
+  protocol: LxdImageRegistryProtocol;
+  description?: string;
+  url?: string;
+  cluster?: string;
+  sourceProject?: string;
+}

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -39,13 +39,15 @@ export interface LxdImageRegistry {
   description: string;
   protocol: LxdImageRegistryProtocol;
   builtin: boolean;
-  config?: {
-    url: string;
-    public: string;
-    cluster: string;
-    source_project: string;
-  };
+  config?: LxdImageRegistryConfig;
   access_entitlements?: string[];
+}
+
+export interface LxdImageRegistryConfig {
+  url?: string;
+  public?: string;
+  cluster?: string;
+  source_project?: string;
 }
 
 export interface ImportImage {

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -18,7 +18,7 @@ export interface PanelHelper {
   target: string | null;
   deviceName: string | null;
   localPeering: string | null;
-
+  createImageRegistry: string | null;
   clear: () => void;
   openCreateClusterGroup: () => void;
   openCreateClusterLink: () => void;
@@ -44,6 +44,7 @@ export interface PanelHelper {
   openCreateNetworkDevice: () => void;
   openCreateLocalPeering: () => void;
   openEditLocalPeering: (peering: string) => void;
+  openCreateImageRegistry: () => void;
 }
 
 export const panels = {
@@ -71,6 +72,7 @@ export const panels = {
   identityGroups: "identity-groups",
   instanceSummary: "instance-summary",
   profileSummary: "profile-summary",
+  createImageRegistry: "create-image-registry",
 };
 
 type ParamMap = Record<string, string>;
@@ -114,6 +116,7 @@ const usePanelParams = (): PanelHelper => {
     newParams.delete("target");
     newParams.delete("device-name");
     newParams.delete("local-peering");
+    newParams.delete("create-image-registry");
     setParams(newParams);
     craftResizeEvent();
   };
@@ -134,7 +137,7 @@ const usePanelParams = (): PanelHelper => {
     target: params.get("target") ?? "",
     deviceName: params.get("device-name"),
     localPeering: params.get("local-peering"),
-
+    createImageRegistry: params.get("create-image-registry"),
     clear: () => {
       clearParams();
     },
@@ -267,6 +270,10 @@ const usePanelParams = (): PanelHelper => {
         profile,
         "panel-project": project,
       });
+    },
+
+    openCreateImageRegistry: () => {
+      setPanelParams(panels.createImageRegistry);
     },
   };
 };

--- a/tests/helpers/image-registries.ts
+++ b/tests/helpers/image-registries.ts
@@ -1,6 +1,11 @@
 import { expect, test, type LxdVersions } from "../fixtures/lxd-test";
 import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
+import { randomNameSuffix } from "./name";
+
+export const randomImageRegistryName = () => {
+  return `playwright-image-registry-${randomNameSuffix()}`;
+};
 
 export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
@@ -13,5 +18,5 @@ export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
 
 export const visitImageRegistries = async (page: Page) => {
   await gotoURL(page, `/ui/image-registries`);
-  await expect(page.getByTitle("Create image registry")).toBeVisible();
+  await expect(page.getByTitle("Create registry")).toBeVisible();
 };

--- a/tests/image-registries.spec.ts
+++ b/tests/image-registries.spec.ts
@@ -2,11 +2,13 @@ import { expect, test } from "./fixtures/lxd-test";
 import {
   skipIfNotSupported,
   visitImageRegistries,
+  randomImageRegistryName,
 } from "./helpers/image-registries";
 import { gotoURL } from "./helpers/navigate";
 
 test("search for an image registry", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
+  const builtinRegistryName = "ubuntu-daily";
 
   await gotoURL(page, "/ui");
   await page.getByRole("button", { name: "Images" }).click();
@@ -16,13 +18,25 @@ test("search for an image registry", async ({ page, lxdVersion }) => {
   await expect(page.getByTitle("Create registry")).toBeVisible();
 
   await page.getByPlaceholder("Search and filter").click();
-  await page.getByPlaceholder("Search and filter").fill("ubuntu-daily"); //builtin image registry
+  await page.getByPlaceholder("Search and filter").fill(builtinRegistryName);
   await page.getByPlaceholder("Search and filter").press("Enter");
   await page.getByPlaceholder("Add filter").press("Escape");
 
-  await expect(
-    page.getByRole("row", { name: /ubuntu-daily/i, exact: true }),
-  ).toBeVisible();
+  const row = page.getByRole("row", {
+    name: builtinRegistryName,
+    exact: true,
+  });
+  await expect(row).toBeVisible();
+  await expect(row.getByRole("cell", { name: "Name" })).toContainText(
+    builtinRegistryName,
+  );
+  await expect(row.getByRole("cell", { name: "Protocol" })).toContainText(
+    "simplestreams",
+  );
+  await expect(row.getByRole("cell", { name: "Built-in" })).toContainText(
+    "Yes",
+  );
+  await expect(row.getByRole("cell", { name: "Public" })).toContainText("Yes");
 });
 
 test("search for built-in image registries", async ({ page, lxdVersion }) => {
@@ -36,4 +50,47 @@ test("search for built-in image registries", async ({ page, lxdVersion }) => {
   await page.getByPlaceholder("Add filter").press("Escape");
 
   await expect(page.getByText("Showing all 5 image registries")).toBeVisible();
+});
+
+test("create SimpleStreams image registry", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+  const registryName = randomImageRegistryName();
+  const url = "https://cloud-images.ubuntu.com/releases/";
+  await visitImageRegistries(page);
+  await page.getByTitle("Create registry").click();
+  await expect(
+    page.getByRole("heading", { name: "Create registry" }),
+  ).toBeVisible();
+
+  await page.getByLabel("Name").fill(registryName);
+  await page
+    .getByLabel("Description")
+    .fill("Playwright SimpleStreams registry");
+  await page
+    .getByLabel("Protocol")
+    .getByRole("radio", { name: "SimpleStreams" })
+    .check();
+  await expect(page.getByLabel("Source Project")).not.toBeVisible();
+  await expect(page.getByLabel("Cluster link")).not.toBeVisible();
+  await page.getByLabel("Server URL").fill(url);
+
+  await page.getByRole("button", { name: "Create" }).click();
+
+  await expect(
+    page.getByText(`Image registry ${registryName} created.`),
+  ).toBeVisible();
+
+  const createdRow = page.getByRole("row", { name: registryName, exact: true });
+  await expect(createdRow.getByRole("cell", { name: "Name" })).toContainText(
+    registryName,
+  );
+  await expect(
+    createdRow.getByRole("cell", { name: "Protocol" }),
+  ).toContainText("simplestreams");
+  await expect(
+    createdRow.getByRole("cell", { name: "Built-in" }),
+  ).toContainText("No");
+  await expect(createdRow.getByRole("cell", { name: "Public" })).toContainText(
+    "Yes",
+  );
 });


### PR DESCRIPTION
## Done

- Create image registry side panel

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Images -> Image registries
    - Click create registry
    - Create a registry and make sure it is displayed correctly in the table.
    - Note the following rules and make sure they are respected in the form:
        - A simplestreams registry is always public and can not have a cluster link or a source project.
        - Public Lxd registries are restricted to the default project.       

## Screenshots
<img width="1902" height="965" alt="image" src="https://github.com/user-attachments/assets/fb6e3b11-5660-411b-8260-cd2dbac34d67" />

<img width="1902" height="965" alt="image" src="https://github.com/user-attachments/assets/fb6e3b11-5660-411b-8260-cd2dbac34d67" />