### PR TITLE
feat(Permissions > Identities): add OIDC configuration from Settings

### DIFF
--- a/src/pages/permissions/CreateTlsIdentityBtn.tsx
+++ b/src/pages/permissions/CreateTlsIdentityBtn.tsx
@@ -1,23 +1,38 @@
-import { Button, Icon } from "@canonical/react-components";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
 import type { FC } from "react";
+import { Button, Icon } from "@canonical/react-components";
+import {
+  largeScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useServerEntitlements } from "util/entitlements/server";
 
 interface Props {
   openPanel: () => void;
+  className?: string;
+  onClose?: () => void;
 }
 
-const CreateTlsIdentityBtn: FC<Props> = ({ openPanel }) => {
-  const isSmallScreen = useIsScreenBelow();
+const CreateTlsIdentityBtn: FC<Props> = ({ openPanel, className, onClose }) => {
   const { canCreateIdentities } = useServerEntitlements();
+  const isSmallOrMediumScreen = useIsScreenBelow(largeScreenBreakpoint);
+
+  const handleClick = () => {
+    openPanel();
+    onClose?.();
+  };
+
+  const buttonClassName = className || "u-float-right u-no-margin--bottom";
+  const appearance = className?.includes("p-contextual-menu__link")
+    ? "base"
+    : "positive";
 
   return (
     <>
       <Button
-        appearance="positive"
-        className="u-float-right u-no-margin--bottom"
-        onClick={openPanel}
-        hasIcon={!isSmallScreen}
+        appearance={appearance}
+        className={buttonClassName}
+        onClick={handleClick}
+        hasIcon
         title={
           canCreateIdentities()
             ? ""
@@ -25,7 +40,7 @@ const CreateTlsIdentityBtn: FC<Props> = ({ openPanel }) => {
         }
         disabled={!canCreateIdentities()}
       >
-        {!isSmallScreen && <Icon name="plus" light />}
+        <Icon name="plus" light={!isSmallOrMediumScreen} />
         <span>Create TLS Identity</span>
       </Button>
     </>

--- a/src/pages/permissions/OidcConfigurationBtn.tsx
+++ b/src/pages/permissions/OidcConfigurationBtn.tsx
@@ -1,0 +1,50 @@
+import type { FC } from "react";
+import { Button, Icon, usePortal } from "@canonical/react-components";
+import OidcConfigurationModal from "pages/permissions/OidcConfigurationModal";
+import { useServerEntitlements } from "util/entitlements/server";
+
+interface Props {
+  isDisabled?: boolean;
+  className?: string;
+  onClose?: () => void;
+}
+
+const OidcConfigurationBtn: FC<Props> = ({
+  isDisabled,
+  className,
+  onClose,
+}) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const { canEditServerConfiguration } = useServerEntitlements();
+
+  const handleClose = () => {
+    closePortal();
+    onClose?.();
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <Portal>
+          <OidcConfigurationModal close={handleClose} />
+        </Portal>
+      )}
+      <Button
+        onClick={openPortal}
+        className={className}
+        disabled={isDisabled || !canEditServerConfiguration()}
+        title={
+          canEditServerConfiguration()
+            ? ""
+            : "You do not have permission to edit server configuration"
+        }
+        hasIcon
+      >
+        <Icon name="security" className="auth-option-icon" />
+        <span>Configure single sign-on</span>
+      </Button>
+    </>
+  );
+};
+
+export default OidcConfigurationBtn;

--- a/src/pages/permissions/OidcConfigurationForm.tsx
+++ b/src/pages/permissions/OidcConfigurationForm.tsx
@@ -1,0 +1,110 @@
+import type { FC } from "react";
+import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import {
+  MainTable,
+  Notification,
+  Spinner,
+  useNotify,
+} from "@canonical/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { fetchConfigOptions } from "api/server";
+import NotificationRow from "components/NotificationRow";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useClusteredSettings } from "context/useClusteredSettings";
+import SsoNotification from "pages/permissions/SsoNotification";
+import { getSettingRow } from "pages/settings/SettingsRow";
+import { toConfigFields } from "util/config";
+import { queryKeys } from "util/queryKeys";
+import { getConfigFieldClusteredValue } from "util/settings";
+
+interface Props {
+  closeModal: () => void;
+}
+
+const OidcConfigurationForm: FC<Props> = ({ closeModal }: Props) => {
+  const notify = useNotify();
+  const {
+    hasMetadataConfiguration,
+    settings,
+    isSettingsLoading,
+    settingsError,
+  } = useSupportedFeatures();
+  const { data: configOptions, isLoading: isConfigOptionsLoading } = useQuery({
+    queryKey: [queryKeys.configOptions],
+    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
+  });
+  const {
+    data: clusteredSettings = [],
+    isLoading: isClusteredSettingsLoading,
+    error: clusterError,
+  } = useClusteredSettings();
+
+  if (clusterError) {
+    notify.failure("Loading clustered settings failed", clusterError);
+    closeModal();
+    return null;
+  }
+
+  if (settingsError) {
+    notify.failure("Loading settings failed", settingsError);
+    closeModal();
+    return null;
+  }
+
+  if (
+    isConfigOptionsLoading ||
+    isSettingsLoading ||
+    isClusteredSettingsLoading
+  ) {
+    return <Spinner className="u-loader" text="Loading..." isMainComponent />;
+  }
+
+  const headers = [
+    { content: "Group", className: "u-hide" },
+    { content: "Key" },
+    { content: "Value" },
+  ];
+  const configFields = toConfigFields(configOptions?.configs?.server ?? {});
+  const rows: MainTableRow[] = configFields
+    .filter((t) => t.key.startsWith("oidc"))
+    .map((configField) => {
+      const clusteredValue = getConfigFieldClusteredValue(
+        clusteredSettings,
+        configField,
+      );
+
+      return getSettingRow(
+        configField,
+        false,
+        clusteredValue,
+        () => {},
+        settings,
+        (message) => notify.success(message),
+        "u-hide",
+      );
+    });
+
+  return (
+    <>
+      {!hasMetadataConfiguration && (
+        <Notification
+          severity="caution"
+          title="Get access to SSO configuration settings"
+          titleElement="h2"
+        >
+          Update to LXD v5.19.0 or later to access these settings
+        </Notification>
+      )}
+      <SsoNotification />
+      <NotificationRow className="u-no-padding" />
+      <MainTable
+        id="settings-table"
+        headers={headers}
+        rows={rows}
+        emptyStateMsg="No data to display"
+      />
+    </>
+  );
+};
+
+export default OidcConfigurationForm;

--- a/src/pages/permissions/OidcConfigurationModal.tsx
+++ b/src/pages/permissions/OidcConfigurationModal.tsx
@@ -1,0 +1,28 @@
+import type { FC } from "react";
+import { Modal, useNotify } from "@canonical/react-components";
+import OidcConfigurationForm from "pages/permissions/OidcConfigurationForm";
+
+interface Props {
+  close: () => void;
+}
+
+const OidcConfigurationModal: FC<Props> = ({ close }) => {
+  const notify = useNotify();
+
+  const onClose = () => {
+    notify.clear();
+    close();
+  };
+
+  return (
+    <Modal
+      close={onClose}
+      className="edit-oidc-config settings"
+      title="Single sign-on configuration"
+    >
+      <OidcConfigurationForm closeModal={onClose} />
+    </Modal>
+  );
+};
+
+export default OidcConfigurationModal;

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -33,16 +33,14 @@ import BulkDeleteIdentitiesBtn from "./actions/BulkDeleteIdentitiesBtn";
 import DeleteIdentityBtn from "./actions/DeleteIdentityBtn";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { isUnrestricted } from "util/helpers";
-import CreateTlsIdentityBtn from "./CreateTlsIdentityBtn";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
 import { pluralize } from "util/helpers";
 import { getIdentityName } from "util/permissionIdentities";
-import CreateTLSIdentity from "./CreateTLSIdentity";
+import CreateTLSIdentity from "pages/permissions/CreateTLSIdentity";
+import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesActions";
 import ResourceLabel from "components/ResourceLabel";
 import type { ResourceIconType } from "components/ResourceIcon";
-import SsoNotification from "pages/permissions/SsoNotification";
-import { AUTH_METHOD } from "util/authentication";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -53,7 +51,6 @@ const PermissionIdentities: FC = () => {
   const [selectedIdentityIds, setSelectedIdentityIds] = useState<string[]>([]);
   const { hasAccessManagementTLS } = useSupportedFeatures();
   const { canEditIdentity } = useIdentityEntitlements();
-  const hasOidc = settings?.auth_methods?.includes(AUTH_METHOD.OIDC);
 
   useEffect(() => {
     const validIdentityIds = new Set(identities.map((identity) => identity.id));
@@ -312,7 +309,7 @@ const PermissionIdentities: FC = () => {
               )}
             </PageHeader.Left>
             <PageHeader.BaseActions>
-              <CreateTlsIdentityBtn
+              <PermissionIdentitiesActions
                 openPanel={panelParams.openCreateTLSIdentity}
               />
             </PageHeader.BaseActions>
@@ -322,7 +319,6 @@ const PermissionIdentities: FC = () => {
         {!panelParams.panel && (
           <div className="row">
             <NotificationConsumer />
-            <SsoNotification hasOidc={hasOidc ?? false} />
           </div>
         )}
         <Row>

--- a/src/pages/permissions/PermissionIdentitiesActions.tsx
+++ b/src/pages/permissions/PermissionIdentitiesActions.tsx
@@ -1,0 +1,56 @@
+import type { FC } from "react";
+import { cloneElement } from "react";
+import { ContextualMenu } from "@canonical/react-components";
+import {
+  largeScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
+import OidcConfigurationBtn from "pages/permissions/OidcConfigurationBtn";
+import CreateTlsIdentityBtn from "pages/permissions/CreateTlsIdentityBtn";
+
+interface Props {
+  openPanel: () => void;
+}
+
+const PermissionIdentitiesActions: FC<Props> = ({ openPanel }) => {
+  const isSmallOrMediumScreen = useIsScreenBelow(largeScreenBreakpoint);
+  const classname = isSmallOrMediumScreen
+    ? "p-contextual-menu__link"
+    : undefined;
+
+  const menuElements = [
+    <OidcConfigurationBtn key="oidc-configuration" className={classname} />,
+    <CreateTlsIdentityBtn
+      key="create-identity"
+      openPanel={openPanel}
+      className={classname}
+    />,
+  ];
+
+  return (
+    <>
+      {isSmallOrMediumScreen ? (
+        <ContextualMenu
+          closeOnOutsideClick={false}
+          toggleLabel="Actions"
+          position="left"
+          hasToggleIcon
+          title="actions"
+          className="p-panel__controls"
+        >
+          {(close: () => void) => (
+            <span>
+              {[...menuElements].map((item) =>
+                cloneElement(item, { onClose: close }),
+              )}
+            </span>
+          )}
+        </ContextualMenu>
+      ) : (
+        <>{menuElements}</>
+      )}
+    </>
+  );
+};
+
+export default PermissionIdentitiesActions;

--- a/src/pages/permissions/SsoNotification.tsx
+++ b/src/pages/permissions/SsoNotification.tsx
@@ -1,48 +1,44 @@
 import type { FC } from "react";
-import { useState } from "react";
-import { Notification } from "@canonical/react-components";
+import { List, Notification } from "@canonical/react-components";
 import DocLink from "components/DocLink";
 
-const loadClosed = () => {
-  const saved = localStorage.getItem("ssoNotificationClosed");
-  return Boolean(saved);
-};
+const SsoNotification: FC = () => {
+  const PROVIDERS = [
+    { name: "Auth0", docPath: "/howto/oidc_auth0/" },
+    { name: "Ory Hydra", docPath: "/howto/oidc_ory/" },
+    { name: "Keycloak", docPath: "/howto/oidc_keycloak/" },
+    { name: "Entra ID", docPath: "/howto/oidc_entra_id/" },
+    { name: "Pocket ID", docPath: "/howto/oidc_pocket_id/" },
+  ];
 
-const saveClosed = () => {
-  localStorage.setItem("ssoNotificationClosed", "yes");
-};
-
-interface Props {
-  hasOidc: boolean;
-}
-
-const SsoNotification: FC<Props> = ({ hasOidc }: Props) => {
-  const [closed, setClosed] = useState(loadClosed());
-
-  if (closed || hasOidc) {
-    return null;
-  }
-
-  const handleClose = () => {
-    saveClosed();
-    setClosed(true);
+  const getOidcProviderLink = (providerName: string, docPath: string) => {
+    return <DocLink docPath={docPath}>{providerName}</DocLink>;
   };
 
   return (
-    <>
-      <Notification
-        severity="information"
-        title="Did you know?"
-        onDismiss={handleClose}
-        actions={[
-          <DocLink docPath="/howto/oidc/" key="sso-doc-link">
-            Show me how
-          </DocLink>,
-        ]}
-      >
-        LXD can be configured to log in using a single sign-on provider.
-      </Notification>
-    </>
+    <Notification
+      severity="information"
+      className="oidc-notification"
+      messageElement="div"
+    >
+      <p>
+        LXD integrates with external identity providers using{" "}
+        <b>OpenID Connect (OIDC)</b> to provide centralized login management.
+      </p>
+      <p className="u-no-margin--bottom">
+        Choose an SSO provider to learn how to connect it to LXD:
+      </p>
+      <List
+        items={PROVIDERS.map((provider) =>
+          getOidcProviderLink(provider.name, provider.docPath),
+        )}
+        middot
+      />
+      <p>
+        Your provider is not listed? Check our{" "}
+        <DocLink docPath="/howto/oidc/">general OIDC documentation</DocLink>.
+      </p>
+    </Notification>
   );
 };
 

--- a/src/pages/settings/SettingForm.tsx
+++ b/src/pages/settings/SettingForm.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import {
   Button,
@@ -27,6 +27,7 @@ interface Props {
   onDelete: (key: string) => void;
   value?: string;
   clusteredValue?: ClusterSpecificValues;
+  onSuccess?: (message: ReactNode) => void;
 }
 
 const SettingForm: FC<Props> = ({
@@ -34,6 +35,7 @@ const SettingForm: FC<Props> = ({
   onDelete,
   value,
   clusteredValue,
+  onSuccess,
 }) => {
   const { isRestricted } = useAuth();
   const [isEditMode, setEditMode] = useState(false);
@@ -68,7 +70,13 @@ const SettingForm: FC<Props> = ({
 
     mutation
       .then(() => {
-        toastNotify.success(<>Setting {settingLabel} updated.</>);
+        const message = <>Setting {settingLabel} updated.</>;
+        if (onSuccess) {
+          onSuccess(message);
+        } else {
+          toastNotify.success(message);
+        }
+
         setEditMode(false);
       })
       .catch((e) => {

--- a/src/pages/settings/SettingsRow.tsx
+++ b/src/pages/settings/SettingsRow.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from "react";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import classnames from "classnames";
 import type { ClusterSpecificValues } from "types/cluster";
 import SettingForm from "pages/settings/SettingForm";
 import type { ConfigField } from "types/config";
@@ -21,6 +23,8 @@ export const getSettingRow = (
   clusteredValue: ClusterSpecificValues,
   deleteUserSetting: (key: string) => void,
   settings?: LxdSettings,
+  onSuccess?: (message: ReactNode) => void,
+  groupClassName?: string,
 ): MainTableRow => {
   const isDefault = !Object.keys(settings?.config ?? {}).some(
     (key) => key === configField.key,
@@ -34,7 +38,7 @@ export const getSettingRow = (
           <h2 className="p-heading--5">{configField.category}</h2>
         ),
         role: "cell",
-        className: "group",
+        className: classnames("group", groupClassName),
         "aria-label": "Group",
       },
       {
@@ -57,6 +61,7 @@ export const getSettingRow = (
             value={value}
             clusteredValue={clusteredValue}
             onDelete={deleteUserSetting}
+            onSuccess={onSuccess}
           />
         ),
         role: "cell",

--- a/src/sass/_permission_identities.scss
+++ b/src/sass/_permission_identities.scss
@@ -44,3 +44,25 @@
     }
   }
 }
+
+.edit-oidc-config {
+  @include large {
+    .p-modal__dialog {
+      min-width: 30rem;
+    }
+  }
+
+  .p-modal__dialog {
+    height: calc(100% - 2rem);
+
+    > div {
+      max-width: 54rem;
+    }
+  }
+
+  .u-loader {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Done

- Permissions > Identities: Add `OIDC configuration` button
- When clicking on this button, a modal appears with the oidc settings. The user can update those settings from the modal.
- On save and error, a notification appears at the top of the modal.  

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions > Identities page: there is a new `OIDC configuration` button next to "Create TLS Identity".
    -  Click on the button: a modal with oidc settings should appear
    -  Update a setting and save. A success notification should appear at the top of the modal.
    -  Pressing `Esc` should close the modal   

## Screenshots

<img width="1559" height="1050" alt="image" src="https://github.com/user-attachments/assets/4125b20e-95d9-4490-93b8-04bfc608f4d7" />

<img width="933" height="1010" alt="image" src="https://github.com/user-attachments/assets/023b30a2-adad-4c57-967a-2d977e1f3413" />

<img width="1856" height="1044" alt="image" src="https://github.com/user-attachments/assets/39b52b53-17b1-4f66-bdb4-c69357e174c8" />





