### PR TITLE
feat(cluster link): disable delete button if cluster link is used

### DIFF
--- a/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
@@ -49,12 +49,22 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
       });
   };
 
+  const disabledReason = () => {
+    if (clusterLink.used_by?.length) {
+      return `Cannot delete this cluster link as it is currently in use.`;
+    }
+    if (!canDelete) {
+      return "You do not have permission to delete this cluster link";
+    }
+    return undefined;
+  };
+
   return (
     <ConfirmationButton
       appearance="base"
       className="has-icon"
-      title="Delete cluster link"
-      disabled={!canDelete}
+      onHoverText={disabledReason()}
+      disabled={Boolean(disabledReason())}
       loading={isLoading}
       confirmationModalProps={{
         title: "Confirm delete",
@@ -64,9 +74,7 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
             <ClusterLinkRichChip clusterLink={clusterLink.name} />.
           </p>
         ),
-        confirmButtonLabel: canDelete
-          ? "Delete cluster link"
-          : "You do not have permission to delete this cluster link",
+        confirmButtonLabel: "Delete cluster link",
         onConfirm: handleDelete,
       }}
       shiftClickEnabled

--- a/src/pages/images/actions/EditImageRegistryButton.tsx
+++ b/src/pages/images/actions/EditImageRegistryButton.tsx
@@ -25,15 +25,13 @@ const EditImageRegistryButton: FC<Props> = ({ imageRegistry }) => {
     return undefined;
   };
 
-  const isDisabled = disabledReason() !== undefined;
-
   return (
     <Button
       appearance="default"
       className={classnames("u-no-margin--bottom", {
         "has-icon": !isSmallScreen,
       })}
-      disabled={isDisabled}
+      disabled={Boolean(disabledReason())}
       type="button"
       hasIcon
       title={disabledReason() || "Edit registry"}

--- a/src/types/cluster.d.ts
+++ b/src/types/cluster.d.ts
@@ -50,6 +50,7 @@ export interface LxdClusterLink {
   name: string;
   type: string;
   access_entitlements?: string[];
+  used_by?: string[];
 }
 
 export interface LxdClusterLinkState {


### PR DESCRIPTION
## Done

- feat(cluster link): disable delete button if cluster link is used

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to cluster link list. Make sure the cluster links that are being used cannot be deleted.

## Screenshots

<img width="1555" height="1056" alt="image" src="https://github.com/user-attachments/assets/34a7451c-ffaa-4f95-88f2-bdf16355fb5c" />
