### PR TITLE
Replicator fixes 2

### DIFF
--- a/src/pages/cluster/ReplicatorList.tsx
+++ b/src/pages/cluster/ReplicatorList.tsx
@@ -90,6 +90,7 @@ const ReplicatorList: FC<Props> = ({ variant = "main" }) => {
           content: <ProjectRichChip projectName={replicator.project} />,
           role: "cell",
           "aria-label": "Project",
+          className: "chip-container",
         },
         {
           content: (
@@ -99,6 +100,7 @@ const ReplicatorList: FC<Props> = ({ variant = "main" }) => {
           ),
           role: "cell",
           "aria-label": "Cluster",
+          className: "chip-container",
         },
         {
           content: <ReplicatorStatus replicator={replicator} />,

--- a/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
@@ -9,6 +9,7 @@ import {
 } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { deleteReplicator } from "api/replicators";
+import classnames from "classnames";
 import ResourceLabel from "components/ResourceLabel";
 import type { LxdReplicator } from "types/replicator";
 import { useReplicatorEntitlements } from "util/entitlements/replicators";
@@ -17,9 +18,11 @@ import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   replicator: LxdReplicator;
+  className?: string;
+  onClose?: () => void;
 }
 
-const DeleteReplicatorBtn: FC<Props> = ({ replicator }) => {
+const DeleteReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const notify = useNotify();
@@ -80,7 +83,7 @@ const DeleteReplicatorBtn: FC<Props> = ({ replicator }) => {
     <ConfirmationButton
       onHoverText={disabledReason()}
       appearance="default"
-      className="u-no-margin--bottom has-icon"
+      className={classnames("u-no-margin--bottom has-icon", className)}
       loading={isLoading}
       confirmationModalProps={{
         title: "Confirm delete",
@@ -108,6 +111,7 @@ const DeleteReplicatorBtn: FC<Props> = ({ replicator }) => {
         ),
         onConfirm: handleDelete,
         confirmButtonLabel: "Delete",
+        close: onClose,
       }}
       disabled={Boolean(disabledReason()) || isLoading}
       shiftClickEnabled

--- a/src/pages/cluster/actions/EditReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/EditReplicatorBtn.tsx
@@ -24,7 +24,7 @@ const EditReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
     <Button
       appearance="default"
       aria-label="Edit replicator"
-      className={classnames("u-no-margin--bottom has-icon", className)}
+      className={classnames("u-no-margin has-icon", className)}
       onClick={() => {
         console.log(
           `Edit replicator ${replicator.name} btn clicked. TODO: open side panel`,

--- a/src/pages/cluster/actions/ReplicatorDetailActions.tsx
+++ b/src/pages/cluster/actions/ReplicatorDetailActions.tsx
@@ -30,7 +30,11 @@ const ReplicatorDetailActions: FC<Props> = ({ replicator }) => {
       replicator={replicator}
       className={classname}
     />,
-    <DeleteReplicatorBtn key="delete" replicator={replicator} />,
+    <DeleteReplicatorBtn
+      key="delete"
+      replicator={replicator}
+      className={classname}
+    />,
   ];
 
   return (

--- a/src/sass/_replicators.scss
+++ b/src/sass/_replicators.scss
@@ -2,6 +2,14 @@
   .status-header {
     padding-left: 1.8rem;
   }
+
+  .chip-container {
+    > span {
+      > span {
+        max-width: 100%;
+      }
+    }
+  }
 }
 
 .replicator-detail {


### PR DESCRIPTION
## Done

- In small screens, Replicator detail page > Delete button: close contextual menu when modal closes
- In small screens, Replicator list page: nicely truncate the chips in the table (project and cluster link)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to replicator list page, reduce screen width. The chips should be nicely truncated
    - Go to a replicator's detail page, reduce screen width. Click on Actions > Delete. Close confirmation modal: the contextual menu should be closed.

## Screenshots

<img width="1309" height="1063" alt="image" src="https://github.com/user-attachments/assets/ab63a32c-fc0f-4ade-961a-6fcf729a1dc3" />


https://github.com/user-attachments/assets/8af1384d-4b93-4fd3-bba8-94429a8debd5

