### PR TITLE
fix(storage bucket): rely on operation if present

### DIFF
--- a/src/api/storage-buckets.tsx
+++ b/src/api/storage-buckets.tsx
@@ -102,12 +102,12 @@ export const updateStorageBucket = async (
   pool: string,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -116,23 +116,31 @@ export const updateStorageBucket = async (
       },
       body: JSON.stringify(bucket),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucket = async (
   bucket: string,
   pool: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketBulk = async (
@@ -231,12 +239,12 @@ export const updateStorageBucketKey = async (
   pool: string,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}/keys/${encodeURIComponent(key.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -245,7 +253,11 @@ export const updateStorageBucketKey = async (
       },
       body: JSON.stringify(key),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketKey = async (
@@ -253,16 +265,20 @@ export const deleteStorageBucketKey = async (
   key: string,
   pool: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}/keys/${encodeURIComponent(key)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketKeyBulk = async (

--- a/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
@@ -11,7 +11,9 @@ import {
 } from "@canonical/react-components";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import { deleteStorageBucket } from "api/storage-buckets";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ResourceLabel from "components/ResourceLabel";
 import { useNavigate } from "react-router-dom";
 import { ROOT_PATH } from "util/rootPath";
@@ -35,9 +37,26 @@ const DeleteStorageBucketBtn: FC<Props> = ({
   const projectName = project?.name || "";
   const navigate = useNavigate();
   const toastNotify = useToastNotification();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const onFinish = () => {
-    navigate(`${ROOT_PATH}/ui/project/${project?.name}/storage/buckets`);
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, projectName, queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+
+    // Only navigate to the storage buckets list if we are still on the deleted storage bucket's detail page
+    const storageBucketDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name || "")}/storage/pool/${encodeURIComponent(bucket.pool)}/bucket/${encodeURIComponent(bucket.name)}`;
+    if (location.pathname.startsWith(storageBucketDetailPath)) {
+      navigate(
+        `${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name || "")}/storage/buckets`,
+      );
+    }
+
     toastNotify.success(
       <>
         Storage bucket <ResourceLabel bold type="bucket" value={bucket.name} />{" "}
@@ -46,18 +65,39 @@ const DeleteStorageBucketBtn: FC<Props> = ({
     );
   };
 
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure("Storage bucket deletion failed", e);
+  };
+
   const handleDelete = () => {
     setLoading(true);
     deleteStorageBucket(bucket.name, bucket.pool, projectName)
-      .then(onFinish)
-      .catch((e) => {
-        notify.failure("Storage bucket deletion failed", e);
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of storage bucket{" "}
+              <ResourceLabel bold type="bucket" value={bucket.name} /> has
+              started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
-      .finally(() => {
-        setLoading(false);
-        queryClient.invalidateQueries({
-          queryKey: [queryKeys.storage, projectName, queryKeys.buckets],
-        });
+      .catch((e) => {
+        onFailure(e);
       });
   };
 

--- a/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
@@ -11,7 +11,9 @@ import {
 } from "@canonical/react-components";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import { deleteStorageBucketKey } from "api/storage-buckets";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
@@ -27,14 +29,40 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
   const toastNotify = useToastNotification();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const onFinish = () => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project?.name ?? "",
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+    setLoading(false);
     toastNotify.success(
       <>
         Key <ResourceLabel bold type="bucket-key" value={bucketKey.name} />{" "}
         deleted for storage bucket{" "}
         <ResourceLabel bold type="bucket" value={bucket.name} />.
       </>,
+    );
+  };
+
+  const onFailure = (e: Error) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(
+      `Deletion of key ${bucketKey.name} for storage bucket ${bucket.name} failed`,
+      e,
     );
   };
 
@@ -46,23 +74,31 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
       bucket.pool,
       projectName,
     )
-      .then(onFinish)
-      .catch((e) => {
-        notify.failure("Key deletion failed", e);
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of key{" "}
+              <ResourceLabel bold type="bucket-key" value={bucketKey.name} />{" "}
+              for storage bucket{" "}
+              <ResourceLabel bold type="bucket" value={bucket.name} />
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
-      .finally(() => {
-        setLoading(false);
-        queryClient.invalidateQueries({
-          queryKey: [
-            queryKeys.storage,
-            bucket.pool,
-            project?.name ?? "",
-            queryKeys.buckets,
-            bucket.name,
-            queryKeys.keys,
-          ],
-        });
-      });
+      .catch(onFailure);
   };
 
   return (

--- a/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
@@ -7,7 +7,9 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import { useState, type FC } from "react";
+import { useEventQueue } from "context/eventQueue";
 import usePanelParams from "util/usePanelParams";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import * as Yup from "yup";
 import { useFormik } from "formik";
 import NotificationRow from "components/NotificationRow";
@@ -23,6 +25,7 @@ import {
   testDuplicateBucketKeyName,
 } from "util/storageBucket";
 import { useCurrentProject } from "context/useCurrentProject";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -35,6 +38,9 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
@@ -57,7 +63,21 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
       .required("Key name is required"),
   });
 
-  const handleSuccess = (keyName: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        panelParams.project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+  };
+
+  const onSuccess = (keyName: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Key <ResourceLink type="bucket-key" value={keyName} to={bucketURL} />{" "}
@@ -67,6 +87,13 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     );
     closePanel();
   };
+
+  const onFailure = (keyName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of key ${keyName} failed`, e);
+  };
+
   const formik = useFormik<StorageBucketKeyFormValues>({
     initialValues: {
       name: "",
@@ -88,22 +115,36 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
         bucket.pool,
         bucket.name,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              panelParams.project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-            ],
-          });
-          handleSuccess(values.name);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of key{" "}
+                <ResourceLabel bold type="bucket-key" value={values.name} /> for
+                storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={bucket.name}
+                  to={bucketURL}
+                />
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Key creation failed`, e);
+          onFailure(values.name, e);
         });
     },
   });

--- a/src/pages/storage/panels/CreateStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketPanel.tsx
@@ -8,10 +8,13 @@ import {
 } from "@canonical/react-components";
 import type { FC } from "react";
 import { useState } from "react";
+import { useEventQueue } from "context/eventQueue";
 import usePanelParams from "util/usePanelParams";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import * as Yup from "yup";
 import { useFormik } from "formik";
 import NotificationRow from "components/NotificationRow";
+import ResourceLabel from "components/ResourceLabel";
 import ResourceLink from "components/ResourceLink";
 import StorageBucketForm from "../forms/StorageBucketForm";
 import type { StorageBucketFormValues } from "types/forms/storageBucket";
@@ -33,6 +36,8 @@ const CreateStorageBucketPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const bucketSchema = Yup.object().shape({
     name: Yup.string()
@@ -43,7 +48,14 @@ const CreateStorageBucketPanel: FC = () => {
     pool: Yup.string().required("Pool must have a Ceph Object driver"),
   });
 
-  const handleSuccess = (bucketName: string, pool: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, panelParams.project, queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = (bucketName: string, pool: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Storage bucket{" "}
@@ -57,6 +69,13 @@ const CreateStorageBucketPanel: FC = () => {
     );
     closePanel();
   };
+
+  const onFailure = (bucketName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of storage bucket ${bucketName} failed`, e);
+  };
+
   const formik = useFormik<StorageBucketFormValues>({
     initialValues: {
       name: "",
@@ -76,19 +95,30 @@ const CreateStorageBucketPanel: FC = () => {
         values.pool,
         values.target,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              panelParams.project,
-              queryKeys.buckets,
-            ],
-          });
-          handleSuccess(values.name, values.pool);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of storage bucket{" "}
+                <ResourceLabel bold type="bucket" value={values.name} /> has
+                started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name, values.pool);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name, values.pool);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Storage bucket creation failed`, e);
+          onFailure(values.name, e);
         });
     },
   });

--- a/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
@@ -18,7 +18,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
 import { pluralize } from "util/helpers";
 import type { StorageBucketKeyFormValues } from "types/forms/storageBucketKey";
+import { useEventQueue } from "context/eventQueue";
 import { useBucketKey } from "context/useBuckets";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import StorageBucketKeyForm from "../forms/StorageBucketKeyForm";
 import { getStorageBucketURL } from "util/storageBucket";
 
@@ -31,10 +33,15 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  const bucketURL = getStorageBucketURL(bucket.name, bucket.pool, project);
 
   const {
     data: bucketKey,
@@ -42,8 +49,32 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     isLoading,
   } = useBucketKey(bucket, key ?? "", project);
 
-  const handleSuccess = (bucket: LxdStorageBucket) => {
-    const bucketURL = getStorageBucketURL(bucket.name, bucket.pool, project);
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+        bucketKey?.name,
+      ],
+    });
+  };
+
+  const onSuccess = (bucket: LxdStorageBucket) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Key{" "}
@@ -58,6 +89,15 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
       </>,
     );
     closePanel();
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(
+      `Update of key ${bucketKey?.name ?? ""} for storage bucket ${bucket?.name ?? ""} failed`,
+      e,
+    );
   };
 
   const formik = useFormik<StorageBucketKeyFormValues>({
@@ -84,33 +124,40 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
         bucket.pool,
         project || "",
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-              bucketKey?.name,
-            ],
-          });
-          handleSuccess(bucket);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of key{" "}
+                <ResourceLink
+                  type="bucket-key"
+                  value={bucketKey?.name ?? ""}
+                  to={bucketURL}
+                />{" "}
+                for storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={bucket?.name ?? ""}
+                  to={bucketURL}
+                />
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(bucket);
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(bucket);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Key update failed`, e);
+          onFailure(e);
         });
     },
   });

--- a/src/pages/storage/panels/EditStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketPanel.tsx
@@ -18,7 +18,9 @@ import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket } from "types/storage";
 import { pluralize } from "util/helpers";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
@@ -34,8 +36,26 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
     panelParams.clear();
     notify.clear();
   };
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const handleSuccess = (bucketName: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project?.name ?? "",
+        queryKeys.buckets,
+        bucket.name,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, project?.name ?? "", queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = (bucketName: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Storage bucket{" "}
@@ -48,6 +68,12 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
       </>,
     );
     closePanel();
+  };
+
+  const onFailure = (storageBucketName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Update of storage bucket ${storageBucketName} failed`, e);
   };
 
   const formik = useFormik<StorageBucketFormValues>({
@@ -72,28 +98,35 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
         project?.name || "",
         values.target,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project?.name ?? "",
-              queryKeys.buckets,
-              bucket.name,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              project?.name ?? "",
-              queryKeys.buckets,
-            ],
-          });
-          handleSuccess(values.name);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={values.name}
+                  to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name ?? "")}/storage/buckets`}
+                />{" "}
+                has started.
+              </>,
+            );
+
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Storage bucket update failed`, e);
+          onFailure(values.name, e);
         });
     },
   });


### PR DESCRIPTION
## Done

- fix(storage bucket): rely on operation when api extension `hasStorageAndNetworkOperations` is present

Follow up of https://github.com/canonical/lxd/pull/18029

Affected endpoints:

- POST /1.0/storage-pools/{pool}/buckets
- PUT /1.0/storage-pools/{pool}/buckets/{name}
- PATCH /1.0/storage-pools/{pool}/buckets/{name}
- DELETE /1.0/storage-pools/{pool}/buckets/{name}
- POST /1.0/storage-pools/{pool}/buckets/{name}/keys
- PUT /1.0/storage-pools/{pool}/buckets/{name}/keys/{key}
- DELETE /1.0/storage-pools/{pool}/buckets/{name}/keys/{key}

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create, update and delete a storage bucket
    - Bulk delete storage buckets
    - Create, update and delete a storage bucket key
    - Bulk delete a storage bucket key

## Screenshots
