### PR TITLE
feat(cluster member): add disable reason for evacuate & restore buttons

### DIFF
--- a/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/EvacuateClusterMemberBtn.tsx
@@ -98,6 +98,22 @@ const EvacuateClusterMemberBtn: FC<Props> = ({
   const isDisabled =
     isLoading || member.status !== "Online" || !!loadingType || !hasPermission;
 
+  const getConfirmButtonLabel = () => {
+    if (!hasPermission) {
+      return "You do not have permission to evacuate cluster members";
+    }
+    if (isLoading || loadingType === "Evacuating") {
+      return "Evacuating cluster member...";
+    }
+    if (member.status !== "Online") {
+      return "Member must be online to evacuate";
+    }
+    if (loadingType) {
+      return `Cluster member is currently ${loadingType.toLowerCase()}...`;
+    }
+    return "Evacuate cluster member";
+  };
+
   return (
     <ConfirmationButton
       appearance={hasLabel ? "" : "base"}
@@ -141,9 +157,7 @@ const EvacuateClusterMemberBtn: FC<Props> = ({
             </p>
           </>
         ),
-        confirmButtonLabel: hasPermission
-          ? "Evacuate cluster member"
-          : "You do not have permission to evacuate cluster members",
+        confirmButtonLabel: getConfirmButtonLabel(),
         onConfirm: handleEvacuate,
       }}
       shiftClickEnabled

--- a/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
+++ b/src/pages/cluster/actions/RestoreClusterMemberBtn.tsx
@@ -102,6 +102,22 @@ const RestoreClusterMemberBtn: FC<Props> = ({
     !!loadingType ||
     !hasPermission;
 
+  const getConfirmButtonLabel = () => {
+    if (!hasPermission) {
+      return "You do not have permission to restore cluster members";
+    }
+    if (isLoading || loadingType === "Restoring") {
+      return "Restoring cluster member...";
+    }
+    if (member.status !== "Evacuated") {
+      return "Member must be evacuated to restore";
+    }
+    if (loadingType) {
+      return `Cluster member is currently ${loadingType.toLowerCase()}...`;
+    }
+    return "Restore cluster member";
+  };
+
   return (
     <ConfirmationButton
       appearance={hasLabel ? "" : "base"}
@@ -132,9 +148,7 @@ const RestoreClusterMemberBtn: FC<Props> = ({
             </p>
           </>
         ),
-        confirmButtonLabel: hasPermission
-          ? "Restore cluster member"
-          : "You do not have permission to restore cluster members",
+        confirmButtonLabel: getConfirmButtonLabel(),
         onConfirm: handleRestore,
         confirmButtonAppearance: "positive",
       }}

--- a/tests/members-clustered.spec.ts
+++ b/tests/members-clustered.spec.ts
@@ -9,26 +9,40 @@ test("cluster member evacuate and restore", async ({
 }, testInfo) => {
   skipIfNotSupported(lxdVersion);
   skipIfNotClustered(testInfo.project.name);
+
   const member = await getFirstClusterMember(page);
   const memberRow = page.getByRole("row").filter({ hasText: member });
 
   await memberRow.hover();
   const restoreBtn = memberRow.getByRole("button", { name: "Restore" });
+
   if (await restoreBtn.isEnabled()) {
     await restoreBtn.click();
-    await page.getByText("Restore cluster member", { exact: true }).click();
+    await page
+      .getByRole("dialog", { name: "Confirm restore" })
+      .getByRole("button", { name: "Restore cluster member" })
+      .click();
     await dismissNotification(page, `Member ${member} restore completed.`);
   }
 
   await memberRow.hover();
-  await memberRow.getByRole("button", { name: "Evacuate" }).click();
-  await page.getByText("Evacuate cluster member", { exact: true }).click();
-
+  await memberRow
+    .getByRole("button", { name: "Evacuate cluster member" })
+    .click();
+  await page
+    .getByRole("dialog", {
+      name: "Confirm evacuation",
+    })
+    .getByRole("button", { name: "Evacuate cluster member" })
+    .click();
   await dismissNotification(page, `Member ${member} evacuation completed.`);
 
   await memberRow.hover();
   await memberRow.getByRole("button", { name: "Restore" }).click();
-  await page.getByText("Restore cluster member", { exact: true }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm restore" })
+    .getByRole("button", { name: "Restore cluster member" })
+    .click();
 
   await dismissNotification(page, `Member ${member} restore completed.`);
 });


### PR DESCRIPTION
## Done

- Cluster member: add disabled reason for `Evacuate` and `Restore` buttons

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In a cluster with multiple nodes, go to Clustering > Members. Hover on the `Evacuate` and `Restore` buttons when they are disabled. You should get a valid reason.

## Screenshots


https://github.com/user-attachments/assets/6913e81c-9254-4445-aa86-1d231a5584bc

