### PR TITLE
fix: storage pool available size

### DIFF
--- a/src/context/useStoragePoolResourceLimit.tsx
+++ b/src/context/useStoragePoolResourceLimit.tsx
@@ -30,5 +30,8 @@ export const useStoragePoolResourceLimit = (
   const availableSpaces = resourceArray.map(
     (r) => r.space.total - (r.space.used ?? 0),
   );
-  return getResourceLimit(availableSpaces, clusterMemberName);
+  return getResourceLimit(
+    availableSpaces,
+    !clusterMemberName || clusterMemberName === "none" ? "" : clusterMemberName,
+  );
 };

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -69,6 +69,9 @@ test("storage pool create, edit and remove", async ({ page }) => {
 test("storage volume create, edit and remove", async ({ page }) => {
   await editVolume(page, volume);
   await page.getByPlaceholder("Enter value").fill("2");
+  await expect(page.getByText("Available space:")).toBeVisible();
+  expect(page.getByText("on cluster member")).not.toBeVisible();
+
   await saveVolume(page, volume);
 
   await page.getByTestId("tab-link-Overview").click();
@@ -110,9 +113,9 @@ test("storage volume edit snapshot configuration", async ({
   await activateOverride(page, scheduleFieldText);
   await page.getByPlaceholder("Enter cron expression").last().fill("@daily");
   await page.getByRole("button", { name: "Save" }).click();
-  await page.waitForSelector(
-    `text=Snapshot configuration updated for volume ${volume}.`,
-  );
+  await page
+    .getByText(`Snapshot configuration updated for volume ${volume}.`)
+    .waitFor();
 });
 
 test("custom storage volume add snapshot from CTA", async ({ page }) => {
@@ -130,9 +133,9 @@ test("custom storage volume add snapshot from CTA", async ({ page }) => {
   await page
     .getByRole("button", { name: "Create snapshot", exact: true })
     .click();
-  await page.waitForSelector(
-    `text=Snapshot ${snapshot} created for volume ${volume}.`,
-  );
+  await page
+    .getByText(`Snapshot ${snapshot} created for volume ${volume}.`)
+    .waitFor();
 
   await expect(row.getByLabel("Snapshots")).toContainText("1");
 
@@ -210,7 +213,7 @@ test("Export and upload a volume backup", async ({ page }) => {
   await page.getByRole("button", { name: "Export" }).click();
   await page.getByRole("button", { name: "Export volume" }).click();
   const download = await downloadPromise;
-  await page.waitForSelector(`text=Volume ${volume} download started`);
+  await page.getByText(`Volume ${volume} download started`).waitFor();
   const VOLUME_FILE = "tests/fixtures/volume.tar.gz";
   await download.saveAs(VOLUME_FILE);
 
@@ -229,8 +232,8 @@ test("Export and upload a volume backup", async ({ page }) => {
   await page.getByLabel("LXD backup archive").setInputFiles(VOLUME_FILE);
   await page.getByRole("textbox", { name: "Enter name" }).fill(uploadVolume);
   await page.getByRole("button", { name: "Upload and create" }).click();
-  await page.waitForSelector(`text=Upload completed. Now creating volume`);
-  await page.waitForSelector(`text=Created volume ${uploadVolume}.`);
+  await page.getByText(`Upload completed. Now creating volume`).waitFor();
+  await page.getByText(`Created volume ${uploadVolume}.`).waitFor();
 
   await deleteVolume(page, uploadVolume);
 });
@@ -252,7 +255,7 @@ test("storage bucket create, edit, delete", async ({ page, lxdVersion }) => {
   await row.getByRole("button", { name: "Edit bucket" }).click();
   await page.getByRole("spinbutton", { name: "Size" }).fill("100");
   await page.getByRole("button", { name: "Save 1 change" }).click();
-  await page.waitForSelector(`text=Storage bucket ${bucket} updated.`);
+  await page.getByText(`Storage bucket ${bucket} updated.`).waitFor();
 
   await page.getByPlaceholder("Search and filter").fill(bucket);
   await page.getByPlaceholder("Search and filter").press("Enter");
@@ -286,7 +289,7 @@ test("storage bucket keys create, edit, delete", async ({
   await page.getByRole("button", { name: "Edit bucket key" }).nth(1).click();
   await page.getByPlaceholder("Enter description").fill("Test description 2");
   await page.getByRole("button", { name: "Save 1 change" }).click();
-  await page.waitForSelector(`text=Key ${bucketkey} updated`);
+  await page.getByText(`Key ${bucketkey} updated`).waitFor();
 
   await deleteBucket(page, bucket);
   await deletePool(page, pool);


### PR DESCRIPTION
## Done

- Fix storage pool available size bug in custom volume edit page WD-35592

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Storage -> Volumes -> {custom_volume} -> Configuration.
    - Make sure available size does not report a cluster member "none" in unclustered servers.

## Screenshots

Before

<img width="1024" height="574" alt="image" src="https://github.com/user-attachments/assets/f051582f-c902-461e-8870-8ce0d889a11d" />


After

<img width="1912" height="944" alt="image" src="https://github.com/user-attachments/assets/423644d9-f349-4f8e-9908-2ac5a021cba9" />

