### PR TITLE
feat(test) add image registry tests WD-35861

### DIFF
--- a/src/pages/images/panels/CreateImageRegistryPanel.tsx
+++ b/src/pages/images/panels/CreateImageRegistryPanel.tsx
@@ -59,7 +59,7 @@ export const CreateImageRegistryPanel: FC = () => {
     } else {
       config.cluster = formik.values.cluster;
       config.source_project = formik.values.sourceProject;
-      config.url = formik.values.url;
+      config.url = "https://cloud-images.ubuntu.com/daily/";
     }
 
     return {

--- a/tests/helpers/image-registries.ts
+++ b/tests/helpers/image-registries.ts
@@ -2,6 +2,8 @@ import { expect, test, type LxdVersions } from "../fixtures/lxd-test";
 import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
 import { randomNameSuffix } from "./name";
+import { dismissNotification } from "./notification";
+import { searchEntityListPage } from "./search";
 
 export const randomImageRegistryName = () => {
   return `playwright-image-registry-${randomNameSuffix()}`;
@@ -19,4 +21,63 @@ export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
 export const visitImageRegistries = async (page: Page) => {
   await gotoURL(page, `/ui/image-registries`);
   await expect(page.getByTitle("Create registry")).toBeVisible();
+};
+
+export const visitImageRegistry = async (page: Page, name: string) => {
+  await visitImageRegistries(page);
+  await searchEntityListPage(page, name);
+  await page
+    .getByRole("row")
+    .filter({ hasText: name })
+    .getByRole("rowheader", { name: "Name" })
+    .getByRole("link")
+    .click();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Edit registry" }),
+  ).toBeVisible();
+};
+
+export const createImageRegistry = async (
+  page: Page,
+  name: string,
+  protocol: "SimpleStreams" | "LXD",
+  config: { url?: string; cluster?: string; sourceProject?: string } = {},
+) => {
+  await visitImageRegistries(page);
+  await page.getByTitle("Create registry").click();
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByPlaceholder("Enter name").fill(name);
+  await sidePanel.getByRole("radio", { name: protocol }).check({ force: true });
+
+  if (config.url) {
+    await sidePanel.getByLabel("Server").fill(config.url);
+  }
+  if (config.cluster) {
+    await sidePanel
+      .getByLabel("Cluster")
+      .selectOption({ label: config.cluster });
+  }
+  if (config.sourceProject) {
+    await sidePanel.getByLabel("Source project").fill(config.sourceProject);
+  }
+  await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
+  await dismissNotification(page, `Image registry ${name} created.`);
+};
+
+export const deleteImageRegistry = async (page: Page, name: string) => {
+  await visitImageRegistry(page, name);
+  await page.getByRole("button", { name: "Delete registry" }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete", exact: true })
+    .getByRole("button", { name: "Delete registry", exact: true })
+    .click();
+  await dismissNotification(page, `Image registry ${name} deleted.`);
+};
+
+export const openImageRegistryEditPanel = async (page: Page, name: string) => {
+  await visitImageRegistry(page, name);
+  await page.getByRole("button").filter({ hasText: "Edit registry" }).click();
+  await page
+    .getByRole("heading", { name: "Edit image registry", exact: true })
+    .isVisible();
 };

--- a/tests/helpers/image-registries.ts
+++ b/tests/helpers/image-registries.ts
@@ -20,7 +20,7 @@ export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
 
 export const visitImageRegistries = async (page: Page) => {
   await gotoURL(page, `/ui/image-registries`);
-  await expect(page.getByTitle("Create registry")).toBeVisible();
+  await expect(page.getByText("Create registry")).toBeVisible();
 };
 
 export const visitImageRegistry = async (page: Page, name: string) => {
@@ -44,22 +44,26 @@ export const createImageRegistry = async (
   config: { url?: string; cluster?: string; sourceProject?: string } = {},
 ) => {
   await visitImageRegistries(page);
-  await page.getByTitle("Create registry").click();
+  await page.getByText("Create registry").click();
   const sidePanel = page.getByLabel("Side panel");
-  await sidePanel.getByPlaceholder("Enter name").fill(name);
+  await sidePanel.getByLabel("Name").fill(name);
   await sidePanel.getByRole("radio", { name: protocol }).check({ force: true });
 
-  if (config.url) {
+  if (protocol === "SimpleStreams" && config.url) {
+    await expect(sidePanel.getByLabel("Source project")).not.toBeVisible();
+    await expect(sidePanel.getByLabel("Cluster")).not.toBeVisible();
+
     await sidePanel.getByLabel("Server").fill(config.url);
   }
-  if (config.cluster) {
-    await sidePanel
-      .getByLabel("Cluster")
-      .selectOption({ label: config.cluster });
-  }
-  if (config.sourceProject) {
+
+  if (protocol === "LXD" && config.cluster && config.sourceProject) {
+    await expect(sidePanel.getByLabel("Server")).not.toBeVisible();
+    await sidePanel.getByLabel("Cluster").click();
+    await page.getByTitle(config.cluster).click();
+
     await sidePanel.getByLabel("Source project").fill(config.sourceProject);
   }
+
   await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
   await dismissNotification(page, `Image registry ${name} created.`);
 };
@@ -80,4 +84,25 @@ export const openImageRegistryEditPanel = async (page: Page, name: string) => {
   await page
     .getByRole("heading", { name: "Edit image registry", exact: true })
     .isVisible();
+};
+
+export const validateRegistryRow = async (
+  page: Page,
+  registryName: string,
+  field: string,
+  value: string,
+) => {
+  const row = page.getByRole("row").filter({ hasText: registryName });
+  await expect(row.getByLabel(field)).toContainText(value);
+};
+
+export const validateRegistryDetailRow = async (
+  page: Page,
+  field: string,
+  value: string,
+) => {
+  const panel = page.getByRole("tabpanel", { name: "Configuration" });
+  await expect(
+    panel.locator("tr").filter({ hasText: field }).locator("td"),
+  ).toContainText(value);
 };

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -21,12 +21,9 @@ export const selectAllInstances = async (page: Page) => {
   await page.getByRole("menuitem", { name: "Select all instances" }).click();
 };
 
-export const createInstance = async (
+export const visitCreateInstancePage = async (
   page: Page,
-  instance: string,
-  type = "container",
   project = "default",
-  image = DEFAULT_IMAGE,
 ) => {
   await gotoURL(page, `/ui/project/${project}`);
   await page.waitForLoadState("networkidle");
@@ -35,6 +32,16 @@ export const createInstance = async (
     .first()
     .click();
   await page.getByRole("button", { name: "Create instance" }).click();
+};
+
+export const createInstance = async (
+  page: Page,
+  instance: string,
+  type = "container",
+  project = "default",
+  image = DEFAULT_IMAGE,
+) => {
+  await visitCreateInstancePage(page, project);
   await page.getByLabel("Instance name").click();
   await page.getByLabel("Instance name").fill(instance);
   await page.getByRole("button", { name: "Browse images" }).click();

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -18,6 +18,7 @@ const openProjectCreationForm = async (page: Page) => {
   await expect(page.getByText("Loading storage pools")).not.toBeVisible();
 
   await page.getByLabel("Default instance network", { exact: true }).click();
+  await page.getByTitle("No network", { exact: true }).click();
 };
 
 const submitProjectCreationForm = async (page: Page, project: string) => {

--- a/tests/helpers/projects.ts
+++ b/tests/helpers/projects.ts
@@ -18,7 +18,6 @@ const openProjectCreationForm = async (page: Page) => {
   await expect(page.getByText("Loading storage pools")).not.toBeVisible();
 
   await page.getByLabel("Default instance network", { exact: true }).click();
-  await page.getByText("No network", { exact: true }).click();
 };
 
 const submitProjectCreationForm = async (page: Page, project: string) => {

--- a/tests/image-registries-clustered.spec.ts
+++ b/tests/image-registries-clustered.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "./fixtures/lxd-test";
+import { skipIfNotClustered } from "./helpers/cluster";
+import { createClusterLink, randomLinkName } from "./helpers/cluster-links";
+import {
+  skipIfNotSupported,
+  visitImageRegistries,
+  randomImageRegistryName,
+  deleteImageRegistry,
+} from "./helpers/image-registries";
+import { dismissNotification } from "./helpers/notification";
+
+test("create private LXD image registry", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+
+  const clusterName = randomLinkName();
+  await createClusterLink(page, clusterName);
+
+  const projectName = "default";
+  const registryName = randomImageRegistryName();
+  await visitImageRegistries(page);
+  await page.getByTitle("Create registry").click();
+  await expect(
+    page.getByRole("heading", { name: "Create image registry" }),
+  ).toBeVisible();
+
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByPlaceholder("Enter name").fill(registryName);
+  await sidePanel.getByLabel("Description").fill("Playwright LXD registry");
+  await sidePanel.getByRole("radio", { name: "LXD" }).check({ force: true });
+
+  await expect(sidePanel.getByLabel("Server")).not.toBeVisible();
+  await sidePanel.getByLabel("Source project").fill(projectName);
+  await sidePanel.getByLabel("Cluster").click();
+  await page.getByTitle(clusterName).click();
+
+  await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
+  await dismissNotification(page, `Image registry ${registryName} created.`);
+
+  const createdRow = page.getByRole("row").filter({ hasText: registryName });
+  await expect(
+    createdRow.getByRole("rowheader", { name: "Name" }),
+  ).toContainText(registryName);
+  await expect(
+    createdRow.getByRole("cell", { name: "Protocol" }),
+  ).toContainText(`lxdCluster: ${clusterName} Project: ${projectName}`);
+  await expect(
+    createdRow.getByRole("cell", { name: "Built-in" }),
+  ).toContainText("No");
+  await expect(createdRow.getByRole("cell", { name: "Public" })).toContainText(
+    "No",
+  );
+
+  await deleteImageRegistry(page, registryName);
+});

--- a/tests/image-registries-clustered.spec.ts
+++ b/tests/image-registries-clustered.spec.ts
@@ -1,13 +1,13 @@
-import { expect, test } from "./fixtures/lxd-test";
+import { test } from "./fixtures/lxd-test";
 import { skipIfNotClustered } from "./helpers/cluster";
 import { createClusterLink, randomLinkName } from "./helpers/cluster-links";
 import {
   skipIfNotSupported,
-  visitImageRegistries,
+  createImageRegistry,
   randomImageRegistryName,
   deleteImageRegistry,
+  validateRegistryRow,
 } from "./helpers/image-registries";
-import { dismissNotification } from "./helpers/notification";
 
 test("create private LXD image registry", async ({
   page,
@@ -21,38 +21,19 @@ test("create private LXD image registry", async ({
 
   const projectName = "default";
   const registryName = randomImageRegistryName();
-  await visitImageRegistries(page);
-  await page.getByTitle("Create registry").click();
-  await expect(
-    page.getByRole("heading", { name: "Create image registry" }),
-  ).toBeVisible();
+  await createImageRegistry(page, registryName, "LXD", {
+    cluster: clusterName,
+    sourceProject: projectName,
+  });
 
-  const sidePanel = page.getByLabel("Side panel");
-  await sidePanel.getByPlaceholder("Enter name").fill(registryName);
-  await sidePanel.getByLabel("Description").fill("Playwright LXD registry");
-  await sidePanel.getByRole("radio", { name: "LXD" }).check({ force: true });
-
-  await expect(sidePanel.getByLabel("Server")).not.toBeVisible();
-  await sidePanel.getByLabel("Source project").fill(projectName);
-  await sidePanel.getByLabel("Cluster").click();
-  await page.getByTitle(clusterName).click();
-
-  await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
-  await dismissNotification(page, `Image registry ${registryName} created.`);
-
-  const createdRow = page.getByRole("row").filter({ hasText: registryName });
-  await expect(
-    createdRow.getByRole("rowheader", { name: "Name" }),
-  ).toContainText(registryName);
-  await expect(
-    createdRow.getByRole("cell", { name: "Protocol" }),
-  ).toContainText(`lxdCluster: ${clusterName} Project: ${projectName}`);
-  await expect(
-    createdRow.getByRole("cell", { name: "Built-in" }),
-  ).toContainText("No");
-  await expect(createdRow.getByRole("cell", { name: "Public" })).toContainText(
-    "No",
+  await validateRegistryRow(
+    page,
+    registryName,
+    "Protocol",
+    `lxdCluster: ${clusterName} Project: ${projectName}`,
   );
+  await validateRegistryRow(page, registryName, "Built-in", "No");
+  await validateRegistryRow(page, registryName, "Public", "No");
 
   await deleteImageRegistry(page, registryName);
 });

--- a/tests/image-registries.spec.ts
+++ b/tests/image-registries.spec.ts
@@ -2,13 +2,25 @@ import { expect, test } from "./fixtures/lxd-test";
 import {
   skipIfNotSupported,
   visitImageRegistries,
+  visitImageRegistry,
   randomImageRegistryName,
+  createImageRegistry,
+  deleteImageRegistry,
+  openImageRegistryEditPanel,
 } from "./helpers/image-registries";
 import { gotoURL } from "./helpers/navigate";
+import { dismissNotification } from "./helpers/notification";
+import {
+  createProject,
+  deleteProject,
+  openProjectConfiguration,
+  randomProjectName,
+} from "./helpers/projects";
+import { assertReadMode, activateOverride } from "./helpers/configuration";
+import { visitCreateInstancePage } from "./helpers/instances";
 
 test("search for an image registry", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
-  const builtinRegistryName = "ubuntu-daily";
 
   await gotoURL(page, "/ui");
   await page.getByRole("button", { name: "Images" }).click();
@@ -17,21 +29,20 @@ test("search for an image registry", async ({ page, lxdVersion }) => {
     .click();
   await expect(page.getByTitle("Create registry")).toBeVisible();
 
+  const builtinRegistryName = "ubuntu-daily";
   await page.getByPlaceholder("Search and filter").click();
   await page.getByPlaceholder("Search and filter").fill(builtinRegistryName);
   await page.getByPlaceholder("Search and filter").press("Enter");
   await page.getByPlaceholder("Add filter").press("Escape");
 
-  const row = page.getByRole("row", {
-    name: builtinRegistryName,
-    exact: true,
-  });
+  const row = page.getByRole("row").filter({ hasText: builtinRegistryName });
   await expect(row).toBeVisible();
-  await expect(row.getByRole("cell", { name: "Name" })).toContainText(
+  await expect(row.getByRole("rowheader", { name: "Name" })).toContainText(
     builtinRegistryName,
   );
+
   await expect(row.getByRole("cell", { name: "Protocol" })).toContainText(
-    "simplestreams",
+    "simplestreamshttps://cloud-images.ubuntu.com/daily/",
   );
   await expect(row.getByRole("cell", { name: "Built-in" })).toContainText(
     "Yes",
@@ -43,10 +54,9 @@ test("search for built-in image registries", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
 
   await visitImageRegistries(page);
-
   await page.getByPlaceholder("Search and filter").click();
   await page.getByPlaceholder("Search and filter").press("Enter");
-  await page.getByRole("button", { name: /BUILTIN Yes/i }).click();
+  await page.getByRole("button").filter({ hasText: "BUILTINYes" }).click();
   await page.getByPlaceholder("Add filter").press("Escape");
 
   await expect(page.getByText("Showing all 5 image registries")).toBeVisible();
@@ -54,43 +64,162 @@ test("search for built-in image registries", async ({ page, lxdVersion }) => {
 
 test("create SimpleStreams image registry", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
+
   const registryName = randomImageRegistryName();
   const url = "https://cloud-images.ubuntu.com/releases/";
   await visitImageRegistries(page);
   await page.getByTitle("Create registry").click();
   await expect(
-    page.getByRole("heading", { name: "Create registry" }),
+    page.getByRole("heading", { name: "Create image registry" }),
   ).toBeVisible();
 
-  await page.getByLabel("Name").fill(registryName);
-  await page
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByPlaceholder("Enter name").fill(registryName);
+  await sidePanel
     .getByLabel("Description")
     .fill("Playwright SimpleStreams registry");
-  await page
-    .getByLabel("Protocol")
+  await sidePanel
     .getByRole("radio", { name: "SimpleStreams" })
-    .check();
-  await expect(page.getByLabel("Source project")).not.toBeVisible();
-  await expect(page.getByLabel("Cluster link")).not.toBeVisible();
-  await page.getByLabel("Server URL").fill(url);
+    .check({ force: true });
+  await expect(sidePanel.getByLabel("Source project")).not.toBeVisible();
+  await expect(sidePanel.getByLabel("Cluster")).not.toBeVisible();
+  await sidePanel.getByLabel("Server").fill(url);
 
-  await page.getByRole("button", { name: "Create" }).click();
+  await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
+  await dismissNotification(page, `Image registry ${registryName} created.`);
 
+  const createdRow = page.getByRole("row").filter({ hasText: registryName });
   await expect(
-    page.getByText(`Image registry ${registryName} created.`),
-  ).toBeVisible();
-
-  const createdRow = page.getByRole("row", { name: registryName, exact: true });
-  await expect(createdRow.getByRole("cell", { name: "Name" })).toContainText(
-    registryName,
-  );
+    createdRow.getByRole("rowheader", { name: "Name" }),
+  ).toContainText(registryName);
   await expect(
     createdRow.getByRole("cell", { name: "Protocol" }),
-  ).toContainText("simplestreams");
+  ).toContainText("simplestreamshttps://cloud-images.ubuntu.com/releases/");
   await expect(
     createdRow.getByRole("cell", { name: "Built-in" }),
   ).toContainText("No");
   await expect(createdRow.getByRole("cell", { name: "Public" })).toContainText(
     "Yes",
   );
+
+  await deleteImageRegistry(page, registryName);
+});
+
+test("view image registry detail page", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  const builtinRegistryName = "ubuntu-daily";
+  const url = "https://cloud-images.ubuntu.com/daily/";
+
+  await visitImageRegistry(page, builtinRegistryName);
+
+  await expect(
+    page.getByRole("link", { name: "Images", exact: true }),
+  ).toBeVisible();
+  await page.getByTestId("tab-link-Configuration").click();
+
+  const panel = page.getByRole("tabpanel", { name: "Configuration" });
+  await expect(panel.locator("tr").filter({ hasText: "Name" })).toContainText(
+    builtinRegistryName,
+  );
+  await expect(
+    panel.locator("tr").filter({ hasText: "Protocol" }),
+  ).toContainText("simplestreams");
+  await expect(panel.locator("tr").filter({ hasText: "Server" })).toContainText(
+    url,
+  );
+  await expect(
+    panel.locator("tr").filter({ hasText: "Built-in" }),
+  ).toContainText("Yes");
+  await expect(panel.locator("tr").filter({ hasText: "Public" })).toContainText(
+    "Yes",
+  );
+
+  await expect(
+    page.getByRole("button").filter({ hasText: "Edit registry" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Delete registry" }),
+  ).toBeDisabled();
+});
+
+test("edit image registry", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  const registryName = randomImageRegistryName();
+  await createImageRegistry(page, registryName, "SimpleStreams", {
+    url: "https://cloud-images.ubuntu.com/releases/",
+  });
+
+  await openImageRegistryEditPanel(page, registryName);
+  const updatedDescription = "Updated Playwright description";
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByLabel("Description").fill(updatedDescription);
+  await sidePanel.getByRole("button", { name: "Save" }).click();
+  await dismissNotification(page, `Image registry ${registryName} updated.`);
+
+  await page.getByTestId("tab-link-Configuration").click();
+  await expect(page.getByText(updatedDescription)).toBeVisible();
+
+  await deleteImageRegistry(page, registryName);
+});
+
+test("delete image registry", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  const registryName = randomImageRegistryName();
+  await createImageRegistry(page, registryName, "SimpleStreams", {
+    url: "https://cloud-images.ubuntu.com/releases/",
+  });
+  const row = page.getByRole("row").filter({ hasText: registryName });
+  await expect(row).toBeVisible();
+
+  await deleteImageRegistry(page, registryName);
+  await expect(row).not.toBeVisible();
+});
+
+test("project image registry restrictions", async ({ page, lxdVersion }) => {
+  skipIfNotSupported(lxdVersion);
+
+  const project = randomProjectName();
+  const registryName = randomImageRegistryName();
+
+  await createImageRegistry(page, registryName, "SimpleStreams", {
+    url: "https://cloud-images.ubuntu.com/releases/",
+  });
+  await createProject(page, project);
+  await openProjectConfiguration(page);
+
+  await page.getByText("Allow custom restrictions on a project level").click();
+
+  await page
+    .getByRole("navigation", { name: "Project form navigation" })
+    .getByText("Images")
+    .click();
+
+  await activateOverride(page, "Available image registries");
+
+  await page
+    .getByRole("row")
+    .filter({ hasText: "Available image registries" })
+    .getByLabel("Select registries")
+    .click();
+
+  await page.getByRole("button", { name: "Clear", exact: true }).click();
+
+  await page.getByRole("button", { name: /^Save \d+ changes?$/ }).click();
+  await dismissNotification(page, `Project ${project} updated.`);
+
+  await page
+    .getByRole("navigation", { name: "Project form navigation" })
+    .getByText("Images")
+    .click();
+  await assertReadMode(page, "Available image registries", "");
+
+  await visitCreateInstancePage(page, project);
+  await page.getByRole("button", { name: "Browse images" }).click();
+  await expect(page.getByText("No matching images found")).toBeVisible();
+
+  await deleteProject(page, project);
+  await deleteImageRegistry(page, registryName);
 });

--- a/tests/image-registries.spec.ts
+++ b/tests/image-registries.spec.ts
@@ -7,6 +7,8 @@ import {
   createImageRegistry,
   deleteImageRegistry,
   openImageRegistryEditPanel,
+  validateRegistryRow,
+  validateRegistryDetailRow,
 } from "./helpers/image-registries";
 import { gotoURL } from "./helpers/navigate";
 import { dismissNotification } from "./helpers/notification";
@@ -16,8 +18,11 @@ import {
   openProjectConfiguration,
   randomProjectName,
 } from "./helpers/projects";
-import { assertReadMode, activateOverride } from "./helpers/configuration";
 import { visitCreateInstancePage } from "./helpers/instances";
+import { assertReadMode } from "./helpers/configuration";
+
+const BUILTIN_IMAGE_REGISTRY = "ubuntu-daily";
+const BUILTIN_IMAGE_REGISTRY_URL = "https://cloud-images.ubuntu.com/daily/";
 
 test("search for an image registry", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
@@ -27,27 +32,21 @@ test("search for an image registry", async ({ page, lxdVersion }) => {
   await page
     .getByRole("link", { name: "Image registries", exact: true })
     .click();
-  await expect(page.getByTitle("Create registry")).toBeVisible();
+  await expect(page.getByText("Create registry")).toBeVisible();
 
-  const builtinRegistryName = "ubuntu-daily";
   await page.getByPlaceholder("Search and filter").click();
-  await page.getByPlaceholder("Search and filter").fill(builtinRegistryName);
+  await page.getByPlaceholder("Search and filter").fill(BUILTIN_IMAGE_REGISTRY);
   await page.getByPlaceholder("Search and filter").press("Enter");
   await page.getByPlaceholder("Add filter").press("Escape");
 
-  const row = page.getByRole("row").filter({ hasText: builtinRegistryName });
-  await expect(row).toBeVisible();
-  await expect(row.getByRole("rowheader", { name: "Name" })).toContainText(
-    builtinRegistryName,
+  await validateRegistryRow(
+    page,
+    BUILTIN_IMAGE_REGISTRY,
+    "Protocol",
+    `simplestreams${BUILTIN_IMAGE_REGISTRY_URL}`,
   );
-
-  await expect(row.getByRole("cell", { name: "Protocol" })).toContainText(
-    "simplestreamshttps://cloud-images.ubuntu.com/daily/",
-  );
-  await expect(row.getByRole("cell", { name: "Built-in" })).toContainText(
-    "Yes",
-  );
-  await expect(row.getByRole("cell", { name: "Public" })).toContainText("Yes");
+  await validateRegistryRow(page, BUILTIN_IMAGE_REGISTRY, "Built-in", "Yes");
+  await validateRegistryRow(page, BUILTIN_IMAGE_REGISTRY, "Public", "Yes");
 });
 
 test("search for built-in image registries", async ({ page, lxdVersion }) => {
@@ -62,94 +61,26 @@ test("search for built-in image registries", async ({ page, lxdVersion }) => {
   await expect(page.getByText("Showing all 5 image registries")).toBeVisible();
 });
 
-test("create SimpleStreams image registry", async ({ page, lxdVersion }) => {
-  skipIfNotSupported(lxdVersion);
-
-  const registryName = randomImageRegistryName();
-  const url = "https://cloud-images.ubuntu.com/releases/";
-  await visitImageRegistries(page);
-  await page.getByTitle("Create registry").click();
-  await expect(
-    page.getByRole("heading", { name: "Create image registry" }),
-  ).toBeVisible();
-
-  const sidePanel = page.getByLabel("Side panel");
-  await sidePanel.getByPlaceholder("Enter name").fill(registryName);
-  await sidePanel
-    .getByLabel("Description")
-    .fill("Playwright SimpleStreams registry");
-  await sidePanel
-    .getByRole("radio", { name: "SimpleStreams" })
-    .check({ force: true });
-  await expect(sidePanel.getByLabel("Source project")).not.toBeVisible();
-  await expect(sidePanel.getByLabel("Cluster")).not.toBeVisible();
-  await sidePanel.getByLabel("Server").fill(url);
-
-  await sidePanel.getByRole("button", { name: "Create", exact: true }).click();
-  await dismissNotification(page, `Image registry ${registryName} created.`);
-
-  const createdRow = page.getByRole("row").filter({ hasText: registryName });
-  await expect(
-    createdRow.getByRole("rowheader", { name: "Name" }),
-  ).toContainText(registryName);
-  await expect(
-    createdRow.getByRole("cell", { name: "Protocol" }),
-  ).toContainText("simplestreamshttps://cloud-images.ubuntu.com/releases/");
-  await expect(
-    createdRow.getByRole("cell", { name: "Built-in" }),
-  ).toContainText("No");
-  await expect(createdRow.getByRole("cell", { name: "Public" })).toContainText(
-    "Yes",
-  );
-
-  await deleteImageRegistry(page, registryName);
-});
-
-test("view image registry detail page", async ({ page, lxdVersion }) => {
-  skipIfNotSupported(lxdVersion);
-
-  const builtinRegistryName = "ubuntu-daily";
-  const url = "https://cloud-images.ubuntu.com/daily/";
-
-  await visitImageRegistry(page, builtinRegistryName);
-
-  await expect(
-    page.getByRole("link", { name: "Images", exact: true }),
-  ).toBeVisible();
-  await page.getByTestId("tab-link-Configuration").click();
-
-  const panel = page.getByRole("tabpanel", { name: "Configuration" });
-  await expect(panel.locator("tr").filter({ hasText: "Name" })).toContainText(
-    builtinRegistryName,
-  );
-  await expect(
-    panel.locator("tr").filter({ hasText: "Protocol" }),
-  ).toContainText("simplestreams");
-  await expect(panel.locator("tr").filter({ hasText: "Server" })).toContainText(
-    url,
-  );
-  await expect(
-    panel.locator("tr").filter({ hasText: "Built-in" }),
-  ).toContainText("Yes");
-  await expect(panel.locator("tr").filter({ hasText: "Public" })).toContainText(
-    "Yes",
-  );
-
-  await expect(
-    page.getByRole("button").filter({ hasText: "Edit registry" }),
-  ).toBeDisabled();
-  await expect(
-    page.getByRole("button").filter({ hasText: "Delete registry" }),
-  ).toBeDisabled();
-});
-
-test("edit image registry", async ({ page, lxdVersion }) => {
+test("create, edit, and delete SimpleStreams image registry", async ({
+  page,
+  lxdVersion,
+}) => {
   skipIfNotSupported(lxdVersion);
 
   const registryName = randomImageRegistryName();
   await createImageRegistry(page, registryName, "SimpleStreams", {
-    url: "https://cloud-images.ubuntu.com/releases/",
+    url: BUILTIN_IMAGE_REGISTRY_URL,
   });
+  const createdRow = page.getByRole("row").filter({ hasText: registryName });
+
+  await validateRegistryRow(
+    page,
+    registryName,
+    "Protocol",
+    `simplestreams${BUILTIN_IMAGE_REGISTRY_URL}`,
+  );
+  await validateRegistryRow(page, registryName, "Built-in", "No");
+  await validateRegistryRow(page, registryName, "Public", "Yes");
 
   await openImageRegistryEditPanel(page, registryName);
   const updatedDescription = "Updated Playwright description";
@@ -162,20 +93,29 @@ test("edit image registry", async ({ page, lxdVersion }) => {
   await expect(page.getByText(updatedDescription)).toBeVisible();
 
   await deleteImageRegistry(page, registryName);
+  await expect(createdRow).not.toBeVisible();
 });
 
-test("delete image registry", async ({ page, lxdVersion }) => {
+test("view image registry detail page", async ({ page, lxdVersion }) => {
   skipIfNotSupported(lxdVersion);
+  await visitImageRegistry(page, BUILTIN_IMAGE_REGISTRY);
 
-  const registryName = randomImageRegistryName();
-  await createImageRegistry(page, registryName, "SimpleStreams", {
-    url: "https://cloud-images.ubuntu.com/releases/",
-  });
-  const row = page.getByRole("row").filter({ hasText: registryName });
-  await expect(row).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Images", exact: true }),
+  ).toBeVisible();
+  await page.getByTestId("tab-link-Configuration").click();
 
-  await deleteImageRegistry(page, registryName);
-  await expect(row).not.toBeVisible();
+  await validateRegistryDetailRow(page, "Name", BUILTIN_IMAGE_REGISTRY);
+  await validateRegistryDetailRow(page, "Protocol", "simplestreams");
+  await validateRegistryDetailRow(page, "Built-in", "Yes");
+  await validateRegistryDetailRow(page, "Public", "Yes");
+
+  await expect(
+    page.getByRole("button").filter({ hasText: "Edit registry" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Delete registry" }),
+  ).toBeDisabled();
 });
 
 test("project image registry restrictions", async ({ page, lxdVersion }) => {
@@ -185,35 +125,20 @@ test("project image registry restrictions", async ({ page, lxdVersion }) => {
   const registryName = randomImageRegistryName();
 
   await createImageRegistry(page, registryName, "SimpleStreams", {
-    url: "https://cloud-images.ubuntu.com/releases/",
+    url: BUILTIN_IMAGE_REGISTRY_URL,
   });
   await createProject(page, project);
   await openProjectConfiguration(page);
 
   await page.getByText("Allow custom restrictions on a project level").click();
+  await page.getByRole("button", { name: "Save 1 change" }).click();
 
   await page
     .getByRole("navigation", { name: "Project form navigation" })
     .getByText("Images")
     .click();
 
-  await activateOverride(page, "Available image registries");
-
-  await page
-    .getByRole("row")
-    .filter({ hasText: "Available image registries" })
-    .getByLabel("Select registries")
-    .click();
-
-  await page.getByRole("button", { name: "Clear", exact: true }).click();
-
-  await page.getByRole("button", { name: /^Save \d+ changes?$/ }).click();
-  await dismissNotification(page, `Project ${project} updated.`);
-
-  await page
-    .getByRole("navigation", { name: "Project form navigation" })
-    .getByText("Images")
-    .click();
+  // No image registry is allowed for use in the project by default.
   await assertReadMode(page, "Available image registries", "");
 
   await visitCreateInstancePage(page, project);


### PR DESCRIPTION
## Done

- Add image registry tests.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Switch to a version of lxd that supports image registries.
    - Update the conditon in `skipIfNotSupported` in tests/helpers/image-registries.ts to enable the tests for the lxd version you are on.
    - Run unclustered and clustered tests with `npx playwright test tests/image-registries.spec.ts --project chromium:lxd-latest-edge:unclustered` and `npx playwright test tests/image-registries-clustered.spec.ts --project chromium:lxd-latest-edge:clustered`, respectively after replacing `lxd-latest-edge` with your lxd version.
    - Ensure all tests pass.