### PR TITLE
fix(load-balancer) avoid confusing highlights on load balancer create/edit form. rely on borders instead

### DIFF
--- a/src/pages/networks/forms/LoadBalancerForm.tsx
+++ b/src/pages/networks/forms/LoadBalancerForm.tsx
@@ -176,7 +176,7 @@ const LoadBalancerForm: FC<Props> = ({ formik, isEdit, network }) => {
           stacked
         />
         {formik.values.ports.length > 0 && (
-          <Row>
+          <Row className="load-balancer-ports-row">
             <LoadBalancerPortsForm formik={formik} network={network} />
           </Row>
         )}

--- a/src/pages/networks/forms/LoadBalancerPortsForm.tsx
+++ b/src/pages/networks/forms/LoadBalancerPortsForm.tsx
@@ -64,17 +64,9 @@ const LoadBalancerPortsForm: FC<Props> = ({ formik, network }) => {
               Target pool
             </Label>
           </th>
-          <th className="instances u-align--right">
-            Instances{" "}
-            <Tooltip message="Determined by selected target pool">
-              <Icon name="information" />
-            </Tooltip>
-          </th>
-          <th className="target-port u-align--right">
-            Target port{" "}
-            <Tooltip message="Determined by selected target pool">
-              <Icon name="information" />
-            </Tooltip>
+          <th className="instances u-align--right u-text--muted">Instances</th>
+          <th className="target-port u-align--right u-text--muted">
+            Target port
           </th>
           <th className="pool-action">
             <span className="u-off-screen">Pool action</span>
@@ -175,10 +167,16 @@ const LoadBalancerPortsForm: FC<Props> = ({ formik, network }) => {
                 />
               </td>
               <td className="instances u-align--right mono-font">
-                <b>{selectedTargetPool?.instances.length ?? 0}</b>
+                <b>{selectedTargetPool?.instances.length ?? "-"}</b>{" "}
+                <Tooltip message="Determined by selected target pool">
+                  <Icon name="information" />
+                </Tooltip>
               </td>
               <td className="target-port u-align--right mono-font">
-                <b>{selectedTargetPool?.config.target_port ?? 0}</b>
+                <b>{selectedTargetPool?.config.target_port ?? "-"}</b>{" "}
+                <Tooltip message="Determined by selected target pool">
+                  <Icon name="information" />
+                </Tooltip>
               </td>
               <td className="pool-action">
                 <EditLoadBalancerPoolBtn
@@ -186,7 +184,7 @@ const LoadBalancerPortsForm: FC<Props> = ({ formik, network }) => {
                   pool={port.targetPool}
                 />
               </td>
-              <td className="actions">
+              <td className="actions u-align--right">
                 <Button
                   appearance=""
                   onClick={async () =>

--- a/src/sass/_load_balancers.scss
+++ b/src/sass/_load_balancers.scss
@@ -92,7 +92,14 @@
   }
 }
 
+.load-balancer-ports-row {
+  max-width: 100%;
+  overflow: auto;
+}
+
 .load-balancer-ports {
+  min-width: 55rem;
+
   label {
     padding-top: 0;
   }
@@ -121,32 +128,29 @@
   }
 
   .target-pool {
-    background-color: $colors--theme--background-hover;
+    border-left: $border-default;
   }
 
   .instances {
-    background-color: $colors--theme--background-hover;
-    width: 7rem;
+    width: 5rem;
   }
 
   .target-port {
-    background-color: $colors--theme--background-hover;
-    width: 8rem;
+    width: 6rem;
   }
 
   .pool-action {
-    background-color: $colors--theme--background-hover;
-    width: 9rem;
+    border-right: $border-default;
+    width: 8.5rem;
   }
 
   .actions {
-    width: 8rem;
+    width: 8.5rem;
   }
 
   tbody {
     .instances,
     .target-port {
-      padding-right: 1.6rem;
       padding-top: 0.75rem;
     }
   }
@@ -165,14 +169,6 @@
   .load-balancer-form .content-details,
   .create-load-balancer .form-footer,
   .edit-load-balancer .form-footer {
-    min-width: 50rem;
     width: calc(100% - 4rem);
-  }
-
-  .load-balancer-ports {
-    .instances,
-    .target-port {
-      display: none;
-    }
   }
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -75,6 +75,7 @@
 @include vf-p-icon-video-play;
 @include vf-p-icon-warning-grey;
 
+$border-default: 1px solid $colors--theme--border-default;
 $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 
 @import "authentication_setup";


### PR DESCRIPTION
## Done

- fix(load-balancer) avoid confusing highlights on load balancer create/edit form. rely on borders instead

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - see https://github.com/canonical/lxd-ui/pull/2010 for steps to setup load balancer backend
    - explore create/edit load balancer form

## Screenshots

<img width="3840" height="1914" alt="image" src="https://github.com/user-attachments/assets/78a87e40-42a0-4451-83e8-e1fd73cde527" />
