### PR TITLE
feat: Mobile improvements

### DIFF
--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -122,9 +122,7 @@ const RenameHeader: FC<Props> = ({
                     {name}
                   </Tooltip>
                 </li>
-                {nameAddon && (
-                  <li className="name-addon-item">{nameAddon}</li>
-                )}
+                {nameAddon && <li className="name-addon-item">{nameAddon}</li>}
               </>
             )}
           </ol>

--- a/src/components/RenameHeader.tsx
+++ b/src/components/RenameHeader.tsx
@@ -18,6 +18,7 @@ interface Props {
   relatedChip?: ReactNode;
   titleClassName?: string;
   parentItems: ReactNode[];
+  nameAddon?: ReactNode;
   centerControls?: ReactNode;
   controls?: ReactNode;
   isLoaded: boolean;
@@ -30,6 +31,7 @@ const RenameHeader: FC<Props> = ({
   relatedChip,
   titleClassName,
   parentItems,
+  nameAddon,
   centerControls,
   controls,
   isLoaded,
@@ -104,18 +106,26 @@ const RenameHeader: FC<Props> = ({
                 </div>
               </li>
             ) : (
-              <li
-                className="p-heading--4 u-no-margin--bottom name continuous-breadcrumb u-truncate"
-                onClick={toggleRename}
-                title={canRename ? `Rename ${name}` : ""}
-              >
-                <Tooltip
-                  message={!canRename && renameDisabledReason}
-                  position="btm-left"
+              <>
+                <li
+                  className={classnames(
+                    "p-heading--4 u-no-margin--bottom name continuous-breadcrumb u-truncate",
+                    { "has-addon": !!nameAddon },
+                  )}
+                  onClick={toggleRename}
+                  title={canRename ? `Rename ${name}` : ""}
                 >
-                  {name}
-                </Tooltip>
-              </li>
+                  <Tooltip
+                    message={!canRename && renameDisabledReason}
+                    position="btm-left"
+                  >
+                    {name}
+                  </Tooltip>
+                </li>
+                {nameAddon && (
+                  <li className="name-addon-item">{nameAddon}</li>
+                )}
+              </>
             )}
           </ol>
           {relatedChip}

--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -1,4 +1,10 @@
-import { useState, type FC, type MouseEvent, type PointerEvent } from "react";
+import {
+  useState,
+  type FC,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
 import type {
   MainTableRow,
   Props as MainTableProps,
@@ -27,6 +33,8 @@ interface SelectableMainTableProps {
   hideContextualMenu?: boolean;
   defaultSortKey?: string;
   disableSelectAll?: boolean;
+  trailingHeaderContent?: ReactNode;
+  trailingRowContent?: (row: MainTableRow) => ReactNode;
 }
 
 type Props = SelectableMainTableProps & MainTableProps;
@@ -46,6 +54,8 @@ const SelectableMainTable: FC<Props> = ({
   hideContextualMenu,
   defaultSortKey,
   disableSelectAll,
+  trailingHeaderContent,
+  trailingRowContent,
   ...props
 }: Props) => {
   const [currentSelectedIndex, setCurrentSelectedIndex] = useState<number>();
@@ -131,6 +141,15 @@ const SelectableMainTable: FC<Props> = ({
       "aria-label": "select",
     },
     ...(headers ?? []),
+    ...(trailingHeaderContent !== undefined
+      ? [
+          {
+            content: trailingHeaderContent,
+            className: "trailing-status-col",
+            "aria-label": "Status",
+          },
+        ]
+      : []),
   ];
 
   const selectedNamesLookup = new Set(selectedNames);
@@ -197,6 +216,15 @@ const SelectableMainTable: FC<Props> = ({
         className: "select",
       },
       ...(row.columns ?? []),
+      ...(trailingRowContent
+        ? [
+            {
+              content: trailingRowContent(row),
+              role: "cell",
+              className: "trailing-status-col",
+            },
+          ]
+        : []),
     ];
 
     const className = classnames(row.className, {

--- a/src/context/useIsScreenBelow.tsx
+++ b/src/context/useIsScreenBelow.tsx
@@ -5,6 +5,7 @@ import { useListener } from "@canonical/react-components";
 export const smallScreenBreakpoint = 620;
 export const mediumScreenBreakpoint = 820;
 export const largeScreenBreakpoint = 1200;
+export const sidePanelBreakpoint = 1090;
 
 export const useIsScreenBelow = (
   breakpoint = smallScreenBreakpoint,

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   CheckboxInput,
   Col,
+  Icon,
   MainTable,
   Modal,
   Notification,
@@ -11,7 +12,9 @@ import {
   SearchBox,
   Select,
   Spinner,
+  useListener,
 } from "@canonical/react-components";
+import classnames from "classnames";
 import type { LxdImageType, RemoteImage } from "types/image";
 import { capitalizeFirstLetter } from "util/helpers";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
@@ -43,6 +46,16 @@ const ANY = "any";
 const CONTAINER = "container";
 const VM = "virtual-machine";
 
+const LARGE_BREAKPOINT = 1090;
+const SMALL_BREAKPOINT = 800;
+
+type ScreenSize = "large" | "medium" | "small";
+const figureScreenSize = (): ScreenSize => {
+  if (window.innerWidth >= LARGE_BREAKPOINT) return "large";
+  if (window.innerWidth >= SMALL_BREAKPOINT) return "medium";
+  return "small";
+};
+
 const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [query, setQuery] = useState<string>("");
   const [os, setOs] = useState<string>("");
@@ -53,7 +66,14 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [hideRemote, setHideRemote] = useState(false);
   const [error, setError] = useState("");
   const [hideError, setHideError] = useState(false);
+  const [screenSize, setScreenSize] = useState<ScreenSize>(figureScreenSize());
+  const [showFilters, setShowFilters] = useState(false);
   const { project } = useParams<{ project: string }>();
+
+  const resize = () => {
+    setScreenSize(figureScreenSize());
+  };
+  useListener(window, resize, "resize", true);
 
   const { data: settings, isLoading: isSettingsLoading } = useSettings();
   const { data: remoteImages, isLoading: isRemoteImagesLoading } =
@@ -247,7 +267,6 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             onClick: selectImage,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: item.aliases.split(",").pop(),
             title: item.aliases.split(",").pop(),
             role: "cell",
@@ -261,14 +280,12 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             onClick: selectImage,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: item.cached ? "Cached" : "Remote",
             role: "cell",
             "aria-label": "Cached",
             onClick: selectImage,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: (
               <Button
                 onClick={selectImage}
@@ -307,21 +324,120 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     {
       content: "Alias",
       sortKey: "alias",
-      className: "u-hide--small u-hide--medium",
     },
     {
       content: "Source",
     },
     {
-      className: "u-hide--small u-hide--medium",
       content: "Cached",
     },
     {
-      className: "u-hide--small u-hide--medium",
       content: "",
       "aria-label": "Actions",
     },
   ];
+
+  const filters = (
+    <div
+      className={classnames("image-select-filters", {
+        "image-select-filters--small": screenSize === "small",
+        "image-select-filters--medium": screenSize === "medium",
+      })}
+    >
+      <Select
+        id="imageFilterDistribution"
+        label="Distribution"
+        name="distribution"
+        onChange={(v) => {
+          setOs(v.target.value);
+          setRelease("");
+        }}
+        options={getOptionList((item: RemoteImage) => item.os)}
+        value={os}
+      />
+      <Select
+        id="imageFilterRelease"
+        label="Release"
+        name="release"
+        onChange={(v) => {
+          setRelease(v.target.value);
+        }}
+        options={getOptionList(
+          (item) => item.release,
+          (item) => item.os === os,
+        )}
+        value={release}
+        disabled={os === ""}
+      />
+      <Select
+        id="imageFilterVariant"
+        label="Variant"
+        name="variant"
+        onChange={(v) => {
+          setVariant(v.target.value);
+        }}
+        options={[
+          {
+            label: "Any",
+            value: ANY,
+          },
+        ].concat(
+          variantAll
+            .filter((item) => Boolean(item))
+            .map((item) => {
+              return {
+                label: item ?? "",
+                value: item ?? "",
+              };
+            }),
+        )}
+        value={variant}
+      />
+      <Select
+        id="imageFilterArchitecture"
+        label="Architecture"
+        name="architecture"
+        onChange={(v) => {
+          setArch(v.target.value);
+        }}
+        options={archAll.map((item) => {
+          return {
+            label: item,
+            value: item,
+          };
+        })}
+        value={arch}
+      />
+      <Select
+        id="imageFilterType"
+        label="Type"
+        name="type"
+        onChange={(v) => {
+          setType(
+            v.target.value === ANY
+              ? undefined
+              : (v.target.value as LxdImageType),
+          );
+        }}
+        options={[
+          {
+            label: "Any",
+            value: ANY,
+          },
+          ...instanceCreationTypes,
+        ]}
+        value={type ?? ""}
+      />
+      <CheckboxInput
+        aria-label="Only show cached images"
+        checked={hideRemote}
+        label="Show only cached images"
+        onChange={() => {
+          setHideRemote((prev) => !prev);
+        }}
+      />
+    </div>
+  );
 
   return (
     <Modal
@@ -330,103 +446,9 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       className="image-select-modal"
     >
       <Row className="u-no-padding--left u-no-padding--right">
-        <Col size={3}>
-          <div className="image-select-filters">
-            <Select
-              id="imageFilterDistribution"
-              label="Distribution"
-              name="distribution"
-              onChange={(v) => {
-                setOs(v.target.value);
-                setRelease("");
-              }}
-              options={getOptionList((item: RemoteImage) => item.os)}
-              value={os}
-            />
-            <Select
-              id="imageFilterRelease"
-              label="Release"
-              name="release"
-              onChange={(v) => {
-                setRelease(v.target.value);
-              }}
-              options={getOptionList(
-                (item) => item.release,
-                (item) => item.os === os,
-              )}
-              value={release}
-              disabled={os === ""}
-            />
-            <Select
-              id="imageFilterVariant"
-              label="Variant"
-              name="variant"
-              onChange={(v) => {
-                setVariant(v.target.value);
-              }}
-              options={[
-                {
-                  label: "Any",
-                  value: ANY,
-                },
-              ].concat(
-                variantAll
-                  .filter((item) => Boolean(item))
-                  .map((item) => {
-                    return {
-                      label: item ?? "",
-                      value: item ?? "",
-                    };
-                  }),
-              )}
-              value={variant}
-            />
-            <Select
-              id="imageFilterArchitecture"
-              label="Architecture"
-              name="architecture"
-              onChange={(v) => {
-                setArch(v.target.value);
-              }}
-              options={archAll.map((item) => {
-                return {
-                  label: item,
-                  value: item,
-                };
-              })}
-              value={arch}
-            />
-            <Select
-              id="imageFilterType"
-              label="Type"
-              name="type"
-              onChange={(v) => {
-                setType(
-                  v.target.value === ANY
-                    ? undefined
-                    : (v.target.value as LxdImageType),
-                );
-              }}
-              options={[
-                {
-                  label: "Any",
-                  value: ANY,
-                },
-                ...instanceCreationTypes,
-              ]}
-              value={type ?? ""}
-            />
-            <CheckboxInput
-              aria-label="Only show cached images"
-              checked={hideRemote}
-              label="Show only cached images"
-              onChange={() => {
-                setHideRemote((prev) => !prev);
-              }}
-            />
-          </div>
-        </Col>
-        <Col size={9}>
+        {screenSize === "large" && <Col size={3}>{filters}</Col>}
+        <Col size={screenSize === "large" ? 9 : 12}>
+          {screenSize === "medium" && filters}
           <div className="image-select-header">
             {error && !hideError ? (
               <Notification
@@ -454,7 +476,22 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 />
               </div>
             )}
+            {screenSize === "small" && (
+              <Button
+                type="button"
+                hasIcon
+                className="image-filter-toggle u-no-margin--bottom"
+                aria-expanded={showFilters}
+                aria-label={showFilters ? "Hide filters" : "Show filters"}
+                onClick={() => {
+                  setShowFilters((prev) => !prev);
+                }}
+              >
+                <Icon name="filter" />
+              </Button>
+            )}
           </div>
+          {screenSize === "small" && showFilters && filters}
           <div className="image-list">
             <ScrollableTable
               dependencies={[images]}
@@ -473,6 +510,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 headers={headers}
                 rows={rows}
                 paginate={null}
+                responsive={screenSize === "small"}
                 sortable
               />
             </ScrollableTable>

--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -12,9 +12,13 @@ import {
   SearchBox,
   Select,
   Spinner,
-  useListener,
 } from "@canonical/react-components";
 import classnames from "classnames";
+import {
+  largeScreenBreakpoint,
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import type { LxdImageType, RemoteImage } from "types/image";
 import { capitalizeFirstLetter } from "util/helpers";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
@@ -46,15 +50,7 @@ const ANY = "any";
 const CONTAINER = "container";
 const VM = "virtual-machine";
 
-const LARGE_BREAKPOINT = 1090;
-const SMALL_BREAKPOINT = 800;
-
 type ScreenSize = "large" | "medium" | "small";
-const figureScreenSize = (): ScreenSize => {
-  if (window.innerWidth >= LARGE_BREAKPOINT) return "large";
-  if (window.innerWidth >= SMALL_BREAKPOINT) return "medium";
-  return "small";
-};
 
 const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [query, setQuery] = useState<string>("");
@@ -66,14 +62,17 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [hideRemote, setHideRemote] = useState(false);
   const [error, setError] = useState("");
   const [hideError, setHideError] = useState(false);
-  const [screenSize, setScreenSize] = useState<ScreenSize>(figureScreenSize());
   const [showFilters, setShowFilters] = useState(false);
   const { project } = useParams<{ project: string }>();
 
-  const resize = () => {
-    setScreenSize(figureScreenSize());
-  };
-  useListener(window, resize, "resize", true);
+  const isBelowLarge = useIsScreenBelow(largeScreenBreakpoint);
+  const isBelowMedium = useIsScreenBelow(mediumScreenBreakpoint);
+  let screenSize: ScreenSize = "large";
+  if (isBelowMedium) {
+    screenSize = "small";
+  } else if (isBelowLarge) {
+    screenSize = "medium";
+  }
 
   const { data: settings, isLoading: isSettingsLoading } = useSettings();
   const { data: remoteImages, isLoading: isRemoteImagesLoading } =

--- a/src/pages/instances/InstanceDetailActions.tsx
+++ b/src/pages/instances/InstanceDetailActions.tsx
@@ -72,16 +72,33 @@ const InstanceDetailActions: FC<Props> = ({ instance, project, isLoading }) => {
         >
           {(close: () => void) => (
             <span>
-              {isMobileScreen && [
-                <StartInstanceBtn key="start" instance={instance} classname={classname} />,
-                <RestartInstanceBtn key="restart" instance={instance} classname={classname} />,
-                <FreezeInstanceBtn key="freeze" instance={instance} classname={classname} />,
-                <StopInstanceBtn key="stop" instance={instance} classname={classname} />,
-              ].map((item) => (
-                <span key={item.key} onClick={close}>
-                  {item}
-                </span>
-              ))}
+              {isMobileScreen &&
+                [
+                  <StartInstanceBtn
+                    key="start"
+                    instance={instance}
+                    classname={classname}
+                  />,
+                  <RestartInstanceBtn
+                    key="restart"
+                    instance={instance}
+                    classname={classname}
+                  />,
+                  <FreezeInstanceBtn
+                    key="freeze"
+                    instance={instance}
+                    classname={classname}
+                  />,
+                  <StopInstanceBtn
+                    key="stop"
+                    instance={instance}
+                    classname={classname}
+                  />,
+                ].map((item) => (
+                  <span key={item.key} onClick={close}>
+                    {item}
+                  </span>
+                ))}
               {isMobileScreen && <hr className="u-no-margin" />}
               {[...menuElements].map((item) =>
                 cloneElement(item, { onClose: close }),

--- a/src/pages/instances/InstanceDetailActions.tsx
+++ b/src/pages/instances/InstanceDetailActions.tsx
@@ -6,8 +6,13 @@ import CreateImageFromInstanceBtn from "./actions/CreateImageFromInstanceBtn";
 import CopyInstanceBtn from "./actions/CopyInstanceBtn";
 import { ContextualMenu } from "@canonical/react-components";
 import ExportInstanceBtn from "pages/instances/actions/ExportInstanceBtn";
+import StartInstanceBtn from "pages/instances/actions/StartInstanceBtn";
+import StopInstanceBtn from "pages/instances/actions/StopInstanceBtn";
+import RestartInstanceBtn from "pages/instances/actions/RestartInstanceBtn";
+import FreezeInstanceBtn from "pages/instances/actions/FreezeInstanceBtn";
 import {
   largeScreenBreakpoint,
+  smallScreenBreakpoint,
   useIsScreenBelow,
 } from "context/useIsScreenBelow";
 
@@ -19,6 +24,7 @@ interface Props {
 
 const InstanceDetailActions: FC<Props> = ({ instance, project, isLoading }) => {
   const isSmallScreen = useIsScreenBelow(largeScreenBreakpoint);
+  const isMobileScreen = useIsScreenBelow(smallScreenBreakpoint);
 
   const classname = isSmallScreen
     ? "p-contextual-menu__link"
@@ -66,6 +72,17 @@ const InstanceDetailActions: FC<Props> = ({ instance, project, isLoading }) => {
         >
           {(close: () => void) => (
             <span>
+              {isMobileScreen && [
+                <StartInstanceBtn key="start" instance={instance} classname={classname} />,
+                <RestartInstanceBtn key="restart" instance={instance} classname={classname} />,
+                <FreezeInstanceBtn key="freeze" instance={instance} classname={classname} />,
+                <StopInstanceBtn key="stop" instance={instance} classname={classname} />,
+              ].map((item) => (
+                <span key={item.key} onClick={close}>
+                  {item}
+                </span>
+              ))}
+              {isMobileScreen && <hr className="u-no-margin" />}
               {[...menuElements].map((item) =>
                 cloneElement(item, { onClose: close }),
               )}

--- a/src/pages/instances/InstanceDetailHeader.tsx
+++ b/src/pages/instances/InstanceDetailHeader.tsx
@@ -16,6 +16,10 @@ import { useToastNotification } from "@canonical/react-components";
 import { useInstanceLoading } from "context/instanceLoading";
 import { InstanceRichChip } from "./InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import {
+  smallScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 
 interface Props {
   name: string;
@@ -37,6 +41,7 @@ const InstanceDetailHeader: FC<Props> = ({
   const controllerState = useState<AbortController | null>(null);
   const { canViewProject } = useCurrentProject();
   const instanceLoading = useInstanceLoading();
+  const isSmallScreen = useIsScreenBelow(smallScreenBreakpoint);
 
   const loadingType = instance ? instanceLoading.getType(instance) : undefined;
 
@@ -143,8 +148,15 @@ const InstanceDetailHeader: FC<Props> = ({
           </Link>,
         ]}
         renameDisabledReason={getDisabledReason()}
+        nameAddon={
+          isSmallScreen && instance ? (
+            <i className="status u-text--muted">
+              {loadingType ?? instance.status}
+            </i>
+          ) : undefined
+        }
         centerControls={
-          instance ? (
+          !isSmallScreen && instance ? (
             <div className="instance-header-state-controls">
               <i className="status u-text--muted">
                 {loadingType ?? instance.status}

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -602,7 +602,7 @@ const InstanceList: FC = () => {
         const loadingType = instanceLoading.getType(instance);
         return (
           <span title={loadingType ?? instance.status}>
-            <InstanceStatusIcon instance={instance} iconOnly />
+            <InstanceStatusIcon instance={instance} compact />
           </span>
         );
       }

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -68,6 +68,7 @@ import PageHeader from "components/PageHeader";
 import InstanceDetailPanel from "./InstanceDetailPanel";
 import {
   mediumScreenBreakpoint,
+  sidePanelBreakpoint,
   useIsScreenBelow,
 } from "context/useIsScreenBelow";
 import InstanceUsageMainMemory from "pages/instances/InstanceUsageMainMemory";
@@ -127,6 +128,7 @@ const InstanceList: FC = () => {
   const [processingNames, setProcessingNames] = useState<string[]>([]);
   const isSmallScreen = useIsScreenBelow();
   const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
+  const isSidePanelScreen = !useIsScreenBelow(sidePanelBreakpoint);
 
   if (!project && !isAllProjects) {
     return <>Missing project</>;
@@ -341,14 +343,18 @@ const InstanceList: FC = () => {
     },
     {
       "aria-label": "Actions",
-      className: classnames({ "u-hide": panelParams.instance }),
       style: { width: `${COLUMN_WIDTHS[ACTIONS]}px` },
     },
   ];
 
+
   const visibleHeaders = visibleHeaderColumns(
     headers,
     userHidden.concat(sizeHidden),
+  ).map((h) =>
+    !h.content
+      ? { ...h, className: classnames(h.className, { "u-hide": panelParams.instance || isSmallScreen }) }
+      : h,
   );
 
   const getRows = (hiddenCols: string[]): MainTableRow[] => {
@@ -415,7 +421,7 @@ const InstanceList: FC = () => {
             ),
             role: "cell",
             className: classnames("u-align--right", {
-              "u-hide": panelParams.instance,
+              "u-hide": panelParams.instance || isSmallScreen,
             }),
             "aria-label": "Actions",
             style: { width: `${COLUMN_WIDTHS[ACTIONS]}px` },
@@ -429,7 +435,13 @@ const InstanceList: FC = () => {
 
     const instanceRows: MainTableRow[] = filteredInstances.map((instance) => {
       const openSummary = () => {
-        panelParams.openInstanceSummary(instance.name, instance.project);
+        if (isSidePanelScreen) {
+          panelParams.openInstanceSummary(instance.name, instance.project);
+        } else if (isSmallScreen) {
+          void navigate(
+            `${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/instance/${encodeURIComponent(instance.name)}`,
+          );
+        }
       };
 
       const ipv4 = getIpAddresses(instance, "inet");
@@ -443,7 +455,9 @@ const InstanceList: FC = () => {
 
       return {
         key: getInstanceKey(instance),
-        className: hasActivePanel ? "u-row-selected" : "u-row",
+        className: classnames(hasActivePanel ? "u-row-selected" : "u-row", {
+          "u-row-no-click": !isSidePanelScreen && !isSmallScreen,
+        }),
         name: getInstanceKey(instance),
         columns: [
           {
@@ -565,7 +579,7 @@ const InstanceList: FC = () => {
             ),
             role: "cell",
             className: classnames("u-align--right", {
-              "u-hide": panelParams.instance,
+              "u-hide": panelParams.instance || isSmallScreen,
             }),
             "aria-label": "Actions",
             style: { width: `${COLUMN_WIDTHS[ACTIONS]}px` },

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -590,6 +590,24 @@ const InstanceList: FC = () => {
     rows: getRows(userHidden.concat(sizeHidden)),
   });
 
+  const instanceByKey = new Map(
+    filteredInstances.map((i) => [getInstanceKey(i), i]),
+  );
+  const showTrailingStatus = sizeHidden.includes(STATUS);
+  const trailingHeaderContent = showTrailingStatus ? null : undefined;
+  const trailingRowContent = showTrailingStatus
+    ? (row: MainTableRow) => {
+        const instance = instanceByKey.get(row.name ?? "");
+        if (!instance) return null;
+        const loadingType = instanceLoading.getType(instance);
+        return (
+          <span title={loadingType ?? instance.status}>
+            <InstanceStatusIcon instance={instance} iconOnly />
+          </span>
+        );
+      }
+    : undefined;
+
   const figureSizeHidden = () => {
     const wrapper = document.getElementById("instance-table-measure");
     const tableHead = wrapper?.children[0]?.children[0]?.children[0];
@@ -786,6 +804,8 @@ const InstanceList: FC = () => {
                       disabledNames={processingNames}
                       filteredNames={filteredInstances.map(getInstanceKey)}
                       onUpdateSort={updateSort}
+                      trailingHeaderContent={trailingHeaderContent}
+                      trailingRowContent={trailingRowContent}
                     />
                   </TablePagination>
                 </ScrollableTable>

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -347,13 +347,17 @@ const InstanceList: FC = () => {
     },
   ];
 
-
   const visibleHeaders = visibleHeaderColumns(
     headers,
     userHidden.concat(sizeHidden),
   ).map((h) =>
     !h.content
-      ? { ...h, className: classnames(h.className, { "u-hide": panelParams.instance || isSmallScreen }) }
+      ? {
+          ...h,
+          className: classnames(h.className, {
+            "u-hide": panelParams.instance || isSmallScreen,
+          }),
+        }
       : h,
   );
 

--- a/src/pages/instances/InstanceStatusIcon.tsx
+++ b/src/pages/instances/InstanceStatusIcon.tsx
@@ -6,9 +6,10 @@ import { Icon } from "@canonical/react-components";
 
 interface Props {
   instance: LxdInstance;
+  iconOnly?: boolean;
 }
 
-const InstanceStatusIcon: FC<Props> = ({ instance }) => {
+const InstanceStatusIcon: FC<Props> = ({ instance, iconOnly = false }) => {
   const instanceLoading = useInstanceLoading();
   const loadingType = instanceLoading.getType(instance);
 
@@ -28,7 +29,7 @@ const InstanceStatusIcon: FC<Props> = ({ instance }) => {
   return loadingType ? (
     <>
       <Icon className="u-animation--spin status-icon" name="spinner" />
-      <i>{loadingType}</i>
+      {!iconOnly && <i>{loadingType}</i>}
     </>
   ) : (
     <>
@@ -38,7 +39,7 @@ const InstanceStatusIcon: FC<Props> = ({ instance }) => {
           "u-animation--spin": instance.status === "Freezing",
         })}
       />
-      {instance.status}
+      {!iconOnly && instance.status}
     </>
   );
 };

--- a/src/pages/instances/InstanceStatusIcon.tsx
+++ b/src/pages/instances/InstanceStatusIcon.tsx
@@ -6,10 +6,10 @@ import { Icon } from "@canonical/react-components";
 
 interface Props {
   instance: LxdInstance;
-  iconOnly?: boolean;
+  compact?: boolean;
 }
 
-const InstanceStatusIcon: FC<Props> = ({ instance, iconOnly = false }) => {
+const InstanceStatusIcon: FC<Props> = ({ instance, compact = false }) => {
   const instanceLoading = useInstanceLoading();
   const loadingType = instanceLoading.getType(instance);
 
@@ -26,10 +26,35 @@ const InstanceStatusIcon: FC<Props> = ({ instance, iconOnly = false }) => {
     );
   };
 
+  const getAbbreviation = (status: string) => {
+    return (
+      {
+        Error: "E",
+        Frozen: "F",
+        Ready: "✓",
+        Running: "R",
+        Stopped: "S",
+      }[status] ?? ""
+    );
+  };
+
+  if (compact) {
+    if (loadingType || instance.status === "Freezing") {
+      return <Icon className="u-animation--spin status-icon" name="spinner" />;
+    }
+    return (
+      <span
+        className={`status-abbr status-abbr--${instance.status.toLowerCase()}`}
+      >
+        {getAbbreviation(instance.status)}
+      </span>
+    );
+  }
+
   return loadingType ? (
     <>
       <Icon className="u-animation--spin status-icon" name="spinner" />
-      {!iconOnly && <i>{loadingType}</i>}
+      <i>{loadingType}</i>
     </>
   ) : (
     <>
@@ -39,7 +64,7 @@ const InstanceStatusIcon: FC<Props> = ({ instance, iconOnly = false }) => {
           "u-animation--spin": instance.status === "Freezing",
         })}
       />
-      {!iconOnly && instance.status}
+      {instance.status}
     </>
   );
 };

--- a/src/pages/instances/actions/FreezeInstanceBtn.tsx
+++ b/src/pages/instances/actions/FreezeInstanceBtn.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import classnames from "classnames";
 import type { LxdInstance } from "types/instance";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
@@ -14,9 +15,10 @@ import { InstanceRichChip } from "../InstanceRichChip";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
 }
 
-const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
+const FreezeInstanceBtn: FC<Props> = ({ instance, classname }) => {
   const eventQueue = useEventQueue();
   const instanceLoading = useInstanceLoading();
   const toastNotify = useToastNotification();
@@ -94,12 +96,13 @@ const FreezeInstanceBtn: FC<Props> = ({ instance }) => {
           ? "Freeze"
           : "You do not have permission to freeze this instance",
       }}
-      className="has-icon is-dense"
+      className={classnames("has-icon", classname ?? "is-dense")}
       disabled={isDisabled || !canUpdateInstanceState(instance) || isLoading}
       shiftClickEnabled
       showShiftClickHint
     >
       <Icon name="pause" />
+      {classname && <span>Freeze</span>}
     </MountedConfirmationButton>
   );
 };

--- a/src/pages/instances/actions/RestartInstanceBtn.tsx
+++ b/src/pages/instances/actions/RestartInstanceBtn.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type FC } from "react";
+import classnames from "classnames";
 import type { LxdInstance } from "types/instance";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
@@ -14,9 +15,10 @@ import MountedConfirmationButton from "components/MountedConfirmationButton";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
 }
 
-const RestartInstanceBtn: FC<Props> = ({ instance }) => {
+const RestartInstanceBtn: FC<Props> = ({ instance, classname }) => {
   const eventQueue = useEventQueue();
   const instanceLoading = useInstanceLoading();
   const toastNotify = useToastNotification();
@@ -77,7 +79,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
     <MountedConfirmationButton
       appearance="base"
       loading={isLoading}
-      className="has-icon is-dense"
+      className={classnames("has-icon", classname ?? "is-dense")}
       confirmationModalProps={{
         title: "Confirm restart",
         children: (
@@ -105,6 +107,7 @@ const RestartInstanceBtn: FC<Props> = ({ instance }) => {
       showShiftClickHint
     >
       <Icon name="restart" />
+      {classname && <span>Restart</span>}
     </MountedConfirmationButton>
   );
 };

--- a/src/pages/instances/actions/StartInstanceBtn.tsx
+++ b/src/pages/instances/actions/StartInstanceBtn.tsx
@@ -7,17 +7,16 @@ import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
 }
 
-const StartInstanceBtn: FC<Props> = ({ instance }) => {
+const StartInstanceBtn: FC<Props> = ({ instance, classname }) => {
   const { handleStart, isLoading, isDisabled } = useInstanceStart(instance);
   const { canUpdateInstanceState } = useInstanceEntitlements();
 
   return (
     <Button
       appearance="base"
-      hasIcon
-      dense={true}
       disabled={isDisabled || !canUpdateInstanceState(instance)}
       onClick={handleStart}
       type="button"
@@ -27,11 +26,13 @@ const StartInstanceBtn: FC<Props> = ({ instance }) => {
           ? "Start"
           : "You do not have permission to start this instance"
       }
+      className={classnames("has-icon", classname ?? "is-dense")}
     >
       <Icon
         className={classnames({ "u-animation--spin": isLoading })}
         name={isLoading ? "spinner" : "play"}
       />
+      {classname && <span>Start</span>}
     </Button>
   );
 };

--- a/src/pages/instances/actions/StopInstanceBtn.tsx
+++ b/src/pages/instances/actions/StopInstanceBtn.tsx
@@ -11,12 +11,14 @@ import { useInstanceEntitlements } from "util/entitlements/instances";
 import ResourceLabel from "components/ResourceLabel";
 import MountedConfirmationButton from "components/MountedConfirmationButton";
 import { InstanceRichChip } from "../InstanceRichChip";
+import classnames from "classnames";
 
 interface Props {
   instance: LxdInstance;
+  classname?: string;
 }
 
-const StopInstanceBtn: FC<Props> = ({ instance }) => {
+const StopInstanceBtn: FC<Props> = ({ instance, classname }) => {
   const eventQueue = useEventQueue();
   const instanceLoading = useInstanceLoading();
   const toastNotify = useToastNotification();
@@ -115,11 +117,12 @@ const StopInstanceBtn: FC<Props> = ({ instance }) => {
           ? "Stop"
           : "You do not have permission to stop this instance",
       }}
-      className="has-icon is-dense"
+      className={classnames("has-icon", classname ?? "is-dense")}
       shiftClickEnabled
       showShiftClickHint
     >
       <Icon name="stop" />
+      {classname && <span>Stop</span>}
     </MountedConfirmationButton>
   );
 };

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type FC } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useListener, useNotify } from "@canonical/react-components";
+import { Button, Icon, useListener, useNotify } from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
@@ -12,6 +12,8 @@ import {
   isOtherDevice,
   isProxyDevice,
 } from "util/devices";
+import { slugify } from "util/slugify";
+import classnames from "classnames";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -48,6 +50,8 @@ const InstanceFormMenu: FC<Props> = ({
   const [isDeviceExpanded, setDeviceExpanded] = useState(true);
   const { hasMetadataConfiguration } = useSupportedFeatures();
 
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+
   const disableReason = isDisabled
     ? "Please select an image before adding custom configuration"
     : undefined;
@@ -64,106 +68,277 @@ const InstanceFormMenu: FC<Props> = ({
   useEffect(resize, [notify.notification?.message]);
   useListener(window, resize, "resize", true);
 
-  return (
-    <div className="p-side-navigation--accordion form-navigation">
-      <nav aria-label="Instance form navigation">
-        <ul className="p-side-navigation__list">
-          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={isDeviceExpanded ? "true" : "false"}
-              onClick={() => {
-                if (!isDisabled) {
-                  setDeviceExpanded(!isDeviceExpanded);
-                }
-              }}
-              disabled={isDisabled}
-              title={disableReason}
-            >
-              {formik.values.devices.length > 0 ? (
-                <strong>Devices</strong>
-              ) : (
-                "Devices"
-              )}
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={isDeviceExpanded ? "true" : "false"}
-            >
-              <MenuItem
-                label={DISK_DEVICES}
-                hasError={hasDiskError}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isDiskDevice)}
-              />
-              <MenuItem
-                label={NETWORK_DEVICES}
-                hasError={hasNetworkError}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isNicDevice)}
-              />
-              <MenuItem
-                label={GPU_DEVICES}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isGPUDevice)}
-              />
-              <MenuItem
-                label={PROXY_DEVICES}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isProxyDevice)}
-              />
-              {hasMetadataConfiguration && (
-                <MenuItem
-                  label={OTHER_DEVICES}
-                  {...menuItemProps}
-                  isBold={formik.values.devices.some(isOtherDevice)}
-                />
-              )}
-            </ul>
-          </li>
-          <MenuItem
-            label={RESOURCE_LIMITS}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "limits_")}
+  const sections = [
+    { label: MAIN_CONFIGURATION, hasError: false },
+    { label: DISK_DEVICES, hasError: hasDiskError },
+    { label: NETWORK_DEVICES, hasError: hasNetworkError },
+    { label: GPU_DEVICES, hasError: false },
+    { label: PROXY_DEVICES, hasError: false },
+    ...(hasMetadataConfiguration ? [{ label: OTHER_DEVICES, hasError: false }] : []),
+    { label: RESOURCE_LIMITS, hasError: false },
+    { label: SECURITY_POLICIES, hasError: false },
+    { label: SNAPSHOTS, hasError: false },
+    { label: MIGRATION, hasError: false },
+    { label: BOOT, hasError: false },
+    { label: CLOUD_INIT, hasError: false },
+  ];
+
+  const activeSection = sections.find(
+    (s) => slugify(s.label) === slugify(active)
+  );
+  const activeLabel = activeSection ? activeSection.label : active;
+
+  const renderDropdownMenu = () => {
+    const onItemClick = (val: string) => {
+      setActive(val);
+      setIsOverlayOpen(false);
+    };
+
+    return (
+      <>
+        {isOverlayOpen && (
+          <div
+            className="mobile-dropdown-backdrop"
+            onClick={() => setIsOverlayOpen(false)}
           />
-          <MenuItem
-            label={SECURITY_POLICIES}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "security_")}
-          />
-          <MenuItem
-            label={SNAPSHOTS}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "snapshots_")}
-          />
-          <MenuItem
-            label={MIGRATION}
-            {...menuItemProps}
-            isBold={
-              hasPrefixValue(formik, "migration_") ||
-              hasPrefixValue(formik, "cluster_")
-            }
-          />
-          <MenuItem
-            label={BOOT}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "boot_")}
-          />
-          <MenuItem
-            label={CLOUD_INIT}
-            {...menuItemProps}
-            isBold={hasPrefixValue(
-              formik,
-              "cloud_init_",
-              "cloud_init_ssh_keys",
+        )}
+        <div className="mobile-menu-trigger-container">
+          <button
+            type="button"
+            className="mobile-menu-trigger-btn"
+            onClick={() => setIsOverlayOpen(!isOverlayOpen)}
+            aria-expanded={isOverlayOpen}
+          >
+            <span>{activeLabel}</span>
+            <Icon name={isOverlayOpen ? "chevron-up" : "chevron-down"} />
+          </button>
+
+          {isOverlayOpen && (
+            <div className="mobile-dropdown-menu">
+              <nav aria-label="Instance form mobile navigation">
+                <ul className="p-side-navigation__list">
+                  <MenuItem
+                    label={MAIN_CONFIGURATION}
+                    {...menuItemProps}
+                    isBold
+                    setActive={onItemClick}
+                  />
+                  <li className="p-side-navigation__item">
+                    <Button
+                      type="button"
+                      className="p-side-navigation__accordion-button"
+                      aria-expanded={isDeviceExpanded ? "true" : "false"}
+                      onClick={() => {
+                        if (!isDisabled) {
+                          setDeviceExpanded(!isDeviceExpanded);
+                        }
+                      }}
+                      disabled={isDisabled}
+                      title={disableReason}
+                    >
+                      {formik.values.devices.length > 0 ? (
+                        <strong>Devices</strong>
+                      ) : (
+                        "Devices"
+                      )}
+                    </Button>
+                    <ul
+                      className="p-side-navigation__list"
+                      aria-expanded={isDeviceExpanded ? "true" : "false"}
+                      >
+                        <MenuItem
+                          label={DISK_DEVICES}
+                          hasError={hasDiskError}
+                          {...menuItemProps}
+                          isBold={formik.values.devices.some(isDiskDevice)}
+                          setActive={onItemClick}
+                        />
+                        <MenuItem
+                          label={NETWORK_DEVICES}
+                          hasError={hasNetworkError}
+                          {...menuItemProps}
+                          isBold={formik.values.devices.some(isNicDevice)}
+                          setActive={onItemClick}
+                        />
+                        <MenuItem
+                          label={GPU_DEVICES}
+                          {...menuItemProps}
+                          isBold={formik.values.devices.some(isGPUDevice)}
+                          setActive={onItemClick}
+                        />
+                        <MenuItem
+                          label={PROXY_DEVICES}
+                          {...menuItemProps}
+                          isBold={formik.values.devices.some(isProxyDevice)}
+                          setActive={onItemClick}
+                        />
+                        {hasMetadataConfiguration && (
+                          <MenuItem
+                            label={OTHER_DEVICES}
+                            {...menuItemProps}
+                            isBold={formik.values.devices.some(isOtherDevice)}
+                            setActive={onItemClick}
+                          />
+                        )}
+                      </ul>
+                    </li>
+                    <MenuItem
+                      label={RESOURCE_LIMITS}
+                      {...menuItemProps}
+                      isBold={hasPrefixValue(formik, "limits_")}
+                      setActive={onItemClick}
+                    />
+                    <MenuItem
+                      label={SECURITY_POLICIES}
+                      {...menuItemProps}
+                      isBold={hasPrefixValue(formik, "security_")}
+                      setActive={onItemClick}
+                    />
+                    <MenuItem
+                      label={SNAPSHOTS}
+                      {...menuItemProps}
+                      isBold={hasPrefixValue(formik, "snapshots_")}
+                      setActive={onItemClick}
+                    />
+                    <MenuItem
+                      label={MIGRATION}
+                      {...menuItemProps}
+                      isBold={
+                        hasPrefixValue(formik, "migration_") ||
+                        hasPrefixValue(formik, "cluster_")
+                      }
+                      setActive={onItemClick}
+                    />
+                    <MenuItem
+                      label={BOOT}
+                      {...menuItemProps}
+                      isBold={hasPrefixValue(formik, "boot_")}
+                      setActive={onItemClick}
+                    />
+                    <MenuItem
+                      label={CLOUD_INIT}
+                      {...menuItemProps}
+                      isBold={hasPrefixValue(
+                        formik,
+                        "cloud_init_",
+                        "cloud_init_ssh_keys",
+                      )}
+                      setActive={onItemClick}
+                    />
+                  </ul>
+                </nav>
+              </div>
             )}
-          />
-        </ul>
-      </nav>
-    </div>
+          </div>
+        </>
+      );
+  };
+
+  return (
+    <>
+      {renderDropdownMenu()}
+
+      <div className="p-side-navigation--accordion form-navigation">
+        <nav aria-label="Instance form navigation">
+          <ul className="p-side-navigation__list">
+            <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
+            <li className="p-side-navigation__item">
+              <Button
+                type="button"
+                className="p-side-navigation__accordion-button"
+                aria-expanded={isDeviceExpanded ? "true" : "false"}
+                onClick={() => {
+                  if (!isDisabled) {
+                    setDeviceExpanded(!isDeviceExpanded);
+                  }
+                }}
+                disabled={isDisabled}
+                title={disableReason}
+              >
+                {formik.values.devices.length > 0 ? (
+                  <strong>Devices</strong>
+                ) : (
+                  "Devices"
+                )}
+              </Button>
+              <ul
+                className="p-side-navigation__list"
+                aria-expanded={isDeviceExpanded ? "true" : "false"}
+              >
+                <MenuItem
+                  label={DISK_DEVICES}
+                  hasError={hasDiskError}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isDiskDevice)}
+                />
+                <MenuItem
+                  label={NETWORK_DEVICES}
+                  hasError={hasNetworkError}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isNicDevice)}
+                />
+                <MenuItem
+                  label={GPU_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isGPUDevice)}
+                />
+                <MenuItem
+                  label={PROXY_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isProxyDevice)}
+                />
+                {hasMetadataConfiguration && (
+                  <MenuItem
+                    label={OTHER_DEVICES}
+                    {...menuItemProps}
+                    isBold={formik.values.devices.some(isOtherDevice)}
+                  />
+                )}
+              </ul>
+            </li>
+            <MenuItem
+              label={RESOURCE_LIMITS}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "limits_")}
+            />
+            <MenuItem
+              label={SECURITY_POLICIES}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "security_")}
+            />
+            <MenuItem
+              label={SNAPSHOTS}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "snapshots_")}
+            />
+            <MenuItem
+              label={MIGRATION}
+              {...menuItemProps}
+              isBold={
+                hasPrefixValue(formik, "migration_") ||
+                hasPrefixValue(formik, "cluster_")
+              }
+            />
+            <MenuItem
+              label={BOOT}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "boot_")}
+            />
+            <MenuItem
+              label={CLOUD_INIT}
+              {...menuItemProps}
+              isBold={hasPrefixValue(
+                formik,
+                "cloud_init_",
+                "cloud_init_ssh_keys",
+              )}
+            />
+          </ul>
+        </nav>
+      </div>
+    </>
   );
 };
 
 export default InstanceFormMenu;
+

--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, type FC } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, Icon, useListener, useNotify } from "@canonical/react-components";
+import {
+  Button,
+  Icon,
+  useListener,
+  useNotify,
+} from "@canonical/react-components";
 import { updateMaxHeight } from "util/updateMaxHeight";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
@@ -13,7 +18,6 @@ import {
   isProxyDevice,
 } from "util/devices";
 import { slugify } from "util/slugify";
-import classnames from "classnames";
 
 export const MAIN_CONFIGURATION = "Main configuration";
 export const DISK_DEVICES = "Disk";
@@ -74,7 +78,9 @@ const InstanceFormMenu: FC<Props> = ({
     { label: NETWORK_DEVICES, hasError: hasNetworkError },
     { label: GPU_DEVICES, hasError: false },
     { label: PROXY_DEVICES, hasError: false },
-    ...(hasMetadataConfiguration ? [{ label: OTHER_DEVICES, hasError: false }] : []),
+    ...(hasMetadataConfiguration
+      ? [{ label: OTHER_DEVICES, hasError: false }]
+      : []),
     { label: RESOURCE_LIMITS, hasError: false },
     { label: SECURITY_POLICIES, hasError: false },
     { label: SNAPSHOTS, hasError: false },
@@ -84,7 +90,7 @@ const InstanceFormMenu: FC<Props> = ({
   ];
 
   const activeSection = sections.find(
-    (s) => slugify(s.label) === slugify(active)
+    (s) => slugify(s.label) === slugify(active),
   );
   const activeLabel = activeSection ? activeSection.label : active;
 
@@ -99,14 +105,18 @@ const InstanceFormMenu: FC<Props> = ({
         {isOverlayOpen && (
           <div
             className="mobile-dropdown-backdrop"
-            onClick={() => setIsOverlayOpen(false)}
+            onClick={() => {
+              setIsOverlayOpen(false);
+            }}
           />
         )}
         <div className="mobile-menu-trigger-container">
           <button
             type="button"
             className="mobile-menu-trigger-btn"
-            onClick={() => setIsOverlayOpen(!isOverlayOpen)}
+            onClick={() => {
+              setIsOverlayOpen(!isOverlayOpen);
+            }}
             aria-expanded={isOverlayOpen}
           >
             <span>{activeLabel}</span>
@@ -145,93 +155,93 @@ const InstanceFormMenu: FC<Props> = ({
                     <ul
                       className="p-side-navigation__list"
                       aria-expanded={isDeviceExpanded ? "true" : "false"}
-                      >
+                    >
+                      <MenuItem
+                        label={DISK_DEVICES}
+                        hasError={hasDiskError}
+                        {...menuItemProps}
+                        isBold={formik.values.devices.some(isDiskDevice)}
+                        setActive={onItemClick}
+                      />
+                      <MenuItem
+                        label={NETWORK_DEVICES}
+                        hasError={hasNetworkError}
+                        {...menuItemProps}
+                        isBold={formik.values.devices.some(isNicDevice)}
+                        setActive={onItemClick}
+                      />
+                      <MenuItem
+                        label={GPU_DEVICES}
+                        {...menuItemProps}
+                        isBold={formik.values.devices.some(isGPUDevice)}
+                        setActive={onItemClick}
+                      />
+                      <MenuItem
+                        label={PROXY_DEVICES}
+                        {...menuItemProps}
+                        isBold={formik.values.devices.some(isProxyDevice)}
+                        setActive={onItemClick}
+                      />
+                      {hasMetadataConfiguration && (
                         <MenuItem
-                          label={DISK_DEVICES}
-                          hasError={hasDiskError}
+                          label={OTHER_DEVICES}
                           {...menuItemProps}
-                          isBold={formik.values.devices.some(isDiskDevice)}
+                          isBold={formik.values.devices.some(isOtherDevice)}
                           setActive={onItemClick}
                         />
-                        <MenuItem
-                          label={NETWORK_DEVICES}
-                          hasError={hasNetworkError}
-                          {...menuItemProps}
-                          isBold={formik.values.devices.some(isNicDevice)}
-                          setActive={onItemClick}
-                        />
-                        <MenuItem
-                          label={GPU_DEVICES}
-                          {...menuItemProps}
-                          isBold={formik.values.devices.some(isGPUDevice)}
-                          setActive={onItemClick}
-                        />
-                        <MenuItem
-                          label={PROXY_DEVICES}
-                          {...menuItemProps}
-                          isBold={formik.values.devices.some(isProxyDevice)}
-                          setActive={onItemClick}
-                        />
-                        {hasMetadataConfiguration && (
-                          <MenuItem
-                            label={OTHER_DEVICES}
-                            {...menuItemProps}
-                            isBold={formik.values.devices.some(isOtherDevice)}
-                            setActive={onItemClick}
-                          />
-                        )}
-                      </ul>
-                    </li>
-                    <MenuItem
-                      label={RESOURCE_LIMITS}
-                      {...menuItemProps}
-                      isBold={hasPrefixValue(formik, "limits_")}
-                      setActive={onItemClick}
-                    />
-                    <MenuItem
-                      label={SECURITY_POLICIES}
-                      {...menuItemProps}
-                      isBold={hasPrefixValue(formik, "security_")}
-                      setActive={onItemClick}
-                    />
-                    <MenuItem
-                      label={SNAPSHOTS}
-                      {...menuItemProps}
-                      isBold={hasPrefixValue(formik, "snapshots_")}
-                      setActive={onItemClick}
-                    />
-                    <MenuItem
-                      label={MIGRATION}
-                      {...menuItemProps}
-                      isBold={
-                        hasPrefixValue(formik, "migration_") ||
-                        hasPrefixValue(formik, "cluster_")
-                      }
-                      setActive={onItemClick}
-                    />
-                    <MenuItem
-                      label={BOOT}
-                      {...menuItemProps}
-                      isBold={hasPrefixValue(formik, "boot_")}
-                      setActive={onItemClick}
-                    />
-                    <MenuItem
-                      label={CLOUD_INIT}
-                      {...menuItemProps}
-                      isBold={hasPrefixValue(
-                        formik,
-                        "cloud_init_",
-                        "cloud_init_ssh_keys",
                       )}
-                      setActive={onItemClick}
-                    />
-                  </ul>
-                </nav>
-              </div>
-            )}
-          </div>
-        </>
-      );
+                    </ul>
+                  </li>
+                  <MenuItem
+                    label={RESOURCE_LIMITS}
+                    {...menuItemProps}
+                    isBold={hasPrefixValue(formik, "limits_")}
+                    setActive={onItemClick}
+                  />
+                  <MenuItem
+                    label={SECURITY_POLICIES}
+                    {...menuItemProps}
+                    isBold={hasPrefixValue(formik, "security_")}
+                    setActive={onItemClick}
+                  />
+                  <MenuItem
+                    label={SNAPSHOTS}
+                    {...menuItemProps}
+                    isBold={hasPrefixValue(formik, "snapshots_")}
+                    setActive={onItemClick}
+                  />
+                  <MenuItem
+                    label={MIGRATION}
+                    {...menuItemProps}
+                    isBold={
+                      hasPrefixValue(formik, "migration_") ||
+                      hasPrefixValue(formik, "cluster_")
+                    }
+                    setActive={onItemClick}
+                  />
+                  <MenuItem
+                    label={BOOT}
+                    {...menuItemProps}
+                    isBold={hasPrefixValue(formik, "boot_")}
+                    setActive={onItemClick}
+                  />
+                  <MenuItem
+                    label={CLOUD_INIT}
+                    {...menuItemProps}
+                    isBold={hasPrefixValue(
+                      formik,
+                      "cloud_init_",
+                      "cloud_init_ssh_keys",
+                    )}
+                    setActive={onItemClick}
+                  />
+                </ul>
+              </nav>
+            </div>
+          )}
+        </div>
+      </>
+    );
   };
 
   return (
@@ -341,4 +351,3 @@ const InstanceFormMenu: FC<Props> = ({
 };
 
 export default InstanceFormMenu;
-

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -487,18 +487,57 @@
     min-height: 100%;
   }
 
+  @media screen and (width < 500px) {
+    .p-modal__dialog {
+      left: 0px;
+      right: 0px;
+    }
+  }
+
   .image-select-filters {
     height: 100%;
     margin-right: 2rem;
   }
 
-  @include mobile-and-tablet {
-    .image-select-filters {
-      display: none;
+  .image-select-filters--medium {
+    column-gap: $sph--large;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    height: auto;
+    margin-bottom: $spv--large;
+    margin-right: 0;
+  }
+
+  .image-select-filters--small {
+    column-gap: $sph--large;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    height: auto;
+    margin-bottom: $spv--large;
+    margin-right: 0;
+  }
+
+  .image-filter-toggle {
+    flex-shrink: 0;
+    margin-left: $sph--small;
+
+    &[aria-expanded="true"] {
+      background-color: $colors--theme--background-active;
     }
   }
 
+  .table-image-select td[data-heading=""]::before {
+    display: none;
+  }
+
+  // vanilla's default minmax(12rem) only fits 2 columns from ~440px viewport.
+  // reducing to 10rem lets 2 columns fit from 400px (content width ~368px).
+  .table-image-select.p-table--mobile-card tbody {
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  }
+
   .image-select-header {
+    align-items: flex-start;
     display: flex;
 
     > :first-child {

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -18,6 +18,11 @@
 .local-peering-create-form {
   padding-bottom: 0;
 
+  .mobile-menu-trigger-container,
+  .mobile-navigation-overlay {
+    display: none;
+  }
+
   .p-notification--caution {
     background-image: none;
     border: 0;
@@ -112,7 +117,64 @@
 
   @include mobile-and-tablet {
     .form {
+      flex-direction: column;
       margin-top: 13px;
+    }
+
+    .form-navigation {
+      display: none;
+    }
+
+    .form-contents {
+      padding-left: 0;
+    }
+
+    .mobile-menu-trigger-container {
+      display: block;
+      margin-bottom: 1.5rem;
+      position: relative;
+      width: 100%;
+
+      .mobile-menu-trigger-btn {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 1rem;
+        margin: 0;
+        background-color: $colors--theme--background-alt;
+        border: 1px solid $colors--theme--border-high-contrast;
+        cursor: pointer;
+      }
+
+      .mobile-dropdown-menu {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 100;
+        background-color: $colors--theme--background-default;
+        border: 1px solid $colors--theme--border-high-contrast;
+        border-top: 0;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        max-height: 70vh;
+        overflow-y: auto;
+
+        .p-side-navigation__list {
+          margin: 0;
+          padding: $spv--small 0;
+
+          .p-side-navigation__link {
+            min-width: unset;
+          }
+        }
+      }
+    }
+
+    .mobile-dropdown-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 99;
     }
   }
 

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -136,29 +136,29 @@
       width: 100%;
 
       .mobile-menu-trigger-btn {
-        width: 100%;
-        display: flex;
         align-items: center;
-        justify-content: space-between;
-        padding: 0.5rem 1rem;
-        margin: 0;
         background-color: $colors--theme--background-alt;
         border: 1px solid $colors--theme--border-high-contrast;
         cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        margin: 0;
+        padding: 0.5rem 1rem;
+        width: 100%;
       }
 
       .mobile-dropdown-menu {
-        position: absolute;
-        top: 100%;
-        left: 0;
-        right: 0;
-        z-index: 100;
         background-color: $colors--theme--background-default;
         border: 1px solid $colors--theme--border-high-contrast;
         border-top: 0;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        box-shadow: 0 4px 8px rgb(0 0 0 / 15%);
+        left: 0;
         max-height: 70vh;
         overflow-y: auto;
+        position: absolute;
+        right: 0;
+        top: 100%;
+        z-index: 100;
 
         .p-side-navigation__list {
           margin: 0;
@@ -172,8 +172,8 @@
     }
 
     .mobile-dropdown-backdrop {
-      position: fixed;
       inset: 0;
+      position: fixed;
       z-index: 99;
     }
   }
@@ -489,8 +489,8 @@
 
   @media screen and (width < 500px) {
     .p-modal__dialog {
-      left: 0px;
-      right: 0px;
+      left: 0;
+      right: 0;
     }
   }
 

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -62,7 +62,7 @@
     }
   }
 
-  @media screen and (pointer: fine) and (min-width: 620px) {
+  @media screen and (pointer: fine) and (width >= 620px) {
     .u-row:hover {
       .instance-actions {
         visibility: visible;
@@ -114,11 +114,25 @@
     font-weight: bold;
     vertical-align: middle;
 
-    &--running { color: $color-positive; }
-    &--stopped { color: $color-mid; }
-    &--error   { color: $color-negative; }
-    &--frozen  { color: $color-information; }
-    &--ready   { color: $color-information; }
+    &--running {
+      color: $color-positive;
+    }
+
+    &--stopped {
+      color: $color-mid;
+    }
+
+    &--error {
+      color: $color-negative;
+    }
+
+    &--frozen {
+      color: $color-information;
+    }
+
+    &--ready {
+      color: $color-information;
+    }
   }
 
   .status-header {

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -43,6 +43,10 @@
     background-color: $colors--theme--background-hover;
   }
 
+  .u-row-no-click td {
+    cursor: default;
+  }
+
   .instance-actions button {
     margin-bottom: -3px;
   }
@@ -51,12 +55,14 @@
     background-color: $colors--theme--background-active;
   }
 
-  // show actions only on hover if a pointing device is used
+  // show actions only on hover if a pointing device is used and screen is wide enough
   @media screen and (pointer: fine) {
     .instance-actions {
       visibility: hidden;
     }
+  }
 
+  @media screen and (pointer: fine) and (min-width: 620px) {
     .u-row:hover {
       .instance-actions {
         visibility: visible;

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -93,6 +93,16 @@
     margin-left: $spv--x-large;
   }
 
+  th.trailing-status-col,
+  td.trailing-status-col {
+    padding-left: 0;
+    width: 1.5rem;
+
+    .status-icon {
+      margin-left: 0;
+    }
+  }
+
   .status-header {
     padding-left: 3.33rem;
     pointer-events: none;

--- a/src/sass/_instance_list.scss
+++ b/src/sass/_instance_list.scss
@@ -103,6 +103,18 @@
     }
   }
 
+  .status-abbr {
+    font-size: 0.7rem;
+    font-weight: bold;
+    vertical-align: middle;
+
+    &--running { color: $color-positive; }
+    &--stopped { color: $color-mid; }
+    &--error   { color: $color-negative; }
+    &--frozen  { color: $color-information; }
+    &--ready   { color: $color-information; }
+  }
+
   .status-header {
     padding-left: 3.33rem;
     pointer-events: none;

--- a/src/sass/_rename_header.scss
+++ b/src/sass/_rename_header.scss
@@ -5,8 +5,8 @@
 
   .p-panel__title {
     display: flex;
-    flex-direction: column;
     flex: 1;
+    flex-direction: column;
     max-width: 100%;
     min-width: 0;
 
@@ -27,29 +27,29 @@
       @include mobile {
         display: grid !important;
         grid-template-columns: 1fr auto;
-        width: 100%;
         margin-top: 8px;
+        width: 100%;
 
         .continuous-breadcrumb:not(.name) {
-          grid-row: 1;
           grid-column: 1;
+          grid-row: 1;
         }
 
         .name-addon-item {
-          grid-row: 1;
-          grid-column: 2;
-          display: flex;
           align-items: center;
+          display: flex;
+          grid-column: 2;
+          grid-row: 1;
           padding-right: $sph--small;
         }
 
         .name {
-          grid-row: 2;
           grid-column: 1 / -1;
-          overflow: hidden !important;
-          white-space: nowrap !important;
-          text-overflow: ellipsis !important;
+          grid-row: 2;
           margin-right: 0;
+          overflow: hidden !important;
+          text-overflow: ellipsis !important;
+          white-space: nowrap !important;
         }
       }
     }

--- a/src/sass/_rename_header.scss
+++ b/src/sass/_rename_header.scss
@@ -1,7 +1,12 @@
 .rename-header {
+  @include mobile {
+    align-items: flex-start;
+  }
+
   .p-panel__title {
     display: flex;
     flex-direction: column;
+    flex: 1;
     max-width: 100%;
     min-width: 0;
 
@@ -10,8 +15,42 @@
       flex-direction: row;
     }
 
+    .p-breadcrumbs {
+      @include mobile {
+        width: 100%;
+      }
+    }
+
     .breadcrumb-wrapper {
       display: flex !important;
+
+      @include mobile {
+        display: grid !important;
+        grid-template-columns: 1fr auto;
+        width: 100%;
+
+        .continuous-breadcrumb:not(.name) {
+          grid-row: 1;
+          grid-column: 1;
+        }
+
+        .name-addon-item {
+          grid-row: 1;
+          grid-column: 2;
+          display: flex;
+          align-items: center;
+          padding-right: $sph--small;
+        }
+
+        .name {
+          grid-row: 2;
+          grid-column: 1 / -1;
+          overflow: hidden !important;
+          white-space: nowrap !important;
+          text-overflow: ellipsis !important;
+          margin-right: 0;
+        }
+      }
     }
 
     .name {
@@ -26,6 +65,10 @@
         display: inherit !important;
       }
 
+      &.has-addon::after {
+        content: "";
+      }
+
       &:hover {
         background: linear-gradient(
             45deg,
@@ -34,6 +77,10 @@
           )
           no-repeat;
       }
+    }
+
+    .name-addon-item {
+      display: none;
     }
 
     .rename {

--- a/src/sass/_rename_header.scss
+++ b/src/sass/_rename_header.scss
@@ -28,6 +28,7 @@
         display: grid !important;
         grid-template-columns: 1fr auto;
         width: 100%;
+        margin-top: 8px;
 
         .continuous-breadcrumb:not(.name) {
           grid-row: 1;
@@ -114,5 +115,11 @@
   .p-panel__controls {
     flex-shrink: 0;
     margin-top: 0.2rem;
+
+    @include mobile {
+      .p-contextual-menu__toggle {
+        margin-bottom: 0;
+      }
+    }
   }
 }

--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -45,6 +45,20 @@
   }
 }
 
+@media screen and (width < 500px) {
+  .select {
+    width: 40px;
+
+    .select-context-menu {
+      display: none;
+    }
+  }
+
+  .select-header {
+    padding-top: 0.75rem;
+  }
+}
+
 .disabled-row {
   opacity: 0.5;
 


### PR DESCRIPTION
After over 100 issues created i thought it was time to make my own PR! I use the mobile view on my phone pretty often and there were some issues that I fixed with this PR.

Feedback from @edlerd (https://github.com/canonical/lxd-ui/issues/2037#issuecomment-4692902588) has been applied.

## Done

instance list:
- increased column size for instance name
- clicking row opens instance detailed page, as the sidepanel summary cannot open.
- add instance state abbrevation (R for running, S for stopped etc)
- prevent sidePanel from trying to open when it can't (https://github.com/canonical/lxd-ui/issues/2037#issuecomment-4719989725)

Create & edit instance:
- configuration tab now uses a dropdown menu instead of the sidebar navigation
- this dropdown menu is sticky, does not scroll.

image selection popup window:
- utilizes full browser window (<500px)
- table uses card layout
- filters moved to the top for < mediumScreenBreakpoint
- filters hidden by default, available via a button for < mediumScreenBreakpoint
- search is now made available on mobile view

instance detail page (`smallScreenBreakpoint`):
- breadcrumbs split onto the next line, allowing for almost 3x longer instance names
- power actions moved onto the Actions dropdown menu
- instance state moved next to Actions dropdown menu 


Fixes #2037 

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:

on a mobile view, medium view and large view:
- Create and edit instances 
- Try out the new configuration panel & dropdown (on small views)
- Test the instance creation image selection menu (filters, search)
- Select/click instances in instance list. Side panel should no longer open on smaller views, and should no longer think it should
- Edit instance name on mobile view

## Screenshots
instance list:
<img width="970" height="706" alt="image" src="https://github.com/user-attachments/assets/687c2a8f-e6ef-4e5f-a1dc-7d787012b366" />

image selection menu:
<img width="878" height="1458" alt="image" src="https://github.com/user-attachments/assets/41582801-1735-4e4d-a5fa-dc5dab24aada" />

image selection menu filters:
<img width="878" height="1458" alt="image" src="https://github.com/user-attachments/assets/d4af1cec-2d93-42fb-9ecc-57391c080609" />

instance configuration navigation:
<img width="878" height="1458" alt="image" src="https://github.com/user-attachments/assets/286c3e36-0e9c-4bb6-860f-8ac17b1ef944" />

instance detail page new header/breadcrumb:
<img width="940" height="676" alt="image" src="https://github.com/user-attachments/assets/e5aecb0b-2fe3-4a25-8509-311ae9626495" />

instance detail action buttons:
<img width="940" height="930" alt="image" src="https://github.com/user-attachments/assets/2382c437-e39e-46c8-9f2f-0008e766cc6c" />


