### PR TITLE
chore(clustered tests): setup another cluster and add cluster links tests

### DIFF
--- a/tests/cluster-links-clustered.spec.ts
+++ b/tests/cluster-links-clustered.spec.ts
@@ -1,10 +1,12 @@
-import { test } from "./fixtures/lxd-test";
+import { test, expect } from "./fixtures/lxd-test";
 import {
   createClusterLink,
   deleteClusterLink,
   editClusterLink,
   randomLinkName,
   skipIfNotSupported,
+  createClusterLinkOnRemoteCluster,
+  deleteClusterLinkOnRemoteCluster,
 } from "./helpers/cluster-links";
 import { skipIfNotClustered } from "./helpers/cluster";
 
@@ -17,6 +19,64 @@ test("cluster link create edit delete", async ({
 
   const link = randomLinkName();
   await createClusterLink(page, link);
+  const row = page.getByRole("row").filter({ hasText: link });
+  await expect(row).toBeVisible();
+  await expect(row.getByRole("cell", { name: "Type" })).toHaveText(
+    "Bidirectional",
+  );
+  await expect(row.getByRole("cell", { name: "Status" })).toHaveText("Pending");
+  await expect(row.getByRole("cell", { name: "Addresses" })).toHaveText("-");
+  await expect(row.getByRole("cell", { name: "Description" })).toHaveText("");
+
   await editClusterLink(page, link);
+  await expect(row.getByRole("cell", { name: "Description" })).toHaveText(
+    "My link",
+  );
+
+  await deleteClusterLink(page, link);
+  await expect(row).toHaveCount(0);
+});
+
+test("cluster link table displays all links", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+
+  const link1 = randomLinkName();
+  const link2 = randomLinkName();
+  await createClusterLink(page, link1);
+  await createClusterLink(page, link2);
+
+  const row1 = page.getByRole("row").filter({ hasText: link1 });
+  const row2 = page.getByRole("row").filter({ hasText: link2 });
+
+  await expect(row1).toBeVisible();
+  await expect(row2).toBeVisible();
+
+  await deleteClusterLink(page, link1);
+  await deleteClusterLink(page, link2);
+});
+
+test("consume token to create cluster link", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+
+  const link = randomLinkName();
+
+  const token = createClusterLinkOnRemoteCluster(link);
+  await createClusterLink(page, link, token);
+
+  const row = page.getByRole("row").filter({ hasText: link });
+  await expect(row.getByRole("cell", { name: "Status" })).toHaveText(
+    "Reachable",
+  );
+  await expect(row.getByRole("cell", { name: "Auth groups" })).toHaveText("1");
+
+  deleteClusterLinkOnRemoteCluster(link);
   await deleteClusterLink(page, link);
 });

--- a/tests/helpers/cluster-links.ts
+++ b/tests/helpers/cluster-links.ts
@@ -3,6 +3,7 @@ import { randomNameSuffix } from "./name";
 import type { Page } from "@playwright/test";
 import { gotoURL } from "./navigate";
 import { dismissNotification } from "./notification";
+import { runCommand } from "./shell";
 
 export const skipIfNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
@@ -15,24 +16,44 @@ export const randomLinkName = (): string => {
   return `playwright-cluster-link-${randomNameSuffix()}`;
 };
 
-export const createClusterLink = async (page: Page, link: string) => {
+export const visitClusterLinks = async (page: Page) => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Clustering" }).click();
-  await page.getByRole("link", { name: "Link" }).click();
+  await page.getByRole("link", { name: "Links" }).click();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Create link" }),
+  ).toBeVisible();
+};
+
+export const createClusterLink = async (
+  page: Page,
+  link: string,
+  token?: string,
+) => {
+  await visitClusterLinks(page);
   await page.getByRole("button", { name: "Create link" }).click();
   await expect(page.getByText("Create cluster link")).toBeVisible();
-
   await page.getByPlaceholder("Enter name").fill(link);
   const panel = page.getByLabel("Side panel");
+  if (token) {
+    await page.getByText("I have a token").click();
+    await page.getByPlaceholder("Enter token").fill(token);
+  }
+  panel.getByRole("rowheader").filter({ hasText: "admins" }).click();
   await panel.getByRole("button", { name: "Create link" }).click();
 
   await expect(page.getByText(`Cluster link ${link} created`)).toBeVisible();
-  await page.getByText("I have copied the token").click();
-  await page.getByRole("button", { name: "Done" }).click();
+
+  if (!token) {
+    await page.getByText("I have copied the token").click();
+    await page.getByRole("button", { name: "Done" }).click();
+  } else {
+    await dismissNotification(page, `Cluster link ${link} created.`);
+  }
 };
 
 export const editClusterLink = async (page: Page, link: string) => {
-  const row = page.locator("tr").filter({ hasText: link });
+  const row = page.getByRole("row").filter({ hasText: link });
   await row.getByRole("button", { name: "Edit cluster link" }).click();
   await expect(page.getByText(`Edit cluster link ${link}`)).toBeVisible();
 
@@ -45,10 +66,7 @@ export const editClusterLink = async (page: Page, link: string) => {
 };
 
 export const deleteClusterLink = async (page: Page, link: string) => {
-  await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Clustering" }).click();
-  await page.getByRole("link", { name: "Links" }).click();
-  const row = page.locator("tr").filter({ hasText: link });
+  const row = page.getByRole("row").filter({ hasText: link });
   await row.getByRole("button", { name: "Delete cluster link" }).click();
   await page
     .getByRole("dialog", { name: "Confirm delete" })
@@ -56,4 +74,30 @@ export const deleteClusterLink = async (page: Page, link: string) => {
     .click();
 
   await dismissNotification(page, `Cluster link ${link} deleted.`);
+};
+
+export const createClusterLinkOnRemoteCluster = (link: string) => {
+  const targetVM = getRemoteClusterVm();
+  const generateTokenCommand = `lxc cluster link create ${link} --auth-group admins`;
+  const output = runCommand(
+    `lxc exec ${targetVM} -- sh -c '${generateTokenCommand}'`,
+  )
+    .toString()
+    .trim();
+
+  // Extract token from the output (it's on the last line)
+  return output.split("\n").pop() || "";
+};
+
+export const deleteClusterLinkOnRemoteCluster = (link: string) => {
+  const targetVM = getRemoteClusterVm();
+  runCommand(`lxc exec ${targetVM} -- sh -c 'lxc cluster link delete ${link}'`);
+};
+
+const getRemoteClusterVm = () => {
+  const targetVM = process.env.LXD_UI_CLUSTER_LINK_TARGET_VM;
+  if (!targetVM) {
+    throw new Error("Missing required env var: LXD_UI_CLUSTER_LINK_TARGET_VM");
+  }
+  return targetVM;
 };

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -18,6 +18,11 @@ export const visitServerSettings = async (page: Page) => {
   await page.getByRole("link", { name: "Settings", exact: true }).click();
 };
 
+export const visitServer = async (page: Page) => {
+  await gotoURL(page, "/ui/");
+  await page.getByRole("link", { name: "Server", exact: true }).click();
+};
+
 export const updateCheckbox = async (settingRow: Locator) => {
   const checkbox = settingRow.locator(".p-checkbox__label");
   await checkbox.click();

--- a/tests/scripts/start_vm_cluster.sh
+++ b/tests/scripts/start_vm_cluster.sh
@@ -15,12 +15,22 @@ until sudo lxc exec vm2 -- true 2>/dev/null; do
 done
 sudo lxc exec vm2 -- cloud-init status --wait
 
+# Additional standalone node used as a second cluster target (for cluster link tests).
+sudo lxc launch ubuntu:24.04 vm3 --vm -c limits.cpu=2 -c limits.memory=4GiB
+until sudo lxc exec vm3 -- true 2>/dev/null; do
+  sleep 1
+done
+sudo lxc exec vm3 -- cloud-init status --wait
+
 sudo lxc exec vm1 -- apt-get update
 sudo lxc exec vm1 -- sudo apt-get install snapd -y
 sudo lxc exec vm1 -- snap install lxd --channel="$1"
 sudo lxc exec vm2 -- apt-get update
 sudo lxc exec vm2 -- sudo apt-get install snapd -y
 sudo lxc exec vm2 -- snap install lxd --channel="$1"
+sudo lxc exec vm3 -- apt-get update
+sudo lxc exec vm3 -- sudo apt-get install snapd -y
+sudo lxc exec vm3 -- snap install lxd --channel="$1"
 
 VM1_IP=$(sudo lxc list vm1 --format csv -c 4 | cut -d' ' -f1 | cut -d',' -f1)
 VM2_IP=$(sudo lxc list vm2 --format csv -c 4 | cut -d' ' -f1 | cut -d',' -f1)
@@ -62,9 +72,16 @@ cluster:
   cluster_token: ${TOKEN}
 EOF
 
+# Bootstrap VM3 as an unclustered standalone LXD.
+sudo lxc exec vm3 -- lxd init --auto
+sudo lxc exec vm3 -- lxc config set core.https_address :8443
+
 cat keys/lxd-ui.crt | sudo lxc exec vm1 -- lxc config trust add - || true
 
-echo "LXD_UI_BACKEND_IP=$VM1_IP" > .env.local
+cat <<EOF > .env.local
+LXD_UI_BACKEND_IP=$VM1_IP
+LXD_UI_CLUSTER_LINK_TARGET_VM=vm3
+EOF
 
 sudo lxc exec vm1 -- sudo snap install snapd --channel=latest/beta
 sudo lxc exec vm1 -- sudo snap install core26 --channel latest/edge

--- a/tests/server.spec.ts
+++ b/tests/server.spec.ts
@@ -7,6 +7,7 @@ import {
   randomSettingValue,
   resetSetting,
   updateSetting,
+  visitServer,
   visitServerSettings,
   type ServerSettingType,
 } from "./helpers/server";
@@ -86,4 +87,30 @@ test("add and delete user defined setting", async ({ page }) => {
 
   await expect(keyElement).toHaveCount(0);
   await expect(valueElement).toHaveCount(0);
+});
+
+test("server page tabs are visible", async ({ page, lxdVersion }) => {
+  await visitServer(page);
+  const tabs = page.locator(".p-tabs__link");
+
+  await expect(tabs.filter({ hasText: "Hardware" })).toBeVisible();
+
+  if (lxdVersion !== "5.0-edge") {
+    await tabs.filter({ hasText: "Clustering" }).click();
+    await expect(page.getByText("This server is not clustered")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Enable clustering" }),
+    ).toBeVisible();
+  }
+
+  if (lxdVersion !== "5.0-edge" && lxdVersion !== "5.21-edge") {
+    await tabs.filter({ hasText: "Cluster links" }).click();
+    await expect(
+      page.getByRole("button", { name: "Create link" }),
+    ).toBeVisible();
+    await tabs.filter({ hasText: "Replicators" }).click();
+    await expect(
+      page.getByRole("button", { name: "Create replicator" }),
+    ).toBeVisible();
+  }
 });


### PR DESCRIPTION
## Done

- Extend the infrastructure of clustered tests to have a second one-node cluster. WD-37019
- Add tests for cluster links. WD-37020

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Trust CI

## Screenshots

<img width="1023" height="477" alt="image" src="https://github.com/user-attachments/assets/9bf86d28-3eba-46ef-bf61-0d0fca5483c2" />

