### PR TITLE
fix(replicators): running icon, empty state icon, project in delete

### DIFF
--- a/src/pages/cluster/ReplicatorDetail.tsx
+++ b/src/pages/cluster/ReplicatorDetail.tsx
@@ -47,14 +47,7 @@ const ReplicatorDetail: FC = () => {
 
   return (
     <>
-      <CustomLayout
-        header={
-          <ReplicatorDetailHeader
-            replicator={replicator}
-            project={project || "default"}
-          />
-        }
-      >
+      <CustomLayout header={<ReplicatorDetailHeader replicator={replicator} />}>
         <NotificationRow />
         <Row className="replicator-detail">
           <Row className="section">

--- a/src/pages/cluster/ReplicatorDetailHeader.tsx
+++ b/src/pages/cluster/ReplicatorDetailHeader.tsx
@@ -14,10 +14,9 @@ import * as Yup from "yup";
 
 interface Props {
   replicator: LxdReplicator;
-  project: string;
 }
 
-const ReplicatorDetailHeader: FC<Props> = ({ replicator, project }) => {
+const ReplicatorDetailHeader: FC<Props> = ({ replicator }) => {
   const navigate = useNavigate();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -97,9 +96,7 @@ const ReplicatorDetailHeader: FC<Props> = ({ replicator, project }) => {
         </Link>,
       ]}
       controls={
-        replicator && (
-          <ReplicatorDetailActions replicator={replicator} project={project} />
-        )
+        replicator && <ReplicatorDetailActions replicator={replicator} />
       }
       isLoaded={Boolean(replicator.name)}
       formik={formik}

--- a/src/pages/cluster/ReplicatorList.tsx
+++ b/src/pages/cluster/ReplicatorList.tsx
@@ -176,7 +176,9 @@ const ReplicatorList: FC<Props> = ({ variant = "main" }) => {
           {isEmptyState && (
             <EmptyState
               className="empty-state"
-              image={<Icon name="connected" className="empty-state-icon" />}
+              image={
+                <Icon name="change-version" className="empty-state-icon" />
+              }
               title="No replicators found"
             >
               <p>There are no replicators on this server.</p>

--- a/src/pages/cluster/ReplicatorStatus.tsx
+++ b/src/pages/cluster/ReplicatorStatus.tsx
@@ -9,7 +9,7 @@ interface Props {
 const STATUS_ICONS: Record<LxdReplicatorStatus, string> = {
   Completed: "status-succeeded-small",
   Failed: "status-failed-small",
-  Running: "status-running-small",
+  Running: "status-waiting-small",
   Pending: "status-queued-small",
 };
 

--- a/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
@@ -17,10 +17,9 @@ import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   replicator: LxdReplicator;
-  project: string;
 }
 
-const DeleteReplicatorBtn: FC<Props> = ({ replicator, project }) => {
+const DeleteReplicatorBtn: FC<Props> = ({ replicator }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const notify = useNotify();
@@ -72,7 +71,9 @@ const DeleteReplicatorBtn: FC<Props> = ({ replicator, project }) => {
 
   const handleDelete = () => {
     setLoading(true);
-    deleteReplicator(replicator.name, project).then(onSuccess).catch(onFailure);
+    deleteReplicator(replicator.name, replicator.project)
+      .then(onSuccess)
+      .catch(onFailure);
   };
 
   return (

--- a/src/pages/cluster/actions/ReplicatorDetailActions.tsx
+++ b/src/pages/cluster/actions/ReplicatorDetailActions.tsx
@@ -11,10 +11,9 @@ import type { LxdReplicator } from "types/replicator";
 
 interface Props {
   replicator: LxdReplicator;
-  project: string;
 }
 
-const ReplicatorDetailActions: FC<Props> = ({ replicator, project }) => {
+const ReplicatorDetailActions: FC<Props> = ({ replicator }) => {
   const isSmallScreen = useIsScreenBelow(largeScreenBreakpoint);
   const classname = isSmallScreen
     ? "p-contextual-menu__link"
@@ -31,11 +30,7 @@ const ReplicatorDetailActions: FC<Props> = ({ replicator, project }) => {
       replicator={replicator}
       className={classname}
     />,
-    <DeleteReplicatorBtn
-      key="delete"
-      replicator={replicator}
-      project={project}
-    />,
+    <DeleteReplicatorBtn key="delete" replicator={replicator} />,
   ];
 
   return (


### PR DESCRIPTION
## Done

- Remove project (from URL) from `DeleteReplicatorBtn` to use `replicator.project` instead
- In `ReplicatorList`'s empty state, change icon from `connected` to `change-version`
- In `ReplicatorStatus`, change icon for Running from `status-running-small` to `status-waiting-small`

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to the replicator list when there is no replicators. Make sure the icon is `change-version`.
    - Run a replicator and refresh the detail page. Make sure the icon next to the status is an orange dot.

## Screenshots

<img width="607" height="301" alt="Screenshot from 2026-06-02 11-44-28" src="https://github.com/user-attachments/assets/5bd06b06-422c-45a9-a51e-9e7d8d9bca68" />

<img width="1547" height="591" alt="Screenshot from 2026-06-02 11-47-25" src="https://github.com/user-attachments/assets/217dcd1e-30e9-491e-9c69-51934c88f26f" />
