### PR TITLE
test(file explorer): e2e tests

### DIFF
--- a/tests/helpers/instance-file-explorer.ts
+++ b/tests/helpers/instance-file-explorer.ts
@@ -1,0 +1,136 @@
+import type { Page } from "@playwright/test";
+import { expect } from "../fixtures/lxd-test";
+import { dismissNotification } from "./notification";
+import { assertTextVisible } from "./permissions";
+import { visitInstance } from "./instances";
+import { randomNameSuffix } from "./name";
+
+export const randomFileName = (): string => {
+  return `playwright-file-${randomNameSuffix()}`;
+};
+const getFileExplorerRow = (
+  page: Page,
+  name: string,
+  type: "file" | "directory",
+) => {
+  const table = page.getByRole("grid").first();
+  return table
+    .getByRole("row")
+    .filter({ hasText: name })
+    .filter({ hasText: type });
+};
+
+export const visitFileExplorer = async (
+  page: Page,
+  instance: string,
+  project = "default",
+) => {
+  await visitInstance(page, instance, project);
+  await page.getByRole("link", { name: "File Explorer" }).click();
+  await expect(page.getByText("Directory: root")).toBeVisible();
+};
+
+export const openDirectory = async (page: Page, directoryName: string) => {
+  const row = getFileExplorerRow(page, directoryName, "directory");
+  const dirLink = row.getByRole("link", {
+    name: directoryName,
+    exact: true,
+  });
+  await expect(dirLink).toHaveCount(1);
+  await dirLink.click();
+
+  const breadcrumb = page.getByRole("navigation", {
+    name: "File Explorer Path",
+  });
+  await expect(
+    breadcrumb.getByText(directoryName, { exact: true }),
+  ).toBeVisible();
+};
+
+export const assertFileExists = async (page: Page, fileName: string) => {
+  const fileRow = getFileExplorerRow(page, fileName, "file");
+  await expect(fileRow).toHaveCount(1);
+};
+
+export const assertFileNotExists = async (page: Page, fileName: string) => {
+  const fileRow = getFileExplorerRow(page, fileName, "file");
+  await expect(fileRow).toHaveCount(0);
+};
+
+export const assertDirectoryExists = async (
+  page: Page,
+  directoryName: string,
+) => {
+  const dirLink = getFileExplorerRow(
+    page,
+    directoryName,
+    "directory",
+  ).getByRole("link", {
+    name: directoryName,
+    exact: true,
+  });
+  await expect(dirLink).toHaveCount(1);
+};
+
+export const deleteFile = async (
+  page: Page,
+  fileName: string,
+  instance: string,
+) => {
+  const fileRow = getFileExplorerRow(page, fileName, "file");
+  await fileRow.getByRole("button", { name: "Delete" }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  await dismissNotification(page, `File ${fileName} deleted from ${instance}`);
+};
+
+export const downloadFile = async (page: Page, fileName: string) => {
+  const fileRow = getFileExplorerRow(page, fileName, "file");
+
+  // Setup download promise before clicking the file link.
+  const downloadPromise = page.waitForEvent("download");
+  await fileRow.getByRole("link", { name: fileName, exact: true }).click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe(fileName);
+
+  return download;
+};
+
+export const uploadFile = async (page: Page, filePath: string) => {
+  const uploadButton = page.getByTitle("Upload files to current directory");
+  await uploadButton.click();
+
+  // Bypass the OS-native file picker dialog by directly setting the file input
+  await page.locator('input[type="file"]').setInputFiles(filePath);
+  await dismissNotification(page, " uploaded successfully");
+};
+
+export const createFile = async (page: Page, fileName: string) => {
+  // Use terminal to create files for now. Later we might add a file creation feature in the file explorer.
+  const url = new URL(page.url());
+  const currentPath = url.searchParams.get("path") ?? "/";
+  const targetPath =
+    currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
+
+  await page.getByTestId("tab-link-Terminal").click();
+  await assertTextVisible(page, "~#");
+  await page.waitForTimeout(1000); // ensure the terminal is ready
+  await page.locator(".xterm-rows").evaluate((e) => {
+    (e as HTMLElement).click();
+  });
+  await page.keyboard.type(`touch "${targetPath}"`, {
+    delay: 100,
+  });
+  await page.keyboard.press("Enter");
+
+  page.once("dialog", async (dialog) => {
+    await dialog.accept();
+  });
+  await page.getByRole("link", { name: "File Explorer" }).click();
+  await openDirectory(page, "tmp"); //hardcoded for now until file creation is implemented in the UI
+  await assertFileExists(page, fileName);
+};

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -15,6 +15,18 @@ import {
   visitInstance,
 } from "./helpers/instances";
 import {
+  visitFileExplorer,
+  randomFileName,
+  openDirectory,
+  assertFileExists,
+  assertFileNotExists,
+  assertDirectoryExists,
+  deleteFile,
+  downloadFile,
+  uploadFile,
+  createFile,
+} from "./helpers/instance-file-explorer";
+import {
   assertCode,
   assertReadMode,
   setCodeInput,
@@ -451,4 +463,93 @@ test("instance deletion (with and without force delete support)", async ({
   await expect(
     page.getByText(`Instance ${toDeleteInstance} deleted.`),
   ).toBeVisible();
+});
+
+// File Explorer Tests
+
+test("navigate with breadcrumb navigation", async ({ page }) => {
+  await visitAndStartInstance(page, instance);
+  await visitFileExplorer(page, instance);
+
+  await assertDirectoryExists(page, "root");
+  await assertDirectoryExists(page, "home");
+  await assertDirectoryExists(page, "etc");
+  await assertDirectoryExists(page, "var");
+  await assertDirectoryExists(page, "tmp");
+
+  await openDirectory(page, "var");
+  await openDirectory(page, "log");
+  await expect(page).toHaveURL(/path=%2Fvar%2Flog/);
+
+  const breadcrumb = page.getByRole("navigation", {
+    name: "File Explorer Path",
+  });
+  await expect(
+    breadcrumb.getByRole("link", { name: "root", exact: true }),
+  ).toBeVisible();
+  await expect(
+    breadcrumb.getByRole("link", { name: "var", exact: true }),
+  ).toBeVisible();
+  await expect(breadcrumb.getByText("log", { exact: true })).toBeVisible();
+
+  // Click on breadcrumb to go back to the parent directory
+  const parentBreadcrumb = breadcrumb.getByRole("link", {
+    name: "var",
+    exact: true,
+  });
+  await parentBreadcrumb.click();
+
+  await expect(page).toHaveURL(/path=%2Fvar/);
+  await assertDirectoryExists(page, "log");
+});
+
+test("upload, download, and delete file from file explorer", async ({
+  page,
+}, testInfo) => {
+  await visitAndStartInstance(page, instance);
+  await visitFileExplorer(page, instance);
+
+  await openDirectory(page, "tmp");
+
+  const createdFileName = randomFileName();
+  const uploadedFileName = randomFileName();
+  await createFile(page, createdFileName);
+  await assertFileExists(page, createdFileName);
+
+  const download = await downloadFile(page, createdFileName);
+  const downloadedFilePath = testInfo.outputPath(uploadedFileName);
+  await download.saveAs(downloadedFilePath);
+
+  expect(download.suggestedFilename()).toBe(createdFileName);
+
+  const rows = page.getByRole("grid").first().getByRole("row");
+  const rowCount = await rows.count();
+
+  await uploadFile(page, downloadedFilePath);
+  await assertFileExists(page, createdFileName);
+  await assertFileExists(page, uploadedFileName);
+  await expect(rows).toHaveCount(rowCount + 1);
+
+  await deleteFile(page, uploadedFileName, instance);
+  await assertFileNotExists(page, uploadedFileName);
+  await expect(rows).toHaveCount(rowCount);
+
+  await deleteFile(page, createdFileName, instance);
+  await assertFileNotExists(page, createdFileName);
+});
+
+test("file explorer shows empty state for a stopped virtual machine", async ({
+  page,
+}) => {
+  test.skip(
+    Boolean(process.env.DISABLE_VM_TESTS),
+    "deactivated due to DISABLE_VM_TESTS environment variable",
+  );
+  await visitInstance(page, vmInstance, "default");
+  await page.getByRole("link", { name: "File Explorer" }).click();
+  await expect(page.getByText("Instance is not running")).toBeVisible();
+  await expect(
+    page.getByText("Virtual machines must be running to browse files."),
+  ).toBeVisible();
+  await expect(page.getByText("Start instance")).toBeVisible();
 });


### PR DESCRIPTION
## Done

- Add instance file explorer e2e tests WD-36644

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure new tests pass