### PR TITLE
fix: clarify nic acl config WD-34770

### DIFF
--- a/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
+++ b/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
@@ -33,6 +33,7 @@ import {
   getNetworkAcls,
   combineAcls,
   ovnType,
+  typesWithAcls,
 } from "util/networks";
 import usePanelParams, { panels } from "util/usePanelParams";
 import NetworkDefaultACLSelector, {
@@ -43,6 +44,8 @@ import type { NetworkDeviceFormValues } from "types/forms/networkDevice";
 import { useNetworkAcls } from "context/useNetworkAcls";
 import { getAttachedNetworkNames } from "util/devices";
 import type { LxdNetwork } from "types/network";
+import { Link } from "react-router";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   project: string;
@@ -282,7 +285,34 @@ const NetworkDevicePanel: FC<Props> = ({
         ? "Some ACLs are inherited from the network. They cannot be deselected here."
         : undefined;
     }
-    return "Network must be of type OVN to customize ACLs.";
+
+    if (!selectedNetwork || !typesWithAcls.includes(selectedNetwork.type)) {
+      return "ACLs require an OVN or a bridge network.";
+    }
+
+    const link = (
+      <Link
+        to={`${ROOT_PATH}/ui/project/${project}/network/${selectedNetwork.name}`}
+      >
+        detail page
+      </Link>
+    );
+
+    if (selectedNetwork.type === "bridge") {
+      return (
+        <>
+          Instance device ACLs require an OVN network. Manage ACLs for all
+          instances using this network in the {link}.
+        </>
+      );
+    }
+
+    return (
+      <>
+        Instance device ACLs can be customized. Manage ACLs for all instances
+        using this network in the {link}.
+      </>
+    );
   };
 
   const handleCancel = () => {

--- a/tests/network-acls.spec.ts
+++ b/tests/network-acls.spec.ts
@@ -114,7 +114,9 @@ test.describe("apply ACLs", () => {
     await expect(aclList).toBeDisabled();
 
     await expect(
-      page.getByText("Network must be of type OVN to customize ACLs."),
+      page.getByText(
+        "Instance device ACLs require an OVN network. Manage ACLs for all instances using this network in the detail page.",
+      ),
     ).toBeVisible();
 
     await expect(page.getByLabel("Egress traffic")).toBeDisabled();
@@ -169,7 +171,9 @@ test.describe("apply ACLs", () => {
     await expect(aclButton).toBeVisible();
     await expect(aclButton).toBeDisabled();
     await expect(
-      page.getByText("Network must be of type OVN to customize ACLs."),
+      page.getByText(
+        "Instance device ACLs require an OVN network. Manage ACLs for all instances using this network in the detail page.",
+      ),
     ).toBeVisible();
 
     await expect(page.getByLabel("Egress traffic")).toBeDisabled();
@@ -179,8 +183,10 @@ test.describe("apply ACLs", () => {
     await page.getByLabel("sub").getByText(ovn).first().click();
     await expect(aclButton).toBeEnabled();
     await expect(
-      page.getByText("Network must be of type OVN to customize ACLs."),
-    ).not.toBeVisible();
+      page.getByText(
+        "Instance device ACLs can be customized. Manage ACLs for all instances using this network in the detail page.",
+      ),
+    ).toBeVisible();
     await expect(page.getByLabel("Egress traffic")).toBeDisabled();
     await expect(page.getByLabel("Ingress traffic")).toBeDisabled();
 


### PR DESCRIPTION
## Done

- clarify acl config helper text in nic device side panel.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Instance -> Create/Edit
    - Add a network device
    - Ensure that the acl selector helper text guides the user on how to add acl to a nic device or a network.

## Screenshots

<img width="1902" height="965" alt="image" src="https://github.com/user-attachments/assets/c0f7db95-1d06-4a22-ad82-d7aadebb8173" />