### PR TITLE
feat: [WD-34756] Proceed with Custom Storage Volume upon creation

### DIFF
--- a/src/pages/storage/CustomVolumeModal.tsx
+++ b/src/pages/storage/CustomVolumeModal.tsx
@@ -36,8 +36,8 @@ const CustomVolumeModal: FC<Props> = ({
   const instanceLocation = getInstanceLocation(formik);
 
   const handleCreateVolume = (volume: LxdStorageVolume) => {
-    setContent(SELECT_VOLUME);
     setPrimaryVolume(volume);
+    onFinish(volume);
   };
 
   const handleGoBack = () => {

--- a/tests/helpers/devices.ts
+++ b/tests/helpers/devices.ts
@@ -11,7 +11,6 @@ export const attachVolume = async (
   await page.getByRole("button", { name: "Create volume" }).click();
   await page.getByPlaceholder("Enter name").fill(volume);
   await page.getByRole("button", { name: "Create volume" }).click();
-  await page.getByTitle(`Select ${volume}`, { exact: true }).click();
   await page.getByPlaceholder("Enter full path (e.g. /data)").last().fill(path);
 };
 


### PR DESCRIPTION
## Done

- When creating a custom storage volume when attaching a disk device, the UI now proceeds with the newly created volume rather than navigating back to the storage volume selection page.
- Amended affected tests.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to any instance
    - Go to configuration > disk
    - Add a new disk device
    - Attach a custom storage volume
    - Create a new volume
    - Minimum: Add a name for the volume and use the default driver.
    - Create the volume and observe that the volume is automatically added as a disk device to the instance.

## Screenshots

[Screencast from 2026-04-28 16-08-56.webm](https://github.com/user-attachments/assets/18a2ef63-99fa-41d6-b592-bc8799b05660)
