### PR TITLE
feat(images) registry configuration on restricted projects

### DIFF
--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -49,7 +49,7 @@ const resourceIcons: Record<ResourceIconType, string> = {
   volume: "storage-volume",
   "iso-volume": "iso",
   image: "image",
-  "image-registry": "image-registry",
+  "image-registry": "image",
   "oidc-identity": "user",
   certificate: "certificate",
   "auth-group": "user-group",

--- a/src/pages/images/ImageRegistrySelector.tsx
+++ b/src/pages/images/ImageRegistrySelector.tsx
@@ -1,0 +1,52 @@
+import type { FC, ReactNode } from "react";
+import { MultiSelect } from "@canonical/react-components";
+import type { FormikProps } from "formik/dist/types";
+import type { ProjectFormValues } from "types/forms/project";
+import { useImageRegistries } from "context/useImageRegistries";
+
+interface Props {
+  formik: FormikProps<ProjectFormValues>;
+  help?: ReactNode;
+}
+
+const ImageRegistrySelector: FC<Props> = ({ formik, help }) => {
+  const { data: registries = [] } = useImageRegistries();
+
+  const selectedValues =
+    formik.values.restricted_registries?.split(",").filter(Boolean) ?? [];
+
+  const setValues = (values: string[]) => {
+    formik.setFieldValue(
+      "restricted_registries",
+      values.filter(Boolean).join(","),
+    );
+  };
+
+  return (
+    <div className="restricted-image-registries">
+      <MultiSelect
+        id="restricted_registries"
+        placeholder="Select registries"
+        help={help}
+        items={registries.map((registry) => {
+          return { label: registry.name, value: registry.name };
+        })}
+        selectedItems={selectedValues.map((value) => {
+          return { value: value, label: value };
+        })}
+        onDeselectItem={(item) => {
+          setValues(selectedValues.filter((value) => value !== item.value));
+        }}
+        onSelectItem={(item) => {
+          setValues(selectedValues.concat([item.value as string]));
+        }}
+        onItemsUpdate={(items) => {
+          setValues(items.map((item) => item.value as string));
+        }}
+        variant="condensed"
+      />
+    </div>
+  );
+};
+
+export default ImageRegistrySelector;

--- a/src/pages/projects/CreateProject.tsx
+++ b/src/pages/projects/CreateProject.tsx
@@ -40,6 +40,7 @@ import { useProfile } from "context/useProfiles";
 import { useAuth } from "context/auth";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { ProjectFormValues } from "types/forms/project";
+import { imageRestrictionPayload } from "pages/projects/forms/ImageRestrictionForm";
 
 const CreateProject: FC = () => {
   const navigate = useNavigate();
@@ -115,6 +116,7 @@ const CreateProject: FC = () => {
             ...instanceRestrictionPayload(values),
             ...deviceUsageRestrictionPayload(values),
             ...networkRestrictionPayload(values),
+            ...imageRestrictionPayload(values),
           }
         : {};
 

--- a/src/pages/projects/forms/ImageRestrictionForm.tsx
+++ b/src/pages/projects/forms/ImageRestrictionForm.tsx
@@ -1,0 +1,62 @@
+import type { FC, ReactNode } from "react";
+import { getConfigurationRow } from "components/ConfigurationRow";
+import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import type {
+  ImageRestrictionFormValues,
+  ProjectFormValues,
+} from "types/forms/project";
+import type { FormikProps } from "formik/dist/types";
+import { getProjectKey } from "util/projectConfigFields";
+import type { LxdConfigPair } from "types/config";
+import ImageRegistrySelector from "pages/images/ImageRegistrySelector";
+import ResourceLink from "components/ResourceLink";
+import { ROOT_PATH } from "util/rootPath";
+
+export const imageRestrictionPayload = (
+  values: ImageRestrictionFormValues,
+): LxdConfigPair => {
+  return {
+    [getProjectKey("restricted_registries")]: values.restricted_registries,
+  };
+};
+
+interface Props {
+  formik: FormikProps<ProjectFormValues>;
+}
+
+const ImageRestrictionForm: FC<Props> = ({ formik }) => {
+  return (
+    <ScrollableConfigurationTable
+      rows={[
+        getConfigurationRow({
+          formik,
+          name: "restricted_registries",
+          label: "Available image registries",
+          defaultValue: "",
+          children: <ImageRegistrySelector formik={formik} />,
+          readOnlyRenderer: (val): ReactNode => {
+            if (val === "block" || typeof val !== "string") {
+              return val;
+            }
+
+            const registries = val.split(",").filter(Boolean);
+            return (
+              <span className="restricted-image-registries">
+                {registries?.map((registry) => (
+                  <ResourceLink
+                    key={registry}
+                    type="image-registry"
+                    value={registry}
+                    to={`${ROOT_PATH}/ui/image-registry/${registry}`}
+                  />
+                ))}
+              </span>
+            );
+          },
+        }),
+      ]}
+    />
+  );
+};
+
+export default ImageRestrictionForm;

--- a/src/pages/projects/forms/ProjectForm.tsx
+++ b/src/pages/projects/forms/ProjectForm.tsx
@@ -4,6 +4,7 @@ import { Col, Form, Row } from "@canonical/react-components";
 import ProjectFormMenu, {
   CLUSTERS,
   DEVICE_USAGE,
+  IMAGES,
   INSTANCES,
   NETWORKS,
   PROJECT_DETAILS,
@@ -20,6 +21,7 @@ import type { FormikProps } from "formik/dist/types";
 import type { LxdProject } from "types/project";
 import NotificationRow from "components/NotificationRow";
 import { slugify } from "util/slugify";
+import ImageRestrictionForm from "pages/projects/forms/ImageRestrictionForm";
 
 interface Props {
   formik: FormikProps<ProjectFormValues>;
@@ -76,6 +78,9 @@ const ProjectForm: FC<Props> = ({
             )}
             {section === slugify(NETWORKS) && (
               <NetworkRestrictionForm formik={formik} />
+            )}
+            {section === slugify(IMAGES) && (
+              <ImageRestrictionForm formik={formik} />
             )}
           </Col>
         </Row>

--- a/src/pages/projects/forms/ProjectFormMenu.tsx
+++ b/src/pages/projects/forms/ProjectFormMenu.tsx
@@ -1,6 +1,8 @@
 import type { FC } from "react";
 import MenuItem from "components/forms/FormMenuItem";
 import { Button } from "@canonical/react-components";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useIsClustered } from "context/useIsClustered";
 
 export const PROJECT_DETAILS = "Project details";
 export const RESOURCE_LIMITS = "Resource limits";
@@ -8,6 +10,7 @@ export const CLUSTERS = "Clusters";
 export const INSTANCES = "Instances";
 export const DEVICE_USAGE = "Device usage";
 export const NETWORKS = "Networks";
+export const IMAGES = "Images";
 
 interface Props {
   isRestrictionsOpen: boolean;
@@ -24,6 +27,9 @@ const ProjectFormMenu: FC<Props> = ({
   active,
   setActive,
 }) => {
+  const { hasImageRegistries } = useSupportedFeatures();
+  const isClustered = useIsClustered();
+
   const menuItemProps = {
     active,
     setActive,
@@ -49,10 +55,13 @@ const ProjectFormMenu: FC<Props> = ({
               className="p-side-navigation__list"
               aria-expanded={isRestrictionsOpen ? "true" : "false"}
             >
-              <MenuItem label={CLUSTERS} {...menuItemProps} />
+              {isClustered && <MenuItem label={CLUSTERS} {...menuItemProps} />}
               <MenuItem label={INSTANCES} {...menuItemProps} />
               <MenuItem label={DEVICE_USAGE} {...menuItemProps} />
               <MenuItem label={NETWORKS} {...menuItemProps} />
+              {hasImageRegistries && (
+                <MenuItem label={IMAGES} {...menuItemProps} />
+              )}
             </ul>
           </li>
         </ul>

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -511,13 +511,25 @@
   }
 }
 
-.restricted-cluster-groups {
+.restricted-cluster-groups,
+.restricted-image-registries {
+  max-width: 20rem;
+
   .multi-select__condensed-text {
     text-align: left;
   }
 
   .p-chip {
     margin-right: $sph--x-small;
+  }
+}
+
+.multi-select .p-contextual-menu__dropdown {
+  z-index: 103; // above footer
+
+  .multi-select__dropdown {
+    max-height: 60vh;
+    overflow-y: auto;
   }
 }
 

--- a/src/types/forms/project.d.ts
+++ b/src/types/forms/project.d.ts
@@ -63,9 +63,14 @@ export interface NetworkRestrictionFormValues {
   restricted_network_zones?: string;
 }
 
+export interface ImageRestrictionFormValues {
+  restricted_registries?: string;
+}
+
 export type ProjectFormValues = ProjectDetailsFormValues &
   ProjectResourceLimitsFormValues &
   ClusterRestrictionFormValues &
   InstanceRestrictionFormValues &
   DeviceUsageRestrictionFormValues &
-  NetworkRestrictionFormValues;
+  NetworkRestrictionFormValues &
+  ImageRestrictionFormValues;

--- a/src/util/projectConfigFields.tsx
+++ b/src/util/projectConfigFields.tsx
@@ -24,6 +24,7 @@ const projectConfigFormFieldsToPayload: Record<string, string> = {
   restricted_network_subnets: "restricted.networks.subnets",
   restricted_network_uplinks: "restricted.networks.uplinks",
   restricted_network_zones: "restricted.networks.zones",
+  restricted_registries: "restricted.registries",
   restricted: "restricted",
   features_images: "features.images",
   features_profiles: "features.profiles",

--- a/src/util/projectEdit.tsx
+++ b/src/util/projectEdit.tsx
@@ -14,6 +14,7 @@ import { networkRestrictionPayload } from "pages/projects/forms/NetworkRestricti
 import { getUnhandledKeyValues } from "util/formFields";
 import { getDefaultNetwork, getDefaultStoragePool } from "./helpers";
 import type { LxdProfile } from "types/profile";
+import { imageRestrictionPayload } from "pages/projects/forms/ImageRestrictionForm";
 
 export const getProjectEditValues = (
   project: LxdProject,
@@ -103,6 +104,9 @@ export const getProjectEditValues = (
     restricted_network_subnets: project.config["restricted.networks.subnets"],
     restricted_network_uplinks: project.config["restricted.networks.uplinks"],
     restricted_network_zones: project.config["restricted.networks.zones"],
+
+    restricted_registries: project.config["restricted.registries"],
+
     editRestriction,
   };
 };
@@ -125,6 +129,7 @@ export const getProjectPayload = (
             ...instanceRestrictionPayload(values),
             ...deviceUsageRestrictionPayload(values),
             ...networkRestrictionPayload(values),
+            ...imageRestrictionPayload(values),
           }
         : {}),
       ...getUnhandledKeyValues(project.config, handledConfigKeys),

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -63,9 +63,6 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await setInput(page, "Max sum of memory", "Enter value", "7");
   await setInput(page, "Max sum of processes", "Enter number", "8");
 
-  await page.getByText("Clusters").click();
-  await setOption(page, "Direct cluster targeting", "allow");
-
   await page
     .getByRole("navigation", { name: "Project form navigation" })
     .getByText("Instances")
@@ -101,9 +98,9 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
 
   if (lxdVersion === "5.0-edge") {
     // network zones option is not available in 5.0-edge, so total changes are one less
-    await page.getByRole("button", { name: "Save 33 changes" }).click();
+    await page.getByRole("button", { name: "Save 32 changes" }).click();
   } else {
-    await page.getByRole("button", { name: "Save 34 changes" }).click();
+    await page.getByRole("button", { name: "Save 33 changes" }).click();
   }
 
   await page.getByText(`Project ${project} updated.`).waitFor();
@@ -128,10 +125,6 @@ test("project edit configuration", async ({ page, lxdVersion }) => {
   await assertReadMode(page, "Max sum of CPU", "6");
   await assertReadMode(page, "Max sum of memory limits", "7GiB");
   await assertReadMode(page, "Max sum of processes", "8");
-
-  await page.getByText("Clusters").click();
-  await assertReadMode(page, "Cluster groups targeting", "");
-  await assertReadMode(page, "Direct cluster targeting", "Allow");
 
   await page
     .getByRole("navigation", { name: "Project form navigation" })


### PR DESCRIPTION
## Done

- add registry configuration on restricted projects

Fixes WD-34378

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run against a LXD backend that has sideloaded the image registries feature from https://github.com/canonical/lxd/pull/17680
    - create a new project, enable restrictions and checkout image restrictions, ensure available image registries can be selected and are persisted correctly.
    - edit a restricted project, ensure both image restrictions save correctly.

## Screenshots

<img width="3844" height="1918" alt="image" src="https://github.com/user-attachments/assets/715953d3-1ed1-44b4-b5ef-7801675615cc" />

<img width="3844" height="1918" alt="image" src="https://github.com/user-attachments/assets/9ea3030a-c953-462c-b39b-d16ff6461f21" />

