### PR TITLE
WD-35831 network peers async

### DIFF
--- a/src/api/network-forwards.tsx
+++ b/src/api/network-forwards.tsx
@@ -1,6 +1,7 @@
-import { handleRawResponse, handleResponse } from "util/helpers";
+import { handleResponse } from "util/helpers";
 import type { LxdNetwork, LxdNetworkForward } from "types/network";
 import type { LxdApiResponse } from "types/apiResponse";
+import type { LxdOperationResponse } from "types/operation";
 import { addTarget } from "util/target";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -49,7 +50,7 @@ export const createNetworkForward = async (
   network: string,
   forward: Partial<LxdNetworkForward>,
   project: string,
-): Promise<string> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, forward.location);
@@ -64,11 +65,9 @@ export const createNetworkForward = async (
       body: JSON.stringify(forward),
     },
   )
-    .then(handleRawResponse)
-    .then((response) => {
-      const locationHeader = response.headers.get("Location");
-      const listenAddress = locationHeader?.split("/").pop() ?? "";
-      return listenAddress;
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
     });
 };
 
@@ -76,12 +75,12 @@ export const updateNetworkForward = async (
   network: string,
   forward: LxdNetworkForward,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, forward.location);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/networks/${encodeURIComponent(network)}/forwards/${encodeURIComponent(forward.listen_address)}?${params.toString()}`,
     {
       method: "PUT",
@@ -90,22 +89,30 @@ export const updateNetworkForward = async (
       },
       body: JSON.stringify(forward),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteNetworkForward = async (
   network: LxdNetwork,
   forward: LxdNetworkForward,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, forward.location);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/networks/${encodeURIComponent(network.name)}/forwards/${encodeURIComponent(forward.listen_address)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/api/network-local-peering.tsx
+++ b/src/api/network-local-peering.tsx
@@ -1,6 +1,7 @@
-import { handleResponse } from "util/helpers";
-import type { LxdNetworkPeer } from "types/network";
 import type { LxdApiResponse } from "types/apiResponse";
+import type { LxdNetworkPeer } from "types/network";
+import type { LxdOperationResponse } from "types/operation";
+import { handleResponse } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 
 export const fetchNetworkPeers = async (
@@ -42,11 +43,11 @@ export const createNetworkPeer = async (
   network: string,
   project: string,
   body: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/networks/${encodeURIComponent(network)}/peers?${params.toString()}`,
     {
       method: "POST",
@@ -55,25 +56,33 @@ export const createNetworkPeer = async (
       },
       body: body,
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteNetworkPeer = async (
   network: string,
   project: string,
   localPeering: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/networks/${encodeURIComponent(
       network,
     )}/peers/${encodeURIComponent(localPeering)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const updateNetworkPeer = async (
@@ -81,11 +90,11 @@ export const updateNetworkPeer = async (
   localPeering: string,
   project: string,
   body: LxdNetworkPeer,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/networks/${encodeURIComponent(network)}/peers/${encodeURIComponent(localPeering)}?${params.toString()}`,
     {
       method: "PUT",
@@ -94,5 +103,9 @@ export const updateNetworkPeer = async (
       },
       body: JSON.stringify(body),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/api/storage-buckets.tsx
+++ b/src/api/storage-buckets.tsx
@@ -102,12 +102,12 @@ export const updateStorageBucket = async (
   pool: string,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -116,23 +116,31 @@ export const updateStorageBucket = async (
       },
       body: JSON.stringify(bucket),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucket = async (
   bucket: string,
   pool: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketBulk = async (
@@ -231,12 +239,12 @@ export const updateStorageBucketKey = async (
   pool: string,
   project: string,
   target?: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
   addTarget(params, target);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}/keys/${encodeURIComponent(key.name)}?${params.toString()}`,
     {
       method: "PUT",
@@ -245,7 +253,11 @@ export const updateStorageBucketKey = async (
       },
       body: JSON.stringify(key),
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketKey = async (
@@ -253,16 +265,20 @@ export const deleteStorageBucketKey = async (
   key: string,
   pool: string,
   project: string,
-): Promise<void> => {
+): Promise<LxdOperationResponse> => {
   const params = new URLSearchParams();
   params.set("project", project);
 
-  await fetch(
+  return fetch(
     `${ROOT_PATH}/1.0/storage-pools/${encodeURIComponent(pool)}/buckets/${encodeURIComponent(bucket)}/keys/${encodeURIComponent(key)}?${params.toString()}`,
     {
       method: "DELETE",
     },
-  ).then(handleResponse);
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };
 
 export const deleteStorageBucketKeyBulk = async (

--- a/src/pages/networks/CreateNetworkForward.tsx
+++ b/src/pages/networks/CreateNetworkForward.tsx
@@ -18,7 +18,9 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import BaseLayout from "components/BaseLayout";
 import HelpLink from "components/HelpLink";
 import FormFooterLayout from "components/forms/FormFooterLayout";
+import { useEventQueue } from "context/eventQueue";
 import { useNetwork } from "context/useNetworks";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { isTypeOvn } from "util/networks";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -31,11 +33,12 @@ const CreateNetworkForward: FC = () => {
     network: string;
     project: string;
   }>();
-
   const { data: network, error: networkError } = useNetwork(
     networkName ?? "",
     project ?? "",
   );
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   useEffect(() => {
     if (networkError) {
@@ -56,6 +59,34 @@ const CreateNetworkForward: FC = () => {
     return "";
   };
 
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        network,
+        queryKeys.forwards,
+      ],
+    });
+  };
+
+  const onSuccess = (listenAddress?: string) => {
+    invalidateCache();
+    toastNotify.success(
+      `Network forward with listen address ${listenAddress} created.`,
+    );
+  };
+
+  const onFailure = (e: unknown, listenAddress?: string) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(
+      `Creation of network forward with listen address ${listenAddress} failed`,
+      e,
+    );
+  };
+
   const formik = useFormik<NetworkForwardFormValues>({
     initialValues: {
       listenAddress: getDefaultListenAddress(),
@@ -65,26 +96,33 @@ const CreateNetworkForward: FC = () => {
     onSubmit: (values) => {
       const forward = toNetworkForward(values);
       createNetworkForward(networkName ?? "", forward, project ?? "")
-        .then((listenAddress) => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              network,
-              queryKeys.forwards,
-            ],
-          });
+        .then((operation) => {
           navigate(
             `${ROOT_PATH}/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(networkName ?? "")}/forwards`,
           );
-          toastNotify.success(
-            `Network forward with listen address ${listenAddress} created.`,
-          );
+
+          if (hasStorageAndNetworkOperations && operation?.metadata.id) {
+            toastNotify.info(
+              <>
+                Creation of network forward with listen address{" "}
+                {formik.values.listenAddress} has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(formik.values.listenAddress);
+              },
+              (msg) => {
+                onFailure(new Error(msg), formik.values.listenAddress);
+              },
+            );
+          } else {
+            onSuccess(formik.values.listenAddress);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure("Network forward creation failed", e);
+          onFailure(e, formik.values.listenAddress);
         });
     },
   });

--- a/src/pages/networks/EditNetworkForward.tsx
+++ b/src/pages/networks/EditNetworkForward.tsx
@@ -21,7 +21,9 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import BaseLayout from "components/BaseLayout";
 import HelpLink from "components/HelpLink";
 import FormFooterLayout from "components/forms/FormFooterLayout";
+import { useEventQueue } from "context/eventQueue";
 import { useNetwork } from "context/useNetworks";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { ROOT_PATH } from "util/rootPath";
 
 const EditNetworkForward: FC = () => {
@@ -40,8 +42,9 @@ const EditNetworkForward: FC = () => {
     forwardAddress: string;
     memberName?: string;
   }>();
-
   const { data: network, error } = useNetwork(networkName ?? "", project ?? "");
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   useEffect(() => {
     if (error) {
@@ -69,6 +72,44 @@ const EditNetworkForward: FC = () => {
       ),
   });
 
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        networkName,
+        queryKeys.forwards,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        networkName,
+        queryKeys.forwards,
+        forwardAddress,
+        queryKeys.members,
+        memberName,
+      ],
+    });
+  };
+
+  const onSuccess = (listenAddress: string) => {
+    invalidateCache();
+    navigate(
+      `${ROOT_PATH}/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(networkName ?? "")}/forwards`,
+    );
+    toastNotify.success(`Network forward ${listenAddress} updated.`);
+  };
+
+  const onFailure = (listenAddress: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Update of network forward ${listenAddress} failed`, e);
+  };
+
   const formik = useFormik<NetworkForwardFormValues>({
     initialValues: {
       listenAddress: forwardAddress ?? "",
@@ -89,38 +130,28 @@ const EditNetworkForward: FC = () => {
       const forward = toNetworkForward(values);
 
       updateNetworkForward(networkName ?? "", forward, project ?? "")
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              networkName,
-              queryKeys.forwards,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              networkName,
-              queryKeys.forwards,
-              forwardAddress,
-              queryKeys.members,
-              memberName,
-            ],
-          });
-          navigate(
-            `${ROOT_PATH}/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(networkName ?? "")}/forwards`,
-          );
-          toastNotify.success(
-            `Network forward ${forward.listen_address} updated.`,
-          );
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of network forward {forward.listen_address} has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(forward.listen_address);
+              },
+              (msg) => {
+                onFailure(forward.listen_address, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(forward.listen_address);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure("Network forward update failed", e);
+          onFailure(forward.listen_address, e);
         });
     },
   });

--- a/src/pages/networks/actions/DeleteLocalPeerBtn.tsx
+++ b/src/pages/networks/actions/DeleteLocalPeerBtn.tsx
@@ -16,6 +16,8 @@ import { deleteNetworkPeer } from "api/network-local-peering";
 import ResourceLink from "components/ResourceLink";
 import NetworkRichChip from "../NetworkRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   network: LxdNetwork;
@@ -30,9 +32,25 @@ const DeleteLocalPeerBtn: FC<Props> = ({ network, localPeering }) => {
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
   const toastNotify = useToastNotification();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
   const networkURL = `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network/${encodeURIComponent(network.name)}`;
 
+  const invalidateQueries = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        projectName,
+        queryKeys.networks,
+        network.name,
+        queryKeys.peers,
+      ],
+    });
+  };
+
   const onSuccess = () => {
+    invalidateQueries();
+    setLoading(false);
     toastNotify.success(
       <>
         Local peering <ResourceLabel type="peering" value={localPeering} bold />{" "}
@@ -42,25 +60,46 @@ const DeleteLocalPeerBtn: FC<Props> = ({ network, localPeering }) => {
     );
   };
 
+  const onFailure = (e: unknown) => {
+    notify.failure(
+      `Deletion of local peering ${localPeering} for network ${network.name} failed`,
+      e,
+    );
+    setLoading(false);
+    invalidateQueries();
+  };
+
   const handleDelete = () => {
     setLoading(true);
     deleteNetworkPeer(network.name, projectName, localPeering)
-      .then(onSuccess)
-      .catch((e) => {
-        notify.failure("Local peering deletion failed", e);
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of local peering{" "}
+              <ResourceLabel type="peering" value={localPeering} bold /> for
+              network{" "}
+              <NetworkRichChip
+                networkName={network.name}
+                projectName={projectName}
+              />{" "}
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
-      .finally(() => {
-        setLoading(false);
-        queryClient.invalidateQueries({
-          queryKey: [
-            queryKeys.projects,
-            projectName,
-            queryKeys.networks,
-            network.name,
-            queryKeys.peers,
-          ],
-        });
-      });
+      .catch(onFailure);
   };
 
   return (

--- a/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
+++ b/src/pages/networks/actions/DeleteNetworkForwardBtn.tsx
@@ -12,6 +12,8 @@ import {
 import { deleteNetworkForward } from "api/network-forwards";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import ResourceLabel from "components/ResourceLabel";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
 
 interface Props {
   network: LxdNetwork;
@@ -25,33 +27,74 @@ const DeleteNetworkForwardBtn: FC<Props> = ({ network, forward, project }) => {
   const queryClient = useQueryClient();
   const [isLoading, setLoading] = useState(false);
   const { canEditNetwork } = useNetworkEntitlements();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) =>
+        query.queryKey[0] === queryKeys.projects &&
+        query.queryKey[1] === project &&
+        query.queryKey[2] === queryKeys.networks &&
+        query.queryKey[3] === network.name,
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+    toastNotify.success(
+      <>
+        Network forward with listen address{" "}
+        <ResourceLabel
+          type="network-forward"
+          value={forward.listen_address}
+          bold
+        />{" "}
+        deleted.
+      </>,
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(
+      `Deletion of network forward with listen address ${forward.listen_address} failed`,
+      e,
+    );
+  };
 
   const handleDelete = () => {
     setLoading(true);
     deleteNetworkForward(network, forward, project)
-      .then(() => {
-        toastNotify.success(
-          <>
-            Network forward with listen address{" "}
-            <ResourceLabel
-              type="network-forward"
-              value={forward.listen_address}
-              bold
-            />{" "}
-            deleted.
-          </>,
-        );
-        queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === queryKeys.projects &&
-            query.queryKey[1] === project &&
-            query.queryKey[2] === queryKeys.networks &&
-            query.queryKey[3] === network.name,
-        });
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of network forward with listen address{" "}
+              <ResourceLabel
+                bold
+                type="network-forward"
+                value={forward.listen_address}
+              />{" "}
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
       .catch((e) => {
-        setLoading(false);
-        notify.failure("Network forward deletion failed", e);
+        onFailure(e);
       });
   };
 

--- a/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
@@ -22,6 +22,9 @@ import type { LocalPeeringFormValues } from "types/forms/localPeering";
 import { testDuplicateLocalPeeringName } from "util/networks";
 import NetworkRichChip from "../NetworkRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useEventQueue } from "context/eventQueue";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   network: LxdNetwork;
@@ -34,6 +37,8 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
@@ -78,7 +83,20 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
       .required("Local peering name is required"),
   });
 
-  const handleSuccess = (peerName: string) => {
+  const invalidateQueries = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        panelParams.project,
+        queryKeys.networks,
+        network.name,
+        queryKeys.peers,
+      ],
+    });
+  };
+
+  const onSuccess = (peerName: string) => {
+    invalidateQueries();
     toastNotify.success(
       <>
         Local peering{" "}
@@ -97,16 +115,13 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
     closePanel();
   };
 
-  const invalidateQueries = () => {
-    queryClient.invalidateQueries({
-      queryKey: [
-        queryKeys.projects,
-        panelParams.project,
-        queryKeys.networks,
-        network.name,
-        queryKeys.peers,
-      ],
-    });
+  const onFailure = (isLocal: boolean, peerName: string, e: unknown) => {
+    invalidateQueries();
+    formik.setSubmitting(false);
+    notify.failure(
+      `Creation of ${isLocal ? "local" : "mutual"} peering ${peerName} for network ${network.name} failed`,
+      e,
+    );
   };
 
   const formik = useFormik<LocalPeeringFormValues>({
@@ -142,7 +157,7 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
         panelParams.project,
         JSON.stringify(localPeeringPayload),
       )
-        .then(() => {
+        .then((operation) => {
           if (formik.values.createMutualPeering) {
             const mutualPeeringPayload = {
               name: values.name,
@@ -156,23 +171,56 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
               values.targetProject,
               JSON.stringify(mutualPeeringPayload),
             )
-              .then(() => {
-                invalidateQueries();
-                handleSuccess(values.name);
+              .then((mutualOperation) => {
+                if (hasStorageAndNetworkOperations) {
+                  toastNotify.info(
+                    <>
+                      Creation of mutual local peering{" "}
+                      <ResourceLabel bold type="peering" value={values.name} />{" "}
+                      has started.
+                    </>,
+                  );
+                  eventQueue.set(
+                    mutualOperation.metadata.id,
+                    () => {
+                      onSuccess(values.name);
+                    },
+                    (msg) => {
+                      onFailure(false, values.name, new Error(msg));
+                    },
+                  );
+                } else {
+                  onSuccess(values.name);
+                }
               })
               .catch((e) => {
-                formik.setSubmitting(false);
-                invalidateQueries();
-                notify.failure(`Mutual local peering creation failed`, e);
+                onFailure(false, values.name, e);
               });
           } else {
-            invalidateQueries();
-            handleSuccess(values.name);
+            if (hasStorageAndNetworkOperations) {
+              toastNotify.info(
+                <>
+                  Creation of local peering{" "}
+                  <ResourceLabel bold type="peering" value={values.name} /> has
+                  started.
+                </>,
+              );
+              eventQueue.set(
+                operation.metadata.id,
+                () => {
+                  onSuccess(values.name);
+                },
+                (msg) => {
+                  onFailure(true, values.name, new Error(msg));
+                },
+              );
+            } else {
+              onSuccess(values.name);
+            }
           }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Local peering creation failed`, e);
+          onFailure(true, values.name, e);
         });
     },
   });

--- a/src/pages/networks/panels/EditLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/EditLocalPeeringPanel.tsx
@@ -17,7 +17,9 @@ import { pluralize } from "util/helpers";
 import type { LxdNetwork, LxdNetworkPeer } from "types/network";
 import NetworkLocalPeeringForm from "../forms/NetworkLocalPeeringForm";
 import type { LocalPeeringFormValues } from "types/forms/localPeering";
+import { useEventQueue } from "context/eventQueue";
 import { useLocalPeering } from "context/useLocalPeerings";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { updateNetworkPeer } from "api/network-local-peering";
 import ResourceLink from "components/ResourceLink";
 import { ROOT_PATH } from "util/rootPath";
@@ -31,6 +33,9 @@ const EditLocalPeeringPanel: FC<Props> = ({ network }) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
@@ -43,7 +48,30 @@ const EditLocalPeeringPanel: FC<Props> = ({ network }) => {
     isLoading,
   } = useLocalPeering(network, project, localPeering ?? "");
 
-  const handleSuccess = () => {
+  const invalidateQueries = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        network.name,
+        queryKeys.peers,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.projects,
+        project,
+        queryKeys.networks,
+        network.name,
+        queryKeys.peers,
+        localPeering,
+      ],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateQueries();
     toastNotify.success(
       <>
         Local peering{" "}
@@ -56,6 +84,12 @@ const EditLocalPeeringPanel: FC<Props> = ({ network }) => {
       </>,
     );
     closePanel();
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateQueries();
+    formik.setSubmitting(false);
+    notify.failure(`Update of local peering ${localPeering} failed`, e);
   };
 
   const formik = useFormik<LocalPeeringFormValues>({
@@ -80,31 +114,34 @@ const EditLocalPeeringPanel: FC<Props> = ({ network }) => {
         project,
         localPeeringPayload,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              network.name,
-              queryKeys.peers,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.projects,
-              project,
-              queryKeys.networks,
-              network.name,
-              queryKeys.peers,
-              localPeering,
-            ],
-          });
-          handleSuccess();
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of local peering{" "}
+                <ResourceLink
+                  type={"peering"}
+                  value={localPeering ?? ""}
+                  to={`${networkURL}/local-peerings`}
+                />{" "}
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess();
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess();
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Local peering update failed`, e);
+          onFailure(e);
         });
     },
   });

--- a/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketBtn.tsx
@@ -11,7 +11,9 @@ import {
 } from "@canonical/react-components";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import { deleteStorageBucket } from "api/storage-buckets";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ResourceLabel from "components/ResourceLabel";
 import { useNavigate } from "react-router-dom";
 import { ROOT_PATH } from "util/rootPath";
@@ -35,9 +37,26 @@ const DeleteStorageBucketBtn: FC<Props> = ({
   const projectName = project?.name || "";
   const navigate = useNavigate();
   const toastNotify = useToastNotification();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const onFinish = () => {
-    navigate(`${ROOT_PATH}/ui/project/${project?.name}/storage/buckets`);
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, projectName, queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+
+    // Only navigate to the storage buckets list if we are still on the deleted storage bucket's detail page
+    const storageBucketDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name || "")}/storage/pool/${encodeURIComponent(bucket.pool)}/bucket/${encodeURIComponent(bucket.name)}`;
+    if (location.pathname.startsWith(storageBucketDetailPath)) {
+      navigate(
+        `${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name || "")}/storage/buckets`,
+      );
+    }
+
     toastNotify.success(
       <>
         Storage bucket <ResourceLabel bold type="bucket" value={bucket.name} />{" "}
@@ -46,18 +65,39 @@ const DeleteStorageBucketBtn: FC<Props> = ({
     );
   };
 
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure("Storage bucket deletion failed", e);
+  };
+
   const handleDelete = () => {
     setLoading(true);
     deleteStorageBucket(bucket.name, bucket.pool, projectName)
-      .then(onFinish)
-      .catch((e) => {
-        notify.failure("Storage bucket deletion failed", e);
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of storage bucket{" "}
+              <ResourceLabel bold type="bucket" value={bucket.name} /> has
+              started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
-      .finally(() => {
-        setLoading(false);
-        queryClient.invalidateQueries({
-          queryKey: [queryKeys.storage, projectName, queryKeys.buckets],
-        });
+      .catch((e) => {
+        onFailure(e);
       });
   };
 

--- a/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
@@ -11,7 +11,9 @@ import {
 } from "@canonical/react-components";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
 import { deleteStorageBucketKey } from "api/storage-buckets";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
@@ -27,14 +29,40 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
   const { project } = useCurrentProject();
   const projectName = project?.name || "";
   const toastNotify = useToastNotification();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const onFinish = () => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project?.name ?? "",
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+  };
+
+  const onSuccess = () => {
+    invalidateCache();
+    setLoading(false);
     toastNotify.success(
       <>
         Key <ResourceLabel bold type="bucket-key" value={bucketKey.name} />{" "}
         deleted for storage bucket{" "}
         <ResourceLabel bold type="bucket" value={bucket.name} />.
       </>,
+    );
+  };
+
+  const onFailure = (e: Error) => {
+    invalidateCache();
+    setLoading(false);
+    notify.failure(
+      `Deletion of key ${bucketKey.name} for storage bucket ${bucket.name} failed`,
+      e,
     );
   };
 
@@ -46,23 +74,31 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
       bucket.pool,
       projectName,
     )
-      .then(onFinish)
-      .catch((e) => {
-        notify.failure("Key deletion failed", e);
+      .then((operation) => {
+        if (hasStorageAndNetworkOperations) {
+          toastNotify.info(
+            <>
+              Deletion of key{" "}
+              <ResourceLabel bold type="bucket-key" value={bucketKey.name} />{" "}
+              for storage bucket{" "}
+              <ResourceLabel bold type="bucket" value={bucket.name} />
+              has started.
+            </>,
+          );
+          eventQueue.set(
+            operation.metadata.id,
+            () => {
+              onSuccess();
+            },
+            (msg) => {
+              onFailure(new Error(msg));
+            },
+          );
+        } else {
+          onSuccess();
+        }
       })
-      .finally(() => {
-        setLoading(false);
-        queryClient.invalidateQueries({
-          queryKey: [
-            queryKeys.storage,
-            bucket.pool,
-            project?.name ?? "",
-            queryKeys.buckets,
-            bucket.name,
-            queryKeys.keys,
-          ],
-        });
-      });
+      .catch(onFailure);
   };
 
   return (

--- a/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
@@ -7,7 +7,9 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import { useState, type FC } from "react";
+import { useEventQueue } from "context/eventQueue";
 import usePanelParams from "util/usePanelParams";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import * as Yup from "yup";
 import { useFormik } from "formik";
 import NotificationRow from "components/NotificationRow";
@@ -23,6 +25,7 @@ import {
   testDuplicateBucketKeyName,
 } from "util/storageBucket";
 import { useCurrentProject } from "context/useCurrentProject";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -35,6 +38,9 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
@@ -57,7 +63,21 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
       .required("Key name is required"),
   });
 
-  const handleSuccess = (keyName: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        panelParams.project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+  };
+
+  const onSuccess = (keyName: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Key <ResourceLink type="bucket-key" value={keyName} to={bucketURL} />{" "}
@@ -67,6 +87,13 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     );
     closePanel();
   };
+
+  const onFailure = (keyName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of key ${keyName} failed`, e);
+  };
+
   const formik = useFormik<StorageBucketKeyFormValues>({
     initialValues: {
       name: "",
@@ -88,22 +115,36 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
         bucket.pool,
         bucket.name,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              panelParams.project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-            ],
-          });
-          handleSuccess(values.name);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of key{" "}
+                <ResourceLabel bold type="bucket-key" value={values.name} /> for
+                storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={bucket.name}
+                  to={bucketURL}
+                />
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Key creation failed`, e);
+          onFailure(values.name, e);
         });
     },
   });

--- a/src/pages/storage/panels/CreateStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketPanel.tsx
@@ -8,10 +8,13 @@ import {
 } from "@canonical/react-components";
 import type { FC } from "react";
 import { useState } from "react";
+import { useEventQueue } from "context/eventQueue";
 import usePanelParams from "util/usePanelParams";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import * as Yup from "yup";
 import { useFormik } from "formik";
 import NotificationRow from "components/NotificationRow";
+import ResourceLabel from "components/ResourceLabel";
 import ResourceLink from "components/ResourceLink";
 import StorageBucketForm from "../forms/StorageBucketForm";
 import type { StorageBucketFormValues } from "types/forms/storageBucket";
@@ -33,6 +36,8 @@ const CreateStorageBucketPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
   const bucketSchema = Yup.object().shape({
     name: Yup.string()
@@ -43,7 +48,14 @@ const CreateStorageBucketPanel: FC = () => {
     pool: Yup.string().required("Pool must have a Ceph Object driver"),
   });
 
-  const handleSuccess = (bucketName: string, pool: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, panelParams.project, queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = (bucketName: string, pool: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Storage bucket{" "}
@@ -57,6 +69,13 @@ const CreateStorageBucketPanel: FC = () => {
     );
     closePanel();
   };
+
+  const onFailure = (bucketName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Creation of storage bucket ${bucketName} failed`, e);
+  };
+
   const formik = useFormik<StorageBucketFormValues>({
     initialValues: {
       name: "",
@@ -76,19 +95,30 @@ const CreateStorageBucketPanel: FC = () => {
         values.pool,
         values.target,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              panelParams.project,
-              queryKeys.buckets,
-            ],
-          });
-          handleSuccess(values.name, values.pool);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Creation of storage bucket{" "}
+                <ResourceLabel bold type="bucket" value={values.name} /> has
+                started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name, values.pool);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name, values.pool);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Storage bucket creation failed`, e);
+          onFailure(values.name, e);
         });
     },
   });

--- a/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
@@ -18,7 +18,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket, LxdStorageBucketKey } from "types/storage";
 import { pluralize } from "util/helpers";
 import type { StorageBucketKeyFormValues } from "types/forms/storageBucketKey";
+import { useEventQueue } from "context/eventQueue";
 import { useBucketKey } from "context/useBuckets";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import StorageBucketKeyForm from "../forms/StorageBucketKeyForm";
 import { getStorageBucketURL } from "util/storageBucket";
 
@@ -31,10 +33,15 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  const bucketURL = getStorageBucketURL(bucket.name, bucket.pool, project);
 
   const {
     data: bucketKey,
@@ -42,8 +49,32 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     isLoading,
   } = useBucketKey(bucket, key ?? "", project);
 
-  const handleSuccess = (bucket: LxdStorageBucket) => {
-    const bucketURL = getStorageBucketURL(bucket.name, bucket.pool, project);
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project,
+        queryKeys.buckets,
+        bucket.name,
+        queryKeys.keys,
+        bucketKey?.name,
+      ],
+    });
+  };
+
+  const onSuccess = (bucket: LxdStorageBucket) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Key{" "}
@@ -58,6 +89,15 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
       </>,
     );
     closePanel();
+  };
+
+  const onFailure = (e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(
+      `Update of key ${bucketKey?.name ?? ""} for storage bucket ${bucket?.name ?? ""} failed`,
+      e,
+    );
   };
 
   const formik = useFormik<StorageBucketKeyFormValues>({
@@ -84,33 +124,40 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
         bucket.pool,
         project || "",
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project,
-              queryKeys.buckets,
-              bucket.name,
-              queryKeys.keys,
-              bucketKey?.name,
-            ],
-          });
-          handleSuccess(bucket);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of key{" "}
+                <ResourceLink
+                  type="bucket-key"
+                  value={bucketKey?.name ?? ""}
+                  to={bucketURL}
+                />{" "}
+                for storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={bucket?.name ?? ""}
+                  to={bucketURL}
+                />
+                has started.
+              </>,
+            );
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(bucket);
+              },
+              (msg) => {
+                onFailure(new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(bucket);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Key update failed`, e);
+          onFailure(e);
         });
     },
   });

--- a/src/pages/storage/panels/EditStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketPanel.tsx
@@ -18,7 +18,9 @@ import { queryKeys } from "util/queryKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import type { LxdStorageBucket } from "types/storage";
 import { pluralize } from "util/helpers";
+import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
@@ -34,8 +36,26 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
     panelParams.clear();
     notify.clear();
   };
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
+  const eventQueue = useEventQueue();
 
-  const handleSuccess = (bucketName: string) => {
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.storage,
+        bucket.pool,
+        project?.name ?? "",
+        queryKeys.buckets,
+        bucket.name,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [queryKeys.storage, project?.name ?? "", queryKeys.buckets],
+    });
+  };
+
+  const onSuccess = (bucketName: string) => {
+    invalidateCache();
     toastNotify.success(
       <>
         Storage bucket{" "}
@@ -48,6 +68,12 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
       </>,
     );
     closePanel();
+  };
+
+  const onFailure = (storageBucketName: string, e: unknown) => {
+    invalidateCache();
+    formik.setSubmitting(false);
+    notify.failure(`Update of storage bucket ${storageBucketName} failed`, e);
   };
 
   const formik = useFormik<StorageBucketFormValues>({
@@ -72,28 +98,35 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
         project?.name || "",
         values.target,
       )
-        .then(() => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              bucket.pool,
-              project?.name ?? "",
-              queryKeys.buckets,
-              bucket.name,
-            ],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              queryKeys.storage,
-              project?.name ?? "",
-              queryKeys.buckets,
-            ],
-          });
-          handleSuccess(values.name);
+        .then((operation) => {
+          if (hasStorageAndNetworkOperations) {
+            toastNotify.info(
+              <>
+                Update of storage bucket{" "}
+                <ResourceLink
+                  type="bucket"
+                  value={values.name}
+                  to={`${ROOT_PATH}/ui/project/${encodeURIComponent(project?.name ?? "")}/storage/buckets`}
+                />{" "}
+                has started.
+              </>,
+            );
+
+            eventQueue.set(
+              operation.metadata.id,
+              () => {
+                onSuccess(values.name);
+              },
+              (msg) => {
+                onFailure(values.name, new Error(msg));
+              },
+            );
+          } else {
+            onSuccess(values.name);
+          }
         })
         .catch((e) => {
-          formik.setSubmitting(false);
-          notify.failure(`Storage bucket update failed`, e);
+          onFailure(values.name, e);
         });
     },
   });


### PR DESCRIPTION
## Done

- fix(network peers): rely on operation when api extension `hasStorageAndNetworkOperations` is present

Follow up of https://github.com/canonical/lxd/pull/18073

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create, update and delete a local peering
    - Create, update and delete a mutual peering

## Screenshots
