### PR TITLE
fix(ImageRegistryDetailHeader): should not throw error if no rename

### DIFF
--- a/src/pages/images/ImageRegistryDetailHeader.tsx
+++ b/src/pages/images/ImageRegistryDetailHeader.tsx
@@ -31,6 +31,7 @@ const ImageRegistryDetailHeader: FC<Props> = ({ imageRegistry }) => {
         "deduplicate",
         "An image registry with this name already exists",
         async (value) =>
+          imageRegistry.name === value ||
           checkDuplicateName(value, "", controllerState, "image-registries"),
       )
       .required("Image registry name is required"),


### PR DESCRIPTION
## Done

- ImageRegistryDetailHeader: when clicking on the name but not changing it, you should be able to cancel without errors.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Sideload LXD backend with image registry branch
    - Go to a custom image registry's detail page. Click on the name of the image registry in the header. Do not change the name, click on Cancel: no errors should be shown

## Screenshots

Before

https://github.com/user-attachments/assets/ac4da303-e5d7-4620-97f5-0072ffccbc82

After

https://github.com/user-attachments/assets/0ba5fec6-9df0-4bec-aabb-bc99084217a8

