### PR TITLE
fix(yaml): fix bug where YAML view does not preserve previous section

### DIFF
--- a/src/components/forms/YamlSwitch.tsx
+++ b/src/components/forms/YamlSwitch.tsx
@@ -1,4 +1,4 @@
-import type { FC, FormEvent } from "react";
+import { useEffect, useRef, type FC, type FormEvent } from "react";
 import { Switch, usePortal } from "@canonical/react-components";
 import YamlConfirmation from "components/forms/YamlConfirmation";
 import { slugify } from "util/slugify";
@@ -26,8 +26,20 @@ const YamlSwitch: FC<Props> = ({
   const { openPortal, closePortal, isOpen, Portal } = usePortal();
   const yamlFormik = formik as FormikProps<{ yaml: string }>;
   const isSmallScreen = useIsScreenBelow();
+  const isYamlSection = slugify(section ?? "") === slugify(YAML_CONFIGURATION);
+  const previousSection = useRef<string>(
+    isYamlSection || !section ? MAIN_CONFIGURATION : section,
+  );
 
-  const isChecked = slugify(section ?? "") === slugify(YAML_CONFIGURATION);
+  useEffect(() => {
+    if (!section) {
+      return;
+    }
+
+    if (!isYamlSection) {
+      previousSection.current = section;
+    }
+  }, [section]);
 
   const handleSwitch = (e: FormEvent<HTMLInputElement>) => {
     if (yamlFormik.values.yaml) {
@@ -35,14 +47,16 @@ const YamlSwitch: FC<Props> = ({
       return;
     }
 
-    const newSection = isChecked ? MAIN_CONFIGURATION : YAML_CONFIGURATION;
+    const newSection = isYamlSection
+      ? previousSection.current
+      : YAML_CONFIGURATION;
     setSection(newSection);
   };
 
   const handleConfirm = () => {
     void yamlFormik.setFieldValue("yaml", undefined);
     closePortal();
-    setSection(MAIN_CONFIGURATION);
+    setSection(previousSection.current);
   };
 
   return (
@@ -60,7 +74,7 @@ const YamlSwitch: FC<Props> = ({
       <div className="u-flex">
         <Switch
           label={isSmallScreen ? "YAML" : "YAML Configuration"}
-          checked={isChecked}
+          checked={isYamlSection}
           onChange={handleSwitch}
           disabled={disableReason !== undefined}
         />

--- a/src/pages/networks/forms/NetworkForm.tsx
+++ b/src/pages/networks/forms/NetworkForm.tsx
@@ -213,6 +213,9 @@ const NetworkForm: FC<Props> = ({
     const wrapper = document.getElementById("content-details");
 
     const activateSectionOnScroll = () => {
+      if (section === slugify(YAML_CONFIGURATION)) {
+        return;
+      }
       const sections = availableSections.map(slugify);
       const activeSection = getFirstVisibleSection(sections, wrapper);
       setSection(activeSection, "scroll");
@@ -223,7 +226,7 @@ const NetworkForm: FC<Props> = ({
     wrapper?.addEventListener("scroll", scrollListener);
 
     return () => wrapper?.removeEventListener("scroll", scrollListener);
-  }, [availableSections]);
+  }, [availableSections, section]);
 
   const isUnmanagedNetwork = formik.values.bareNetwork?.managed === false;
 


### PR DESCRIPTION
## Done

- fix bug where YAML view does not preserve previous section
- fix bug where YAML view does not open in create network tab if user is not on the GENERAL section

WD-37200

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Instances/Profiles -> Create/Edit 
    - Go to any section and click on the YAML switch
    - Make edits and turn off the YAML switch (without saving is fine)
    - Make sure you are back on the same section before opening the YAML view
    - Go to Networking -> Networks -> Create
    - Make sure you can open the YAML view when in a section other than GENERAL (compare with previous behavior in the video attached below)

## Screenshots



https://github.com/user-attachments/assets/f7ff130e-3021-4e6e-9d5e-e5dd842d4fb3


