### PR TITLE
fix(cluster-link) ensure entered token is only sent with token consume and not with token generate mode

### DIFF
--- a/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
+++ b/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
@@ -69,7 +69,7 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
       const payload = {
         name: values.name,
         description: values.description,
-        trust_token: values.token,
+        trust_token: values.tokenType === "consume" ? values.token : undefined,
         auth_groups: values.authGroups,
         type: "bidirectional",
       };


### PR DESCRIPTION
## Done

- ensure entered token is only sent with token consume and not with token generate mode

Fixes WD-36882

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - start cluster link creation, select "I have a token", enter token, then switch back to "generate token"
    - ensure the cluster link is generated.