### PR TITLE
chore: replace <Input type="checkbox" /> by <CheckboxInput />

### DIFF
--- a/src/components/SelectableMainTable.tsx
+++ b/src/components/SelectableMainTable.tsx
@@ -186,7 +186,7 @@ const SelectableMainTable: FC<Props> = ({
             label={
               <div className="u-off-screen">Select {row.name ?? "row"}</div>
             }
-            labelClassName="u-no-margin--bottom"
+            className="u-no-margin--bottom"
             checked={isRowSelected}
             onChange={toggleRow}
             disabled={isRowDisabled || !row.name || disableSelect}

--- a/src/components/forms/ClusterSpecificInput.tsx
+++ b/src/components/forms/ClusterSpecificInput.tsx
@@ -73,7 +73,7 @@ const ClusterSpecificInput: FC<Props> = ({
           id={`${id}-same-for-all-toggle`}
           label="Same for all cluster members"
           checked={!isSpecific}
-          labelClassName="cluster-specific-toggle-label"
+          className="cluster-specific-toggle-label"
           onChange={() => {
             if (isSpecific) {
               setValueForAllMembers(firstValue ?? "");

--- a/src/components/forms/GPUDeviceInput.tsx
+++ b/src/components/forms/GPUDeviceInput.tsx
@@ -18,7 +18,7 @@ const GpuDeviceInput: FC<Props> = ({ device, onChange, disableReason }) => {
       <div className="u-sv1">
         <RadioInput
           inline
-          labelClassName="margin-right--large"
+          className="margin-right--large"
           label="ID"
           checked={!isPci}
           onClick={() => {

--- a/src/pages/cluster/ClusterLinkForm.tsx
+++ b/src/pages/cluster/ClusterLinkForm.tsx
@@ -67,7 +67,7 @@ const ClusterLinkForm: FC<Props> = ({ formik }) => {
           >
             <RadioInput
               inline
-              labelClassName="margin-right--large"
+              className="margin-right--large"
               label="Generate token"
               checked={formik.values.tokenType === "generate"}
               onChange={() => {

--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -32,12 +32,11 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
         </>
       }
       buttonRow={[
-        <span className="u-float-left confirm-input" key="confirm-input">
-          <ConfirmationCheckbox
-            label="I have copied the token"
-            confirmed={[isConfirmed, setConfirmed]}
-          />
-        </span>,
+        <ConfirmationCheckbox
+          label="I have copied the token"
+          confirmed={[isConfirmed, setConfirmed]}
+          key="confirm-checkbox"
+        />,
         <ActionButton
           key="confirm-action-button"
           appearance="positive"

--- a/src/pages/images/ImageRegistryProtocolSelector.tsx
+++ b/src/pages/images/ImageRegistryProtocolSelector.tsx
@@ -26,7 +26,7 @@ export const ImageRegistryProtocolSelector: FC<Props> = ({ formik }) => {
         <RadioInput
           inline
           aria-label="LXD"
-          labelClassName="lxd-protocol-input"
+          className="lxd-protocol-input"
           label="LXD"
           checked={formik.values.protocol === "lxd"}
           onChange={() => {

--- a/src/pages/images/actions/forms/ImportImageForm.tsx
+++ b/src/pages/images/actions/forms/ImportImageForm.tsx
@@ -5,6 +5,7 @@ import { createImageAlias, importImage } from "api/images";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -205,9 +206,8 @@ const ImportImageForm: FC<Props> = ({ close, projectName }) => {
               : "You do not have permission to create image aliases"
           }
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("isPublic")}
-          type="checkbox"
           label="Make the image publicly available"
           error={formik.touched.isPublic ? formik.errors.isPublic : null}
         />

--- a/src/pages/instances/InstanceConsole.tsx
+++ b/src/pages/instances/InstanceConsole.tsx
@@ -88,7 +88,7 @@ const InstanceConsole: FC<Props> = ({ instance }) => {
         <div className="p-panel__controls">
           <div className="console-radio-wrapper">
             <RadioInput
-              labelClassName="right-margin"
+              className="right-margin"
               label="Graphic"
               checked={isGraphic}
               onChange={() => {

--- a/src/pages/instances/forms/CopyInstanceForm.tsx
+++ b/src/pages/instances/forms/CopyInstanceForm.tsx
@@ -4,6 +4,7 @@ import { useFormik } from "formik";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -229,9 +230,8 @@ const CopyInstanceForm: FC<Props> = ({ instance, close }) => {
             };
           })}
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("allowInconsistent")}
-          type="checkbox"
           label="Ignore copy errors for volatile files"
           error={
             formik.touched.allowInconsistent
@@ -239,9 +239,8 @@ const CopyInstanceForm: FC<Props> = ({ instance, close }) => {
               : null
           }
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("instanceOnly")}
-          type="checkbox"
           label="Copy without instance snapshots"
           error={
             formik.touched.instanceOnly ? formik.errors.instanceOnly : null

--- a/src/pages/instances/forms/CreateImageFromInstanceForm.tsx
+++ b/src/pages/instances/forms/CreateImageFromInstanceForm.tsx
@@ -6,6 +6,7 @@ import { createImage } from "api/images";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -154,9 +155,8 @@ const CreateImageFromInstanceForm: FC<Props> = ({ instance, close }) => {
               : `You do not have permission to create image aliases in this project`
           }
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("isPublic")}
-          type="checkbox"
           label="Make the image publicly available"
           error={formik.touched.isPublic ? formik.errors.isPublic : null}
         />

--- a/src/pages/instances/forms/CreateImageFromInstanceSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateImageFromInstanceSnapshotForm.tsx
@@ -6,6 +6,7 @@ import { createImage } from "api/images";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -154,9 +155,8 @@ const CreateImageFromInstanceSnapshotForm: FC<Props> = ({
               : "You do not have permission to create image aliases in this project"
           }
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("isPublic")}
-          type="checkbox"
           label="Make the image publicly available"
           error={formik.touched.isPublic ? formik.errors.isPublic : null}
         />

--- a/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceFromSnapshotForm.tsx
@@ -4,6 +4,7 @@ import { useFormik } from "formik";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -286,9 +287,8 @@ const CreateInstanceFromSnapshotForm: FC<Props> = ({
           error={formik.errors.targetProject}
         />
         {snapshot.stateful && (
-          <Input
+          <CheckboxInput
             {...formik.getFieldProps("stateful")}
-            type="checkbox"
             label="Copy stateful"
           />
         )}

--- a/src/pages/instances/forms/CreateInstanceSnapshotForm.tsx
+++ b/src/pages/instances/forms/CreateInstanceSnapshotForm.tsx
@@ -7,8 +7,8 @@ import {
 import SnapshotForm from "components/forms/SnapshotForm";
 import { useEventQueue } from "context/eventQueue";
 import {
+  CheckboxInput,
   Icon,
-  Input,
   List,
   Tooltip,
   useNotify,
@@ -131,13 +131,12 @@ const CreateInstanceSnapshotForm: FC<Props> = ({
     <List
       inline
       items={[
-        <Input
+        <CheckboxInput
           key="stateful"
           id="stateful"
           name="stateful"
-          type="checkbox"
           label="Stateful"
-          wrapperClassName="u-inline-block"
+          className="u-inline-block"
           disabled={!isStateful || !isRunning}
           onChange={formik.handleChange}
           onBlur={formik.handleBlur}

--- a/src/pages/instances/forms/ExportInstanceModal.tsx
+++ b/src/pages/instances/forms/ExportInstanceModal.tsx
@@ -4,6 +4,7 @@ import { useFormik } from "formik";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -204,16 +205,14 @@ const ExportInstanceModal: FC<Props> = ({ instance, close }) => {
             }))}
           />
         )}
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("optimizedStorage")}
-          type="checkbox"
           label="Use storage driver optimized format"
           help="Can only be restored on a similar pool"
           checked={formik.values.optimizedStorage}
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("instanceOnly")}
-          type="checkbox"
           label="Export without instance snapshots"
           error={
             formik.touched.instanceOnly ? formik.errors.instanceOnly : null

--- a/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
+++ b/src/pages/instances/forms/UploadExternalFormatFileForm.tsx
@@ -1,6 +1,7 @@
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Icon,
   Input,
@@ -295,9 +296,8 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           title={noFileSelectedMessage}
         />
         <label htmlFor="">Conversion options</label>
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("formatConversion")}
-          type="checkbox"
           label={
             <span title={noFileSelectedMessage}>
               Convert to raw format{" "}
@@ -314,9 +314,8 @@ const UploadExternalFormatFileForm: FC<Props> = ({
           disabled={!!noFileSelectedMessage}
           checked={formik.values.formatConversion}
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("virtioConversion")}
-          type="checkbox"
           label={
             <span title={noFileSelectedMessage}>
               Add Virtio drivers{" "}

--- a/src/pages/networks/forms/NetworkLocalPeeringForm.tsx
+++ b/src/pages/networks/forms/NetworkLocalPeeringForm.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from "react";
-import { Form, Input } from "@canonical/react-components";
+import { Form, Input, CheckboxInput } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import type { LxdNetwork } from "types/network";
@@ -197,13 +197,12 @@ const NetworkLocalPeeringForm: FC<Props> = ({ formik, network, isEditing }) => {
       )}
 
       {!isEditing && (
-        <Input
+        <CheckboxInput
           id="createMutualPeering"
           name="createMutualPeering"
-          type="checkbox"
           label="Create mutual peering"
           checked={formik.values.createMutualPeering}
-          onChange={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             formik.setFieldValue("createMutualPeering", e.target.checked);
           }}
           disabled={

--- a/src/pages/permissions/CreateIdentityModal.tsx
+++ b/src/pages/permissions/CreateIdentityModal.tsx
@@ -38,12 +38,11 @@ const CreateIdentityModal: FC<Props> = ({ onClose, token, identityName }) => {
         </>
       }
       buttonRow={[
-        <span className="u-float-left confirm-input" key="confirm-input">
-          <ConfirmationCheckbox
-            label="I have copied the token"
-            confirmed={[isConfirmed, setConfirmed]}
-          />
-        </span>,
+        <ConfirmationCheckbox
+          label="I have copied the token"
+          confirmed={[isConfirmed, setConfirmed]}
+          key="confirm-checkbox"
+        />,
         <ActionButton
           key="confirm-action-button"
           appearance="positive"

--- a/src/pages/settings/SettingFormCheckbox.tsx
+++ b/src/pages/settings/SettingFormCheckbox.tsx
@@ -1,5 +1,5 @@
 import { useState, type FC } from "react";
-import { Input, Button, Icon } from "@canonical/react-components";
+import { CheckboxInput, Button, Icon } from "@canonical/react-components";
 import type { ConfigField } from "types/config";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 
@@ -33,14 +33,13 @@ const SettingFormCheckbox: FC<Props> = ({
 
   return (
     <>
-      <Input
+      <CheckboxInput
         autoFocus
         label={label}
         id={configField.key}
-        wrapperClassName="input-wrapper"
-        type="checkbox"
+        className="input-wrapper"
         checked={checked}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           setChecked(e.target.checked);
         }}
         help={<ConfigFieldDescription description={configField.longdesc} />}

--- a/src/pages/storage/forms/CopyVolumeForm.tsx
+++ b/src/pages/storage/forms/CopyVolumeForm.tsx
@@ -3,6 +3,7 @@ import { useFormik } from "formik";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -204,9 +205,8 @@ const CopyVolumeForm: FC<Props> = ({ volume, close }) => {
             };
           })}
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("copySnapshots")}
-          type="checkbox"
           label="Copy with snapshots"
           checked={formik.values.copySnapshots}
           error={

--- a/src/pages/storage/forms/ExportVolumeModal.tsx
+++ b/src/pages/storage/forms/ExportVolumeModal.tsx
@@ -3,6 +3,7 @@ import { useFormik } from "formik";
 import {
   ActionButton,
   Button,
+  CheckboxInput,
   Form,
   Input,
   Modal,
@@ -182,16 +183,14 @@ const ExportVolumeModal: FC<Props> = ({ volume, close }) => {
             }))}
           />
         )}
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("optimizedStorage")}
-          type="checkbox"
           label="Use storage driver optimized format"
           help="Can only be restored on a similar pool"
           checked={formik.values.optimizedStorage}
         />
-        <Input
+        <CheckboxInput
           {...formik.getFieldProps("volumeOnly")}
-          type="checkbox"
           label="Export without volume snapshots"
           error={formik.touched.volumeOnly ? formik.errors.volumeOnly : null}
           checked={formik.values.volumeOnly}


### PR DESCRIPTION
## Done

- Replace `<Input type="checkbox" />` by `<CheckboxInput />`

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Existing usage of CheckboxInput
        - ClusterSpecificSelect
        - ConfirmationCheckbox
        - SelectableMainTable
        - ClusteredDiskSizeSelector
        - ClusterSpecificInput
        - RestoreClusterMemberBtn: Clustering > Members > Restore
        - ImageSelector: Create instance > Browser images
        - ImportImageForm: Images > Local images > Import image
        - ProjectDetailsForm: Create a project
    - Existing usage of RadioInput
        - SnapshotScheduleInput: instance >snapshots > See configuration > Schedule > Edit
        - CpuLimitSelector: instance > configuration > Resource limits > Exposed CPU limit
        - GpuDeviceInput: instance > configuration > devices > GPU > Attach GPU > select a GPU
        - MemoryLimitSelector: instance > configuration > Resource limits > Memory limit
        - YamlTypeSelector: instance > configuration > YAML configuration
        - ClusterLinkForm: Clustering > Links > Create cluster link
        - ImageRegistryProtocolSelector: Images > Image registries > Create registry
        - InstanceConsole: instance > console
        - InstanceFileTypeSelector: create instance > Upload instance file
        - IpAddressSelector: networks > a network > IPv4 address > Edit
        - LoadBalancerForm: networks > an OVN network > Load balancers > Create load balancer
        - NetworkForwardForm: networks > an OVN network > Forwards > Create forwards
    - Replace Input type="checkbox"
        - CopyInstanceForm (2): instance > Copy
        - CreateImageFromInstanceForm: instance > Create image 
        - CreateImageFromInstanceSnapshotForm: instance > Snapshots > Create a snapshot (optional) > Create image
        - CreateInstanceFromSnapshotForm: instance > Snapshots > Create a snapshot (optional), has to be stateful > Create instance
        - CreateInstanceSnapshotForm: instance > Snapshots > Create a snapshot 
        - ExportInstanceModal (2): instance > Export
        - UploadExternalFormatFileForm (2): create instance > Upload instance file > External format
        - NetworkLocalPeeringForm: networks > an OVN network > Local peerings > Create local peering
        - SettingFormCheckbox: Settings > Edit acme.agree_tos
        - CopyVolumeForm: Storage > Volumes > Create a volume (optional) > a volume > Copy
        - ExportVolumeModal (2): Storage > Volumes > Create a volume (optional) > a volume > Export
        - ImportImageForm: Images > Local images > Import image

## Screenshots

