### PR TITLE
feat(load-balancer) guard load balancer health checks with an api extension

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -62,5 +62,8 @@ export const useSupportedFeatures = () => {
     hasReplicators: apiExtensions.has("replicators"),
     hasLoadBalancerPools: apiExtensions.has("network_load_balancer_pool"),
     hasStorageNvmeTcp: apiExtensions.has("storage_nvme_tcp"),
+    hasLoadBalancerHealthChecks: apiExtensions.has(
+      "network_load_balancer_pool_health_checks",
+    ),
   };
 };

--- a/src/pages/networks/LoadBalancerPoolInstanceStatuses.tsx
+++ b/src/pages/networks/LoadBalancerPoolInstanceStatuses.tsx
@@ -3,7 +3,6 @@ import type { LxdLoadBalancerPool } from "types/loadBalancers";
 import type { LxdNetwork } from "types/network";
 import { useLoadBalancerPoolState } from "context/useLoadBalancerPools";
 import { useCurrentProject } from "context/useCurrentProject";
-import { Icon } from "@canonical/react-components";
 import LoadBalancerPoolInstanceStatus from "pages/networks/LoadBalancerPoolInstanceStatus";
 
 interface Props {
@@ -28,11 +27,7 @@ const LoadBalancerPoolInstanceStatuses: FC<Props> = ({ pool, network }) => {
   };
 
   if (pool.instances.length === 0) {
-    return (
-      <>
-        <Icon name="status-queued-small" className="status-icon" /> -
-      </>
-    );
+    return <div className="empty-instance-status">-</div>;
   }
 
   return pool.instances.map((instance) => {

--- a/src/pages/networks/LoadBalancerPoolsTable.tsx
+++ b/src/pages/networks/LoadBalancerPoolsTable.tsx
@@ -7,6 +7,7 @@ import EditLoadBalancerPoolBtn from "pages/networks/actions/EditLoadBalancerPool
 import LoadBalancerPoolInstances from "pages/networks/LoadBalancerPoolInstances";
 import LoadBalancerPoolHealthCheck from "pages/networks/LoadBalancerPoolHealthCheck";
 import LoadBalancerPoolStatuses from "pages/networks/LoadBalancerPoolInstanceStatuses";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   loadBalancerPools: LxdLoadBalancerPool[];
@@ -14,6 +15,8 @@ interface Props {
 }
 
 const LoadBalancerPoolsTable: FC<Props> = ({ loadBalancerPools, network }) => {
+  const { hasLoadBalancerHealthChecks } = useSupportedFeatures();
+
   const headers = [
     { content: "Name", sortKey: "name", className: "name" },
     {
@@ -26,7 +29,9 @@ const LoadBalancerPoolsTable: FC<Props> = ({ loadBalancerPools, network }) => {
       sortKey: "usedBy",
       className: "u-align--right used-by",
     },
-    { content: "Health check", className: "health-check" },
+    ...(hasLoadBalancerHealthChecks
+      ? [{ content: "Health check", className: "health-check" }]
+      : []),
     { content: "Instances" },
     { content: "Instance statuses", className: "status-header" },
     {
@@ -70,12 +75,16 @@ const LoadBalancerPoolsTable: FC<Props> = ({ loadBalancerPools, network }) => {
           "aria-label": "Used by",
           className: "u-align--right used-by",
         },
-        {
-          content: <LoadBalancerPoolHealthCheck pool={pool} />,
-          role: "cell",
-          "aria-label": "Health check",
-          className: "health-check",
-        },
+        ...(hasLoadBalancerHealthChecks
+          ? [
+              {
+                content: <LoadBalancerPoolHealthCheck pool={pool} />,
+                role: "cell",
+                "aria-label": "Health check",
+                className: "health-check",
+              },
+            ]
+          : []),
         {
           content: <LoadBalancerPoolInstances pool={pool} />,
           role: "cell",

--- a/src/pages/networks/forms/LoadBalancerPoolForm.tsx
+++ b/src/pages/networks/forms/LoadBalancerPoolForm.tsx
@@ -15,6 +15,7 @@ import { updateMaxHeight } from "util/updateMaxHeight";
 import type { LoadBalancerPoolFormValues } from "types/forms/loadBalancers";
 import LoadBalancerInstanceSelector from "pages/networks/forms/LoadBalancerInstanceSelector";
 import type { LxdLoadBalancerPool } from "types/loadBalancers";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 export const toLoadBalancerPool = (
   values: LoadBalancerPoolFormValues,
@@ -75,6 +76,7 @@ interface Props {
 
 const LoadBalancerPoolForm: FC<Props> = ({ formik, isEdit, network }) => {
   const notify = useNotify();
+  const { hasLoadBalancerHealthChecks } = useSupportedFeatures();
 
   const updateFormHeight = () => {
     updateMaxHeight("form-contents", "p-bottom-controls");
@@ -145,17 +147,19 @@ const LoadBalancerPoolForm: FC<Props> = ({ formik, isEdit, network }) => {
           }}
           network={network}
         />
-        <Select
-          {...formik.getFieldProps("healthCheckType")}
-          id="healthCheckType"
-          label="Health check"
-          options={[
-            { value: "custom", label: "Custom" },
-            { value: "default", label: "Default" },
-            { value: "disabled", label: "Disabled" },
-          ]}
-          help="Default uses LXD's default health check settings. Custom allows you to specify the health check settings. Disabled turns off health checks."
-        />
+        {hasLoadBalancerHealthChecks && (
+          <Select
+            {...formik.getFieldProps("healthCheckType")}
+            id="healthCheckType"
+            label="Health check"
+            options={[
+              { value: "custom", label: "Custom" },
+              { value: "default", label: "Default" },
+              { value: "disabled", label: "Disabled" },
+            ]}
+            help="Default uses LXD's default health check settings. Custom allows you to specify the health check settings. Disabled turns off health checks."
+          />
+        )}
         {formik.values.healthCheckType === "custom" && (
           <>
             <Input

--- a/src/sass/_load_balancers.scss
+++ b/src/sass/_load_balancers.scss
@@ -90,6 +90,12 @@
   .actions {
     max-width: 8rem;
   }
+
+  @include large {
+    .empty-instance-status {
+      padding-left: 1.4rem;
+    }
+  }
 }
 
 .load-balancer-ports-row {


### PR DESCRIPTION
## Done

- feat(load-balancer) guard load balancer health checks with an api extension

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check an ovn network load balancer pool creation is not exposing health check configuration:
    - use a lxd latest edge backend with ovn configured:
      - sudo snap install microovn --channel=latest/edge
      -  microovn init (create a new cluster)
      -  lxd init (let it listen on the network)
      -  set lxd config to network.ovn.northbound_connection: ssl:127.0.0.1:6641
      -  connect the ui from this branch to the container as a backend
      -  In the ui configure the lxdbr0 created by lxd init above to have:
      -  IPv4 DHCP ranges: With about 20 ips, such as 10.115.100.170-10.115.100.190, needs to match the network mask
      -  IPv4 OVN ranges: With about 50 ips, such as 10.115.100.100-10.115.100.150, needs to match the network mask
      -  IPV4 routes: Set to a valid CIDR, such as 10.115.100.208/28
      -  in the ui create an ovn network
      -  use lxdbr0 as an uplink, other settings default
      -  in the ui visit ovn network detail page
      -  in the ui go to load balancers
      - in the ui create a load balancer pool

## Screenshots

<img width="3834" height="1916" alt="image" src="https://github.com/user-attachments/assets/05b176f4-0da4-4fa3-b8d5-60011ffd24cc" />

