### PR TITLE
feat(navigation): stay on the same global page when switching project

### DIFF
--- a/src/pages/projects/NavigationProjectSelector.tsx
+++ b/src/pages/projects/NavigationProjectSelector.tsx
@@ -6,12 +6,14 @@ import {
   Icon,
   SearchBox,
 } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom";
-import NavigationProjectSelectorList from "pages/projects/NavigationProjectSelectorList";
-import { defaultFirst } from "util/helpers";
-import { ROOT_PATH } from "util/rootPath";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useCurrentProject } from "context/useCurrentProject";
 import { useProjects } from "context/useProjects";
+import NavigationProjectSelectorList from "pages/projects/NavigationProjectSelectorList";
 import { useServerEntitlements } from "util/entitlements/server";
+import { defaultFirst } from "util/helpers";
+import { isGlobalPage, ALL_PROJECTS } from "util/projects";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   activeProject: string;
@@ -21,8 +23,11 @@ const NavigationProjectSelector: FC<Props> = ({
   activeProject,
 }): React.JSX.Element => {
   const navigate = useNavigate();
+  const location = useLocation();
   const searchRef = useRef<HTMLInputElement>(null);
   const { canCreateProjects } = useServerEntitlements();
+  const { setProjectName } = useCurrentProject();
+  const isOnGlobalPage = isGlobalPage(location.pathname);
 
   const { data: projects = [] } = useProjects();
 
@@ -49,53 +54,62 @@ const NavigationProjectSelector: FC<Props> = ({
         title={`Select project (${activeProject})`}
         className="project-select is-dark"
       >
-        <div className="list is-dark" key="my-div">
-          {projects.length > 5 && (
-            <SearchBox
-              id="searchProjectSelector"
-              key="searchProjectSelector"
-              autoFocus={true}
-              autocomplete="off"
-              name="query"
-              placeholder="Search"
-              onChange={(val) => {
-                updateQuery(val);
+        {(close: () => void) => (
+          <div className="list is-dark" key="my-div">
+            {projects.length > 5 && (
+              <SearchBox
+                id="searchProjectSelector"
+                key="searchProjectSelector"
+                autoFocus={true}
+                autocomplete="off"
+                name="query"
+                placeholder="Search"
+                onChange={(val) => {
+                  updateQuery(val);
+                }}
+                ref={searchRef}
+              />
+            )}
+            <Button
+              onClick={() => {
+                if (isOnGlobalPage) {
+                  setProjectName(ALL_PROJECTS);
+                } else {
+                  navigate(`${ROOT_PATH}/ui/all-projects/instances`);
+                }
+                close();
               }}
-              ref={searchRef}
+              className="p-contextual-menu__link all-projects"
+              hasIcon
+            >
+              <Icon name="folder" light />
+              <span>All projects</span>
+            </Button>
+            <NavigationProjectSelectorList
+              projects={projects}
+              onMount={onChildMount}
+              onClose={close}
             />
-          )}
-          <Button
-            onClick={() => {
-              navigate(`${ROOT_PATH}/ui/all-projects/instances`);
-            }}
-            className="p-contextual-menu__link all-projects"
-            hasIcon
-          >
-            <Icon name="folder" light />
-            <span>All projects</span>
-          </Button>
-          <NavigationProjectSelectorList
-            projects={projects}
-            onMount={onChildMount}
-          />
-          <hr className="is-dark" />
-          <Button
-            onClick={() => {
-              navigate(`${ROOT_PATH}/ui/projects/create`);
-            }}
-            className="p-contextual-menu__link"
-            hasIcon
-            disabled={!canCreateProjects()}
-            title={
-              canCreateProjects()
-                ? ""
-                : "You do not have permission to create projects"
-            }
-          >
-            <Icon name="plus" light />
-            <span>Create project</span>
-          </Button>
-        </div>
+            <hr className="is-dark" />
+            <Button
+              onClick={() => {
+                navigate(`${ROOT_PATH}/ui/projects/create`);
+                close();
+              }}
+              className="p-contextual-menu__link"
+              hasIcon
+              disabled={!canCreateProjects()}
+              title={
+                canCreateProjects()
+                  ? ""
+                  : "You do not have permission to create projects"
+              }
+            >
+              <Icon name="plus" light />
+              <span>Create project</span>
+            </Button>
+          </div>
+        )}
       </ContextualMenu>
     </>
   );

--- a/src/pages/projects/NavigationProjectSelectorList.tsx
+++ b/src/pages/projects/NavigationProjectSelectorList.tsx
@@ -1,22 +1,28 @@
 import type { Dispatch, FC, SetStateAction } from "react";
 import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { Button } from "@canonical/react-components";
+import { useCurrentProject } from "context/useCurrentProject";
 import type { LxdProject } from "types/project";
-import { getProjectSwitchTarget } from "util/projects";
-import { filterUsedByType } from "util/usedBy";
 import { pluralize } from "util/helpers";
+import { getProjectSwitchTarget, isGlobalPage } from "util/projects";
+import { filterUsedByType } from "util/usedBy";
 
 interface Props {
   projects: LxdProject[];
   onMount: (val: Dispatch<SetStateAction<string>>) => void;
+  onClose: () => void;
 }
 
 const NavigationProjectSelectorList: FC<Props> = ({
   projects,
   onMount,
+  onClose,
 }): React.JSX.Element => {
   const location = useLocation();
   const [query, setQuery] = useState("");
+  const { setProjectName } = useCurrentProject();
+  const isOnGlobalPage = isGlobalPage(location.pathname);
 
   onMount(setQuery);
 
@@ -43,24 +49,48 @@ const NavigationProjectSelectorList: FC<Props> = ({
         })
         .map((project) => (
           <div key={project.name} className="p-contextual-menu__group">
-            <Link
-              to={getProjectSwitchTarget(location.pathname, project.name)}
-              className="p-contextual-menu__link link"
-            >
-              <div title={project.name} className="u-truncate name">
-                {project.name}
-              </div>
-              <div className="p-text--x-small u-float-right u-no-margin--bottom count">
-                {getInstanceCount(project)}
-              </div>
-              <br />
-              <div
-                className="p-text--x-small u-no-margin--bottom u-truncate description"
-                title={project.description}
+            {isOnGlobalPage ? (
+              <Button
+                onClick={() => {
+                  setProjectName(project.name);
+                  onClose();
+                }}
+                className="p-contextual-menu__link link"
               >
-                {project.description || "-"}
-              </div>
-            </Link>
+                <div title={project.name} className="u-truncate name">
+                  {project.name}
+                </div>
+                <div className="p-text--x-small u-float-right u-no-margin--bottom count">
+                  {getInstanceCount(project)}
+                </div>
+                <br />
+                <div
+                  className="p-text--x-small u-no-margin--bottom u-truncate description"
+                  title={project.description}
+                >
+                  {project.description || "-"}
+                </div>
+              </Button>
+            ) : (
+              <Link
+                to={getProjectSwitchTarget(location.pathname, project.name)}
+                className="p-contextual-menu__link link"
+              >
+                <div title={project.name} className="u-truncate name">
+                  {project.name}
+                </div>
+                <div className="p-text--x-small u-float-right u-no-margin--bottom count">
+                  {getInstanceCount(project)}
+                </div>
+                <br />
+                <div
+                  className="p-text--x-small u-no-margin--bottom u-truncate description"
+                  title={project.description}
+                >
+                  {project.description || "-"}
+                </div>
+              </Link>
+            )}
           </div>
         ))}
     </div>

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -50,17 +50,28 @@ export const getSubpageFromUrl = (url: string): string | undefined => {
   return undefined;
 };
 
+export const isGlobalPage = (url: string): boolean => {
+  const urlWithoutQuery = url.split("?")[0];
+  const globalPages = [
+    "/ui/server",
+    "/ui/cluster",
+    "/ui/operations",
+    "/ui/warnings",
+    "/ui/permissions",
+    "/ui/settings",
+    "/ui/image-registries",
+    "/ui/image-registry/",
+  ];
+
+  return globalPages.some((page) => urlWithoutQuery.includes(page));
+};
+
 export const getProjectSwitchTarget = (
   url: string,
   projectName: string,
 ): string => {
-  const urlWithoutQuery = url.split("?")[0];
-
-  if (
-    urlWithoutQuery.includes("/ui/image-registry/") ||
-    urlWithoutQuery.includes("/ui/image-registries")
-  ) {
-    return `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/instances`;
+  if (isGlobalPage(url)) {
+    return url;
   }
 
   const targetSection = getSubpageFromUrl(url) ?? "instances";


### PR DESCRIPTION
## Done

- Switching project when on a global page doesn’t trigger navigation but newly selected project is correctly set.
Global pages: Server, Cluster, Operations, Warnings, Permissions, Settings, Image registries (and all sub-pages)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a global page. Select another project: you should stay on the same page.
    - Go to Instances list: you should see the instances of the newly selected project (you can check the URL to be sure)

## Screenshots

https://github.com/user-attachments/assets/94148b25-1e28-41c1-8f4e-98669b7bade9

