### PR TITLE
feat(settings): autofocus on Input

### DIFF
--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -35,6 +35,7 @@ const SettingFormCheckbox: FC<Props> = ({
   return (
     <>
       <Input
+        autoFocus
         label={label}
         id={configField.key}
         wrapperClassName="input-wrapper"

--- a/src/pages/settings/SettingFormInput.tsx
+++ b/src/pages/settings/SettingFormInput.tsx
@@ -47,6 +47,7 @@ const SettingFormInput: FC<Props> = ({
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden value="Hidden input" />
       <Input
+        autoFocus
         aria-label={configField.key}
         id={configField.key}
         wrapperClassName="input-wrapper"

--- a/src/pages/settings/SettingFormPassword.tsx
+++ b/src/pages/settings/SettingFormPassword.tsx
@@ -34,6 +34,7 @@ const SettingFormPassword: FC<Props> = ({
         <>
           <div className="input-row">
             <Input
+              autoFocus
               aria-label={configField.key}
               id={configField.key}
               wrapperClassName="input-wrapper"


### PR DESCRIPTION
## Done

- feat(Settings): when clicking on the “Edit” button of a settings, focus is automatically be on the corresponding input.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Settings. Click on any setting's Edit button: the input should be focused

## Screenshots

https://github.com/user-attachments/assets/af8fd423-7520-4af9-b020-b0a81ebf3f6f

