### PR TITLE
feat(CreateStoragePool): disable Create button if Rados gateway endpoint is empty

### DIFF
--- a/src/pages/storage/CreateStoragePool.tsx
+++ b/src/pages/storage/CreateStoragePool.tsx
@@ -17,6 +17,7 @@ import { queryKeys } from "util/queryKeys";
 import { zfsDriver } from "util/storageOptions";
 import {
   isAlletraIncomplete,
+  isCephObjectIncomplete,
   isPowerflexIncomplete,
   isPureStorageIncomplete,
   testDuplicateStoragePoolName,
@@ -193,7 +194,8 @@ const CreateStoragePool: FC = () => {
             !formik.values.name ||
             isPowerflexIncomplete(formik) ||
             isPureStorageIncomplete(formik) ||
-            isAlletraIncomplete(formik)
+            isAlletraIncomplete(formik) ||
+            isCephObjectIncomplete(formik)
           }
           onClick={() => void formik.submitForm()}
         >

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -183,6 +183,15 @@ export const isAlletraIncomplete = (
   );
 };
 
+export const isCephObjectIncomplete = (
+  formik: FormikProps<StoragePoolFormValues>,
+): boolean => {
+  return (
+    formik.values.driver === cephObject &&
+    !formik.values.cephobject_radosgw_endpoint
+  );
+};
+
 export const isCephDriver = (values: StoragePoolFormValues) => {
   return values.driver === cephDriver;
 };


### PR DESCRIPTION
## Done

- When creating a storage pool with driver = ceph object, disable `Create` button if `Rados gateway endpoint` is empty

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Storage > Pools, click on Create pool. Select driver = Ceph Object.
    - Make sure the `Create` button is disabled when `Rados gateway endpoint` is empty
    - Make sure the `Create` button is enabled when `Rados gateway endpoint` is not empty

## Screenshots

<img width="1557" height="1052" alt="image" src="https://github.com/user-attachments/assets/22138147-19d3-4e3e-a15c-9d70227cceb6" />

<img width="1557" height="1052" alt="image" src="https://github.com/user-attachments/assets/af9ca351-dc32-487f-b52a-24dd32c8bb66" />
