### PR TITLE
fix(registry) allow images from custom registries to show up in the image selector on instance launch

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -194,13 +194,19 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             ? item.registryName.split("-").map(capitalizeFirstLetter).join(" ")
             : item.registryName;
         }
-        if (item.server === canonicalServer) {
+        const isKnownRegistry = [
+          "images",
+          "ubuntu",
+          "ubuntu-minimal",
+          "",
+        ].includes(item.registryName ?? "");
+        if (item.server === canonicalServer && isKnownRegistry) {
           source = "Ubuntu";
         }
-        if (item.server === minimalServer) {
+        if (item.server === minimalServer && isKnownRegistry) {
           source = "Ubuntu Minimal";
         }
-        if (item.server === imagesLxdServer) {
+        if (item.server === imagesLxdServer && isKnownRegistry) {
           source = "LXD Images";
         }
         return source;
@@ -213,7 +219,8 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
           displayRelease +
           displayVariant +
           item.server +
-          item.fingerprint,
+          item.fingerprint +
+          item.registryName,
         className: "u-row",
         columns: [
           {

--- a/src/util/imageRegistry.ts
+++ b/src/util/imageRegistry.ts
@@ -37,10 +37,12 @@ export const loadImagesFromAllRegistries = async (
       );
 
       imagesByRegistry[registry.name] = registryImages
-        .filter((image) => image.aliases !== null)
+        .filter((image) => {
+          return !(registry.builtin && image.aliases === null);
+        })
         .map((image) => {
           const item = localLxdToRemoteImage(image);
-          const ltsAlias = image.aliases.find((a) => a.name === "lts");
+          const ltsAlias = image.aliases?.find((a) => a.name === "lts");
 
           return {
             ...item,
@@ -106,9 +108,9 @@ export const loadImagesFromAllRegistries = async (
   ];
 
   // add images from custom registries
-  Object.entries(imagesByRegistry).forEach(([registry, images]) => {
+  Object.entries(imagesByRegistry).forEach(([registry, registryImages]) => {
     if (!ubuntuRegistries.includes(registry) && registry !== "images") {
-      images.push(...images);
+      images.push(...registryImages);
     }
   });
 


### PR DESCRIPTION
## Done

- fix(registry) allow images from custom registries to show up in the image selector on instance launch

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run with a custom backend that supports image registries
    - create an image registry with a simplestreams server, using `https://cloud-images.ubuntu.com/releases/` as url
    - create a new instance, in the image selector, ensure the custom registry images show up from the "LXD Images" and from the custom registry.