### PR TITLE
chore(CI): fix playwright install browsers

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -101,7 +101,7 @@ jobs:
           curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
 
           yarn test-e2e-cluster-coverage
-          
+
           # combine coverage reports
           yarn test-report-coverage
           zip -r coverage/playwright-report/cobertura-coverage.zip coverage/playwright-report/cobertura-coverage.xml
@@ -151,7 +151,7 @@ jobs:
           run: |
             git add .
             git commit -m "workflow: update coverage report"
-            
+
             # In case of another action job pushing to gh-pages while we are rebasing for the current job
             while true; do
               git pull --rebase
@@ -159,7 +159,7 @@ jobs:
                 echo "Failed to rebase. Please review manually."
                 exit 1
               fi
-  
+
               git push
               if [ $? -eq 0 ]; then
                 echo "Successfully pushed HTML report to repo."

--- a/.github/workflows/screenshot_automation.yaml
+++ b/.github/workflows/screenshot_automation.yaml
@@ -92,7 +92,7 @@ jobs:
         run: |
           npx playwright test --project screenshots
           npx playwright test --project screenshots-clustered
-      
+
       - name: List screenshots
         run: ls -R tests/screenshots || echo "No screenshots found"
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.28.5",
     "@canonical/typescript-config-react": "0.27.0",
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.60.0",
     "@types/convert-source-map": "2.0.3",
     "@types/dotenv": "8.2.3",
     "@types/js-yaml": "4.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,12 +1123,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@1.58.2":
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
-  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+"@playwright/test@1.60.0":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
+  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
   dependencies:
-    playwright "1.58.2"
+    playwright "1.60.0"
 
 "@rolldown/pluginutils@1.0.0-beta.53":
   version "1.0.0-beta.53"
@@ -4904,17 +4904,17 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
-  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
 
-playwright@1.58.2:
-  version "1.58.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
-  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+playwright@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
   dependencies:
-    playwright-core "1.58.2"
+    playwright-core "1.60.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Done

- Fix CI: CI was blocked at the step `Install Playwright browsers`, this step successfully downloaded the binaries but then got stuck at extraction time. All the tests would then time out after 6 hours and be automatically canceled.

Explanation by Gemini: The underlying culprit was a version incompatibility between Node.js 24 and the upstream file stream extraction utilities utilized internally by Playwright (specifically yauzl). When executing on the modern Ubuntu 24.04 kernel layout under Node 24, the extraction worker thread would enter an unhandled infinite synchronization loop rather than flushing the unzipped binary assets to disk.

As suggested by @edlerd, I upgraded Playwright.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Trust CI passing

## Screenshots

<img width="1037" height="574" alt="image" src="https://github.com/user-attachments/assets/f5a12b6d-f609-4d28-ad59-a350a0fc50b9" />
