### PR TITLE
fix(replicator): force flag for promote and demote project

### DIFF
--- a/src/components/ConfirmationCheckbox.tsx
+++ b/src/components/ConfirmationCheckbox.tsx
@@ -11,19 +11,17 @@ const ConfirmationCheckbox: FC<Props> = ({ label, confirmed, disabled }) => {
   const [isConfirmed, setConfirmed] = confirmed;
 
   return (
-    <span className="u-float-left">
-      <CheckboxInput
-        key={`confirmation-checkbox-${isConfirmed}`}
-        inline
-        label={label}
-        tabIndex={-1}
-        defaultChecked={isConfirmed}
-        onChange={() => {
-          setConfirmed((prev) => !prev);
-        }}
-        disabled={disabled}
-      />
-    </span>
+    <CheckboxInput
+      key={`confirmation-checkbox-${isConfirmed}`}
+      inline
+      label={label}
+      defaultChecked={isConfirmed}
+      onChange={() => {
+        setConfirmed((prev) => !prev);
+      }}
+      disabled={disabled}
+      className="confirmation-checkbox"
+    />
   );
 };
 

--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -3,7 +3,6 @@ import {
   ConfirmationButton,
   Icon,
   Notification,
-  useNotify,
   useToastNotification,
 } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
@@ -42,7 +41,6 @@ const RunReplicatorBtn: FC<Props> = ({
 }) => {
   const queryClient = useQueryClient();
   const eventQueue = useEventQueue();
-  const notify = useNotify();
   const toastNotify = useToastNotification();
   const replicatorLoading = useReplicatorLoading();
   const [isLoading, setLoading] = useState(false);
@@ -103,7 +101,7 @@ const RunReplicatorBtn: FC<Props> = ({
     setLoading(false);
     replicatorLoading.setFinish(replicator);
     invalidateCache();
-    notify.failure(`Running replicator ${replicator.name} failed`, e);
+    toastNotify.failure(`Running replicator ${replicator.name} failed`, e);
   };
 
   const onOperationSuccess = () => {

--- a/src/pages/instances/actions/InstanceBulkAction.tsx
+++ b/src/pages/instances/actions/InstanceBulkAction.tsx
@@ -151,7 +151,7 @@ const InstanceBulkAction: FC<Props> = ({
             {getRestrictedInstances()}
           </p>
         ),
-        confirmExtra: confirmExtra,
+        confirmExtra,
         onConfirm: onClick,
         confirmButtonLabel: confirmLabel,
         confirmButtonAppearance: confirmAppearance,

--- a/src/pages/projects/actions/DemoteProjectBtn.tsx
+++ b/src/pages/projects/actions/DemoteProjectBtn.tsx
@@ -1,9 +1,9 @@
 import {
-  ActionButton,
-  useNotify,
+  ConfirmationButton,
   useToastNotification,
 } from "@canonical/react-components";
 import { type FC, useState } from "react";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
@@ -17,9 +17,9 @@ interface Props {
 const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const [isDemoting, setIsDemoting] = useState(false);
   const isSmallScreen = useIsScreenBelow();
-  const notify = useNotify();
   const toastNotify = useToastNotification();
   const { canEditProject } = useProjectEntitlements();
+  const [isForce, setForce] = useState(false);
 
   const disabledReason = () => {
     if (!canEditProject) {
@@ -42,35 +42,54 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   };
 
   const handleFailure = (e: unknown) => {
-    notify.failure("Could not demote project to standby.", e as Error);
+    toastNotify.failure("Could not demote project to standby.", e as Error);
   };
 
   const demoteToStandby = () => {
     setIsDemoting(true);
-    updateReplicaMode(project, "standby", handleSuccess, handleFailure).finally(
-      () => {
-        setIsDemoting(false);
-      },
-    );
+    updateReplicaMode(
+      project,
+      "standby",
+      handleSuccess,
+      handleFailure,
+      isForce,
+    ).finally(() => {
+      setIsDemoting(false);
+    });
   };
 
   return (
-    <ActionButton
+    <ConfirmationButton
       type="button"
       name="Demote to standby"
       hasIcon
       appearance="default"
       onClick={demoteToStandby}
       loading={isDemoting}
-      title={
+      onHoverText={
         disabledReason() ??
         "Project will become the read-only replication target."
       }
       className="u-no-margin--bottom"
       disabled={Boolean(disabledReason())}
+      confirmationModalProps={{
+        title: "Confirm demote",
+        children: (
+          <p>
+            This will demote project <ProjectRichChip projectName={project} />{" "}
+            to standby.
+          </p>
+        ),
+        confirmButtonLabel: "Demote",
+        onConfirm: demoteToStandby,
+        confirmExtra: (
+          <ConfirmationCheckbox label="Force" confirmed={[isForce, setForce]} />
+        ),
+        confirmButtonAppearance: "positive",
+      }}
     >
       <span>{isSmallScreen ? "Demote" : "Demote to standby"}</span>
-    </ActionButton>
+    </ConfirmationButton>
   );
 };
 

--- a/src/pages/projects/actions/PromoteProjectBtn.tsx
+++ b/src/pages/projects/actions/PromoteProjectBtn.tsx
@@ -1,9 +1,9 @@
 import {
-  ActionButton,
-  useNotify,
+  ConfirmationButton,
   useToastNotification,
 } from "@canonical/react-components";
 import { type FC, useState } from "react";
+import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
@@ -17,9 +17,9 @@ interface Props {
 const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const [isPromoting, setIsPromoting] = useState(false);
   const isSmallScreen = useIsScreenBelow();
-  const notify = useNotify();
   const toastNotify = useToastNotification();
   const { canEditProject } = useProjectEntitlements();
+  const [isForce, setForce] = useState(false);
 
   const disabledReason = () => {
     if (!canEditProject) {
@@ -42,34 +42,53 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   };
 
   const handleFailure = (e: unknown) => {
-    notify.failure("Could not promote project to leader.", e as Error);
+    toastNotify.failure("Could not promote project to leader.", e as Error);
   };
 
   const promoteToLeader = () => {
     setIsPromoting(true);
-    updateReplicaMode(project, "leader", handleSuccess, handleFailure).finally(
-      () => {
-        setIsPromoting(false);
-      },
-    );
+    updateReplicaMode(
+      project,
+      "leader",
+      handleSuccess,
+      handleFailure,
+      isForce,
+    ).finally(() => {
+      setIsPromoting(false);
+    });
   };
 
   return (
-    <ActionButton
+    <ConfirmationButton
       type="button"
       name="Promote to leader"
       hasIcon
       appearance="default"
       onClick={promoteToLeader}
       loading={isPromoting}
-      title={
+      onHoverText={
         disabledReason() ?? "Project will become the active replication source."
       }
       className="u-no-margin--bottom"
       disabled={Boolean(disabledReason())}
+      confirmationModalProps={{
+        title: "Confirm promote",
+        children: (
+          <p>
+            This will promote project <ProjectRichChip projectName={project} />{" "}
+            to leader.
+          </p>
+        ),
+        confirmButtonLabel: "Promote",
+        onConfirm: promoteToLeader,
+        confirmExtra: (
+          <ConfirmationCheckbox label="Force" confirmed={[isForce, setForce]} />
+        ),
+        confirmButtonAppearance: "positive",
+      }}
     >
       <span>{isSmallScreen ? "Promote" : "Promote to leader"}</span>
-    </ActionButton>
+    </ConfirmationButton>
   );
 };
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -488,3 +488,15 @@ body.is-dark .lxd-icon {
   margin-left: $sph--small !important;
   margin-right: $sph--small !important;
 }
+
+.confirmation-checkbox {
+  margin: 0;
+  margin-right: auto;
+  padding: 0;
+}
+
+.p-modal__footer {
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -100,9 +100,10 @@ export const updateReplicaMode = async (
   mode: ProjectReplicaMode,
   onSuccess: () => void,
   onFailure: (e: unknown) => void,
+  force?: boolean,
 ) => {
   try {
-    const operation = await updateProjectReplicaMode(project, mode);
+    const operation = await updateProjectReplicaMode(project, mode, force);
     const operationId = operation?.metadata?.id;
     if (!operationId) {
       onFailure(new Error("Operation id missing"));


### PR DESCRIPTION
## Done

- feat(replicators): add `force` flag for promoting and demoting project
Note: no `force` flag for clearing the replica mode.
- fix(ConfirmationButton): align confirmExtra checkbox with buttons in footer

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a project's configuration. Open Replication tab.
    - Click on Promote or Demote depending on your project's replica mode.
    - Make sure a confirmation modal opens.
    - Make sure the force checkbox works.

## Screenshots

<img width="449" height="241" alt="image" src="https://github.com/user-attachments/assets/6c8949cc-e774-4376-926a-c31c8bedb367" />

<img width="502" height="241" alt="image" src="https://github.com/user-attachments/assets/90c1eb12-1470-4bbd-a831-c386d47eb67b" />



