### PR TITLE
fix(async operations): bulk delete storage bucket & key, mutual peering

### DIFF
--- a/src/api/storage-buckets.tsx
+++ b/src/api/storage-buckets.tsx
@@ -4,12 +4,13 @@ import type { LxdApiResponse } from "types/apiResponse";
 import { addEntitlements } from "util/entitlements/api";
 import { fetchStoragePools } from "./storage-pools";
 import type { BulkOperationItem, BulkOperationResult } from "util/promises";
-import { continueOrFinish, pushFailure, pushSuccess } from "util/promises";
+import { continueOrFinish, pushSuccess } from "util/promises";
 import type { LxdOperationResponse } from "types/operation";
 import { isBucketCompatibleDriver } from "util/storageOptions";
 import { addTarget } from "util/target";
 import { getStorageBucketURL } from "util/storageBucket";
 import { ROOT_PATH } from "util/rootPath";
+import { waitForOperation } from "api/operations";
 
 export const storageBucketEntitlements = ["can_delete", "can_edit"];
 
@@ -146,27 +147,47 @@ export const deleteStorageBucket = async (
 export const deleteStorageBucketBulk = async (
   buckets: LxdStorageBucket[],
   project: string,
+  hasStorageAndNetworkOperations: boolean,
 ): Promise<BulkOperationResult[]> => {
   const results: BulkOperationResult[] = [];
-  return new Promise((resolve, reject) => {
-    Promise.allSettled(
-      buckets.map(async (bucket) => {
-        const item: BulkOperationItem = {
-          name: bucket.name,
-          type: "bucket",
-          href: getStorageBucketURL(bucket.name, bucket.pool, project),
-        };
-        return deleteStorageBucket(bucket.name, bucket.pool, project)
-          .then(() => {
-            pushSuccess(results, item);
-            continueOrFinish(results, buckets.length, resolve);
-          })
-          .catch((e) => {
-            pushFailure(results, e instanceof Error ? e.message : "", item);
-            continueOrFinish(results, buckets.length, resolve);
-          });
+  const operations = await Promise.allSettled(
+    buckets.map(async (bucket) => {
+      const operation = await deleteStorageBucket(
+        bucket.name,
+        bucket.pool,
+        project,
+      );
+      return { operation, bucket };
+    }),
+  );
+
+  const pendingOperations = operations.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
+  });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation }) => {
+        if (operation.metadata.id) {
+          await waitForOperation(operation.metadata.id);
+        }
       }),
-    ).catch(reject);
+    );
+  }
+
+  return new Promise((resolve) => {
+    buckets.forEach((bucket) => {
+      const item: BulkOperationItem = {
+        name: bucket.name,
+        type: "bucket",
+        href: getStorageBucketURL(bucket.name, bucket.pool, project),
+      };
+      pushSuccess(results, item);
+      continueOrFinish(results, buckets.length, resolve);
+    });
   });
 };
 
@@ -285,31 +306,47 @@ export const deleteStorageBucketKeyBulk = async (
   bucket: LxdStorageBucket,
   keys: LxdStorageBucketKey[],
   project: string,
+  hasStorageAndNetworkOperations: boolean,
 ): Promise<BulkOperationResult[]> => {
   const results: BulkOperationResult[] = [];
-  return new Promise((resolve, reject) => {
-    Promise.allSettled(
-      keys.map(async (key) => {
-        const item: BulkOperationItem = {
-          name: key.name,
-          type: "bucket-key",
-          href: getStorageBucketURL(bucket.name, bucket.pool, project),
-        };
-        return deleteStorageBucketKey(
-          bucket.name,
-          key.name,
-          bucket.pool,
-          project,
-        )
-          .then(() => {
-            pushSuccess(results, item);
-            continueOrFinish(results, keys.length, resolve);
-          })
-          .catch((e) => {
-            pushFailure(results, e instanceof Error ? e.message : "", item);
-            continueOrFinish(results, keys.length, resolve);
-          });
+  const operations = await Promise.allSettled(
+    keys.map(async (key) => {
+      const operation = await deleteStorageBucketKey(
+        bucket.name,
+        key.name,
+        bucket.pool,
+        project,
+      );
+      return { operation, key };
+    }),
+  );
+
+  const pendingOperations = operations.map((res) => {
+    if (res.status === "rejected") {
+      throw res?.reason as Error;
+    }
+    return res.value;
+  });
+
+  if (hasStorageAndNetworkOperations) {
+    await Promise.all(
+      pendingOperations.map(async ({ operation }) => {
+        if (operation.metadata.id) {
+          await waitForOperation(operation.metadata.id);
+        }
       }),
-    ).catch(reject);
+    );
+  }
+
+  return new Promise((resolve) => {
+    keys.forEach((key) => {
+      const item: BulkOperationItem = {
+        name: key.name,
+        type: "bucket-key",
+        href: getStorageBucketURL(bucket.name, bucket.pool, project),
+      };
+      pushSuccess(results, item);
+      continueOrFinish(results, keys.length, resolve);
+    });
   });
 };

--- a/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
@@ -124,6 +124,33 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
     );
   };
 
+  const createMutualPeering = (
+    network: string,
+    project: string,
+    payload: object,
+    localPeeringName: string,
+  ) => {
+    createNetworkPeer(network, project, JSON.stringify(payload))
+      .then((mutualOperation) => {
+        if (hasStorageAndNetworkOperations) {
+          eventQueue.set(
+            mutualOperation.metadata.id,
+            () => {
+              onSuccess(localPeeringName);
+            },
+            (msg) => {
+              onFailure(false, localPeeringName, new Error(msg));
+            },
+          );
+        } else {
+          onSuccess(localPeeringName);
+        }
+      })
+      .catch((e) => {
+        onFailure(false, localPeeringName, e);
+      });
+  };
+
   const formik = useFormik<LocalPeeringFormValues>({
     initialValues: {
       name: "",
@@ -139,17 +166,21 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
     validateOnChange: true,
     validateOnBlur: true,
     onSubmit: (values) => {
+      const targetProject =
+        values.targetProject === projectOtherLabel
+          ? values.customTargetProject || ""
+          : values.targetProject;
+
+      const targetNetwork =
+        values.targetNetwork === networkOtherLabel
+          ? values.customTargetNetwork || ""
+          : values.targetNetwork;
+
       const localPeeringPayload = {
         name: values.name,
         description: values.description,
-        target_project:
-          values.targetProject === projectOtherLabel
-            ? values.customTargetProject
-            : values.targetProject,
-        target_network:
-          values.targetNetwork === networkOtherLabel
-            ? values.customTargetNetwork
-            : values.targetNetwork,
+        target_project: targetProject,
+        target_network: targetNetwork,
       };
 
       createNetworkPeer(
@@ -166,36 +197,36 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
               target_network: network.name,
             };
 
-            createNetworkPeer(
-              values.targetNetwork,
-              values.targetProject,
-              JSON.stringify(mutualPeeringPayload),
-            )
-              .then((mutualOperation) => {
-                if (hasStorageAndNetworkOperations) {
-                  toastNotify.info(
-                    <>
-                      Creation of mutual local peering{" "}
-                      <ResourceLabel bold type="peering" value={values.name} />{" "}
-                      has started.
-                    </>,
+            if (hasStorageAndNetworkOperations) {
+              toastNotify.info(
+                <>
+                  Creation of mutual peering{" "}
+                  <ResourceLabel bold type="peering" value={values.name} /> has
+                  started.
+                </>,
+              );
+              eventQueue.set(
+                operation.metadata.id,
+                () => {
+                  createMutualPeering(
+                    targetNetwork,
+                    targetProject,
+                    mutualPeeringPayload,
+                    values.name,
                   );
-                  eventQueue.set(
-                    mutualOperation.metadata.id,
-                    () => {
-                      onSuccess(values.name);
-                    },
-                    (msg) => {
-                      onFailure(false, values.name, new Error(msg));
-                    },
-                  );
-                } else {
-                  onSuccess(values.name);
-                }
-              })
-              .catch((e) => {
-                onFailure(false, values.name, e);
-              });
+                },
+                (msg) => {
+                  onFailure(true, values.name, new Error(msg));
+                },
+              );
+            } else {
+              createMutualPeering(
+                targetNetwork,
+                targetProject,
+                mutualPeeringPayload,
+                values.name,
+              );
+            }
           } else {
             if (hasStorageAndNetworkOperations) {
               toastNotify.info(

--- a/src/pages/storage/actions/StorageBucketBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketBulkDelete.tsx
@@ -11,6 +11,7 @@ import { deleteStorageBucketBulk } from "api/storage-buckets";
 import { getPromiseSettledCounts } from "util/promises";
 import { useCurrentProject } from "context/useCurrentProject";
 import { useBulkDetails } from "context/useBulkDetails";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   buckets: LxdStorageBucket[];
@@ -25,6 +26,7 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
   const { canDeleteBucket } = useStorageBucketEntitlements();
   const viewBulkDetails = useBulkDetails();
   const { project } = useCurrentProject();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
   const projectName = project?.name || "";
 
   const deleteableBuckets = buckets.filter((bucket) => canDeleteBucket(bucket));
@@ -38,7 +40,11 @@ const StorageBucketBulkDelete: FC<Props> = ({ buckets, onStart, onFinish }) => {
     onStart();
     const successMessage = `${deleteableBuckets.length} ${pluralize("bucket", deleteableBuckets.length)} successfully deleted`;
 
-    deleteStorageBucketBulk(deleteableBuckets, projectName)
+    deleteStorageBucketBulk(
+      deleteableBuckets,
+      projectName,
+      hasStorageAndNetworkOperations,
+    )
       .then((results) => {
         const { fulfilledCount, rejectedCount } =
           getPromiseSettledCounts(results);

--- a/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
+++ b/src/pages/storage/actions/StorageBucketKeyBulkDelete.tsx
@@ -12,6 +12,7 @@ import { useCurrentProject } from "context/useCurrentProject";
 import ResourceLink from "components/ResourceLink";
 import { getStorageBucketURL } from "util/storageBucket";
 import { useBulkDetails } from "context/useBulkDetails";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   keys: LxdStorageBucketKey[];
@@ -31,6 +32,7 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
   const [isLoading, setLoading] = useState(false);
   const viewBulkDetails = useBulkDetails();
   const { project } = useCurrentProject();
+  const { hasStorageAndNetworkOperations } = useSupportedFeatures();
   const projectName = project?.name || "";
   const totalCount = keys.length;
 
@@ -55,7 +57,12 @@ const StorageBucketKeyBulkDelete: FC<Props> = ({
       </>
     );
 
-    deleteStorageBucketKeyBulk(bucket, keys, projectName)
+    deleteStorageBucketKeyBulk(
+      bucket,
+      keys,
+      projectName,
+      hasStorageAndNetworkOperations,
+    )
       .then((results) => {
         const { fulfilledCount, rejectedCount } =
           getPromiseSettledCounts(results);


### PR DESCRIPTION
## Done

- fix bulk delete of storage buckets
- fix bulk delete of storage bucket keys
- fix mutual peering

Fixes https://github.com/canonical/lxd-ui/pull/1946

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Bulk delete storage buckets
    - Bulk delete storage bucket keys
    - Create mutual peering

## Screenshots

<img width="747" height="236" alt="image" src="https://github.com/user-attachments/assets/d6faea9c-6c28-407a-9bb7-b1c419f764dd" />

<img width="754" height="172" alt="image" src="https://github.com/user-attachments/assets/b53f8d0d-7991-479f-aac1-96aee4934654" />

<img width="724" height="339" alt="image" src="https://github.com/user-attachments/assets/39bca5aa-964a-46a3-8d2f-98738c219921" />


