### PR TITLE
fix(idenity) header buttons on select to have proper size

### DIFF
--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -298,14 +298,16 @@ const PermissionIdentities: FC = () => {
                   <PermissionIdentitiesFilter />
                 </PageHeader.Search>
               )}
-              {!!selectedIdentityIds.length && (
-                <EditIdentityGroupsBtn
-                  identities={selectedIdentities}
-                  className="u-no-margin--bottom"
-                />
-              )}
-              {!!selectedIdentityIds.length && hasAccessManagementTLS && (
-                <BulkDeleteIdentitiesBtn identities={selectedIdentities} />
+              {selectedIdentityIds.length > 0 && (
+                <div>
+                  <EditIdentityGroupsBtn
+                    identities={selectedIdentities}
+                    className="u-no-margin--bottom"
+                  />
+                  {hasAccessManagementTLS && (
+                    <BulkDeleteIdentitiesBtn identities={selectedIdentities} />
+                  )}
+                </div>
               )}
             </PageHeader.Left>
             <PageHeader.BaseActions>


### PR DESCRIPTION
## Done

- fix(idenity) header buttons on select to have proper size

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open permissions > identities, select an identity > observer the button size in the header

## Screenshots

with fix:

<img width="3844" height="1918" alt="image" src="https://github.com/user-attachments/assets/a710ec87-5c3b-47bd-ba56-5b68374ec776" />

before:

<img width="3844" height="1918" alt="image" src="https://github.com/user-attachments/assets/c5580fd9-4c3c-4ced-93fa-77f59ed41e72" />
