### PR TITLE
feat(CreateStorageBucketPanel): improve name validation

### DIFF
--- a/src/pages/storage/panels/CreateStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketPanel.tsx
@@ -41,10 +41,16 @@ const CreateStorageBucketPanel: FC = () => {
 
   const bucketSchema = Yup.object().shape({
     name: Yup.string()
+      .min(3, "Name must be at least 3 characters")
+      .max(63, "Name must be at most 63 characters")
+      .matches(
+        /^[a-z0-9][a-z0-9.-]*$/,
+        "Name must contain only lowercase letters, numbers, periods, or hyphens and must start with a letter or number",
+      )
       .test(
         ...testDuplicateStorageBucketName(panelParams.project, controllerState),
       )
-      .required("Bucket name is required"),
+      .required("Storage bucket name is required"),
     pool: Yup.string().required("Pool must have a Ceph Object driver"),
   });
 


### PR DESCRIPTION
## Done

- CreateStorageBucketPanel: improve name validation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a storage bucket: try valid and invalid names. Make sure the `Create` button is appropriately disabled and that you cannot create a storage bucket with an invalid name.
 Error from backend is: Bucket name must be between 3 and 63 lowercase letters, numbers, periods or hyphens and must start with a letter or number

## Screenshots

<img width="665" height="1051" alt="image" src="https://github.com/user-attachments/assets/482e316c-1087-4a2c-95e5-1f03ae5d03a7" />
