### PR TITLE
fix(replicators): edit form validation

### DIFF
--- a/src/pages/cluster/panels/CreateReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/CreateReplicatorPanel.tsx
@@ -134,7 +134,7 @@ const CreateReplicatorPanel: FC = () => {
     cluster: Yup.string()
       .test({
         name: "Reachable cluster link",
-        test: testReachableClusterLink(),
+        test: testReachableClusterLink,
       })
       .required("Cluster is required."),
   });

--- a/src/pages/cluster/panels/EditReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/EditReplicatorPanel.tsx
@@ -58,9 +58,12 @@ const EditReplicatorPanel: FC = () => {
           });
         },
       })
-      .test({
-        name: "Reachable cluster link",
-        test: testReachableClusterLink(),
+      .test("Reachable cluster link", async (value, context) => {
+        if (replicator?.config?.cluster === value) {
+          // Skip this test if cluster has not changed (to avoid blocking update if the current cluster is not reachable)
+          return true;
+        }
+        return testReachableClusterLink(value, context);
       })
       .required("Cluster is required."),
   });

--- a/src/util/clusterLink.tsx
+++ b/src/util/clusterLink.tsx
@@ -42,23 +42,25 @@ const isClusterLinkReachable = async (cluster: string): Promise<boolean> => {
 const NOT_REACHABLE_ERROR_MESSAGE =
   "The cluster must be Reachable. Make sure a matching link has been created on the target cluster using the generated token.";
 
-export const testReachableClusterLink =
-  () => async (value: string | undefined, context: TestContext) => {
-    if (!value) {
+export const testReachableClusterLink = async (
+  value: string | undefined,
+  context: TestContext,
+) => {
+  if (!value) {
+    return true;
+  }
+
+  try {
+    const isReachable = await isClusterLinkReachable(value);
+    if (isReachable) {
       return true;
     }
 
-    try {
-      const isReachable = await isClusterLinkReachable(value);
-      if (isReachable) {
-        return true;
-      }
-
-      return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
-    } catch {
-      return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
-    }
-  };
+    return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
+  } catch {
+    return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
+  }
+};
 
 export const testProjectReplicaCluster = (
   project?: LxdProject,


### PR DESCRIPTION
## Done
 - allow editing other fields even when cluster link is not reachable

Fixes
WD-37116

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create an unreachable cluster link (you can do it by only creating one end)
    - Create a replicator using that link in the CLI `lxc replicator create my_replicator cluster=<unreachable_cluster_link_name> --project <project_name>`
    - Attempt to edit the replicator.
    - Ensure that you can edit other fields even when cluster is unreachable.
    - Ensure that you can change the cluster but only to a reachable cluster.
