### PR TITLE
fix: Image tab state in All Projects view

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -462,6 +462,7 @@ const Navigation: FC = () => {
                           open={
                             openNavMenus.includes("images") && !menuCollapsed
                           }
+                          disabled={isAllProjects}
                         >
                           <NavLink
                             to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/local-images`}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -462,6 +462,7 @@ const Navigation: FC = () => {
                           open={
                             openNavMenus.includes("images") && !menuCollapsed
                           }
+                          disabled={isAllProjects && !hasImageRegistries}
                         >
                           <NavLink
                             to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/local-images`}


### PR DESCRIPTION
## Done

- Adds disabled flag to Image Navigation component.

Fixes https://github.com/canonical/lxd-ui/issues/1988

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Open LXDUI (Or demo server)
    - In the project dropdown, select 'All projects'
    - Ensure that the Images tab is disabled in the navigation.
    - Go back to the project dropdown and navigate back to the default project (or any project)
    - Ensure the Images tab is enabled and accessible.

## Screenshots

<img width="267" height="484" alt="image" src="https://github.com/user-attachments/assets/18e2d21d-1de8-46b9-b747-381d05315c8c" />