### PR TITLE
fix(replicator) avoid visual glitch on opening edit replicator with empty cache

### DIFF
--- a/src/pages/cluster/panels/EditReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/EditReplicatorPanel.tsx
@@ -73,7 +73,7 @@ const EditReplicatorPanel: FC = () => {
   const formik = useFormik<ReplicatorFormValues>({
     initialValues: {
       isCreating: false,
-      name: replicator?.name || "",
+      name: replicatorName || "",
       description: replicator?.description || "",
       project: panelParams.project,
       cluster: replicator?.config?.cluster || "",


### PR DESCRIPTION
## Done

- fix(replicator) avoid visual glitch on opening edit replicator with empty cache

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to replicator list
    - open edit replicator (need empty cache to reproduce old behaviour, so refresh just before)
