### PR TITLE
feat(Network name): improve validation

### DIFF
--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -13,7 +13,7 @@ import * as Yup from "yup";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useNavigate, useParams } from "react-router-dom";
-import { checkDuplicateName } from "util/helpers";
+import { getNetworkNameValidation } from "util/networkForm";
 import { ROOT_PATH } from "util/rootPath";
 import {
   createClusterNetwork,
@@ -72,14 +72,7 @@ const CreateNetwork: FC = () => {
   }
 
   const NetworkSchema = Yup.object().shape({
-    name: Yup.string()
-      .test(
-        "deduplicate",
-        "A network with this name already exists",
-        async (value) =>
-          checkDuplicateName(value, project, controllerState, "networks"),
-      )
-      .required("Network name is required"),
+    name: getNetworkNameValidation(project, controllerState),
   });
 
   const invalidateCache = () => {

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -8,8 +8,8 @@ import {
 import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useQueryClient } from "@tanstack/react-query";
+import { getNetworkNameValidation } from "util/networkForm";
 import { queryKeys } from "util/queryKeys";
-import { checkDuplicateName } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import { updateNetwork, updateClusterNetwork } from "api/networks";
 import type { NetworkFormValues } from "types/forms/network";
@@ -85,15 +85,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
   }, [networkOnMembers]);
 
   const NetworkSchema = Yup.object().shape({
-    name: Yup.string()
-      .test(
-        "deduplicate",
-        "A network with this name already exists",
-        async (value) =>
-          value === network.name ||
-          checkDuplicateName(value, project, controllerState, "networks"),
-      )
-      .required("Network name is required"),
+    name: getNetworkNameValidation(project, controllerState, network.name),
     network: Yup.string().test(
       "required",
       "Uplink network is required",

--- a/src/pages/networks/NetworkDetailHeader.tsx
+++ b/src/pages/networks/NetworkDetailHeader.tsx
@@ -5,7 +5,7 @@ import type { RenameHeaderValues } from "components/RenameHeader";
 import RenameHeader from "components/RenameHeader";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import { checkDuplicateName } from "util/helpers";
+import { getNetworkNameValidation } from "util/networkForm";
 import { ROOT_PATH } from "util/rootPath";
 import type { LxdNetwork } from "types/network";
 import { renameNetwork } from "api/networks";
@@ -34,15 +34,7 @@ const NetworkDetailHeader: FC<Props> = ({ name, network, project }) => {
   const eventQueue = useEventQueue();
 
   const RenameSchema = Yup.object().shape({
-    name: Yup.string()
-      .test(
-        "deduplicate",
-        "A network with this name already exists",
-        async (value) =>
-          network?.name === value ||
-          checkDuplicateName(value, project, controllerState, "networks"),
-      )
-      .required("Network name is required"),
+    name: getNetworkNameValidation(project, controllerState, network?.name),
   });
 
   const onSuccess = (networkName: string) => {

--- a/src/util/networkForm.tsx
+++ b/src/util/networkForm.tsx
@@ -1,3 +1,4 @@
+import * as Yup from "yup";
 import type {
   LxdNetwork,
   LxdNetworkBridgeDriver,
@@ -5,8 +6,10 @@ import type {
   LXDNetworkOnClusterMemberFulfilled,
 } from "types/network";
 import type { NetworkFormValues } from "types/forms/network";
-import { getNetworkAcls, getNetworkKey } from "util/networks";
 import type { ClusterSpecificValues } from "types/cluster";
+import type { AbortControllerState } from "util/helpers";
+import { checkDuplicateName } from "util/helpers";
+import { getNetworkAcls, getNetworkKey } from "util/networks";
 
 export const toNetworkFormValues = (
   network: LxdNetwork,
@@ -87,4 +90,31 @@ export const toNetworkFormValues = (
     security_acls_default_ingress:
       network.config[getNetworkKey("security_acls_default_ingress")],
   };
+};
+
+export const getNetworkNameValidation = (
+  project: string,
+  controllerState: AbortControllerState,
+  excludeName?: string,
+) => {
+  return Yup.string()
+    .min(2, "Minimum length is 2 characters")
+    .max(15, "Maximum length is 15 characters")
+    .test(
+      "no-double-dots",
+      "Network name must not contain '..'",
+      (value) => !value || !value.includes(".."),
+    )
+    .matches(
+      /^[-_a-zA-Z0-9.]+$/,
+      "Network name can only contain letters, numbers, hyphens, underscores, and periods",
+    )
+    .test(
+      "deduplicate",
+      "A network with this name already exists",
+      async (value) =>
+        (excludeName && value === excludeName) ||
+        checkDuplicateName(value, project, controllerState, "networks"),
+    )
+    .required("Network name is required");
 };


### PR DESCRIPTION
## Done

- Network name: improve validation
- Validation is based on backend code:
```
func IsInterfaceName(value string) error {
	// Validate the length.
	if len(value) < 2 {
		return errors.New("Network interface is too short (minimum 2 characters)")
	}

	if len(value) > 15 {
		return errors.New("Network interface is too long (maximum 15 characters)")
	}

	// Reject known bad names that might cause problem when dealing with paths.
	if strings.Contains(value, "..") {
		return errors.New("Network interface name must not contain '..'")
	}

	// Validate the character set.
	match, _ := regexp.MatchString(`^[-_a-zA-Z0-9.]+$`, value)
	if !match {
		return errors.New("Network interface contains invalid characters")
	}

	return nil
}
```

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Networking > Networks. Click on Create network.
    - Input an invalid name, make sure the Create button is disabled.
    - Input a valid name, make sure the Create button is enabled.
    - Do the same in network detail page's header.

## Screenshots

<img width="1557" height="1052" alt="Screenshot from 2026-04-27 16-50-47" src="https://github.com/user-attachments/assets/c81a5a10-1d29-4b29-b365-50ba178e054a" />

<img width="1557" height="1052" alt="image" src="https://github.com/user-attachments/assets/9e34f5c5-3ae8-4da9-af1c-c8af6ca7f45c" />
