### PR TITLE
Ux fixes

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -433,6 +433,19 @@ const Navigation: FC = () => {
                                 Volumes
                               </NavLink>
                             </SideNavigationItem>,
+                            <SideNavigationItem
+                              key={`/ui/project/${encodeURIComponent(projectName)}/storage/buckets`}
+                            >
+                              <NavLink
+                                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/storage/buckets`}
+                                title="Buckets"
+                                onClick={softToggleMenu}
+                                className="accordion-nav-secondary"
+                                activeUrlMatches={["/bucket/"]}
+                              >
+                                Buckets
+                              </NavLink>
+                            </SideNavigationItem>,
                             ...(hasCustomVolumeIso
                               ? [
                                   <SideNavigationItem
@@ -449,19 +462,6 @@ const Navigation: FC = () => {
                                   </SideNavigationItem>,
                                 ]
                               : []),
-                            <SideNavigationItem
-                              key={`/ui/project/${encodeURIComponent(projectName)}/storage/buckets`}
-                            >
-                              <NavLink
-                                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/storage/buckets`}
-                                title="Buckets"
-                                onClick={softToggleMenu}
-                                className="accordion-nav-secondary"
-                                activeUrlMatches={["/bucket/"]}
-                              >
-                                Buckets
-                              </NavLink>
-                            </SideNavigationItem>,
                           ]}
                         </NavAccordion>
                       </SideNavigationItem>

--- a/src/components/forms/BootForm.tsx
+++ b/src/components/forms/BootForm.tsx
@@ -6,6 +6,7 @@ import { getConfigurationRow } from "components/ConfigurationRow";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
 import { optionRenderer } from "util/formFields";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -13,6 +14,11 @@ interface Props {
 
 const BootForm: FC<Props> = ({ formik }) => {
   const { hasInstanceBootMode } = useSupportedFeatures();
+  const isInstance = formik.values.entityType === "instance";
+  const isVmOnlyDisabled =
+    isInstance &&
+    (formik.values as CreateInstanceFormValues).instanceType !==
+      "virtual-machine";
 
   return (
     <ScrollableConfigurationTable
@@ -55,10 +61,19 @@ const BootForm: FC<Props> = ({ formik }) => {
           ? [
               getConfigurationRow({
                 formik,
-                label: "Boot mode",
+                label: "Boot mode (VMs only)",
                 name: "boot_mode",
                 defaultValue: "",
-                children: <Select options={bootModeOptions} />,
+                disabled: isVmOnlyDisabled,
+                disabledReason: isVmOnlyDisabled
+                  ? "Only available for virtual machines"
+                  : undefined,
+                children: (
+                  <Select
+                    options={bootModeOptions}
+                    disabled={isVmOnlyDisabled}
+                  />
+                ),
               }),
             ]
           : []),

--- a/src/pages/networks/CreateNetworkForward.tsx
+++ b/src/pages/networks/CreateNetworkForward.tsx
@@ -148,6 +148,7 @@ const CreateNetworkForward: FC = () => {
           Cancel
         </Link>
         <ActionButton
+          appearance="positive"
           loading={formik.isSubmitting}
           disabled={
             !formik.isValid ||


### PR DESCRIPTION
## Done

- fix(nav) ensure custom iso appear next to images in side navigation 
- fix(instance) disable boot mode configuration on containers 
- fix(forwards) positive appearance on network forward create button 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check side navigation storage section has the custom ISOs as last entry
    - check instance configuration on a container, the boot > boot mode option should be disabled for override and marked as for vms only
    - check instance configuration on a container, the boot > boot mode option should be enabled, and a override should save properly and persist a reload
    - create a network forward networks > any bridge network > forwards > create. Ensure the form has a green/positive button to submit
    - browse a running instance console, ensure the border color matches the background. check the terminal for instances has the proper ubuntu theme.

## Screenshots

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/42286ce7-71a6-4674-bdc9-3937ede93105" />

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/9f732d69-55bc-41fa-a8d5-e19cd6b0867a" />

<img width="3844" height="1916" alt="image" src="https://github.com/user-attachments/assets/b1bc7e03-a2f5-49ae-97f4-2016adac2488" />