### PR TITLE
fix: standardize redirection links for cluster links WD-36883

### DIFF
--- a/src/api/instance-snapshots.tsx
+++ b/src/api/instance-snapshots.tsx
@@ -9,7 +9,7 @@ import {
 import type { LxdInstance, LxdInstanceSnapshot } from "types/instance";
 import type { LxdOperationResponse } from "types/operation";
 import type { EventQueue } from "context/eventQueue";
-import { linkForInstanceDetail } from "util/instances";
+import { getInstanceDetailUrl } from "util/instances";
 import { ROOT_PATH } from "util/rootPath";
 
 export const createInstanceSnapshot = async (
@@ -72,7 +72,7 @@ export const deleteInstanceSnapshotBulk = async (
         const item: BulkOperationItem = {
           name: name,
           type: "snapshot",
-          href: `${linkForInstanceDetail(instance.name, instance.project)}/snapshots`,
+          href: `${getInstanceDetailUrl(instance.name, instance.project)}/snapshots`,
         };
         await deleteInstanceSnapshot(instance, { name })
           .then((operation) => {

--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -19,7 +19,7 @@ import axios, { type AxiosResponse } from "axios";
 import type { UploadState } from "types/upload";
 import { addEntitlements } from "util/entitlements/api";
 import { addTarget } from "util/target";
-import { linkForInstanceDetail } from "util/instances";
+import { getInstanceDetailUrl } from "util/instances";
 import { ROOT_PATH } from "util/rootPath";
 import type { LxdFileExplorerItem, LxdFileMetadata } from "types/fileExplorer";
 
@@ -273,7 +273,7 @@ export const updateInstanceBulkAction = async (
         const item: BulkOperationItem = {
           name,
           type: "instance",
-          href: linkForInstanceDetail(name, project),
+          href: getInstanceDetailUrl(name, project),
         };
         await putInstanceAction(name, project, action, isForce)
           .then((operation) => {
@@ -333,7 +333,7 @@ export const deleteInstanceBulk = async (
         const item: BulkOperationItem = {
           name: instance.name,
           type: "instance",
-          href: linkForInstanceDetail(instance.name, instance.project),
+          href: getInstanceDetailUrl(instance.name, instance.project),
         };
         await deleteInstance(instance)
           .then((operation) => {

--- a/src/api/storage-volumes.tsx
+++ b/src/api/storage-volumes.tsx
@@ -13,7 +13,7 @@ import {
   type BulkOperationItem,
   type BulkOperationResult,
 } from "util/promises";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 import { ROOT_PATH } from "util/rootPath";
 
 export const volumeEntitlements = [
@@ -250,7 +250,7 @@ export const deleteStorageVolumeBulk = async (
         const item: BulkOperationItem = {
           name: volume.name,
           type: "volume",
-          href: linkForVolumeDetail(volume),
+          href: getVolumeDetailUrl(volume),
         };
         return deleteStorageVolume(
           volume.name,

--- a/src/api/volume-snapshots.tsx
+++ b/src/api/volume-snapshots.tsx
@@ -11,7 +11,7 @@ import type { LxdStorageVolume, LxdVolumeSnapshot } from "types/storage";
 import type { LxdApiResponse } from "types/apiResponse";
 import type { EventQueue } from "context/eventQueue";
 import {
-  linkForVolumeDetail,
+  getVolumeDetailUrl,
   splitVolumeSnapshotName,
 } from "util/storageVolume";
 import { addTarget } from "util/target";
@@ -77,7 +77,7 @@ export const deleteVolumeSnapshotBulk = async (
         const item: BulkOperationItem = {
           name: name,
           type: "snapshot",
-          href: `${linkForVolumeDetail(volume)}/snapshots`,
+          href: `${getVolumeDetailUrl(volume)}/snapshots`,
         };
         await deleteVolumeSnapshot(volume, { name })
           .then((operation) => {

--- a/src/components/UsedByItem.tsx
+++ b/src/components/UsedByItem.tsx
@@ -3,7 +3,7 @@ import ResourceLink from "./ResourceLink";
 import type { LxdUsedBy } from "util/usedBy";
 import type { ResourceIconType } from "./ResourceIcon";
 import { useLocalImagesInProject } from "context/useImages";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 import type { LxdStorageVolume } from "types/storage";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
@@ -60,7 +60,7 @@ const UsedByItem: FC<Props> = ({
           <ResourceLink
             type="volume"
             value={item.volume}
-            to={linkForVolumeDetail({
+            to={getVolumeDetailUrl({
               name: item.volume,
               project: item.project,
               pool: item.pool,

--- a/src/pages/cluster/ClusterLinkRichChip.tsx
+++ b/src/pages/cluster/ClusterLinkRichChip.tsx
@@ -4,7 +4,8 @@ import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ResourceLink from "components/ResourceLink";
 import { SMALL_TOOLTIP_BREAKPOINT } from "components/RichTooltipTable";
 import ClusterLinkRichTooltip from "./ClusterLinkRichTooltip";
-import { ROOT_PATH } from "util/rootPath";
+import { getClusterLinkListUrl } from "util/clusterLink";
+import { useIsClustered } from "context/useIsClustered";
 
 interface Props {
   clusterLink: string;
@@ -18,13 +19,13 @@ const ClusterLinkRichChip: FC<Props> = ({
   disabled,
 }) => {
   const showTooltip = !useIsScreenBelow(SMALL_TOOLTIP_BREAKPOINT, "height");
+  const isClustered = useIsClustered();
 
-  const url = `${ROOT_PATH}/ui/cluster/links`;
   const resourceLink = (
     <ResourceLink
       type="cluster-link"
       value={clusterLink}
-      to={url}
+      to={getClusterLinkListUrl(isClustered)}
       hasTitle={!showTooltip}
       className={className}
       disabled={disabled}

--- a/src/pages/cluster/ClusterLinkRichTooltip.tsx
+++ b/src/pages/cluster/ClusterLinkRichTooltip.tsx
@@ -7,10 +7,10 @@ import ItemName from "components/ItemName";
 import { useClusterLink } from "context/useClusterLinks";
 import ClusterLinkStatus from "./ClusterLinkStatus";
 import ResourceLabel from "components/ResourceLabel";
-import { ROOT_PATH } from "util/rootPath";
 import ClusterLinkAddresses from "./ClusterLinkAddresses";
-import { getLinkIdentity } from "util/clusterLink";
 import { useIdentities } from "context/useIdentities";
+import { getClusterLinkListUrl, getLinkIdentity } from "util/clusterLink";
+import { useIsClustered } from "context/useIsClustered";
 
 interface Props {
   clusterLink: string;
@@ -19,6 +19,7 @@ interface Props {
 const ClusterLinkRichTooltip: FC<Props> = ({ clusterLink }) => {
   const { data: link, isLoading: isLinkLoading } = useClusterLink(clusterLink);
   const { data: identities = [] } = useIdentities();
+  const isClustered = useIsClustered();
 
   if (!link && !isLinkLoading) {
     return (
@@ -37,7 +38,7 @@ const ClusterLinkRichTooltip: FC<Props> = ({ clusterLink }) => {
       title: "Cluster link",
       value: link ? (
         <Link
-          to={`${ROOT_PATH}/ui/cluster/links`}
+          to={getClusterLinkListUrl(isClustered)}
           onClick={(e) => {
             e.stopPropagation();
           }}

--- a/src/pages/cluster/ReplicatorClusterLinkSelector.tsx
+++ b/src/pages/cluster/ReplicatorClusterLinkSelector.tsx
@@ -3,9 +3,10 @@ import { CustomSelect, useNotify } from "@canonical/react-components";
 import { useClusterLinks } from "context/useClusterLinks";
 import type { FormikProps } from "formik";
 import { Link } from "react-router-dom";
-import { ROOT_PATH } from "util/rootPath";
 import type { ReplicatorFormValues } from "types/forms/replicator";
 import ClusterLinkStatus from "pages/cluster/ClusterLinkStatus";
+import { useIsClustered } from "context/useIsClustered";
+import { getClusterLinkListUrl } from "util/clusterLink";
 
 interface Props {
   formik: FormikProps<ReplicatorFormValues>;
@@ -17,7 +18,7 @@ export const ReplicatorClusterLinkSelector: FC<Props> = ({
 }) => {
   const { data: links = [], error, isLoading } = useClusterLinks();
   const notify = useNotify();
-
+  const isClustered = useIsClustered();
   const hasNoLinks = links.length === 0 && !isLoading;
 
   if (error) {
@@ -39,16 +40,14 @@ export const ReplicatorClusterLinkSelector: FC<Props> = ({
     ),
   }));
 
+  const helpLink = (
+    <Link to={getClusterLinkListUrl(isClustered)}>cluster links</Link>
+  );
+
   const helpText = hasNoLinks ? (
-    <>
-      Cluster to replicate to. Create your first{" "}
-      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
-    </>
+    <>Cluster to replicate to. Create your first {helpLink}.</>
   ) : (
-    <>
-      Cluster to replicate to. Manage your{" "}
-      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>.
-    </>
+    <>Cluster to replicate to. Manage your {helpLink}.</>
   );
   return (
     <CustomSelect

--- a/src/pages/cluster/ReplicatorDetailHeader.tsx
+++ b/src/pages/cluster/ReplicatorDetailHeader.tsx
@@ -11,6 +11,8 @@ import { checkDuplicateName } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import * as Yup from "yup";
 import ReplicatorRichChip from "./ReplicatorRichChip";
+import { useIsClustered } from "context/useIsClustered";
+import { getReplicatorListUrl } from "util/replicator";
 
 interface Props {
   replicator: LxdReplicator;
@@ -22,6 +24,7 @@ const ReplicatorDetailHeader: FC<Props> = ({ replicator }) => {
   const toastNotify = useToastNotification();
   const { canEditReplicator } = useReplicatorEntitlements();
   const controllerState = useState<AbortController | null>(null);
+  const isClustered = useIsClustered();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
@@ -94,7 +97,7 @@ const ReplicatorDetailHeader: FC<Props> = ({ replicator }) => {
     <RenameHeader
       name={replicator.name}
       parentItems={[
-        <Link to={`${ROOT_PATH}/ui/cluster/replicators`} key={1}>
+        <Link to={getReplicatorListUrl(isClustered)} key={1}>
           Replicators
         </Link>,
       ]}

--- a/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
@@ -16,6 +16,8 @@ import { queryKeys } from "util/queryKeys";
 import { ROOT_PATH } from "util/rootPath";
 import classNames from "classnames";
 import ReplicatorRichChip from "../ReplicatorRichChip";
+import { useIsClustered } from "context/useIsClustered";
+import { getReplicatorListUrl } from "util/replicator";
 
 interface Props {
   replicator: LxdReplicator;
@@ -36,6 +38,7 @@ const DeleteReplicatorBtn: FC<Props> = ({
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
   const { canDeleteReplicator } = useReplicatorEntitlements();
+  const isClustered = useIsClustered();
   const isReplicatorRunning = replicator.last_run_status === "Running";
 
   const disabledReason = () => {
@@ -67,7 +70,8 @@ const DeleteReplicatorBtn: FC<Props> = ({
     // Only navigate to the replicators list if we are still on the deleted replicator's detail page
     const replicatorDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`;
     if (location.pathname.startsWith(replicatorDetailPath)) {
-      navigate(`${ROOT_PATH}/ui/cluster/replicators`);
+      const replicatorListUrl = getReplicatorListUrl(isClustered);
+      navigate(replicatorListUrl);
     }
 
     notifySuccess(replicator.name);

--- a/src/pages/images/ImageRegistryClusterLinkSelector.tsx
+++ b/src/pages/images/ImageRegistryClusterLinkSelector.tsx
@@ -4,7 +4,8 @@ import { useClusterLinks } from "context/useClusterLinks";
 import type { FormikProps } from "formik";
 import type { ImageRegistryFormValues } from "types/forms/image";
 import { Link } from "react-router-dom";
-import { ROOT_PATH } from "util/rootPath";
+import { useIsClustered } from "context/useIsClustered";
+import { getClusterLinkListUrl } from "util/clusterLink";
 
 interface Props {
   formik: FormikProps<ImageRegistryFormValues>;
@@ -17,6 +18,7 @@ export const ImageRegistryClusterLinkSelector: FC<Props> = ({
 }) => {
   const { data: links = [], error } = useClusterLinks();
   const notify = useNotify();
+  const isClustered = useIsClustered();
   const hasNoLinks = links.length === 0;
 
   if (error) {
@@ -40,16 +42,14 @@ export const ImageRegistryClusterLinkSelector: FC<Props> = ({
     ),
   }));
 
+  const helpLink = (
+    <Link to={getClusterLinkListUrl(isClustered)}>cluster links</Link>
+  );
+
   const helpText = hasNoLinks ? (
-    <>
-      Cluster containing the images. Create your first{" "}
-      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
-    </>
+    <>Cluster containing the images. Create your first {helpLink}.</>
   ) : (
-    <>
-      Cluster containing the images. Manage your{" "}
-      <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>.
-    </>
+    <>Cluster containing the images. Manage your {helpLink}.</>
   );
 
   return (

--- a/src/pages/images/ImageRegistryRichTooltip.tsx
+++ b/src/pages/images/ImageRegistryRichTooltip.tsx
@@ -7,7 +7,8 @@ import { Link } from "react-router";
 import { useImageRegistry } from "context/useImageRegistries";
 import { isImageRegistryPublic } from "util/imageRegistries";
 import ItemName from "components/ItemName";
-import { ROOT_PATH } from "util/rootPath";
+import { getClusterLinkListUrl } from "util/clusterLink";
+import { useIsClustered } from "context/useIsClustered";
 
 interface Props {
   imageRegistryName: string;
@@ -20,6 +21,7 @@ const ImageRegistryRichTooltip: FC<Props> = ({
 }) => {
   const { data: imageRegistry, isLoading: isLoading } =
     useImageRegistry(imageRegistryName);
+  const isClustered = useIsClustered();
 
   if (!imageRegistry && !isLoading) {
     return (
@@ -83,7 +85,7 @@ const ImageRegistryRichTooltip: FC<Props> = ({
     rows.push({
       title: "Cluster",
       value: cluster ? (
-        <Link to={`${ROOT_PATH}/ui/cluster/links`}>{cluster}</Link>
+        <Link to={getClusterLinkListUrl(isClustered)}>{cluster}</Link>
       ) : (
         "-"
       ),

--- a/src/pages/storage/StorageVolumeDetail.tsx
+++ b/src/pages/storage/StorageVolumeDetail.tsx
@@ -8,7 +8,7 @@ import EditStorageVolume from "pages/storage/forms/EditStorageVolume";
 import TabLinks from "components/TabLinks";
 import StorageVolumeSnapshots from "./StorageVolumeSnapshots";
 import { useStorageVolume } from "context/useVolumes";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 import NotFound from "components/NotFound";
 
 const tabs: string[] = ["Overview", "Configuration", "Snapshots"];
@@ -70,7 +70,7 @@ const StorageVolumeDetail: FC = () => {
         <TabLinks
           tabs={tabs}
           activeTab={activeTab}
-          tabUrl={linkForVolumeDetail(volume)}
+          tabUrl={getVolumeDetailUrl(volume)}
         />
         <NotificationRow />
         {!activeTab && (

--- a/src/pages/storage/StorageVolumeNameLink.tsx
+++ b/src/pages/storage/StorageVolumeNameLink.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { Link } from "react-router-dom";
 import type { LxdStorageVolume } from "types/storage";
 import classnames from "classnames";
-import { linkForVolumeDetail, hasVolumeDetailPage } from "util/storageVolume";
+import { getVolumeDetailUrl, hasVolumeDetailPage } from "util/storageVolume";
 import { useInstances } from "context/useInstances";
 import { useLocalImagesInProject } from "context/useImages";
 import { getImageAlias, getImageName } from "util/images";
@@ -58,7 +58,7 @@ const StorageVolumeNameLink: FC<Props> = ({
       >
         {displayLink ? (
           <Link
-            to={linkForVolumeDetail(volume)}
+            to={getVolumeDetailUrl(volume)}
             className={isExternalLink ? "has-icon" : undefined}
           >
             {caption}

--- a/src/pages/storage/VolumeLinkChip.tsx
+++ b/src/pages/storage/VolumeLinkChip.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import ResourceLink from "components/ResourceLink";
 import type { LxdStorageVolume } from "types/storage";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 
 interface Props {
   volume: LxdStorageVolume;
@@ -12,7 +12,7 @@ const VolumeLinkChip: FC<Props> = ({ volume }) => {
     <ResourceLink
       type="volume"
       value={volume.name}
-      to={linkForVolumeDetail(volume)}
+      to={getVolumeDetailUrl(volume)}
     />
   );
 };

--- a/src/pages/storage/VolumeSnapshotLinkChip.tsx
+++ b/src/pages/storage/VolumeSnapshotLinkChip.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import ResourceLink from "components/ResourceLink";
 import type { LxdStorageVolume } from "types/storage";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 
 interface Props {
   name: string;
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const VolumeSnapshotLinkChip: FC<Props> = ({ name, volume }) => {
-  const baseUrl = linkForVolumeDetail(volume);
+  const baseUrl = getVolumeDetailUrl(volume);
 
   return (
     <ResourceLink type="snapshot" value={name} to={`${baseUrl}/snapshots`} />

--- a/src/pages/storage/forms/EditStorageVolume.tsx
+++ b/src/pages/storage/forms/EditStorageVolume.tsx
@@ -21,7 +21,7 @@ import FormFooterLayout from "components/forms/FormFooterLayout";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import { updateStorageVolume } from "api/storage-volumes";
 import { useStorageVolumeEntitlements } from "util/entitlements/storage-volumes";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 import VolumeLinkChip from "pages/storage/VolumeLinkChip";
 import { useEventQueue } from "context/eventQueue";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
@@ -118,7 +118,7 @@ const EditStorageVolume: FC<Props> = ({ volume }) => {
     },
   });
 
-  const baseUrl = `${linkForVolumeDetail(volume)}/configuration`;
+  const baseUrl = `${getVolumeDetailUrl(volume)}/configuration`;
 
   const setSection = (newSection: string) => {
     if (newSection === MAIN_CONFIGURATION) {

--- a/src/pages/storage/forms/UploadVolumeBackupFileForm.tsx
+++ b/src/pages/storage/forms/UploadVolumeBackupFileForm.tsx
@@ -26,7 +26,7 @@ import ResourceLink from "components/ResourceLink";
 import ResourceLabel from "components/ResourceLabel";
 import { uploadVolume } from "api/storage-volumes";
 import {
-  linkForVolumeDetail,
+  getVolumeDetailUrl,
   testDuplicateStorageVolumeName,
 } from "util/storageVolume";
 import ClusterMemberSelector from "pages/cluster/ClusterMemberSelector";
@@ -64,7 +64,7 @@ const UploadVolumeBackupFileForm: FC<Props> = ({
     location: string,
     pool: string,
   ) => {
-    const volumeDetailURL = linkForVolumeDetail({
+    const volumeDetailURL = getVolumeDetailUrl({
       location: location,
       name: volumeName,
       pool: pool,

--- a/src/util/clusterLink.tsx
+++ b/src/util/clusterLink.tsx
@@ -3,6 +3,7 @@ import type { LxdClusterLinkState, StatusCaption } from "types/cluster";
 import type { LxdIdentity } from "types/permissions";
 import type { LxdProject } from "types/project";
 import type { TestContext } from "yup";
+import { ROOT_PATH } from "./rootPath";
 
 export const getClusterLinksStatus = (
   identity?: LxdIdentity,
@@ -74,4 +75,10 @@ export const testProjectReplicaCluster = (
   }
 
   return replicaCluster === selectedCluster;
+};
+
+export const getClusterLinkListUrl = (isClustered = false): string => {
+  return isClustered
+    ? `${ROOT_PATH}/ui/cluster/links`
+    : `${ROOT_PATH}/ui/server/cluster-links`;
 };

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -8,7 +8,7 @@ import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfi
 
 export const CLUSTER_GROUP_PREFIX = "@";
 
-export const linkForInstanceDetail = (name: string, project?: string) => {
+export const getInstanceDetailUrl = (name: string, project?: string) => {
   return `${ROOT_PATH}/ui/project/${encodeURIComponent(project ?? "default")}/instance/${encodeURIComponent(name)}`;
 };
 

--- a/src/util/replicator.ts
+++ b/src/util/replicator.ts
@@ -1,6 +1,7 @@
 import type { FormikProps } from "formik";
 import type { ReplicatorFormValues } from "types/forms/replicator";
 import type { LxdReplicator } from "types/replicator";
+import { ROOT_PATH } from "./rootPath";
 
 export const getPayload = (
   formik: FormikProps<ReplicatorFormValues>,
@@ -14,4 +15,10 @@ export const getPayload = (
       snapshot: formik.values.snapshot,
     },
   };
+};
+
+export const getReplicatorListUrl = (isClustered = false): string => {
+  return isClustered
+    ? `${ROOT_PATH}/ui/cluster/replicators`
+    : `${ROOT_PATH}/ui/server/replicators`;
 };

--- a/src/util/storageVolume.tsx
+++ b/src/util/storageVolume.tsx
@@ -133,7 +133,7 @@ const collapsedViewMaxWidth = 1250;
 export const figureCollapsedScreen = (): boolean =>
   window.innerWidth <= collapsedViewMaxWidth;
 
-export const linkForVolumeDetail = (volume: LxdStorageVolume): string => {
+export const getVolumeDetailUrl = (volume: LxdStorageVolume): string => {
   // NOTE: name of a volume created from an instance is exactly the same as the instance name
   if (volume.type === "container" || volume.type === "virtual-machine") {
     return `${ROOT_PATH}/ui/project/${encodeURIComponent(volume.project)}/instance/${encodeURIComponent(volume.name)}`;
@@ -162,7 +162,7 @@ export const hasLocation = (volume?: LxdStorageVolume): boolean => {
 };
 
 export const hasVolumeDetailPage = (volume: LxdStorageVolume): boolean => {
-  return linkForVolumeDetail(volume).includes("/storage/pool/");
+  return getVolumeDetailUrl(volume).includes("/storage/pool/");
 };
 
 export const getStorageVolumeFormProps = (

--- a/src/util/storageVolumeMigration.tsx
+++ b/src/util/storageVolumeMigration.tsx
@@ -13,7 +13,7 @@ import { useNavigate } from "react-router-dom";
 import type { LxdStorageVolume } from "types/storage";
 import { capitalizeFirstLetter } from "./helpers";
 import { queryKeys } from "./queryKeys";
-import { linkForVolumeDetail } from "./storageVolume";
+import { getVolumeDetailUrl } from "./storageVolume";
 import VolumeLinkChip from "pages/storage/VolumeLinkChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { ROOT_PATH } from "util/rootPath";
@@ -41,8 +41,8 @@ export const useStorageVolumeMigration = ({
   const handleSuccess = () => {
     let successMessage: ReactNode = "";
 
-    const oldVolumeDetailPage = linkForVolumeDetail(volume);
-    const newVolumeDetailPage = linkForVolumeDetail({
+    const oldVolumeDetailPage = getVolumeDetailUrl(volume);
+    const newVolumeDetailPage = getVolumeDetailUrl({
       ...volume,
       project: type === "project" ? target : volume.project,
       pool: type === "pool" ? target : volume.pool,

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -3,9 +3,9 @@ import {
   extractResourceDetailsFromUrl,
   type ResourceType,
 } from "util/resourceDetails";
-import { linkForVolumeDetail } from "util/storageVolume";
+import { getVolumeDetailUrl } from "util/storageVolume";
 import { getStorageBucketURL } from "util/storageBucket";
-import { linkForInstanceDetail } from "util/instances";
+import { getInstanceDetailUrl } from "util/instances";
 import { ROOT_PATH } from "util/rootPath";
 
 export interface LxdUsedBy {
@@ -105,11 +105,11 @@ export const getProfileInstances = (
 export const getLinkTarget = (resource: LxdUsedBy, entityType: string) => {
   if (entityType === "snapshot") {
     if (resource.instance) {
-      return `${linkForInstanceDetail(resource.instance, resource.project)}/snapshots`;
+      return `${getInstanceDetailUrl(resource.instance, resource.project)}/snapshots`;
     }
 
     if (resource.volume && resource.pool) {
-      const volumeDetailUrl = linkForVolumeDetail({
+      const volumeDetailUrl = getVolumeDetailUrl({
         name: resource.volume,
         project: resource.project,
         pool: resource.pool,
@@ -121,7 +121,7 @@ export const getLinkTarget = (resource: LxdUsedBy, entityType: string) => {
   }
 
   if (entityType === "volume" && resource.pool) {
-    return linkForVolumeDetail({
+    return getVolumeDetailUrl({
       name: resource.name,
       project: resource.project,
       pool: resource.pool,


### PR DESCRIPTION
## Done

- Standardize redirection links for cluster links depending on clustered vs unclustered environments.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure the links in the following places direct to "/ui/cluster/links" if clustered or  "/ui/server/cluster-links" otherwise
       - Clicking on a cluster link rich chip
       - Clicking on the name in the cluster link tooltip
       - Clicking on the help message under the cluster field in a replicator/image registry form when no cluster links exist (empty state)
       -  Clicking on the cluster link in the image registry tooltip

    - Ensure the links in the following places direct to "/ui/cluster/replicators" if clustered or  "/ui/server/replicators" otherwise
       - Clicking on the link in the replicator detail page header
       - After deleting a replicator
      