### PR TITLE
fix(layout) avoid round corners on progress bar and meter

### DIFF
--- a/src/sass/_meter.scss
+++ b/src/sass/_meter.scss
@@ -1,14 +1,12 @@
 .p-meter {
   background-color: $colors--theme--background-alt;
   border: $border-thin;
-  border-radius: 0.75rem;
   display: flex;
   height: 0.75rem;
   margin-bottom: 0.375rem;
 
   div {
     background-color: #06c;
-    border-radius: 0.75rem;
     border-right: $border-thin;
     height: 100%;
   }

--- a/src/sass/_progress_bar.scss
+++ b/src/sass/_progress_bar.scss
@@ -1,14 +1,12 @@
 .p-progress-bar {
   border: 1px solid $colors--theme--border-default;
-  border-radius: 2px;
   height: 30px;
   margin-top: 5px;
   padding: 2px;
   width: 100%;
 
   div {
-    background-color: #0e8420;
-    border-radius: 2px;
+    background-color: #06c;
     height: 100%;
   }
 }


### PR DESCRIPTION
## Done

- fix(layout) avoid round corners on progress bar and meter and align colors between them

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check meter on storage pool list and on instance detail page for a running instance
    - check progress bar: export an instance, then create a new instance from the export (create instance > upload instance)
    - both components should have no round corners and an aligned color between them. both should look correctly in their respective contexts

## Screenshots

<img width="3844" height="1920" alt="image" src="https://github.com/user-attachments/assets/65c0a86e-70d5-45a9-870f-f8e9bb329abf" />

<img width="3844" height="1920" alt="image" src="https://github.com/user-attachments/assets/06701ea7-60fe-4f63-aba2-1e83332e6c62" />
