### PR TITLE
fix(search) match queries always in lowercase

### DIFF
--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -216,9 +216,11 @@ const InstanceList: FC = () => {
     if (
       !filters.queries.every(
         (q) =>
-          item.name.toLowerCase().includes(q) ||
-          item.description.toLowerCase().includes(q) ||
-          item.config["image.description"]?.toLowerCase().includes(q),
+          item.name.toLowerCase().includes(q.toLowerCase()) ||
+          item.description.toLowerCase().includes(q.toLowerCase()) ||
+          item.config["image.description"]
+            ?.toLowerCase()
+            .includes(q.toLowerCase()),
       )
     ) {
       return false;

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -141,8 +141,8 @@ const NetworkList: FC = () => {
       if (
         !filters.queries.every(
           (q) =>
-            network.name.toLowerCase().includes(q) ||
-            network.description?.toLowerCase().includes(q),
+            network.name.toLowerCase().includes(q.toLowerCase()) ||
+            network.description?.toLowerCase().includes(q.toLowerCase()),
         )
       ) {
         return false;

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -93,8 +93,8 @@ const PermissionIdentities: FC = () => {
     if (
       !filters.queries.every(
         (q) =>
-          getIdentityName(identity).toLowerCase().includes(q) ||
-          identity.id.toLowerCase().includes(q),
+          getIdentityName(identity).toLowerCase().includes(q.toLowerCase()) ||
+          identity.id.toLowerCase().includes(q.toLowerCase()),
       )
     ) {
       return false;

--- a/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
@@ -209,8 +209,8 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
     if (
       !filters.queries.every(
         (q) =>
-          getIdentityName(identity).toLowerCase().includes(q) ||
-          identity.id.toLowerCase().includes(q),
+          getIdentityName(identity).toLowerCase().includes(q.toLowerCase()) ||
+          identity.id.toLowerCase().includes(q.toLowerCase()),
       )
     ) {
       return false;

--- a/src/pages/storage/StorageBuckets.tsx
+++ b/src/pages/storage/StorageBuckets.tsx
@@ -122,7 +122,11 @@ const StorageBuckets: FC = () => {
   ];
 
   const filteredBuckets = buckets.filter((item) => {
-    if (!filters.queries.every((q) => item.name.toLowerCase().includes(q))) {
+    if (
+      !filters.queries.every((q) =>
+        item.name.toLowerCase().includes(q.toLowerCase()),
+      )
+    ) {
       return false;
     }
     if (filters.pools.length > 0 && !filters.pools.includes(item.pool)) {

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -201,7 +201,11 @@ const StorageVolumes: FC = () => {
       return false;
     }
 
-    if (!filters.queries.every((q) => item.name.toLowerCase().includes(q))) {
+    if (
+      !filters.queries.every((q) =>
+        item.name.toLowerCase().includes(q.toLowerCase()),
+      )
+    ) {
       return false;
     }
     if (filters.pools.length > 0 && !filters.pools.includes(item.pool)) {

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -52,8 +52,8 @@ const WarningList: FC = () => {
     if (
       !filters.queries.every(
         (q) =>
-          item.type.toLowerCase().includes(q) ||
-          item.last_message.toLowerCase().includes(q),
+          item.type.toLowerCase().includes(q.toLowerCase()) ||
+          item.last_message.toLowerCase().includes(q.toLowerCase()),
       )
     ) {
       return false;


### PR DESCRIPTION
## Done

- fix(search) match queries always in lowercase

Fixes #2086

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - search for an instance, network, identity, volume or warning with a mixed case and ensure the objects are matched ignoring the case

## Screenshots

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/f2b319e4-a745-4643-b827-053b7c602705" />