### PR TITLE
feat(replicators): Run modal

### DIFF
--- a/src/Events.tsx
+++ b/src/Events.tsx
@@ -134,6 +134,20 @@ const Events: FC = () => {
     }
   };
 
+  const updateReplicators = (event: LxdEvent) => {
+    const isReplicatorOperation =
+      event.type === "operation" &&
+      event.metadata.description.toLowerCase().includes("replicator");
+
+    if (!isReplicatorOperation) {
+      return;
+    }
+
+    queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[2] === queryKeys.replicators,
+    });
+  };
+
   const reEvaluateOperations = () => {
     operations.forEach((operation) => {
       handleEvent(operation.id, operation.status, operation.err, operation);
@@ -206,6 +220,7 @@ const Events: FC = () => {
           });
         }
         updateClusterMemberLoading(event);
+        updateReplicators(event);
         // ensure open requests that reply with an operation and register
         // new handlers in the eventQueue are closed before handling the event
         setTimeout(() => {

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import Navigation from "components/Navigation";
 import { Application, SkipLink } from "@canonical/react-components";
-import Events from "pages/instances/Events";
+import Events from "./Events";
 import App from "./App";
 import ErrorBoundary from "components/ErrorBoundary";
 import ErrorPage from "components/ErrorPage";

--- a/src/api/replicators.tsx
+++ b/src/api/replicators.tsx
@@ -1,6 +1,7 @@
 import { handleResponse } from "util/helpers";
 import type { LxdReplicator } from "types/replicator";
 import type { LxdApiResponse } from "types/apiResponse";
+import type { LxdOperationResponse } from "types/operation";
 import { addEntitlements } from "util/entitlements/api";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -100,4 +101,25 @@ export const updateReplicator = async (
       body: body,
     },
   ).then(handleResponse);
+};
+
+export const runReplicator = async (
+  name: string,
+  project: string,
+  action: "restore" | "start",
+): Promise<LxdOperationResponse> => {
+  return fetch(
+    `${ROOT_PATH}/1.0/replicators/${encodeURIComponent(name)}/state?project=${encodeURIComponent(project)}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ action }),
+    },
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/components/ConfirmationCheckbox.tsx
+++ b/src/components/ConfirmationCheckbox.tsx
@@ -4,9 +4,10 @@ import { CheckboxInput } from "@canonical/react-components";
 interface Props {
   label: string;
   confirmed: [boolean, Dispatch<SetStateAction<boolean>>];
+  disabled?: boolean;
 }
 
-const ConfirmationCheckbox: FC<Props> = ({ label, confirmed }) => {
+const ConfirmationCheckbox: FC<Props> = ({ label, confirmed, disabled }) => {
   const [isConfirmed, setConfirmed] = confirmed;
 
   return (
@@ -20,6 +21,7 @@ const ConfirmationCheckbox: FC<Props> = ({ label, confirmed }) => {
         onChange={() => {
           setConfirmed((prev) => !prev);
         }}
+        disabled={disabled}
       />
     </span>
   );

--- a/src/context/appProviders.tsx
+++ b/src/context/appProviders.tsx
@@ -11,6 +11,7 @@ import { EventQueueProvider } from "context/eventQueue";
 import { InstanceLoadingProvider } from "context/instanceLoading";
 import { ProjectProvider } from "context/useCurrentProject";
 import OperationsProvider from "context/operationsProvider";
+import { ReplicatorRunningProvider } from "context/replicatorLoading";
 import { MetricHistoryProvider } from "context/metricHistory";
 import { MemberLoadingProvider } from "context/memberLoading";
 import { ModalProvider } from "context/useModal";
@@ -59,7 +60,9 @@ const AppProviders: FC<AppProvidersProps> = ({ children }) => {
                         pathname={pathname}
                       >
                         <MetricHistoryProvider>
-                          {children}
+                          <ReplicatorRunningProvider>
+                            {children}
+                          </ReplicatorRunningProvider>
                         </MetricHistoryProvider>
                       </NotificationProvider>
                     </ToastNotificationProvider>

--- a/src/context/replicatorLoading.tsx
+++ b/src/context/replicatorLoading.tsx
@@ -1,0 +1,201 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  type FC,
+  type ReactNode,
+} from "react";
+import { useOperations } from "context/operationsProvider";
+import type { LxdOperation } from "types/operation";
+import type { LxdReplicator, LxdReplicatorStatus } from "types/replicator";
+import { getOperationEntityUrls } from "util/operations";
+
+interface ReplicatorLoadingType {
+  getStatus: (replicator: LxdReplicator) => LxdReplicatorStatus;
+  getLastRunError: (replicator: LxdReplicator) => string | undefined;
+  setRunning: (replicator: LxdReplicator) => void;
+  setFinish: (replicator: LxdReplicator) => void;
+  setLastRunError: (replicator: LxdReplicator, error: string) => void;
+  clearLastRunError: (replicator: LxdReplicator) => void;
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+const ReplicatorRunningContext = createContext<ReplicatorLoadingType>({
+  getStatus: (replicator: LxdReplicator) => replicator.last_run_status,
+  getLastRunError: () => undefined,
+  setRunning: () => undefined,
+  setFinish: () => undefined,
+  setLastRunError: () => undefined,
+  clearLastRunError: () => undefined,
+});
+
+const getReplicatorKey = ({
+  name,
+  project,
+}: Pick<LxdReplicator, "name" | "project">) => `${project}/${name}`;
+
+const parseReplicatorKeyFromUrl = (url: string): string | null => {
+  try {
+    const parsed = new URL(url, "http://localhost");
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+    const replicatorIndex = pathParts.indexOf("replicators");
+
+    if (replicatorIndex === -1 || !pathParts[replicatorIndex + 1]) {
+      return null;
+    }
+
+    const name = decodeURIComponent(pathParts[replicatorIndex + 1]);
+    const project = decodeURIComponent(
+      parsed.searchParams.get("project") || "default",
+    );
+
+    return getReplicatorKey({ name, project });
+  } catch {
+    return null;
+  }
+};
+
+const getOperationReplicatorKeys = (operation: LxdOperation): string[] => {
+  return getOperationEntityUrls(operation, [])
+    .map(parseReplicatorKeyFromUrl)
+    .filter((key): key is string => Boolean(key));
+};
+
+const isRunningReplicatorOperation = (operation: LxdOperation): boolean => {
+  return operation.description === "Running replicator";
+};
+
+const isFailedReplicatorOperation = (operation: LxdOperation): boolean => {
+  return (
+    operation.description === "Running replicator" &&
+    operation.status === "Failure"
+  );
+};
+
+const getOperationTimestamp = (operation: LxdOperation): number => {
+  const timestamp = Date.parse(
+    operation.updated_at || operation.created_at || "",
+  );
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+export const ReplicatorRunningProvider: FC<Props> = ({ children }) => {
+  const { runningOperations, operations } = useOperations();
+  const [manualRunningKeys, setManualRunningKeys] = useState(new Set<string>());
+  const [manualLastRunErrors, setManualLastRunErrors] = useState(
+    new Map<string, string>(),
+  );
+
+  const setRunning = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualRunningKeys((prev) => {
+      if (prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  };
+
+  const setFinish = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualRunningKeys((prev) => {
+      if (!prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  };
+
+  const setLastRunError = (replicator: LxdReplicator, error: string) => {
+    const key = getReplicatorKey(replicator);
+    setManualLastRunErrors((prev) => {
+      const next = new Map(prev);
+      next.set(key, error);
+      return next;
+    });
+  };
+
+  const clearLastRunError = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualLastRunErrors((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+  };
+
+  const getStatus = (replicator: LxdReplicator): LxdReplicatorStatus => {
+    const key = getReplicatorKey(replicator);
+    const hasRunningOperation = runningOperations
+      .filter(
+        (operation) =>
+          isRunningReplicatorOperation(operation) &&
+          operation.status === "Running",
+      )
+      .some((operation) => getOperationReplicatorKeys(operation).includes(key));
+
+    if (manualRunningKeys.has(key) || hasRunningOperation) {
+      return "Running";
+    }
+
+    return replicator.last_run_status;
+  };
+
+  const getLastRunError = (replicator: LxdReplicator): string | undefined => {
+    if (getStatus(replicator) !== "Failed") {
+      return undefined;
+    }
+
+    const key = getReplicatorKey(replicator);
+    let latestOperationError: string | undefined;
+    let latestOperationTimestamp = -1;
+
+    for (const operation of operations) {
+      if (
+        !isFailedReplicatorOperation(operation) ||
+        !operation.err ||
+        !getOperationReplicatorKeys(operation).includes(key)
+      ) {
+        continue;
+      }
+
+      const timestamp = getOperationTimestamp(operation);
+      if (timestamp >= latestOperationTimestamp) {
+        latestOperationTimestamp = timestamp;
+        latestOperationError = operation.err;
+      }
+    }
+
+    return (
+      replicator.last_run_error ||
+      latestOperationError ||
+      manualLastRunErrors.get(key)
+    );
+  };
+
+  return (
+    <ReplicatorRunningContext.Provider
+      value={{
+        getStatus,
+        getLastRunError,
+        setRunning,
+        setFinish,
+        setLastRunError,
+        clearLastRunError,
+      }}
+    >
+      {children}
+    </ReplicatorRunningContext.Provider>
+  );
+};
+
+export const useReplicatorLoading = (): ReplicatorLoadingType => {
+  return useContext(ReplicatorRunningContext);
+};

--- a/src/pages/cluster/ReplicatorDetail.tsx
+++ b/src/pages/cluster/ReplicatorDetail.tsx
@@ -1,18 +1,19 @@
-import type { FC } from "react";
+import { type FC } from "react";
 import { useParams } from "react-router-dom";
 import { Col, CustomLayout, Row, Spinner } from "@canonical/react-components";
 import NotFound from "components/NotFound";
 import NotificationRow from "components/NotificationRow";
 import { useClusterLink } from "context/useClusterLinks";
+import { useReplicatorLoading } from "context/replicatorLoading";
 import { useReplicator } from "context/useReplicators";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
 import ClusterLinkStatus from "pages/cluster/ClusterLinkStatus";
 import ReplicatorDetailHeader from "pages/cluster/ReplicatorDetailHeader";
 import ReplicatorRunTime from "pages/cluster/ReplicatorRunTime";
 import ReplicatorStatus from "pages/cluster/ReplicatorStatus";
+import EditReplicatorPanel from "pages/cluster/panels/EditReplicatorPanel";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
-import ClusterLinkRichChip from "./ClusterLinkRichChip";
 import usePanelParams, { panels } from "util/usePanelParams";
-import { EditReplicatorPanel } from "./panels/EditReplicatorPanel";
 
 const ReplicatorDetail: FC = () => {
   const { project, name } = useParams<{
@@ -31,9 +32,14 @@ const ReplicatorDetail: FC = () => {
     error,
     isLoading,
   } = useReplicator(name, project || "default");
+  const replicatorRunning = useReplicatorLoading();
   const { data: clusterLink } = useClusterLink(
     replicator?.config?.cluster || "",
   );
+
+  const lastRunError = replicator
+    ? replicatorRunning.getLastRunError(replicator)
+    : undefined;
 
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading..." isMainComponent />;
@@ -142,6 +148,10 @@ const ReplicatorDetail: FC = () => {
                     <td className="status-cell">
                       <ReplicatorStatus replicator={replicator} />
                     </td>
+                  </tr>
+                  <tr>
+                    <th className="u-text--muted">Last error</th>
+                    <td>{lastRunError ?? "-"}</td>
                   </tr>
                 </tbody>
               </table>

--- a/src/pages/cluster/ReplicatorList.tsx
+++ b/src/pages/cluster/ReplicatorList.tsx
@@ -21,15 +21,15 @@ import { CreateReplicatorButton } from "pages/cluster/actions/CreateReplicatorBt
 import ReplicatorRunTime from "pages/cluster/ReplicatorRunTime";
 import ReplicatorStatus from "pages/cluster/ReplicatorStatus";
 import { useDocs } from "context/useDocs";
-import ProjectRichChip from "pages/projects/ProjectRichChip";
-import { ROOT_PATH } from "util/rootPath";
-import ClusterLinkRichChip from "./ClusterLinkRichChip";
-import { CreateReplicatorPanel } from "./panels/CreateReplicatorPanel";
-import usePanelParams, { panels } from "util/usePanelParams";
-import { EditReplicatorPanel } from "./panels/EditReplicatorPanel";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
 import DeleteReplicatorBtn from "pages/cluster/actions/DeleteReplicatorBtn";
 import EditReplicatorBtn from "pages/cluster/actions/EditReplicatorBtn";
 import RunReplicatorBtn from "pages/cluster/actions/RunReplicatorBtn";
+import CreateReplicatorPanel from "pages/cluster/panels/CreateReplicatorPanel";
+import EditReplicatorPanel from "pages/cluster/panels/EditReplicatorPanel";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
+import { ROOT_PATH } from "util/rootPath";
+import usePanelParams, { panels } from "util/usePanelParams";
 
 interface Props {
   variant?: "main" | "panel";

--- a/src/pages/cluster/ReplicatorStatus.tsx
+++ b/src/pages/cluster/ReplicatorStatus.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Icon } from "@canonical/react-components";
+import { useReplicatorLoading } from "context/replicatorLoading";
 import type { LxdReplicator, LxdReplicatorStatus } from "types/replicator";
 
 interface Props {
@@ -14,7 +15,8 @@ const STATUS_ICONS: Record<LxdReplicatorStatus, string> = {
 };
 
 const ReplicatorStatus: FC<Props> = ({ replicator }) => {
-  const status = replicator.last_run_status;
+  const replicatorLoading = useReplicatorLoading();
+  const status = replicatorLoading.getStatus(replicator);
   const iconName = STATUS_ICONS[status] ?? "";
 
   return (

--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -1,7 +1,27 @@
-import type { FC } from "react";
-import { Button, Icon } from "@canonical/react-components";
+import { useState, type FC } from "react";
+import {
+  ConfirmationButton,
+  Icon,
+  Notification,
+  useNotify,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import { runReplicator } from "api/replicators";
 import classnames from "classnames";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
+import ResourceLink from "components/ResourceLink";
+import { useReplicatorLoading } from "context/replicatorLoading";
+import { useProject } from "context/useProjects";
+import { useEventQueue } from "context/eventQueue";
+import RunReplicatorPreflightChecks from "pages/cluster/actions/RunReplicatorPreflightChecks";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { LxdReplicator } from "types/replicator";
+import { useReplicatorEntitlements } from "util/entitlements/replicators";
+import { isProjectReplicaModeStandby } from "util/projects";
+import { queryKeys } from "util/queryKeys";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   replicator: LxdReplicator;
@@ -13,31 +33,220 @@ interface Props {
 const RunReplicatorBtn: FC<Props> = ({
   replicator,
   className,
-  onClose,
   hasLabel = false,
+  onClose,
 }) => {
-  return (
-    <Button
-      appearance={hasLabel ? "default" : "base"}
-      aria-label="Run replicator"
-      className={classnames(
-        "u-no-margin--bottom has-icon",
-        {
-          "is-dense": !hasLabel,
-        },
-        className,
-      )}
-      onClick={() => {
-        console.log(
-          `Run replicator ${replicator.name} btn clicked. TODO: open modal`,
-          onClose,
+  const queryClient = useQueryClient();
+  const eventQueue = useEventQueue();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const replicatorLoading = useReplicatorLoading();
+  const [isLoading, setLoading] = useState(false);
+  const [canSubmit, setCanSubmit] = useState(false);
+  const { canEditReplicator } = useReplicatorEntitlements();
+  const { data: project, isLoading: isProjectLoading } = useProject(
+    replicator.project,
+  );
+  const [isOverwriteConfirmed, setIsOverwriteConfirmed] = useState(false);
+
+  const clusterLink = replicator.config.cluster;
+  const isRestore = isProjectReplicaModeStandby(project);
+  const buttonLabel = isRestore ? "Restore" : "Run";
+  const hasPermission = canEditReplicator(replicator);
+
+  const disabledReason = () => {
+    if (!hasPermission) {
+      return "You do not have permission to run this replicator";
+    }
+    if (isLoading) {
+      return "Replicator is starting...";
+    }
+    if (replicatorLoading.getStatus(replicator) === "Running") {
+      return "This replicator is currently running";
+    }
+    return undefined;
+  };
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[2] === queryKeys.replicators,
+    });
+  };
+
+  const onReplicationStarted = () => {
+    setLoading(false);
+    replicatorLoading.clearLastRunError(replicator);
+    replicatorLoading.setRunning(replicator);
+    invalidateCache();
+
+    toastNotify.info(
+      <>
+        Replicator{" "}
+        <ResourceLink
+          type="replicator"
+          value={replicator.name}
+          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+        />{" "}
+        started.
+      </>,
+    );
+  };
+
+  const onReplicatorStartFailure = (e: unknown) => {
+    setLoading(false);
+    replicatorLoading.setFinish(replicator);
+    invalidateCache();
+    notify.failure(`Running replicator ${replicator.name} failed`, e);
+  };
+
+  const onOperationSuccess = () => {
+    replicatorLoading.setFinish(replicator);
+    replicatorLoading.clearLastRunError(replicator);
+    toastNotify.success(
+      <>
+        Replicator{" "}
+        <ResourceLink
+          type="replicator"
+          value={replicator.name}
+          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+        />{" "}
+        completed successfully.
+      </>,
+    );
+    invalidateCache();
+  };
+
+  const onOperationFailure = (msg: string) => {
+    replicatorLoading.setFinish(replicator);
+    replicatorLoading.setLastRunError(replicator, msg);
+    invalidateCache();
+    toastNotify.failure(
+      `Replicator${replicator.name} failed while running`,
+      new Error(msg),
+    );
+  };
+
+  const handleRun = () => {
+    setLoading(true);
+    runReplicator(
+      replicator.name,
+      replicator.project,
+      isRestore ? "restore" : "start",
+    )
+      .then((response) => {
+        onReplicationStarted();
+        eventQueue.set(
+          response.metadata.id,
+          onOperationSuccess,
+          onOperationFailure,
+          invalidateCache,
         );
+      })
+      .catch(onReplicatorStartFailure);
+  };
+
+  return (
+    <ConfirmationButton
+      onHoverText={disabledReason()}
+      appearance={hasLabel ? "default" : "base"}
+      className={classnames("u-no-margin has-icon", className, {
+        "is-dense": !hasLabel,
+      })}
+      loading={isLoading || isProjectLoading}
+      confirmationModalProps={{
+        className: "run-replicator-modal",
+        title: (
+          <>
+            {isRestore ? "Restore" : "Run"} replicator{" "}
+            <ResourceLink
+              type="replicator"
+              value={replicator.name}
+              to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+            />
+          </>
+        ),
+        children: (
+          <>
+            <RunReplicatorPreflightChecks
+              replicator={replicator}
+              onValidationChange={(isValid) => {
+                setCanSubmit(isValid);
+              }}
+              isRestore={isRestore}
+            />
+
+            <div
+              className={classnames("replicator-data-flow u-hide--small", {
+                "replicator-data-flow--restore": isRestore,
+              })}
+            >
+              <div className="replicator-data-flow__node replicator-data-flow__source">
+                <span className="node-heading u-text--muted">
+                  {isRestore ? "standby" : "leader"} project (local)
+                </span>
+                <ProjectRichChip projectName={replicator.project} />
+              </div>
+              <div className="replicator-data-flow__arrow-shaft">
+                <ClusterLinkRichChip clusterLink={clusterLink} />
+              </div>
+              <div className="replicator-data-flow__node replicator-data-flow__target">
+                <span className="node-heading u-text--muted">
+                  {isRestore ? "leader" : "standby"} project (remote)
+                </span>
+                <strong className="mono-font">{replicator.project}</strong>
+              </div>
+            </div>
+
+            {isRestore ? (
+              <p>
+                This will sync all instances from the{" "}
+                <ClusterLinkRichChip clusterLink={clusterLink} /> cluster back
+                to the <ProjectRichChip projectName={replicator.project} />{" "}
+                project.
+              </p>
+            ) : (
+              <p>
+                This will sync all instances from the source project{" "}
+                <ProjectRichChip projectName={replicator.project} /> to the
+                standby cluster{" "}
+                <ClusterLinkRichChip clusterLink={clusterLink} />.
+              </p>
+            )}
+
+            {isRestore && (
+              <Notification
+                severity="caution"
+                messageElement="div"
+                title="All local data will be overwritten by the remote version"
+              >
+                <p>
+                  All current instances in local project{" "}
+                  <ProjectRichChip projectName={replicator.project} /> will be
+                  permanently replaced by the version fetched from the remote
+                  cluster. This cannot be undone.
+                </p>
+              </Notification>
+            )}
+          </>
+        ),
+        onConfirm: handleRun,
+        confirmButtonLabel: buttonLabel,
+        confirmButtonDisabled:
+          !canSubmit || isLoading || (isRestore && !isOverwriteConfirmed),
+        close: onClose,
+        confirmExtra: isRestore ? (
+          <ConfirmationCheckbox
+            label="Overwrite local data"
+            confirmed={[isOverwriteConfirmed, setIsOverwriteConfirmed]}
+            disabled={!canSubmit || isLoading}
+          />
+        ) : undefined,
       }}
-      title="Run replicator"
+      disabled={Boolean(disabledReason())}
     >
       <Icon name="play" />
-      {hasLabel && <span>Run</span>}
-    </Button>
+      {hasLabel && <span>{buttonLabel}</span>}
+    </ConfirmationButton>
   );
 };
 

--- a/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
@@ -1,0 +1,53 @@
+import type { FC, ReactNode } from "react";
+import { Icon, Spinner } from "@canonical/react-components";
+import classnames from "classnames";
+
+export interface PreflightCheck {
+  id: string;
+  label: ReactNode;
+  status: "pass" | "fail" | "loading";
+  message?: ReactNode;
+}
+
+interface RunReplicatorPreflightCheckRowProps {
+  check: PreflightCheck;
+}
+
+const RunReplicatorPreflightCheckRow: FC<
+  RunReplicatorPreflightCheckRowProps
+> = ({ check }) => {
+  const getIcon = () => {
+    if (check.status === "loading") {
+      return <Spinner className="u-no-padding--top" />;
+    }
+    if (check.status === "pass") {
+      return <Icon name="success" />;
+    }
+    if (check.status === "fail") {
+      return <Icon name="error" />;
+    }
+    return null;
+  };
+
+  return (
+    <div className="preflight-check-row">
+      <div className="u-flex u-gap--small">
+        {getIcon()}
+        <p
+          className={classnames("u-no-padding--top", "u-no-margin--bottom", {
+            "u-text--muted": check.status === "loading",
+          })}
+        >
+          {check.label}
+        </p>
+      </div>
+      {check.message && check.status === "fail" && (
+        <p className="preflight-check-row-error-message u-text--muted u-no-padding--top u-no-margin--bottom">
+          {check.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default RunReplicatorPreflightCheckRow;

--- a/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
@@ -1,0 +1,177 @@
+import { useEffect, type FC } from "react";
+import { Link } from "react-router";
+import { List } from "@canonical/react-components";
+import { useClusterLinkState } from "context/useClusterLinks";
+import { useIdentities } from "context/useIdentities";
+import { useInstances } from "context/useInstances";
+import { useProject } from "context/useProjects";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import RunReplicatorPreflightCheckRow, {
+  type PreflightCheck,
+} from "pages/cluster/actions/RunReplicatorPreflightCheckRow";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
+import type { LxdReplicator } from "types/replicator";
+import { getClusterLinksStatus, getLinkIdentity } from "util/clusterLink";
+import { pluralize } from "util/helpers";
+
+interface Props {
+  replicator: LxdReplicator;
+  onValidationChange: (isValid: boolean) => void;
+  isRestore?: boolean;
+}
+
+const RunReplicatorPreflightChecks: FC<Props> = ({
+  replicator,
+  onValidationChange,
+  isRestore = false,
+}) => {
+  const { data: project, isLoading: isProjectLoading } = useProject(
+    replicator.project,
+  );
+  const { data: instances, isLoading: isInstancesLoading } = useInstances(
+    replicator.project,
+  );
+  const { data: identities = [] } = useIdentities();
+  const { data: clusterLinkState, isLoading: isClusterLinkStateLoading } =
+    useClusterLinkState(replicator.config?.cluster || "");
+  const identity = getLinkIdentity(identities, replicator.config?.cluster);
+
+  const checks: PreflightCheck[] = [];
+
+  const projectMode = project?.config?.["replica.mode"];
+  const projectModeValid =
+    projectMode === "leader" || projectMode === "standby";
+  checks.push({
+    id: "project-mode",
+    label: projectMode ? (
+      <>
+        Project <ProjectRichChip projectName={replicator.project} /> is in{" "}
+        <strong>{projectMode}</strong> mode
+      </>
+    ) : (
+      <>
+        Project <ProjectRichChip projectName={replicator.project} />{" "}
+        <strong>replica mode</strong> is unset
+      </>
+    ),
+    status: isProjectLoading ? "loading" : projectModeValid ? "pass" : "fail",
+    message:
+      !isProjectLoading && !projectModeValid ? (
+        <>
+          {projectMode ? (
+            <>
+              The project replica mode <strong>{projectMode}</strong> is
+              invalid.
+            </>
+          ) : null}{" "}
+          It must be either <strong>leader</strong> or <strong>standby</strong>{" "}
+          to run replicator.{" "}
+          <Link
+            to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration`}
+          >
+            See project configuration
+          </Link>
+        </>
+      ) : undefined,
+  });
+
+  const projectCluster = project?.config?.["replica.cluster"];
+  const replicatorCluster = replicator.config?.cluster;
+  const clusterMatches = projectCluster === replicatorCluster;
+  checks.push({
+    id: "replica-cluster-match",
+    label: (
+      <>
+        Project <ProjectRichChip projectName={project?.name || "default"} />{" "}
+        <strong>replica cluster</strong> configuration matches replicator
+        cluster
+      </>
+    ),
+    status: isProjectLoading ? "loading" : clusterMatches ? "pass" : "fail",
+    message:
+      !isProjectLoading && !clusterMatches ? (
+        <>
+          Project replica cluster <strong>{projectCluster || "none"}</strong>{" "}
+          does not equal replicator cluster{" "}
+          <strong>{replicatorCluster || "none"}</strong>.{" "}
+          <Link
+            to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration`}
+          >
+            See project configuration
+          </Link>
+        </>
+      ) : undefined,
+  });
+
+  const clusterLinkStatus = getClusterLinksStatus(identity, clusterLinkState);
+  const isReachable = clusterLinkStatus === "Reachable";
+
+  checks.push({
+    id: "cluster-link-reachable",
+    label: (
+      <>
+        Cluster link{" "}
+        <ClusterLinkRichChip clusterLink={replicator.config?.cluster} /> is
+        reachable
+      </>
+    ),
+    status: isClusterLinkStateLoading
+      ? "loading"
+      : isReachable
+        ? "pass"
+        : "fail",
+    message:
+      !isClusterLinkStateLoading && !isReachable
+        ? `Cluster link status is '${clusterLinkStatus}' but must be 'Reachable' to run replicator. Ensure both clusters are online, can reach each other over the network, and the link is configured bi-directionally.`
+        : undefined,
+  });
+
+  if (isRestore) {
+    const runningInstances =
+      instances?.filter(
+        (inst) =>
+          inst.project === replicator.project && inst.status === "Running",
+      ) || [];
+    const allInstancesStopped = runningInstances.length === 0;
+
+    checks.push({
+      id: "instances-stopped",
+      label: (
+        <>
+          All instances in the project{" "}
+          <ProjectRichChip projectName={replicator.project} /> are stopped
+        </>
+      ),
+      status: isInstancesLoading
+        ? "loading"
+        : allInstancesStopped
+          ? "pass"
+          : "fail",
+      message:
+        !isInstancesLoading && !allInstancesStopped
+          ? `${runningInstances.length} running ${pluralize(
+              "instance",
+              runningInstances.length,
+            )} in the project. Stop ${runningInstances.length > 1 ? "them" : "it"} to allow restore.`
+          : undefined,
+    });
+  }
+
+  const allChecksPassed = checks.every((check) => check.status === "pass");
+  const isAnyCheckLoading = checks.some((check) => check.status === "loading");
+
+  useEffect(() => {
+    onValidationChange(allChecksPassed && !isAnyCheckLoading);
+  }, [allChecksPassed, isAnyCheckLoading, onValidationChange]);
+
+  return (
+    <List
+      items={checks.map((check) => (
+        <RunReplicatorPreflightCheckRow key={check.id} check={check} />
+      ))}
+      className="u-no-margin--bottom"
+    ></List>
+  );
+};
+
+export default RunReplicatorPreflightChecks;

--- a/src/pages/cluster/panels/CreateReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/CreateReplicatorPanel.tsx
@@ -29,7 +29,7 @@ import {
 } from "util/clusterLink";
 import { Link } from "react-router-dom";
 
-export const CreateReplicatorPanel: FC = () => {
+const CreateReplicatorPanel: FC = () => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -237,3 +237,5 @@ export const CreateReplicatorPanel: FC = () => {
     </>
   );
 };
+
+export default CreateReplicatorPanel;

--- a/src/pages/cluster/panels/EditReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/EditReplicatorPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from "util/clusterLink";
 import { useProject } from "context/useProjects";
 
-export const EditReplicatorPanel: FC = () => {
+const EditReplicatorPanel: FC = () => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -162,3 +162,5 @@ export const EditReplicatorPanel: FC = () => {
     </>
   );
 };
+
+export default EditReplicatorPanel;

--- a/src/sass/_replicators.scss
+++ b/src/sass/_replicators.scss
@@ -12,7 +12,7 @@
   }
 
   .actions {
-    width: 8rem;
+    width: calc(3 * (16px + 2rem) + 2px);
   }
 }
 
@@ -23,5 +23,110 @@
 
   td:not(.status-cell) {
     padding-left: 1.8rem;
+  }
+}
+
+.run-replicator-modal {
+  .preflight-check-row {
+    &-error-message {
+      margin-left: calc(16px + 0.5rem);
+    }
+  }
+
+  .replicator-data-flow {
+    align-items: stretch;
+    background-color: transparent;
+    display: flex;
+    gap: $sph--x-large;
+    justify-content: center;
+    padding: $sph--x-large 0;
+
+    &__node {
+      align-items: center;
+      border: 1px solid var(--vf-color-border-default);
+      display: flex;
+      flex-direction: column;
+      gap: $spv--small;
+      justify-content: center;
+      padding: $sph--large $sph--x-large;
+    }
+
+    &__target {
+      margin-left: 20px;
+    }
+
+    .node-heading {
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    &__arrow-shaft {
+      align-items: center;
+      border-bottom: 1px solid var(--vf-color-border-default);
+      border-top: 1px solid var(--vf-color-border-default);
+      display: flex;
+      flex-grow: 1;
+      height: 3rem;
+      justify-content: center;
+      margin: auto 0;
+      max-width: 20rem;
+      position: relative;
+
+      &::after {
+        border-bottom: 32px solid transparent;
+        border-left: 1.5rem solid var(--vf-color-border-default);
+        border-top: 32px solid transparent;
+        content: "";
+        height: 0;
+        position: absolute;
+        right: -1.5rem;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        z-index: 1;
+      }
+
+      &::before {
+        border-bottom: 30px solid transparent;
+        border-left: 20px solid var(--vf-color-background-default);
+        border-top: 30px solid transparent;
+        content: "";
+        height: 0;
+        position: absolute;
+        right: -20px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        z-index: 2;
+      }
+    }
+
+    &--restore {
+      .replicator-data-flow__arrow-shaft {
+        &::after {
+          border-left: 0;
+          border-right: 1.5rem solid var(--vf-color-border-default);
+          left: -1.5rem;
+          right: auto;
+        }
+
+        &::before {
+          border-left: 0;
+          border-right: 20px solid var(--vf-color-background-default);
+          left: -20px;
+          right: auto;
+        }
+      }
+
+      .replicator-data-flow__target {
+        margin-left: 0;
+      }
+
+      .replicator-data-flow__source {
+        margin-right: 20px;
+      }
+    }
   }
 }

--- a/src/types/replicator.d.ts
+++ b/src/types/replicator.d.ts
@@ -15,5 +15,6 @@ export interface LxdReplicator {
   };
   last_run_at: string;
   last_run_status: LxdReplicatorStatus;
+  last_run_error?: string;
   access_entitlements?: string[];
 }

--- a/src/util/clusterLink.tsx
+++ b/src/util/clusterLink.tsx
@@ -32,11 +32,10 @@ export const getLinkIdentity = (
   );
 };
 
-export const isClusterLinkReachable = async (
-  cluster: string,
-): Promise<boolean> => {
+const isClusterLinkReachable = async (cluster: string): Promise<boolean> => {
   const state = await fetchClusterLinkState(cluster);
-  return getClusterLinksStatus(undefined, state) === "Reachable";
+  const status = getClusterLinksStatus(undefined, state);
+  return status === "Reachable";
 };
 
 const NOT_REACHABLE_ERROR_MESSAGE =

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -4,7 +4,7 @@ import type { LxdEvent } from "types/event";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
 
 // Extracts entity URLs from an operation, considering renaming operations where the original_entity_url is returned.
-const getOperationEntityUrls = (
+export const getOperationEntityUrls = (
   operation?: LxdOperation,
   entities: string[] = [],
 ): string[] => {

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -81,3 +81,6 @@ export const isProjectWithProfiles = (project?: LxdProject): boolean =>
 
 export const isProjectWithVolumes = (project?: LxdProject): boolean =>
   project?.config["features.storage.volumes"] === "true";
+
+export const isProjectReplicaModeStandby = (project?: LxdProject): boolean =>
+  project?.config["replica.mode"] === "standby";


### PR DESCRIPTION
## Done

- Replicator: run modal

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create 2 VMs with LXD latest edge installed. We are going to call them lxd1 (leader) and lxd2 (standby).
    - On lxd1 and lxd2, create auth group with admin rights. In the following commands, the auth group is called `link`:
    ```
    lxc auth group create link
    llxc auth group permission add link server admin
    ```

    - Create a cluster link between lxd1 and lxd2:
        - On lxd1, run `lxc cluster link create link-to-lxd2 --auth-group link`. This command returns a token, copy it.
        - On lxd2, run `lxc cluster link create link-to-lxd1 --token <token> --auth-group link`
    - Create projects for replication:
        - On lxd1, run `lxc project create polar-penguin -c replica.cluster=link-to-lxd2`
        - On lxd2, run `lxc project create polar-penguin -c replica.cluster=link-to-lxd1`
    - Setup projects for replication:
        - On **lxd2**, run `lxc project set polar-penguin replica.mode=standby`
        - On lxd1, run `lxc project set polar-penguin replica.mode=leader`
    - Create replicators:
        - On lxd1, run `lxc replicator create replicator-alligator cluster=link-to-lxd2 --project polar-penguin`
        - On lxd2, run `lxc replicator create repligator cluster=link-to-lxd1 --project polar-penguin`

You now have 2 replicators: `replicator-alligator` on lxd1 where the local project is leader and `repligator` on lxd2 where the local project is standby.


## Screenshots

Local project is in leader mode
<img width="839" height="579" alt="image" src="https://github.com/user-attachments/assets/b1be8330-ce87-4450-8a10-84460ff5c650" />

Local project is in standby mode
<img width="949" height="754" alt="image" src="https://github.com/user-attachments/assets/3325d2ed-9037-4ebe-876b-a11a78b88d5e" />

Status on detail page is automatically updated
https://github.com/user-attachments/assets/fd33ff23-dd0a-472d-891e-708272ea19a0

Error handling when the operation fails
https://github.com/user-attachments/assets/d030fc76-3ec0-43ef-b24c-cd2c990246eb


