### PR TITLE
feat(pragma): consume annoucement

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "@canonical/react-components": "4.3.1",
+    "@canonical/react-ds-global": "0.25.0",
+    "@canonical/styles": "0.25.0",
     "@monaco-editor/react": "4.7.0",
     "@tanstack/react-query": "5.90.16",
     "@xterm/addon-fit": "0.11.0",
@@ -112,6 +114,7 @@
   },
   "resolutions": {
     "path-to-regexp": "8.4.0",
-    "wrap-ansi": "9.0.2"
+    "wrap-ansi": "9.0.2",
+    "@canonical/styles-old": "npm:@canonical/styles@0.24.0"
   }
 }

--- a/src/components/forms/GPUDeviceForm.tsx
+++ b/src/components/forms/GPUDeviceForm.tsx
@@ -38,6 +38,7 @@ import { useProfiles } from "context/useProfiles";
 import DocLink from "components/DocLink";
 import DeviceName from "components/forms/DeviceName";
 import { isDeviceModified } from "util/formChangeCount";
+import { Announcement } from "@canonical/react-ds-global";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -248,6 +249,20 @@ const GPUDevicesForm: FC<Props> = ({ formik, project }) => {
           container GPU passthrough with Docker
         </DocLink>
       </Notification>
+
+      <Announcement className="announcement-override">
+        <div>
+          <h5 className="u-no-margin--bottom">GPU passthrough</h5>
+          Learn more about{" "}
+          <DocLink docPath="/reference/devices_gpu/#devices-gpu">
+            GPU devices
+          </DocLink>{" "}
+          and{" "}
+          <DocLink docPath="/howto/container_gpu_passthrough_with_docker/#container-gpu-passthrough-with-docker">
+            container GPU passthrough with Docker
+          </DocLink>
+        </div>
+      </Announcement>
 
       {inheritedRows.length > 0 && (
         <div className="inherited-devices">

--- a/src/sass/_pragma_override.scss
+++ b/src/sass/_pragma_override.scss
@@ -1,0 +1,5 @@
+.ds.announcement.announcement-override {
+  font-size: 1rem;
+  justify-content: flex-start;
+  margin-bottom: $spv--x-large;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -4,6 +4,7 @@
 @import "vanilla-framework/scss/build";
 @import "./breakpoints";
 @import "pattern_icon";
+@import "@canonical/styles";
 @include lxdui-p-icon;
 @include vf-p-icon-add-canvas;
 @include vf-p-icon-add-logical-volume;
@@ -138,6 +139,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "permission_group_selection";
 @import "permission_groups";
 @import "pool_rich_tooltip";
+@import "pragma_override";
 @import "profile_detail_overview";
 @import "profile_detail_panel";
 @import "profile_list";


### PR DESCRIPTION
## Done

- Use Pragma's Annoucement instead of Notification in instance configuration > Devices > GPU

Both Notification and Announcement are displayed to easily compare them.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to an instance configuration > Devices > GPU

## Screenshots

<img width="1576" height="1062" alt="image" src="https://github.com/user-attachments/assets/242885e3-2afa-4941-94cf-13af3775a312" />

<img width="1156" height="601" alt="image" src="https://github.com/user-attachments/assets/c0b7e719-0196-497a-841c-81e2ecc5c464" />
