### PR TITLE
fix(cluster-links) surface cluster links also on single node servers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,6 +542,12 @@ const App: FC = () => {
           }
         />
         <Route
+          path={`${ROOT_PATH}/ui/server/cluster-links`}
+          element={
+            <ProtectedRoute outlet={<Server activeTab="cluster-links" />} />
+          }
+        />
+        <Route
           path={`${ROOT_PATH}/ui/cluster/groups`}
           element={<ProtectedRoute outlet={<ClusterGroupList />} />}
         />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -86,8 +86,12 @@ const Navigation: FC = () => {
 
   const isSmallScreen = useIsScreenBelow();
   const isAllProjects = projectName === ALL_PROJECTS;
-  const { hasCustomVolumeIso, hasAccessManagement, hasImageRegistries } =
-    useSupportedFeatures();
+  const {
+    hasCustomVolumeIso,
+    hasAccessManagement,
+    hasImageRegistries,
+    hasClusterLinks,
+  } = useSupportedFeatures();
   const { loggedInUserName, loggedInUserID } = useLoggedInUser();
   const [scroll, setScroll] = useState(false);
   const location = useLocation();
@@ -542,16 +546,20 @@ const Navigation: FC = () => {
                                   Groups
                                 </NavLink>
                               </SideNavigationItem>,
-                              <SideNavigationItem key="links">
-                                <NavLink
-                                  to={`${ROOT_PATH}/ui/cluster/links`}
-                                  title="Links"
-                                  onClick={softToggleMenu}
-                                  className="accordion-nav-secondary"
-                                >
-                                  Links
-                                </NavLink>
-                              </SideNavigationItem>,
+                              ...(hasClusterLinks
+                                ? [
+                                    <SideNavigationItem key="links">
+                                      <NavLink
+                                        to={`${ROOT_PATH}/ui/cluster/links`}
+                                        title="Links"
+                                        onClick={softToggleMenu}
+                                        className="accordion-nav-secondary"
+                                      >
+                                        Links
+                                      </NavLink>
+                                    </SideNavigationItem>,
+                                  ]
+                                : []),
                               <SideNavigationItem key="placement">
                                 <NavLink
                                   to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/placement-groups`}

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -58,5 +58,6 @@ export const useSupportedFeatures = () => {
     ),
     hasImageRegistries: apiExtensions.has("image_registries"),
     hasBulkOperations: apiExtensions.has("bulk_operations"),
+    hasClusterLinks: apiExtensions.has("cluster_links"),
   };
 };

--- a/src/pages/cluster/ClusterLinkList.tsx
+++ b/src/pages/cluster/ClusterLinkList.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   List,
   MainTable,
+  Panel,
   Row,
   ScrollableTable,
   Spinner,
@@ -28,7 +29,11 @@ import { useClusterLinks } from "context/useClusterLinks";
 import ClusterLinkAddresses from "pages/cluster/ClusterLinkAddresses";
 import CreateClusterLink from "pages/cluster/CreateClusterLink";
 
-const ClusterLinkList: FC = () => {
+interface Props {
+  variant?: "main" | "panel";
+}
+
+const ClusterLinkList: FC<Props> = ({ variant = "main" }) => {
   const docBaseLink = useDocs();
   const notify = useNotify();
   const panelParams = usePanelParams();
@@ -149,9 +154,11 @@ const ClusterLinkList: FC = () => {
   const isEmptyState = clusterLinks.length === 0 && !isLoading;
   const panelIdentity = getLinkIdentity(panelParams.identity);
 
+  const Element = variant === "main" ? BaseLayout : Panel;
+
   return (
     <>
-      <BaseLayout
+      <Element
         title={
           <HelpLink
             docPath="/explanation/clustering/"
@@ -162,7 +169,7 @@ const ClusterLinkList: FC = () => {
         }
         controls={!isEmptyState && <CreateClusterLinkBtn />}
       >
-        <NotificationRow />
+        {variant === "main" && <NotificationRow />}
         <Row>
           {!isEmptyState && (
             <>
@@ -218,7 +225,7 @@ const ClusterLinkList: FC = () => {
             </EmptyState>
           )}
         </Row>
-      </BaseLayout>
+      </Element>
       <CreateClusterLink />
       {panelParams.panel === panels.editClusterLink && panelIdentity && (
         <EditClusterLinkPanel identity={panelIdentity} />

--- a/src/pages/cluster/Server.tsx
+++ b/src/pages/cluster/Server.tsx
@@ -7,18 +7,26 @@ import TabLinks from "components/TabLinks";
 import EnableClusteringBtn from "pages/cluster/actions/EnableClusteringBtn";
 import DocLink from "components/DocLink";
 import { ROOT_PATH } from "util/rootPath";
+import ClusterLinkList from "pages/cluster/ClusterLinkList";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   activeTab?: string;
 }
 
 const Server: FC<Props> = ({ activeTab }) => {
+  const { hasClusterLinks } = useSupportedFeatures();
+
   const tabs = ["Hardware", "Clustering"];
+
+  if (hasClusterLinks) {
+    tabs.push("Cluster links");
+  }
 
   return (
     <BaseLayout
       title="Server"
-      contentClassName="detail-page cluster-member-details"
+      contentClassName="detail-page cluster-member-details server"
     >
       <NotificationRow />
       <Row>
@@ -42,6 +50,7 @@ const Server: FC<Props> = ({ activeTab }) => {
             <EnableClusteringBtn />
           </EmptyState>
         )}
+        {activeTab === "cluster-links" && <ClusterLinkList variant="panel" />}
       </Row>
     </BaseLayout>
   );

--- a/src/sass/_cluster_list.scss
+++ b/src/sass/_cluster_list.scss
@@ -105,3 +105,13 @@
     padding-left: 1.8rem;
   }
 }
+
+.server {
+  .p-panel__title {
+    display: none;
+  }
+
+  .pagination {
+    margin-right: $sph--x-large;
+  }
+}


### PR DESCRIPTION
## Done

- surface cluster links also on single node servers 

Fixes https://github.com/canonical/lxd-ui/issues/2003

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run this PR against a backend that is not clustered and has latest/edge version of LXD
    - open server page and explore cluster link tab
    - create a cluster link
    - edit a cluster link
    - delete a cluster link
    - re-run PR against a backend that is clustered and has latest/edge version of LXD
    - open clustering > cluster links page
    - create a cluster link
    - edit a cluster link
    - delete a cluster link

## Screenshots

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/c1a272b9-40b5-4362-b939-e3773c9f77e3" />

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/db383a4c-403c-40e8-b576-b2c723e66968" />

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/68685c66-d34f-4841-84bb-06cd214b906c" />

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/c0ac17a3-059d-4b1d-8c35-5bd45c0e0e33" />

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/805c797b-21a8-40fe-be57-3e45d5e6c8cf" />

<img width="3842" height="1918" alt="image" src="https://github.com/user-attachments/assets/c6b4ea58-09f0-4b59-9e08-4ec433aaccf7" />
