### PR TITLE
Load balancer instance

### DIFF
--- a/src/components/InstanceLoadBalancerTable.tsx
+++ b/src/components/InstanceLoadBalancerTable.tsx
@@ -1,0 +1,80 @@
+import type { FC } from "react";
+import { MainTable } from "@canonical/react-components";
+import type { LxdNicDevice } from "types/device";
+import type { LxdInstance } from "types/instance";
+import { useLoadBalancerPools } from "context/useLoadBalancerPools";
+import LoadBalancerPoolChip from "pages/networks/LoadBalancerPoolChip";
+import InstanceLoadBalancerPoolStatus from "pages/instances/InstanceLoadBalancerPoolStatus";
+
+interface Props {
+  device: LxdNicDevice;
+  instance: LxdInstance;
+}
+
+const InstanceLoadBalancerTable: FC<Props> = ({ device, instance }) => {
+  const { data: pools = [] } = useLoadBalancerPools(
+    device.network,
+    instance.project,
+  );
+
+  const poolsReferencingInstance = pools.filter((pool) =>
+    pool.instances.some((item) => item.name === instance.name),
+  );
+
+  if (poolsReferencingInstance.length === 0) {
+    return null;
+  }
+
+  const headers = [
+    {
+      content: "Load balancer pools",
+      className: "u-text--muted u-no-padding--bottom pools-header",
+    },
+    {
+      content: "Status",
+      className: "u-text--muted u-no-padding--bottom status-header",
+    },
+  ];
+
+  const rows = [
+    {
+      key: device.network,
+      columns: [
+        {
+          content: poolsReferencingInstance.map((item) => {
+            return (
+              <div key={item.name}>
+                <LoadBalancerPoolChip
+                  name={item.name}
+                  network={device.network}
+                  project={instance.project}
+                />
+              </div>
+            );
+          }),
+          role: "cell",
+          "aria-label": "Load balancer pool",
+        },
+        {
+          content: poolsReferencingInstance.map((item) => {
+            return (
+              <div key={item.name}>
+                <InstanceLoadBalancerPoolStatus
+                  pool={item}
+                  network={device.network}
+                  instance={instance}
+                />
+              </div>
+            );
+          }),
+          role: "cell",
+          "aria-label": "Instance status in pool",
+        },
+      ],
+    },
+  ];
+
+  return <MainTable headers={headers} rows={rows} />;
+};
+
+export default InstanceLoadBalancerTable;

--- a/src/components/NetworkListTable.tsx
+++ b/src/components/NetworkListTable.tsx
@@ -1,12 +1,14 @@
 import type { FC } from "react";
 import { MainTable, Notification, Spinner } from "@canonical/react-components";
 import { getDeviceAcls, isNicDevice } from "util/devices";
-import { getNetworkAcls } from "util/networks";
+import { getNetworkAcls, typesWithLoadBalancers } from "util/networks";
 import { Link, useParams } from "react-router-dom";
 import type { LxdDevices } from "types/device";
 import { useNetworks } from "context/useNetworks";
 import type { LxdInstance } from "types/instance";
 import NetworkRichChip from "pages/networks/NetworkRichChip";
+import InstanceLoadBalancerTable from "components/InstanceLoadBalancerTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   onFailure: (title: string, e: unknown) => void;
@@ -16,6 +18,7 @@ interface Props {
 
 const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
   const { project } = useParams<{ project: string }>();
+  const { hasLoadBalancerPools } = useSupportedFeatures();
 
   const {
     data: networks = [],
@@ -71,6 +74,10 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
       const deviceAcls = getDeviceAcls(device);
       const networkAcls = getNetworkAcls(network);
       const aclsCount = new Set(deviceAcls.concat(networkAcls)).size;
+      const hasLoadBalancers =
+        !!instance &&
+        hasLoadBalancerPools &&
+        typesWithLoadBalancers.includes(network.type);
 
       return {
         key: network.name,
@@ -106,6 +113,7 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
             content: instance?.config?.[`volatile.${deviceName}.hwaddr`] || "-",
             role: "cell",
             "aria-label": "MAC address",
+            className: "u-hide--small u-hide--medium",
           },
           {
             content:
@@ -116,11 +124,21 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
               ),
             role: "cell",
             "aria-label": "ACLs count",
+            className: "u-hide--small u-hide--medium",
           },
         ],
+        expanded: hasLoadBalancers,
+        expandedContent: hasLoadBalancers && (
+          <div className="instance-load-balancers">
+            <InstanceLoadBalancerTable
+              device={networkDevice}
+              instance={instance}
+            />
+          </div>
+        ),
         sortData: {
           name: network.name.toLowerCase(),
-          type: network.type + network.managed ? "managed" : "unmanaged",
+          type: `${network.type} ${network.managed ? "managed" : "unmanaged"}`,
           interfaceName: deviceName.toLowerCase(),
           macAddress:
             instance?.config?.[`volatile.${deviceName}.hwaddr`] || "-",
@@ -130,34 +148,30 @@ const NetworkListTable: FC<Props> = ({ onFailure, devices, instance }) => {
     })
     .filter((row) => row !== null);
 
-  const getContent = () => {
-    if (isLoading) {
-      return <Spinner className="u-loader" text="Loading networks..." />;
-    }
+  if (isLoading) {
+    return <Spinner className="u-loader" text="Loading networks..." />;
+  }
 
-    if (instanceHasNetworks && !userHasNetworks) {
-      return (
-        <Notification severity="caution" title="Restricted permissions">
-          You do not have permission to view network details.
-        </Notification>
-      );
-    }
-
-    if (!instanceHasNetworks) {
-      return <>-</>;
-    }
-
+  if (instanceHasNetworks && !userHasNetworks) {
     return (
-      <MainTable
-        headers={networksHeaders}
-        rows={networksRows}
-        sortable
-        className={"network-table"}
-      />
+      <Notification severity="caution" title="Restricted permissions">
+        You do not have permission to view network details.
+      </Notification>
     );
-  };
+  }
 
-  return getContent();
+  if (!instanceHasNetworks) {
+    return <>-</>;
+  }
+
+  return (
+    <MainTable
+      headers={networksHeaders}
+      rows={networksRows}
+      sortable
+      expanding
+    />
+  );
 };
 
 export default NetworkListTable;

--- a/src/pages/instances/InstanceLoadBalancerPoolStatus.tsx
+++ b/src/pages/instances/InstanceLoadBalancerPoolStatus.tsx
@@ -1,0 +1,31 @@
+import type { FC } from "react";
+import type { LxdInstance } from "types/instance";
+import { useLoadBalancerPoolState } from "context/useLoadBalancerPools";
+import type { LxdLoadBalancerPool } from "types/loadBalancers";
+import LoadBalancerPoolInstanceStatus from "pages/networks/LoadBalancerPoolInstanceStatus";
+
+interface Props {
+  instance: LxdInstance;
+  pool: LxdLoadBalancerPool;
+  network: string;
+}
+
+const InstanceLoadBalancerPoolStatus: FC<Props> = ({
+  instance,
+  pool,
+  network,
+}) => {
+  const { data: poolStatuses } = useLoadBalancerPoolState(
+    network,
+    instance.project,
+    pool.name,
+  );
+
+  const poolStatus = poolStatuses?.targets?.find(
+    (target) => target.name === instance.name,
+  );
+
+  return <LoadBalancerPoolInstanceStatus status={poolStatus?.status} />;
+};
+
+export default InstanceLoadBalancerPoolStatus;

--- a/src/sass/_instance_detail_overview.scss
+++ b/src/sass/_instance_detail_overview.scss
@@ -81,4 +81,35 @@
   .resource-label {
     max-width: 100%; // allow base image to take full width
   }
+
+  .instance-load-balancers {
+    margin-left: 40%;
+    margin-top: -0.5rem;
+    width: 21rem;
+
+    @include mobile-and-tablet {
+      margin-left: 33%;
+      width: auto;
+
+      .status-header {
+        padding-left: 1rem !important;
+      }
+    }
+
+    tr {
+      border-bottom: 0;
+    }
+
+    .pools-header {
+      min-width: 10rem;
+    }
+
+    .status-header {
+      padding-left: 2.1rem;
+    }
+  }
+
+  .p-table__expanding-panel:has(.instance-load-balancers:empty) {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Done

- show load balancers on instance overview
- adjust load balancer create/edit form. remove highlight for target pool, rely on border to indicate column groups instead.

Fixes WD-36745

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a LXD container with lxd and microovn as backend
      - Create a LXD container with ubuntu 26.04, in it run:
      - sudo snap install lxd --channel=latest/edge
      - replace lxd with debug files build from this upstream branch https://github.com/canonical/lxd/pull/18179
        - lxc file push /home/david.edler@canonical.com/go/bin/lxd load-balancers/var/snap/lxd/common/lxd.debug --project=latest-lxd
        - lxc file push /home/david.edler@canonical.com/go/bin/lxc load-balancers/var/snap/lxd/common/lxc.debug --project=latest-lxd
        - reboot the container
      - sudo snap install microovn --channel=latest/edge
      - microovn init (create a new cluster)
      - lxd init (let it listen on the network)
      - set lxd config to `network.ovn.northbound_connection: ssl:127.0.0.1:6641`
    - connect the ui from this branch to the container as a backend
    - In the ui configure the lxdbr0 created by lxd init above to have:
      - IPv4 DHCP ranges: With about 20 ips, such as 10.115.100.170-10.115.100.190, needs to match the network mask
      - IPv4 OVN ranges: With about 50 ips, such as 10.115.100.100-10.115.100.150, needs to match the network mask
      - IPV4 routes: Set to a valid CIDR, such as 10.115.100.208/28
    - in the ui create an ovn network
      - use lxdbr0 as an uplink, other settings default
    - in the ui visit ovn network detail page
    - in the ui create an instance
    - in the ui go to load balancers
    - in the ui create a load balancer pool, add the instance to the pool
    - visit the instance detail page and see the network section with load balancer pool in it.

## Screenshots

<img width="2754" height="1494" alt="image" src="https://github.com/user-attachments/assets/2ea9d2c5-5b2f-4b78-a761-805ae1d2c7e3" />