### PR TITLE
fix(links) cluster link modal copy align with radio labels

### DIFF
--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -121,7 +121,7 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
                           <>Open the target cluster UI.</>,
                           <>
                             Select <b>Clustering</b>, <b>Links</b>,{" "}
-                            <b>Create link</b> and <b>Consume token</b>.
+                            <b>Create link</b> and <b>I have a token</b>.
                           </>,
                           <>
                             Use this trust token to establish the cluster link.


### PR DESCRIPTION
## Done

- fix(links) cluster link modal copy align with radio labels

## Screenshots

<img width="1458" height="1454" alt="image" src="https://github.com/user-attachments/assets/8dce22fb-3e61-47ca-a165-11b8f7c1b2a2" />
