### PR TITLE
fix(Powerstore): [WD-36457] Dell PowerStore mode amendments

### DIFF
--- a/src/components/ConfigurationRow.tsx
+++ b/src/components/ConfigurationRow.tsx
@@ -161,6 +161,9 @@ export const getConfigurationRow = ({
     if (isOverridden) {
       return getForm();
     }
+    if (hideOverrideBtn) {
+      return overrideValue;
+    }
     return wrapDisabledTooltip(
       <Button
         onClick={toggleDefault}

--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -61,5 +61,6 @@ export const useSupportedFeatures = () => {
     hasClusterLinks: apiExtensions.has("cluster_links"),
     hasReplicators: apiExtensions.has("replicators"),
     hasLoadBalancerPools: apiExtensions.has("network_load_balancer_pool"),
+    hasStorageNvmeTcp: apiExtensions.has("storage_nvme_tcp"),
   };
 };

--- a/src/pages/storage/forms/StoragePoolFormAlletra.tsx
+++ b/src/pages/storage/forms/StoragePoolFormAlletra.tsx
@@ -6,12 +6,15 @@ import { Input, Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/options";
 import { optionIscsiNvme } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormAlletra: FC<Props> = ({ formik }) => {
+  const { hasStorageNvmeTcp } = useSupportedFeatures();
+
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -34,7 +37,7 @@ const StoragePoolFormAlletra: FC<Props> = ({ formik }) => {
           label: "Mode",
           name: "alletra_mode",
           defaultValue: "",
-          children: <Select options={optionIscsiNvme} />,
+          children: <Select options={optionIscsiNvme(hasStorageNvmeTcp)} />,
         }),
       ]}
     />

--- a/src/pages/storage/forms/StoragePoolFormPowerflex.tsx
+++ b/src/pages/storage/forms/StoragePoolFormPowerflex.tsx
@@ -6,12 +6,15 @@ import { Input, Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/options";
 import { optionNvmeSdc } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormPowerflex: FC<Props> = ({ formik }) => {
+  const { hasStorageNvmeTcp } = useSupportedFeatures();
+
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -41,8 +44,20 @@ const StoragePoolFormPowerflex: FC<Props> = ({ formik }) => {
           label: "Mode",
           name: "powerflex_mode",
           defaultValue: "",
-          children: <Select options={optionNvmeSdc} />,
+          children: <Select options={optionNvmeSdc(hasStorageNvmeTcp)} />,
         }),
+        ...(formik.values.powerflex_version
+          ? [
+              getConfigurationRow({
+                formik,
+                label: "Storage array version",
+                name: "powerflex_version",
+                defaultValue: formik.values.powerflex_version || "",
+                children: <></>,
+                hideOverrideBtn: true,
+              }),
+            ]
+          : []),
       ]}
     />
   );

--- a/src/pages/storage/forms/StoragePoolFormPure.tsx
+++ b/src/pages/storage/forms/StoragePoolFormPure.tsx
@@ -6,12 +6,14 @@ import { Input, Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/options";
 import { optionIscsiNvme } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormPure: FC<Props> = ({ formik }) => {
+  const { hasStorageNvmeTcp } = useSupportedFeatures();
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -28,7 +30,7 @@ const StoragePoolFormPure: FC<Props> = ({ formik }) => {
           name: "pure_mode",
           defaultValue: "",
           disabled: !formik.values.isCreating,
-          children: <Select options={optionIscsiNvme} />,
+          children: <Select options={optionIscsiNvme(hasStorageNvmeTcp)} />,
         }),
         getConfigurationRow({
           formik,

--- a/src/types/forms/storagePool.d.ts
+++ b/src/types/forms/storagePool.d.ts
@@ -34,6 +34,7 @@ export interface StoragePoolFormValues {
   powerflex_sdt?: string;
   powerflex_user_name?: string;
   powerflex_user_password?: string;
+  powerflex_version?: string;
   powerstore_gateway?: string;
   powerstore_gateway_verify?: string;
   powerstore_mode?: string;

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -1,3 +1,7 @@
+export const getNVMeTcpValue = (hasStorageNvmeTcp: boolean) => {
+  return hasStorageNvmeTcp ? "nvme/tcp" : "nvme";
+};
+
 export const instanceCreationTypes = [
   {
     label: "Container",
@@ -57,7 +61,7 @@ export const clusterEvacuationOptions = [
   },
 ];
 
-export const optionIscsiNvme = [
+export const optionIscsiNvme = (hasStorageNvmeTcp: boolean) => [
   {
     label: "Select option",
     value: "",
@@ -69,7 +73,7 @@ export const optionIscsiNvme = [
   },
   {
     label: "NVMe over TCP",
-    value: "nvme",
+    value: getNVMeTcpValue(hasStorageNvmeTcp),
   },
 ];
 
@@ -80,12 +84,16 @@ export const optionPowerStoreMode = [
     disabled: true,
   },
   {
-    label: "SCSI over TCP",
+    label: "iSCSI",
     value: "iscsi",
+  },
+  {
+    label: "SCSI over FC",
+    value: "scsi/fc",
   },
 ];
 
-export const optionNvmeSdc = [
+export const optionNvmeSdc = (hasStorageNvmeTcp: boolean) => [
   {
     label: "Select option",
     value: "",
@@ -93,7 +101,7 @@ export const optionNvmeSdc = [
   },
   {
     label: "NVMe over TCP",
-    value: "nvme",
+    value: getNVMeTcpValue(hasStorageNvmeTcp),
   },
   {
     label: "Dell Storage Data Client",

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -44,6 +44,7 @@ export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   powerflex_sdt: "powerflex.sdt",
   powerflex_user_name: "powerflex.user.name",
   powerflex_user_password: "powerflex.user.password",
+  powerflex_version: "volatile.powerflex.version",
   powerstore_gateway: "powerstore.gateway",
   powerstore_gateway_verify: "powerstore.gateway.verify",
   powerstore_mode: "powerstore.mode",

--- a/src/util/storagePoolForm.tsx
+++ b/src/util/storagePoolForm.tsx
@@ -83,6 +83,7 @@ export const toStoragePoolFormValues = (
     powerflex_sdt: pool.config?.["powerflex.sdt"],
     powerflex_user_name: pool.config?.["powerflex.user.name"],
     powerflex_user_password: pool.config?.["powerflex.user.password"],
+    powerflex_version: pool.config?.["volatile.powerflex.version"],
     powerstore_gateway: pool.config?.["powerstore.gateway"],
     powerstore_gateway_verify: pool.config?.["powerstore.gateway.verify"],
     powerstore_mode: pool.config?.["powerstore.mode"],


### PR DESCRIPTION
## Done

- Adds scsi/fc, nvme/cp, nvme/fc and sdc to Powerstore modes.
- Adds readonly storage array version to **PowerFlex** config.

Relevant PRS:
- Followup on: https://github.com/canonical/lxd-ui/pull/1966
- Implements: https://github.com/canonical/lxd/pull/18367
- Adds volatile.powerflex.version from: https://github.com/canonical/lxd/pull/18425

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In the Demo server, observe that Powerstore can facilitate the new modes.

## Screenshots

<img width="1539" height="432" alt="image" src="https://github.com/user-attachments/assets/ea086dbf-46eb-4825-9eb1-ff15e75c18ac" />

In the Powerstore config section, a 5th row should appear here for the powerstore version.
<img width="1539" height="687" alt="image" src="https://github.com/user-attachments/assets/771fb5ce-f5c8-4f73-b5af-6e001fe7c54c" />
