### PR TITLE
feat(replicator): number of instances used by a project

### DIFF
--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -19,7 +19,11 @@ import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import type { LxdReplicator } from "types/replicator";
 import { useReplicatorEntitlements } from "util/entitlements/replicators";
-import { isProjectReplicaModeStandby } from "util/projects";
+import { pluralize } from "util/helpers";
+import {
+  getInstancesUsedByProject,
+  isProjectReplicaModeStandby,
+} from "util/projects";
 import { queryKeys } from "util/queryKeys";
 import { ROOT_PATH } from "util/rootPath";
 
@@ -53,6 +57,9 @@ const RunReplicatorBtn: FC<Props> = ({
   const isRestore = isProjectReplicaModeStandby(project);
   const buttonLabel = isRestore ? "Restore" : "Run";
   const hasPermission = canEditReplicator(replicator);
+  const numberOfInstances = project
+    ? getInstancesUsedByProject(project).length
+    : 0;
 
   const disabledReason = () => {
     if (!hasPermission) {
@@ -199,16 +206,18 @@ const RunReplicatorBtn: FC<Props> = ({
 
             {isRestore ? (
               <p>
-                This will sync all instances from the{" "}
+                This will sync {numberOfInstances}{" "}
+                {pluralize("instance", numberOfInstances)} from the{" "}
                 <ClusterLinkRichChip clusterLink={clusterLink} /> cluster back
                 to the <ProjectRichChip projectName={replicator.project} />{" "}
                 project.
               </p>
             ) : (
               <p>
-                This will sync all instances from the source project{" "}
-                <ProjectRichChip projectName={replicator.project} /> to the
-                standby cluster{" "}
+                This will sync {numberOfInstances}{" "}
+                {pluralize("instance", numberOfInstances)} from the source
+                project <ProjectRichChip projectName={replicator.project} /> to
+                the standby cluster{" "}
                 <ClusterLinkRichChip clusterLink={clusterLink} />.
               </p>
             )}
@@ -220,7 +229,7 @@ const RunReplicatorBtn: FC<Props> = ({
                 title="All local data will be overwritten by the remote version"
               >
                 <p>
-                  All current instances in local project{" "}
+                  {numberOfInstances} instances in local project{" "}
                   <ProjectRichChip projectName={replicator.project} /> will be
                   permanently replaced by the version fetched from the remote
                   cluster. This cannot be undone.

--- a/src/pages/projects/ProjectRichTooltip.tsx
+++ b/src/pages/projects/ProjectRichTooltip.tsx
@@ -7,7 +7,10 @@ import ResourceLabel from "components/ResourceLabel";
 import { Link } from "react-router-dom";
 import ItemName from "components/ItemName";
 import { useProfile } from "context/useProfiles";
-import { isProjectWithProfiles } from "util/projects";
+import {
+  getInstancesUsedByProject,
+  isProjectWithProfiles,
+} from "util/projects";
 import { getDefaultStoragePool, getDefaultNetwork } from "util/helpers";
 import ResourceLink from "components/ResourceLink";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
@@ -153,6 +156,11 @@ const ProjectRichTooltip: FC<Props> = ({ projectName }) => {
         ) : (
           "-"
         ),
+      truncate: false,
+    },
+    {
+      title: "Number of instances",
+      value: project ? getInstancesUsedByProject(project).length : "-",
       truncate: false,
     },
     {

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -84,3 +84,11 @@ export const isProjectWithVolumes = (project?: LxdProject): boolean =>
 
 export const isProjectReplicaModeStandby = (project?: LxdProject): boolean =>
   project?.config["replica.mode"] === "standby";
+
+export const getInstancesUsedByProject = (project: LxdProject): string[] => {
+  if (!project.used_by) {
+    return [];
+  }
+
+  return project.used_by.filter((item) => item.startsWith("/1.0/instances/"));
+};


### PR DESCRIPTION
## Done

- In ProjectRichChip, add the number of instances used by the project
- In RunReplicatorBtn's modal, add the number of instances used by the project

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Hover on a project rich chip (you can find one in replicator list). Make sure the number of instances is correct.
    - Click on Run button of a replicator (either in replicator list or from the detail page of a replicator). Make sure the modal displays the correct number of instances.

## Screenshots

<img width="769" height="357" alt="image" src="https://github.com/user-attachments/assets/0be5e9a3-3ddd-4e13-a750-fabe9da64d28" />

<img width="874" height="667" alt="image" src="https://github.com/user-attachments/assets/0632f031-2138-4a02-aa3a-546f7d91ee64" />
