### PR TITLE
fix(links) enhance cluster link ux copy on creation and creation confirmation modal

### DIFF
--- a/src/pages/cluster/ClusterLinkForm.tsx
+++ b/src/pages/cluster/ClusterLinkForm.tsx
@@ -77,7 +77,7 @@ const ClusterLinkForm: FC<Props> = ({ formik }) => {
             />
             <RadioInput
               inline
-              label="Consume token"
+              label="I have a token"
               checked={formik.values.tokenType === "consume"}
               onChange={() => {
                 formik.setFieldValue("tokenType", "consume");
@@ -90,7 +90,8 @@ const ClusterLinkForm: FC<Props> = ({ formik }) => {
               {...formik.getFieldProps("token")}
               type="text"
               label="Token"
-              placeholder="Enter token"
+              placeholder="Enter token (e.g. eyJhbGciOiJIUzI1Ni...)"
+              help="Paste the token you have generated on the target cluster"
             />
           )}
         </>

--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -2,6 +2,7 @@ import { useState, type FC } from "react";
 import {
   Accordion,
   ActionButton,
+  Input,
   List,
   Modal,
   Notification,
@@ -20,6 +21,7 @@ interface Props {
 const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
   const [isConfirmed, setConfirmed] = useState(false);
   const [howToUseActiveTab, setHowToUseActiveTab] = useState("ui-tab");
+  const [clusterName, setClusterName] = useState(linkName);
 
   return (
     <Modal
@@ -93,14 +95,22 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
                         For use with the LXC command-line tool, run on the
                         target cluster:
                         <CodeSnippetWithCopyButton
-                          code={`lxc cluster link create ${location.hostname} --auth-group admins --token ${token}`}
+                          code={`lxc cluster link create ${clusterName} --auth-group admins --token ${token}`}
                           tooltipMessage="Copy command"
                           className="u-no-margin--bottom"
+                          onCopyButtonClick={() => {
+                            setConfirmed(true);
+                          }}
                         />
-                        <span className="u-text--muted p-text--small u-sv3">
-                          You can replace <code>{location.hostname}</code> with
-                          a nickname for this server.
-                        </span>
+                        <Input
+                          label="Cluster link name"
+                          type="text"
+                          help="Customize the cluster link name for the command above."
+                          onChange={(e) => {
+                            setClusterName(e.target.value);
+                          }}
+                          value={clusterName}
+                        />
                       </>
                     )}
 


### PR DESCRIPTION
## Done

- enhance cluster link ux copy on creation and creation confirmation modal

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to server > cluster links (or clustering > links) and create a new cluster link token. validate the "i have a token" input and help text. After submit validate the modal: how to steps for the cli should be clear 

## Screenshots

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/dff0c7ac-18ad-405c-b30e-7d840e5ce0af" />

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/1fc6c31f-7e91-47a8-8a83-a627aa2f2ead" />
