### PR TITLE
fix(forms) hide access entitlements in yaml forms

### DIFF
--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -425,7 +425,7 @@ const CreateInstance: FC = () => {
     setSection(newItem);
   };
 
-  function getYaml() {
+  const getYaml = () => {
     if (
       location.state?.retryFormSection === YAML_CONFIGURATION &&
       formik.values.yaml
@@ -434,7 +434,7 @@ const CreateInstance: FC = () => {
     }
     const payload = getPayload(formik.values);
     return objectToYaml(payload);
-  }
+  };
 
   const diskError = hasDiskError(formik);
   const networkError = hasNetworkError(formik);

--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -174,6 +174,7 @@ const EditInstance: FC<Props> = ({ instance }) => {
 
   const getYaml = () => {
     const exclude = new Set([
+      "access_entitlements",
       "backups",
       "snapshots",
       "state",

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -46,6 +46,7 @@ import type { NetworkFormValues } from "types/forms/network";
 
 export const toNetwork = (values: NetworkFormValues): Partial<LxdNetwork> => {
   const excludeMainKeys = new Set([
+    "access_entitlements",
     "used_by",
     "etag",
     "status",

--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -173,7 +173,7 @@ const EditProfile: FC<Props> = ({ profile }) => {
   };
 
   const getYaml = () => {
-    const exclude = new Set(["used_by", "etag"]);
+    const exclude = new Set(["access_entitlements", "used_by", "etag"]);
     const profilePayload = getProfilePayload(profile, formik.values);
     const bareProfile = Object.fromEntries(
       Object.entries(profilePayload).filter((e) => !exclude.has(e[0])),

--- a/src/pages/storage/forms/StoragePoolForm.tsx
+++ b/src/pages/storage/forms/StoragePoolForm.tsx
@@ -172,6 +172,7 @@ export const toStoragePool = (
   };
 
   const excludeMainKeys = new Set([
+    "access_entitlements",
     "used_by",
     "etag",
     "status",

--- a/src/util/yaml.spec.ts
+++ b/src/util/yaml.spec.ts
@@ -30,6 +30,7 @@ describe("expandInheritedValuesYaml", () => {
   ];
 
   const instance: LxdInstance = {
+    access_entitlements: ["can_delete"],
     name: "test-vm",
     status: "Running",
     profiles: ["default", "cloud-init"],

--- a/src/util/yaml.tsx
+++ b/src/util/yaml.tsx
@@ -42,6 +42,7 @@ export const expandInheritedValuesYaml = (
   const sections: string[] = [];
 
   const exclude = [
+    "access_entitlements",
     "config",
     "devices",
     "expanded_config",


### PR DESCRIPTION
## Done

- fix(forms) hide access entitlements in yaml forms. fixes 

Fixes #2085

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - check edit object, yaml editor when fine grained permissions are enabled for:
    - instances
    - profiles
    - networks
    - storage pools
    - All of the above should not surface the access entitlements for the object

## Screenshots

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/22ceb95f-4688-4667-9976-b9fba0bf3d4f" />
