### PR TITLE
WD-37021: Disable delete cluster link button if used by replicator(s)

### DIFF
--- a/src/Events.tsx
+++ b/src/Events.tsx
@@ -134,6 +134,20 @@ const Events: FC = () => {
     }
   };
 
+  const updateReplicatorLoading = (event: LxdEvent) => {
+    const isReplicatorOperation =
+      event.type === "operation" &&
+      event.metadata.description.toLowerCase().includes("replicator");
+
+    if (!isReplicatorOperation) {
+      return;
+    }
+
+    queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[2] === queryKeys.replicators,
+    });
+  };
+
   const reEvaluateOperations = () => {
     operations.forEach((operation) => {
       handleEvent(operation.id, operation.status, operation.err, operation);
@@ -206,6 +220,7 @@ const Events: FC = () => {
           });
         }
         updateClusterMemberLoading(event);
+        updateReplicatorLoading(event);
         // ensure open requests that reply with an operation and register
         // new handlers in the eventQueue are closed before handling the event
         setTimeout(() => {

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import Navigation from "components/Navigation";
 import { Application, SkipLink } from "@canonical/react-components";
-import Events from "pages/instances/Events";
+import Events from "./Events";
 import App from "./App";
 import ErrorBoundary from "components/ErrorBoundary";
 import ErrorPage from "components/ErrorPage";

--- a/src/api/replicators.tsx
+++ b/src/api/replicators.tsx
@@ -1,6 +1,7 @@
 import { handleResponse } from "util/helpers";
 import type { LxdReplicator } from "types/replicator";
 import type { LxdApiResponse } from "types/apiResponse";
+import type { LxdOperationResponse } from "types/operation";
 import { addEntitlements } from "util/entitlements/api";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -66,4 +67,25 @@ export const deleteReplicator = async (
       method: "DELETE",
     },
   ).then(handleResponse);
+};
+
+export const runReplicator = async (
+  name: string,
+  project: string,
+  action: "restore" | "start",
+): Promise<LxdOperationResponse> => {
+  return fetch(
+    `${ROOT_PATH}/1.0/replicators/${encodeURIComponent(name)}/state?project=${encodeURIComponent(project)}`,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ action }),
+    },
+  )
+    .then(handleResponse)
+    .then((data: LxdOperationResponse) => {
+      return data;
+    });
 };

--- a/src/context/appProviders.tsx
+++ b/src/context/appProviders.tsx
@@ -11,6 +11,7 @@ import { EventQueueProvider } from "context/eventQueue";
 import { InstanceLoadingProvider } from "context/instanceLoading";
 import { ProjectProvider } from "context/useCurrentProject";
 import OperationsProvider from "context/operationsProvider";
+import { ReplicatorRunningProvider } from "context/replicatorLoading";
 import { MetricHistoryProvider } from "context/metricHistory";
 import { MemberLoadingProvider } from "context/memberLoading";
 import { ModalProvider } from "context/useModal";
@@ -59,7 +60,9 @@ const AppProviders: FC<AppProvidersProps> = ({ children }) => {
                         pathname={pathname}
                       >
                         <MetricHistoryProvider>
-                          {children}
+                          <ReplicatorRunningProvider>
+                            {children}
+                          </ReplicatorRunningProvider>
                         </MetricHistoryProvider>
                       </NotificationProvider>
                     </ToastNotificationProvider>

--- a/src/context/replicatorLoading.tsx
+++ b/src/context/replicatorLoading.tsx
@@ -1,0 +1,197 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  type FC,
+  type ReactNode,
+} from "react";
+import { useOperations } from "context/operationsProvider";
+import type { LxdOperation } from "types/operation";
+import type { LxdReplicator, LxdReplicatorStatus } from "types/replicator";
+import { getReplicatorOperationUrls } from "util/operations";
+
+interface ReplicatorLoadingType {
+  getStatus: (replicator: LxdReplicator) => LxdReplicatorStatus;
+  getLastRunError: (replicator: LxdReplicator) => string | undefined;
+  setRunning: (replicator: LxdReplicator) => void;
+  setFinish: (replicator: LxdReplicator) => void;
+  setLastRunError: (replicator: LxdReplicator, error: string) => void;
+  clearLastRunError: (replicator: LxdReplicator) => void;
+}
+
+interface Props {
+  children: ReactNode;
+}
+
+const ReplicatorRunningContext = createContext<ReplicatorLoadingType>({
+  getStatus: (replicator: LxdReplicator) => replicator.last_run_status,
+  getLastRunError: () => undefined,
+  setRunning: () => undefined,
+  setFinish: () => undefined,
+  setLastRunError: () => undefined,
+  clearLastRunError: () => undefined,
+});
+
+const getReplicatorKey = ({
+  name,
+  project,
+}: Pick<LxdReplicator, "name" | "project">) => `${project}/${name}`;
+
+const parseReplicatorKeyFromUrl = (url: string): string | null => {
+  try {
+    const parsed = new URL(url, "http://localhost");
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+    const replicatorIndex = pathParts.indexOf("replicators");
+
+    if (replicatorIndex === -1 || !pathParts[replicatorIndex + 1]) {
+      return null;
+    }
+
+    const name = decodeURIComponent(pathParts[replicatorIndex + 1]);
+    const project = decodeURIComponent(
+      parsed.searchParams.get("project") || "default",
+    );
+
+    return `${project}/${name}`;
+  } catch {
+    return null;
+  }
+};
+
+const getOperationReplicatorKeys = (operation: LxdOperation): string[] => {
+  return getReplicatorOperationUrls(operation)
+    .map(parseReplicatorKeyFromUrl)
+    .filter((key): key is string => Boolean(key));
+};
+
+const isRunningReplicatorOperation = (operation: LxdOperation): boolean => {
+  return operation.description === "Running replicator";
+};
+
+const isFailedReplicatorOperation = (operation: LxdOperation): boolean => {
+  return (
+    operation.description === "Running replicator" &&
+    operation.status === "Failure"
+  );
+};
+
+const getOperationTimestamp = (operation: LxdOperation): number => {
+  const timestamp = Date.parse(
+    operation.updated_at || operation.created_at || "",
+  );
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+export const ReplicatorRunningProvider: FC<Props> = ({ children }) => {
+  const { runningOperations, operations } = useOperations();
+  const [manualRunningKeys, setManualRunningKeys] = useState(new Set<string>());
+  const [manualLastRunErrors, setManualLastRunErrors] = useState(
+    new Map<string, string>(),
+  );
+
+  const setRunning = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualRunningKeys((prev) => {
+      if (prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  };
+
+  const setFinish = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualRunningKeys((prev) => {
+      if (!prev.has(key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  };
+
+  const setLastRunError = (replicator: LxdReplicator, error: string) => {
+    const key = getReplicatorKey(replicator);
+    setManualLastRunErrors((prev) => {
+      const next = new Map(prev);
+      next.set(key, error);
+      return next;
+    });
+  };
+
+  const clearLastRunError = (replicator: LxdReplicator) => {
+    const key = getReplicatorKey(replicator);
+    setManualLastRunErrors((prev) => {
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+  };
+
+  const getStatus = (replicator: LxdReplicator): LxdReplicatorStatus => {
+    const key = getReplicatorKey(replicator);
+    const hasRunningOperation = runningOperations
+      .filter(isRunningReplicatorOperation)
+      .some((operation) => getOperationReplicatorKeys(operation).includes(key));
+
+    if (manualRunningKeys.has(key) || hasRunningOperation) {
+      return "Running";
+    }
+
+    return replicator.last_run_status;
+  };
+
+  const getLastRunError = (replicator: LxdReplicator): string | undefined => {
+    if (getStatus(replicator) !== "Failed") {
+      return undefined;
+    }
+
+    const key = getReplicatorKey(replicator);
+    let latestOperationError: string | undefined;
+    let latestOperationTimestamp = -1;
+
+    for (const operation of operations) {
+      if (!isFailedReplicatorOperation(operation) || !operation.err) {
+        continue;
+      }
+
+      if (!getOperationReplicatorKeys(operation).includes(key)) {
+        continue;
+      }
+
+      const timestamp = getOperationTimestamp(operation);
+      if (timestamp >= latestOperationTimestamp) {
+        latestOperationTimestamp = timestamp;
+        latestOperationError = operation.err;
+      }
+    }
+
+    return (
+      replicator.last_run_error ||
+      latestOperationError ||
+      manualLastRunErrors.get(key)
+    );
+  };
+
+  return (
+    <ReplicatorRunningContext.Provider
+      value={{
+        getStatus,
+        getLastRunError,
+        setRunning,
+        setFinish,
+        setLastRunError,
+        clearLastRunError,
+      }}
+    >
+      {children}
+    </ReplicatorRunningContext.Provider>
+  );
+};
+
+export const useReplicatorLoading = (): ReplicatorLoadingType => {
+  return useContext(ReplicatorRunningContext);
+};

--- a/src/context/useReplicators.tsx
+++ b/src/context/useReplicators.tsx
@@ -2,6 +2,36 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useAuth } from "context/auth";
 import { fetchReplicators, fetchReplicator } from "api/replicators";
+import type { LxdReplicator } from "types/replicator";
+
+const POLLING_INTERVAL = 3000;
+
+const shouldPollReplicator = (replicator?: LxdReplicator) => {
+  if (!replicator) {
+    return false;
+  }
+
+  return replicator.last_run_status === "Running";
+};
+
+const mergeReplicatorClientState = (
+  oldReplicator: LxdReplicator | undefined,
+  newReplicator: LxdReplicator,
+) => {
+  if (!oldReplicator) {
+    return newReplicator;
+  }
+
+  return {
+    ...newReplicator,
+    // Keep client-side error captured from operation events while API has no dedicated field yet.
+    last_run_error:
+      newReplicator.last_run_error ??
+      (newReplicator.last_run_status === "Failed"
+        ? oldReplicator.last_run_error
+        : undefined),
+  };
+};
 
 export const useReplicators = (
   project: string | null = null,
@@ -25,5 +55,12 @@ export const useReplicator = (
     queryKey: [queryKeys.projects, project, queryKeys.replicators, name],
     queryFn: async () => fetchReplicator(name, project, isFineGrained),
     enabled: isEnabled && isFineGrained !== null,
+    refetchInterval: (query) =>
+      shouldPollReplicator(query.state.data) ? POLLING_INTERVAL : false,
+    structuralSharing: (oldData, newData) =>
+      mergeReplicatorClientState(
+        oldData as LxdReplicator | undefined,
+        newData as LxdReplicator,
+      ),
   });
 };

--- a/src/context/useReplicators.tsx
+++ b/src/context/useReplicators.tsx
@@ -2,36 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useAuth } from "context/auth";
 import { fetchReplicators, fetchReplicator } from "api/replicators";
-import type { LxdReplicator } from "types/replicator";
-
-const POLLING_INTERVAL = 3000;
-
-const shouldPollReplicator = (replicator?: LxdReplicator) => {
-  if (!replicator) {
-    return false;
-  }
-
-  return replicator.last_run_status === "Running";
-};
-
-const mergeReplicatorClientState = (
-  oldReplicator: LxdReplicator | undefined,
-  newReplicator: LxdReplicator,
-) => {
-  if (!oldReplicator) {
-    return newReplicator;
-  }
-
-  return {
-    ...newReplicator,
-    // Keep client-side error captured from operation events while API has no dedicated field yet.
-    last_run_error:
-      newReplicator.last_run_error ??
-      (newReplicator.last_run_status === "Failed"
-        ? oldReplicator.last_run_error
-        : undefined),
-  };
-};
 
 export const useReplicators = (
   project: string | null = null,
@@ -55,12 +25,5 @@ export const useReplicator = (
     queryKey: [queryKeys.projects, project, queryKeys.replicators, name],
     queryFn: async () => fetchReplicator(name, project, isFineGrained),
     enabled: isEnabled && isFineGrained !== null,
-    refetchInterval: (query) =>
-      shouldPollReplicator(query.state.data) ? POLLING_INTERVAL : false,
-    structuralSharing: (oldData, newData) =>
-      mergeReplicatorClientState(
-        oldData as LxdReplicator | undefined,
-        newData as LxdReplicator,
-      ),
   });
 };

--- a/src/pages/cluster/ReplicatorDetail.tsx
+++ b/src/pages/cluster/ReplicatorDetail.tsx
@@ -1,9 +1,10 @@
-import type { FC } from "react";
+import { useMemo, type FC } from "react";
 import { useParams } from "react-router-dom";
 import { Col, CustomLayout, Row, Spinner } from "@canonical/react-components";
 import NotFound from "components/NotFound";
 import NotificationRow from "components/NotificationRow";
 import { useClusterLink } from "context/useClusterLinks";
+import { useOperations } from "context/operationsProvider";
 import { useReplicator } from "context/useReplicators";
 import ClusterLinkStatus from "pages/cluster/ClusterLinkStatus";
 import ReplicatorDetailHeader from "pages/cluster/ReplicatorDetailHeader";
@@ -27,9 +28,43 @@ const ReplicatorDetail: FC = () => {
     error,
     isLoading,
   } = useReplicator(name, project || "default");
+  const { operations } = useOperations();
   const { data: clusterLink } = useClusterLink(
     replicator?.config?.cluster || "",
   );
+
+  const persistedLastRunError = useMemo(() => {
+    if (!replicator || replicator.last_run_status !== "Failed") {
+      return undefined;
+    }
+
+    const replicatorPath = `/1.0/replicators/${encodeURIComponent(replicator.name)}`;
+    const projectQuery = `project=${encodeURIComponent(replicator.project)}`;
+
+    const latestFailure = operations
+      .filter((operation) => operation.status === "Failure")
+      .find((operation) => {
+        const entityUrl =
+          operation.original_entity_url ||
+          operation.entity_url ||
+          operation.metadata?.original_entity_url ||
+          operation.metadata?.entity_url ||
+          "";
+
+        return (
+          operation.description === "Running replicator" &&
+          entityUrl.startsWith(replicatorPath) &&
+          entityUrl.includes(projectQuery)
+        );
+      });
+
+    return latestFailure?.err || undefined;
+  }, [operations, replicator]);
+
+  const lastRunError =
+    replicator?.last_run_status === "Failed"
+      ? replicator.last_run_error || persistedLastRunError
+      : undefined;
 
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading..." isMainComponent />;
@@ -139,6 +174,12 @@ const ReplicatorDetail: FC = () => {
                       <ReplicatorStatus replicator={replicator} />
                     </td>
                   </tr>
+                  {lastRunError && (
+                    <tr>
+                      <th className="u-text--muted">Last error</th>
+                      <td className="u-text--error">{lastRunError}</td>
+                    </tr>
+                  )}
                 </tbody>
               </table>
             </Col>

--- a/src/pages/cluster/ReplicatorDetail.tsx
+++ b/src/pages/cluster/ReplicatorDetail.tsx
@@ -1,10 +1,10 @@
-import { useMemo, type FC } from "react";
+import { type FC } from "react";
 import { useParams } from "react-router-dom";
 import { Col, CustomLayout, Row, Spinner } from "@canonical/react-components";
 import NotFound from "components/NotFound";
 import NotificationRow from "components/NotificationRow";
 import { useClusterLink } from "context/useClusterLinks";
-import { useOperations } from "context/operationsProvider";
+import { useReplicatorLoading } from "context/replicatorLoading";
 import { useReplicator } from "context/useReplicators";
 import ClusterLinkStatus from "pages/cluster/ClusterLinkStatus";
 import ReplicatorDetailHeader from "pages/cluster/ReplicatorDetailHeader";
@@ -28,43 +28,14 @@ const ReplicatorDetail: FC = () => {
     error,
     isLoading,
   } = useReplicator(name, project || "default");
-  const { operations } = useOperations();
+  const replicatorRunning = useReplicatorLoading();
   const { data: clusterLink } = useClusterLink(
     replicator?.config?.cluster || "",
   );
 
-  const persistedLastRunError = useMemo(() => {
-    if (!replicator || replicator.last_run_status !== "Failed") {
-      return undefined;
-    }
-
-    const replicatorPath = `/1.0/replicators/${encodeURIComponent(replicator.name)}`;
-    const projectQuery = `project=${encodeURIComponent(replicator.project)}`;
-
-    const latestFailure = operations
-      .filter((operation) => operation.status === "Failure")
-      .find((operation) => {
-        const entityUrl =
-          operation.original_entity_url ||
-          operation.entity_url ||
-          operation.metadata?.original_entity_url ||
-          operation.metadata?.entity_url ||
-          "";
-
-        return (
-          operation.description === "Running replicator" &&
-          entityUrl.startsWith(replicatorPath) &&
-          entityUrl.includes(projectQuery)
-        );
-      });
-
-    return latestFailure?.err || undefined;
-  }, [operations, replicator]);
-
-  const lastRunError =
-    replicator?.last_run_status === "Failed"
-      ? replicator.last_run_error || persistedLastRunError
-      : undefined;
+  const lastRunError = replicator
+    ? replicatorRunning.getLastRunError(replicator)
+    : undefined;
 
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading..." isMainComponent />;

--- a/src/pages/cluster/ReplicatorStatus.tsx
+++ b/src/pages/cluster/ReplicatorStatus.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Icon } from "@canonical/react-components";
+import { useReplicatorLoading } from "context/replicatorLoading";
 import type { LxdReplicator, LxdReplicatorStatus } from "types/replicator";
 
 interface Props {
@@ -14,7 +15,8 @@ const STATUS_ICONS: Record<LxdReplicatorStatus, string> = {
 };
 
 const ReplicatorStatus: FC<Props> = ({ replicator }) => {
-  const status = replicator.last_run_status;
+  const replicatorLoading = useReplicatorLoading();
+  const status = replicatorLoading.getStatus(replicator);
   const iconName = STATUS_ICONS[status] ?? "";
 
   return (

--- a/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
@@ -8,10 +8,12 @@ import {
   useNotify,
   useToastNotification,
 } from "@canonical/react-components";
-import type { LxdClusterLink } from "types/cluster";
 import ResourceLabel from "components/ResourceLabel";
-import { useClusterLinkEntitlements } from "util/entitlements/cluster-links";
+import { useReplicators } from "context/useReplicators";
 import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import type { LxdClusterLink } from "types/cluster";
+import { useClusterLinkEntitlements } from "util/entitlements/cluster-links";
+import { pluralize } from "util/helpers";
 
 interface Props {
   clusterLink: LxdClusterLink;
@@ -23,8 +25,13 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
   const queryClient = useQueryClient();
+  const { data: replicators = [] } = useReplicators();
 
   const canDelete = canDeleteClusterLink(clusterLink);
+  const replicatorsUsingLink = replicators.filter(
+    (r) => r.config?.cluster === clusterLink.name,
+  );
+  const isUsedByReplicator = replicatorsUsingLink.length > 0;
 
   const handleDelete = () => {
     setLoading(true);
@@ -49,12 +56,22 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
       });
   };
 
+  const disabledReason = () => {
+    if (isUsedByReplicator) {
+      return `This cluster link is used by ${replicatorsUsingLink.length} ${pluralize("replicator", replicatorsUsingLink.length)}: ${replicatorsUsingLink.map((r) => r.name).join(", ")}. Please delete the ${pluralize("replicator", replicatorsUsingLink.length)} to continue.`;
+    }
+    if (!canDelete) {
+      return "You do not have permission to delete this cluster link";
+    }
+    return undefined;
+  };
+
   return (
     <ConfirmationButton
       appearance="base"
       className="has-icon"
-      title="Delete cluster link"
-      disabled={!canDelete}
+      onHoverText={disabledReason()}
+      disabled={Boolean(disabledReason())}
       loading={isLoading}
       confirmationModalProps={{
         title: "Confirm delete",
@@ -64,9 +81,7 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
             <ClusterLinkRichChip clusterLink={clusterLink.name} />.
           </p>
         ),
-        confirmButtonLabel: canDelete
-          ? "Delete cluster link"
-          : "You do not have permission to delete this cluster link",
+        confirmButtonLabel: "Delete cluster link",
         onConfirm: handleDelete,
       }}
       shiftClickEnabled

--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -1,7 +1,24 @@
-import type { FC } from "react";
-import { Button, Icon } from "@canonical/react-components";
+import { useState, type FC } from "react";
+import {
+  ConfirmationButton,
+  Icon,
+  Notification,
+  useNotify,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import { runReplicator } from "api/replicators";
 import classnames from "classnames";
+import ResourceLink from "components/ResourceLink";
+import { useProject } from "context/useProjects";
+import { useEventQueue } from "context/eventQueue";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { LxdReplicator } from "types/replicator";
+import { useReplicatorEntitlements } from "util/entitlements/replicators";
+import { isProjectReplicaModeStandby } from "util/projects";
+import { queryKeys } from "util/queryKeys";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   replicator: LxdReplicator;
@@ -10,22 +27,283 @@ interface Props {
 }
 
 const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
-  return (
-    <Button
-      appearance="default"
-      aria-label="Run replicator"
-      className={classnames("u-no-margin--bottom has-icon", className)}
-      onClick={() => {
-        console.log(
-          `Run replicator ${replicator.name} btn clicked. TODO: open modal`,
-          onClose,
+  const queryClient = useQueryClient();
+  const eventQueue = useEventQueue();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const [isLoading, setLoading] = useState(false);
+  const { canEditReplicator } = useReplicatorEntitlements();
+  const { data: project, isLoading: isProjectLoading } = useProject(
+    replicator.project,
+  );
+  const clusterLink = replicator.config.cluster;
+  const isReverseFlow = isProjectReplicaModeStandby(project);
+  const buttonLabel = isReverseFlow ? "Restore" : "Run";
+
+  const disabledReason = () => {
+    if (!canEditReplicator(replicator)) {
+      return "You do not have permission to run this replicator";
+    }
+
+    if (isLoading) {
+      // Request was sent, waiting for a response
+      return "Replicator is starting...";
+    }
+
+    if (replicator.last_run_status === "Running") {
+      return "This replicator is currently running";
+    }
+
+    return undefined;
+  };
+
+  const notifySuccess = (replicatorName: string) => {
+    toastNotify.success(
+      <>
+        Replicator{" "}
+        <ResourceLink
+          type="replicator"
+          value={replicatorName}
+          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicatorName)}`}
+        />{" "}
+        started.
+      </>,
+    );
+  };
+
+  const markReplicatorRunning = () => {
+    const detailQueryKey = [
+      queryKeys.projects,
+      replicator.project,
+      queryKeys.replicators,
+      replicator.name,
+    ];
+
+    queryClient.setQueryData<LxdReplicator>(
+      detailQueryKey,
+      (currentReplicator) => {
+        if (!currentReplicator) {
+          return currentReplicator;
+        }
+
+        return {
+          ...currentReplicator,
+          last_run_status: "Running",
+          last_run_error: undefined,
+        };
+      },
+    );
+
+    const listQueryKey = [
+      queryKeys.projects,
+      replicator.project,
+      queryKeys.replicators,
+    ];
+    queryClient.setQueryData<LxdReplicator[]>(
+      listQueryKey,
+      (currentReplicators) => {
+        if (!currentReplicators) {
+          return currentReplicators;
+        }
+
+        return currentReplicators.map((currentReplicator) =>
+          currentReplicator.name === replicator.name
+            ? {
+                ...currentReplicator,
+                last_run_status: "Running",
+                last_run_error: undefined,
+              }
+            : currentReplicator,
         );
+      },
+    );
+  };
+
+  const invalidateCache = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[2] === queryKeys.replicators,
+    });
+  };
+
+  const storeRunError = (errorMsg?: string) => {
+    const detailQueryKey = [
+      queryKeys.projects,
+      replicator.project,
+      queryKeys.replicators,
+      replicator.name,
+    ];
+
+    queryClient.setQueryData<LxdReplicator>(
+      detailQueryKey,
+      (currentReplicator) => {
+        if (!currentReplicator) {
+          return currentReplicator;
+        }
+
+        return {
+          ...currentReplicator,
+          last_run_error: errorMsg,
+        };
+      },
+    );
+  };
+
+  const onSuccess = () => {
+    setLoading(false);
+    markReplicatorRunning();
+    invalidateCache();
+    notifySuccess(replicator.name);
+  };
+
+  const onOperationSuccess = () => {
+    storeRunError(undefined);
+    toastNotify.success(
+      <>
+        Replicator{" "}
+        <ResourceLink
+          type="replicator"
+          value={replicator.name}
+          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+        />{" "}
+        completed successfully.
+      </>,
+    );
+    invalidateCache();
+  };
+
+  const onOperationFailure = (msg: string) => {
+    storeRunError(msg);
+    invalidateCache();
+    notify.failure(
+      `Replicator ${replicator.name} failed while running`,
+      new Error(msg),
+    );
+  };
+
+  const onFailure = (e: unknown) => {
+    setLoading(false);
+    invalidateCache();
+    notify.failure(`Running replicator ${replicator.name} failed`, e);
+  };
+
+  const handleRun = () => {
+    setLoading(true);
+    runReplicator(
+      replicator.name,
+      replicator.project,
+      isReverseFlow ? "restore" : "start",
+    )
+      .then((response) => {
+        onSuccess();
+        eventQueue.set(
+          response.metadata.id,
+          onOperationSuccess,
+          onOperationFailure,
+          invalidateCache,
+        );
+      })
+      .catch(onFailure);
+  };
+
+  return (
+    <ConfirmationButton
+      onHoverText={disabledReason()}
+      appearance="default"
+      className={classnames("u-no-margin has-icon", className)}
+      loading={isLoading || isProjectLoading}
+      confirmationModalProps={{
+        className: "run-replicator-modal",
+        title: (
+          <>
+            Run replicator{" "}
+            <ResourceLink
+              type="replicator"
+              value={replicator.name}
+              to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+            />
+          </>
+        ),
+        children: (
+          <>
+            <p>
+              The project <ProjectRichChip projectName={replicator.project} />{" "}
+              is in{" "}
+              <strong>{project?.config["replica.mode"] || "unknown"}</strong>{" "}
+              mode.
+              <br />
+              {/* TODO: use new API endpoint to promote/demote a project
+              https://github.com/canonical/lxd/pull/18312
+              Need to switch to standby ?{" "}
+              <Link
+                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
+              >
+                Change mode
+              </Link> */}
+            </p>
+
+            <div
+              className={classnames("replicator-data-flow u-hide--small", {
+                "replicator-data-flow--reverse": isReverseFlow,
+              })}
+            >
+              <div className="replicator-data-flow__node replicator-data-flow__source">
+                <span className="node-heading u-text--muted">
+                  {isReverseFlow ? "standby" : "leader"} project (local)
+                </span>
+                <ProjectRichChip projectName={replicator.project} />
+              </div>
+
+              <div className="replicator-data-flow__arrow-shaft">
+                <ClusterLinkRichChip clusterLink={clusterLink} />
+              </div>
+
+              <div className="replicator-data-flow__node replicator-data-flow__target">
+                <span className="node-heading u-text--muted">
+                  {isReverseFlow ? "leader" : "standby"} project (remote)
+                </span>
+                <strong className="mono-font">{replicator.project}</strong>
+              </div>
+            </div>
+
+            {isReverseFlow ? (
+              <p>
+                This will sync all instances from the{" "}
+                <ClusterLinkRichChip clusterLink={clusterLink} /> cluster back
+                to the
+                <ProjectRichChip projectName={replicator.project} /> project.
+              </p>
+            ) : (
+              <p>
+                This will sync all instances in the source project{" "}
+                <ProjectRichChip projectName={replicator.project} /> to the
+                standby cluster{" "}
+                <ClusterLinkRichChip clusterLink={clusterLink} />.
+              </p>
+            )}
+
+            {isReverseFlow && (
+              <Notification
+                severity="caution"
+                messageElement="div"
+                title="This operation will synchronize instances from the remote cluster to this project."
+              >
+                <p>
+                  All current local data will be overwritten by the remote
+                  version.
+                </p>
+              </Notification>
+            )}
+          </>
+        ),
+        onConfirm: handleRun,
+        confirmButtonLabel: buttonLabel,
+        close: onClose,
       }}
-      title="Run replicator"
+      disabled={Boolean(disabledReason())}
     >
       <Icon name="play" />
-      <span>Run</span>
-    </Button>
+      <span>{buttonLabel}</span>
+    </ConfirmationButton>
   );
 };
 

--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -12,6 +12,7 @@ import classnames from "classnames";
 import ResourceLink from "components/ResourceLink";
 import { useProject } from "context/useProjects";
 import { useEventQueue } from "context/eventQueue";
+import RunReplicatorPreflightChecks from "pages/cluster/actions/RunReplicatorPreflightChecks";
 import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { LxdReplicator } from "types/replicator";
@@ -32,28 +33,27 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
+  const [canSubmit, setCanSubmit] = useState(false);
   const { canEditReplicator } = useReplicatorEntitlements();
   const { data: project, isLoading: isProjectLoading } = useProject(
     replicator.project,
   );
+
   const clusterLink = replicator.config.cluster;
-  const isReverseFlow = isProjectReplicaModeStandby(project);
-  const buttonLabel = isReverseFlow ? "Restore" : "Run";
+  const isRestore = isProjectReplicaModeStandby(project);
+  const buttonLabel = isRestore ? "Restore" : "Run";
+  const hasPermission = canEditReplicator(replicator);
 
   const disabledReason = () => {
-    if (!canEditReplicator(replicator)) {
+    if (!hasPermission) {
       return "You do not have permission to run this replicator";
     }
-
     if (isLoading) {
-      // Request was sent, waiting for a response
       return "Replicator is starting...";
     }
-
     if (replicator.last_run_status === "Running") {
       return "This replicator is currently running";
     }
-
     return undefined;
   };
 
@@ -78,14 +78,12 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
       queryKeys.replicators,
       replicator.name,
     ];
-
     queryClient.setQueryData<LxdReplicator>(
       detailQueryKey,
       (currentReplicator) => {
         if (!currentReplicator) {
           return currentReplicator;
         }
-
         return {
           ...currentReplicator,
           last_run_status: "Running",
@@ -105,15 +103,10 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
         if (!currentReplicators) {
           return currentReplicators;
         }
-
-        return currentReplicators.map((currentReplicator) =>
-          currentReplicator.name === replicator.name
-            ? {
-                ...currentReplicator,
-                last_run_status: "Running",
-                last_run_error: undefined,
-              }
-            : currentReplicator,
+        return currentReplicators.map((r) =>
+          r.name === replicator.name
+            ? { ...r, last_run_status: "Running", last_run_error: undefined }
+            : r,
         );
       },
     );
@@ -132,18 +125,13 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
       queryKeys.replicators,
       replicator.name,
     ];
-
     queryClient.setQueryData<LxdReplicator>(
       detailQueryKey,
       (currentReplicator) => {
         if (!currentReplicator) {
           return currentReplicator;
         }
-
-        return {
-          ...currentReplicator,
-          last_run_error: errorMsg,
-        };
+        return { ...currentReplicator, last_run_error: errorMsg };
       },
     );
   };
@@ -191,7 +179,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
     runReplicator(
       replicator.name,
       replicator.project,
-      isReverseFlow ? "restore" : "start",
+      isRestore ? "restore" : "start",
     )
       .then((response) => {
         onSuccess();
@@ -225,52 +213,49 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
         ),
         children: (
           <>
+            <RunReplicatorPreflightChecks
+              replicator={replicator}
+              onValidationChange={(isValid) => {
+                setCanSubmit(isValid);
+              }}
+              isRestore={isRestore}
+            />
+
             <p>
               The project <ProjectRichChip projectName={replicator.project} />{" "}
               is in{" "}
               <strong>{project?.config["replica.mode"] || "unknown"}</strong>{" "}
               mode.
-              <br />
-              {/* TODO: use new API endpoint to promote/demote a project
-              https://github.com/canonical/lxd/pull/18312
-              Need to switch to standby ?{" "}
-              <Link
-                to={`${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`}
-              >
-                Change mode
-              </Link> */}
             </p>
 
             <div
               className={classnames("replicator-data-flow u-hide--small", {
-                "replicator-data-flow--reverse": isReverseFlow,
+                "replicator-data-flow--restore": isRestore,
               })}
             >
               <div className="replicator-data-flow__node replicator-data-flow__source">
                 <span className="node-heading u-text--muted">
-                  {isReverseFlow ? "standby" : "leader"} project (local)
+                  {isRestore ? "standby" : "leader"} project (local)
                 </span>
                 <ProjectRichChip projectName={replicator.project} />
               </div>
-
               <div className="replicator-data-flow__arrow-shaft">
                 <ClusterLinkRichChip clusterLink={clusterLink} />
               </div>
-
               <div className="replicator-data-flow__node replicator-data-flow__target">
                 <span className="node-heading u-text--muted">
-                  {isReverseFlow ? "leader" : "standby"} project (remote)
+                  {isRestore ? "leader" : "standby"} project (remote)
                 </span>
                 <strong className="mono-font">{replicator.project}</strong>
               </div>
             </div>
 
-            {isReverseFlow ? (
+            {isRestore ? (
               <p>
                 This will sync all instances from the{" "}
                 <ClusterLinkRichChip clusterLink={clusterLink} /> cluster back
-                to the
-                <ProjectRichChip projectName={replicator.project} /> project.
+                to the <ProjectRichChip projectName={replicator.project} />{" "}
+                project.
               </p>
             ) : (
               <p>
@@ -281,7 +266,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
               </p>
             )}
 
-            {isReverseFlow && (
+            {isRestore && (
               <Notification
                 severity="caution"
                 messageElement="div"
@@ -297,6 +282,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
         ),
         onConfirm: handleRun,
         confirmButtonLabel: buttonLabel,
+        confirmButtonDisabled: !canSubmit || isLoading,
         close: onClose,
       }}
       disabled={Boolean(disabledReason())}

--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -10,6 +10,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { runReplicator } from "api/replicators";
 import classnames from "classnames";
 import ResourceLink from "components/ResourceLink";
+import { useReplicatorLoading } from "context/replicatorLoading";
 import { useProject } from "context/useProjects";
 import { useEventQueue } from "context/eventQueue";
 import RunReplicatorPreflightChecks from "pages/cluster/actions/RunReplicatorPreflightChecks";
@@ -32,6 +33,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
   const eventQueue = useEventQueue();
   const notify = useNotify();
   const toastNotify = useToastNotification();
+  const replicatorLoading = useReplicatorLoading();
   const [isLoading, setLoading] = useState(false);
   const [canSubmit, setCanSubmit] = useState(false);
   const { canEditReplicator } = useReplicatorEntitlements();
@@ -51,7 +53,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
     if (isLoading) {
       return "Replicator is starting...";
     }
-    if (replicator.last_run_status === "Running") {
+    if (replicatorLoading.getStatus(replicator) === "Running") {
       return "This replicator is currently running";
     }
     return undefined;
@@ -71,80 +73,23 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
     );
   };
 
-  const markReplicatorRunning = () => {
-    const detailQueryKey = [
-      queryKeys.projects,
-      replicator.project,
-      queryKeys.replicators,
-      replicator.name,
-    ];
-    queryClient.setQueryData<LxdReplicator>(
-      detailQueryKey,
-      (currentReplicator) => {
-        if (!currentReplicator) {
-          return currentReplicator;
-        }
-        return {
-          ...currentReplicator,
-          last_run_status: "Running",
-          last_run_error: undefined,
-        };
-      },
-    );
-
-    const listQueryKey = [
-      queryKeys.projects,
-      replicator.project,
-      queryKeys.replicators,
-    ];
-    queryClient.setQueryData<LxdReplicator[]>(
-      listQueryKey,
-      (currentReplicators) => {
-        if (!currentReplicators) {
-          return currentReplicators;
-        }
-        return currentReplicators.map((r) =>
-          r.name === replicator.name
-            ? { ...r, last_run_status: "Running", last_run_error: undefined }
-            : r,
-        );
-      },
-    );
-  };
-
   const invalidateCache = () => {
     queryClient.invalidateQueries({
       predicate: (query) => query.queryKey[2] === queryKeys.replicators,
     });
   };
 
-  const storeRunError = (errorMsg?: string) => {
-    const detailQueryKey = [
-      queryKeys.projects,
-      replicator.project,
-      queryKeys.replicators,
-      replicator.name,
-    ];
-    queryClient.setQueryData<LxdReplicator>(
-      detailQueryKey,
-      (currentReplicator) => {
-        if (!currentReplicator) {
-          return currentReplicator;
-        }
-        return { ...currentReplicator, last_run_error: errorMsg };
-      },
-    );
-  };
-
   const onSuccess = () => {
     setLoading(false);
-    markReplicatorRunning();
+    replicatorLoading.clearLastRunError(replicator);
+    replicatorLoading.setRunning(replicator);
     invalidateCache();
     notifySuccess(replicator.name);
   };
 
   const onOperationSuccess = () => {
-    storeRunError(undefined);
+    replicatorLoading.setFinish(replicator);
+    replicatorLoading.clearLastRunError(replicator);
     toastNotify.success(
       <>
         Replicator{" "}
@@ -160,7 +105,8 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
   };
 
   const onOperationFailure = (msg: string) => {
-    storeRunError(msg);
+    replicatorLoading.setFinish(replicator);
+    replicatorLoading.setLastRunError(replicator, msg);
     invalidateCache();
     notify.failure(
       `Replicator ${replicator.name} failed while running`,
@@ -170,6 +116,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
 
   const onFailure = (e: unknown) => {
     setLoading(false);
+    replicatorLoading.setFinish(replicator);
     invalidateCache();
     notify.failure(`Running replicator ${replicator.name} failed`, e);
   };
@@ -203,7 +150,7 @@ const RunReplicatorBtn: FC<Props> = ({ replicator, className, onClose }) => {
         className: "run-replicator-modal",
         title: (
           <>
-            Run replicator{" "}
+            {isRestore ? "Restore" : "Run"} replicator{" "}
             <ResourceLink
               type="replicator"
               value={replicator.name}

--- a/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
@@ -18,7 +18,7 @@ const RunReplicatorPreflightCheckRow: FC<
 > = ({ check }) => {
   const getIcon = () => {
     if (check.status === "loading") {
-      return <Spinner />;
+      return <Spinner className="u-no-padding--top" />;
     }
     if (check.status === "pass") {
       return <Icon name="success" />;

--- a/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightCheckRow.tsx
@@ -1,0 +1,53 @@
+import type { FC, ReactNode } from "react";
+import { Icon, Spinner } from "@canonical/react-components";
+import classnames from "classnames";
+
+export interface PreflightCheck {
+  id: string;
+  label: ReactNode;
+  status: "pass" | "fail" | "loading";
+  message?: ReactNode;
+}
+
+interface RunReplicatorPreflightCheckRowProps {
+  check: PreflightCheck;
+}
+
+const RunReplicatorPreflightCheckRow: FC<
+  RunReplicatorPreflightCheckRowProps
+> = ({ check }) => {
+  const getIcon = () => {
+    if (check.status === "loading") {
+      return <Spinner />;
+    }
+    if (check.status === "pass") {
+      return <Icon name="success" />;
+    }
+    if (check.status === "fail") {
+      return <Icon name="error" />;
+    }
+    return null;
+  };
+
+  return (
+    <div className="preflight-check-row">
+      <div className="u-flex u-gap--small">
+        {getIcon()}
+        <p
+          className={classnames("u-no-padding--top", "u-no-margin--bottom", {
+            "u-text--muted": check.status === "loading",
+          })}
+        >
+          {check.label}
+        </p>
+      </div>
+      {check.message && check.status === "fail" && (
+        <p className="preflight-check-row-error-message u-text--muted u-no-padding--top u-no-margin--bottom">
+          {check.message}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default RunReplicatorPreflightCheckRow;

--- a/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
@@ -12,6 +12,7 @@ import RunReplicatorPreflightCheckRow, {
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { LxdReplicator } from "types/replicator";
 import { getClusterLinksStatus, getLinkIdentity } from "util/clusterLink";
+import { pluralize } from "util/helpers";
 
 interface Props {
   replicator: LxdReplicator;
@@ -44,8 +45,8 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
     id: "replica-cluster-match",
     label: (
       <>
-        Replicator cluster matches the project{" "}
-        <ProjectRichChip projectName={project?.name || "default"} /> replica
+        Project <ProjectRichChip projectName={project?.name || "default"} />{" "}
+        <strong>replica cluster</strong> configuration matches replicator
         cluster
       </>
     ),
@@ -53,8 +54,9 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
     message:
       !isProjectLoading && !clusterMatches ? (
         <>
-          Project cluster <strong>{projectCluster || "none"}</strong> must match
-          replicator cluster <strong>{replicatorCluster || "none"}</strong>.{" "}
+          Project replica cluster <strong>{projectCluster || "none"}</strong>{" "}
+          must match replicator cluster{" "}
+          <strong>{replicatorCluster || "none"}</strong>.{" "}
           <Link
             to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration`}
           >
@@ -110,7 +112,10 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
           : "fail",
       message:
         !isInstancesLoading && !allInstancesStopped
-          ? `${runningInstances.length} active instance(s) running in this project namespace. Stop them to prevent data drift during sync.`
+          ? `${runningInstances.length} running ${pluralize(
+              "instance",
+              runningInstances.length,
+            )} in the project. Stop them to allow restore.`
           : undefined,
     });
   }
@@ -123,16 +128,11 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
   }, [allChecksPassed, isAnyCheckLoading, onValidationChange]);
 
   return (
-    <>
-      <p>
-        <strong>Preflight checks:</strong>
-      </p>
-      <List
-        items={checks.map((check) => (
-          <RunReplicatorPreflightCheckRow key={check.id} check={check} />
-        ))}
-      ></List>
-    </>
+    <List
+      items={checks.map((check) => (
+        <RunReplicatorPreflightCheckRow key={check.id} check={check} />
+      ))}
+    ></List>
   );
 };
 

--- a/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
@@ -1,0 +1,139 @@
+import { useEffect, type FC } from "react";
+import { Link } from "react-router";
+import { List } from "@canonical/react-components";
+import { useClusterLinkState } from "context/useClusterLinks";
+import { useIdentities } from "context/useIdentities";
+import { useInstances } from "context/useInstances";
+import { useProject } from "context/useProjects";
+import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import RunReplicatorPreflightCheckRow, {
+  type PreflightCheck,
+} from "pages/cluster/actions/RunReplicatorPreflightCheckRow";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
+import type { LxdReplicator } from "types/replicator";
+import { getClusterLinksStatus, getLinkIdentity } from "util/clusterLink";
+
+interface Props {
+  replicator: LxdReplicator;
+  onValidationChange: (isValid: boolean) => void;
+  isRestore?: boolean;
+}
+
+const RunReplicatorPreflightChecks: FC<Props> = ({
+  replicator,
+  onValidationChange,
+  isRestore = false,
+}) => {
+  const { data: project, isLoading: isProjectLoading } = useProject(
+    replicator.project,
+  );
+  const { data: instances, isLoading: isInstancesLoading } = useInstances(
+    replicator.project,
+  );
+  const { data: identities = [] } = useIdentities();
+  const { data: clusterLinkState, isLoading: isClusterLinkStateLoading } =
+    useClusterLinkState(replicator.config?.cluster || "");
+  const identity = getLinkIdentity(identities, replicator.config?.cluster);
+
+  const checks: PreflightCheck[] = [];
+
+  const projectCluster = project?.config?.["replica.cluster"];
+  const replicatorCluster = replicator.config?.cluster;
+  const clusterMatches = projectCluster === replicatorCluster;
+  checks.push({
+    id: "replica-cluster-match",
+    label: (
+      <>
+        Replicator cluster matches the project{" "}
+        <ProjectRichChip projectName={project?.name || "default"} /> replica
+        cluster
+      </>
+    ),
+    status: isProjectLoading ? "loading" : clusterMatches ? "pass" : "fail",
+    message:
+      !isProjectLoading && !clusterMatches ? (
+        <>
+          Project cluster <strong>{projectCluster || "none"}</strong> must match
+          replicator cluster <strong>{replicatorCluster || "none"}</strong>.{" "}
+          <Link
+            to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration`}
+          >
+            Update the project configuration
+          </Link>
+        </>
+      ) : undefined,
+  });
+
+  const clusterLinkStatus = getClusterLinksStatus(identity, clusterLinkState);
+  const isReachable = clusterLinkStatus === "Reachable";
+
+  checks.push({
+    id: "cluster-link-reachable",
+    label: (
+      <>
+        Cluster link{" "}
+        <ClusterLinkRichChip clusterLink={replicator.config?.cluster} /> is
+        reachable
+      </>
+    ),
+    status: isClusterLinkStateLoading
+      ? "loading"
+      : isReachable
+        ? "pass"
+        : "fail",
+    message:
+      !isClusterLinkStateLoading && !isReachable
+        ? `The cluster link connection state is '${clusterLinkStatus}'. It must be Reachable.`
+        : undefined,
+  });
+
+  if (isRestore) {
+    const runningInstances =
+      instances?.filter(
+        (inst) =>
+          inst.project === replicator.project && inst.status === "Running",
+      ) || [];
+    const allInstancesStopped = runningInstances.length === 0;
+
+    checks.push({
+      id: "instances-stopped",
+      label: (
+        <>
+          All instances in the project{" "}
+          <ProjectRichChip projectName={replicator.project} /> are stopped
+        </>
+      ),
+      status: isInstancesLoading
+        ? "loading"
+        : allInstancesStopped
+          ? "pass"
+          : "fail",
+      message:
+        !isInstancesLoading && !allInstancesStopped
+          ? `${runningInstances.length} active instance(s) running in this project namespace. Stop them to prevent data drift during sync.`
+          : undefined,
+    });
+  }
+
+  const allChecksPassed = checks.every((check) => check.status === "pass");
+  const isAnyCheckLoading = checks.some((check) => check.status === "loading");
+
+  useEffect(() => {
+    onValidationChange(allChecksPassed && !isAnyCheckLoading);
+  }, [allChecksPassed, isAnyCheckLoading, onValidationChange]);
+
+  return (
+    <>
+      <p>
+        <strong>Preflight checks:</strong>
+      </p>
+      <List
+        items={checks.map((check) => (
+          <RunReplicatorPreflightCheckRow key={check.id} check={check} />
+        ))}
+      ></List>
+    </>
+  );
+};
+
+export default RunReplicatorPreflightChecks;

--- a/src/pages/images/actions/EditImageRegistryButton.tsx
+++ b/src/pages/images/actions/EditImageRegistryButton.tsx
@@ -25,15 +25,13 @@ const EditImageRegistryButton: FC<Props> = ({ imageRegistry }) => {
     return undefined;
   };
 
-  const isDisabled = disabledReason() !== undefined;
-
   return (
     <Button
       appearance="default"
       className={classnames("u-no-margin--bottom", {
         "has-icon": !isSmallScreen,
       })}
-      disabled={isDisabled}
+      disabled={Boolean(disabledReason())}
       type="button"
       hasIcon
       title={disabledReason() || "Edit registry"}

--- a/src/sass/_replicators.scss
+++ b/src/sass/_replicators.scss
@@ -21,3 +21,102 @@
     padding-left: 1.8rem;
   }
 }
+
+.run-replicator-modal {
+  .replicator-data-flow {
+    align-items: stretch;
+    background-color: transparent;
+    display: flex;
+    gap: $sph--x-large;
+    justify-content: center;
+    padding: $sph--x-large 0;
+
+    &__node {
+      align-items: center;
+      border: 1px solid var(--vf-color-border-default);
+      display: flex;
+      flex-direction: column;
+      gap: $spv--small;
+      justify-content: center;
+      padding: $sph--large $sph--x-large;
+    }
+
+    &__target {
+      margin-left: 20px;
+    }
+
+    .node-heading {
+      font-size: 0.75rem;
+      letter-spacing: 0.05em;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    &__arrow-shaft {
+      align-items: center;
+      border-bottom: 1px solid var(--vf-color-border-default);
+      border-top: 1px solid var(--vf-color-border-default);
+      display: flex;
+      flex-grow: 1;
+      height: 3rem;
+      justify-content: center;
+      margin: auto 0;
+      max-width: 20rem;
+      position: relative;
+
+      &::after {
+        border-bottom: 32px solid transparent;
+        border-left: 1.5rem solid var(--vf-color-border-default);
+        border-top: 32px solid transparent;
+        content: "";
+        height: 0;
+        position: absolute;
+        right: -1.5rem;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        z-index: 1;
+      }
+
+      &::before {
+        border-bottom: 30px solid transparent;
+        border-left: 20px solid var(--vf-color-background-default);
+        border-top: 30px solid transparent;
+        content: "";
+        height: 0;
+        position: absolute;
+        right: -20px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        z-index: 2;
+      }
+    }
+
+    &--reverse {
+      .replicator-data-flow__arrow-shaft {
+        &::after {
+          border-left: 0;
+          border-right: 1.5rem solid var(--vf-color-border-default);
+          left: -1.5rem;
+          right: auto;
+        }
+
+        &::before {
+          border-left: 0;
+          border-right: 20px solid var(--vf-color-background-default);
+          left: -20px;
+          right: auto;
+        }
+      }
+
+      .replicator-data-flow__target {
+        margin-left: 0;
+      }
+
+      .replicator-data-flow__source {
+        margin-right: 20px;
+      }
+    }
+  }
+}

--- a/src/sass/_replicators.scss
+++ b/src/sass/_replicators.scss
@@ -23,6 +23,12 @@
 }
 
 .run-replicator-modal {
+  .preflight-check-row {
+    &-error-message {
+      margin-left: calc(16px + 0.5rem);
+    }
+  }
+
   .replicator-data-flow {
     align-items: stretch;
     background-color: transparent;
@@ -93,7 +99,7 @@
       }
     }
 
-    &--reverse {
+    &--restore {
       .replicator-data-flow__arrow-shaft {
         &::after {
           border-left: 0;

--- a/src/types/replicator.d.ts
+++ b/src/types/replicator.d.ts
@@ -15,5 +15,6 @@ export interface LxdReplicator {
   };
   last_run_at: string;
   last_run_status: LxdReplicatorStatus;
+  last_run_error?: string;
   access_entitlements?: string[];
 }

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -18,6 +18,23 @@ const getOperationEntityUrls = (
   return Array.from(candidates);
 };
 
+export const getReplicatorOperationUrls = (
+  operation: LxdOperation,
+): string[] => {
+  const metadataUrls = Object.entries(operation.metadata ?? {})
+    .filter(
+      ([key, value]) =>
+        (key === "entity_url" ||
+          key === "original_entity_url" ||
+          key.endsWith("_url")) &&
+        typeof value === "string" &&
+        value.length > 0,
+    )
+    .map(([, value]) => value);
+
+  return [...new Set(metadataUrls)];
+};
+
 export const getInstanceName = (operation?: LxdOperation): string => {
   // the url can be one of below formats
   // /1.0/instances/<instance_name>

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -81,3 +81,6 @@ export const isProjectWithProfiles = (project?: LxdProject): boolean =>
 
 export const isProjectWithVolumes = (project?: LxdProject): boolean =>
   project?.config["features.storage.volumes"] === "true";
+
+export const isProjectReplicaModeStandby = (project?: LxdProject): boolean =>
+  project?.config["replica.mode"] === "standby";


### PR DESCRIPTION
## Done

- DeleteClusterLinkBtn: disable if cluster link is used by replicator(s), nice hover text

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create a replicator
    - Go to Server/Clustering > Cluster Links: make sure the cluster link used by your replicator cannot be deleted. The delete button should be disabled and the hover text should include your replicator.

## Screenshots

<img width="1568" height="1060" alt="image" src="https://github.com/user-attachments/assets/a6716714-7d9f-4aaa-9e5f-fd4cf5bd5b44" />