### PR TITLE
fix(replicators): pluralize instances

### DIFF
--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -234,7 +234,8 @@ const RunReplicatorBtn: FC<Props> = ({
                 title="All local data will be overwritten by the remote version"
               >
                 <p>
-                  {numberOfInstances} instances in local project{" "}
+                  {numberOfInstances} {pluralize("instance", numberOfInstances)}{" "}
+                  in local project{" "}
                   <ProjectRichChip projectName={replicator.project} /> will be
                   permanently replaced by the version fetched from the remote
                   cluster. This cannot be undone.

--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -119,8 +119,15 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
                         items={[
                           <>Open the target cluster UI.</>,
                           <>
-                            Select <b>Clustering</b>, <b>Links</b>,{" "}
-                            <b>Create link</b> and <b>I have a token</b>.
+                            For a single-node cluster, click <b>Server</b> in
+                            the navigation sidebar, then select the{" "}
+                            <b>Cluster links</b> tab in the main content pane.
+                            Otherwise, click <b>Clustering</b> in the navigation
+                            sidebar, then select <b>Links</b> from the expanded
+                            drop-down list.
+                          </>,
+                          <>
+                            Click <b>Create link</b> and <b>I have a token</b>
                           </>,
                           <>
                             Use this trust token to establish the cluster link.

--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -119,15 +119,13 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
                         items={[
                           <>Open the target cluster UI.</>,
                           <>
-                            For a single-node cluster, click <b>Server</b> in
-                            the navigation sidebar, then select the{" "}
-                            <b>Cluster links</b> tab in the main content pane.
-                            Otherwise, click <b>Clustering</b> in the navigation
-                            sidebar, then select <b>Links</b> from the expanded
-                            drop-down list.
+                            Click <b>Clustering</b> in the navigation, then
+                            select <b>Links</b> from the expanded drop-down
+                            list.
                           </>,
                           <>
-                            Click <b>Create link</b> and <b>I have a token</b>
+                            Click <b>Create link</b> and check{" "}
+                            <b>I have a token</b>
                           </>,
                           <>
                             Use this trust token to establish the cluster link.

--- a/src/pages/cluster/panels/CreateReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/CreateReplicatorPanel.tsx
@@ -91,7 +91,7 @@ const CreateReplicatorPanel: FC = () => {
               <ReplicatorRichChip
                 replicator={formik.values.name}
                 project={formik.values.project}
-              />
+              />{" "}
               created.
             </>,
           );

--- a/src/pages/cluster/panels/EditReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/EditReplicatorPanel.tsx
@@ -14,16 +14,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import type { ReplicatorFormValues } from "types/forms/replicator";
 import { updateReplicator } from "api/replicators";
-import { ReplicatorForm } from "../ReplicatorForm";
+import { ReplicatorForm } from "pages/cluster/ReplicatorForm";
+import ReplicatorRichChip from "pages/cluster/ReplicatorRichChip";
 import { useReplicator } from "context/useReplicators";
 import { getPayload } from "util/replicator";
 import * as Yup from "yup";
-import {
-  testReachableClusterLink,
-  testProjectReplicaCluster,
-} from "util/clusterLink";
-import { useProject } from "context/useProjects";
-import ReplicatorRichChip from "../ReplicatorRichChip";
 
 const EditReplicatorPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -36,36 +31,9 @@ const EditReplicatorPanel: FC = () => {
     panelParams.project,
     !!replicatorName,
   );
-  const { data: project } = useProject(panelParams.project);
 
   const schema = Yup.object().shape({
-    cluster: Yup.string()
-      .test({
-        name: "replica cluster matches selected cluster link",
-        test(value) {
-          if (testProjectReplicaCluster(project, value)) {
-            return true;
-          }
-          const replicaCluster = project?.config["replica.cluster"];
-
-          return this.createError({
-            message: (
-              <>
-                Cluster must match the project <code>replica.cluster</code>{" "}
-                <code>{replicaCluster}</code>.
-              </>
-            ) as unknown as string,
-          });
-        },
-      })
-      .test("Reachable cluster link", async (value, context) => {
-        if (replicator?.config?.cluster === value) {
-          // Skip this test if cluster has not changed (to avoid blocking update if the current cluster is not reachable)
-          return true;
-        }
-        return testReachableClusterLink(value, context);
-      })
-      .required("Cluster is required."),
+    cluster: Yup.string().required("Cluster is required."),
   });
 
   const closePanel = () => {
@@ -99,7 +67,7 @@ const EditReplicatorPanel: FC = () => {
               <ReplicatorRichChip
                 replicator={formik.values.name}
                 project={formik.values.project}
-              />
+              />{" "}
               updated.
             </>,
           );

--- a/src/util/clusterLink.tsx
+++ b/src/util/clusterLink.tsx
@@ -1,9 +1,6 @@
-import { fetchClusterLinkState } from "api/cluster-links";
 import type { LxdClusterLinkState, StatusCaption } from "types/cluster";
 import type { LxdIdentity } from "types/permissions";
-import type { LxdProject } from "types/project";
-import type { TestContext } from "yup";
-import { ROOT_PATH } from "./rootPath";
+import { ROOT_PATH } from "util/rootPath";
 
 export const getClusterLinksStatus = (
   identity?: LxdIdentity,
@@ -31,52 +28,6 @@ export const getLinkIdentity = (
       identity.name === linkName &&
       identity.type.startsWith("Cluster link certificate"),
   );
-};
-
-const isClusterLinkReachable = async (cluster: string): Promise<boolean> => {
-  const state = await fetchClusterLinkState(cluster);
-  const status = getClusterLinksStatus(undefined, state);
-  return status === "Reachable";
-};
-
-const NOT_REACHABLE_ERROR_MESSAGE =
-  "The cluster must be Reachable. Make sure a matching link has been created on the target cluster using the generated token.";
-
-export const testReachableClusterLink = async (
-  value: string | undefined,
-  context: TestContext,
-) => {
-  if (!value) {
-    return true;
-  }
-
-  try {
-    const isReachable = await isClusterLinkReachable(value);
-    if (isReachable) {
-      return true;
-    }
-
-    return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
-  } catch {
-    return context.createError({ message: NOT_REACHABLE_ERROR_MESSAGE });
-  }
-};
-
-export const testProjectReplicaCluster = (
-  project?: LxdProject,
-  selectedCluster?: string,
-): boolean => {
-  if (!project) {
-    return true;
-  }
-
-  const replicaCluster = project.config?.["replica.cluster"];
-
-  if (!replicaCluster || !selectedCluster) {
-    return true;
-  }
-
-  return replicaCluster === selectedCluster;
 };
 
 export const getClusterLinkListUrl = (isClustered = false): string => {


### PR DESCRIPTION
## Done

- In the run replicator modal, if restore, pluralize instance
- Update instructions in CreateClusterLinkModal to handle Server/Clustering


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run a replicator in restore mode
    - Create cluster link and generate token

## Screenshots

<img width="944" height="760" alt="image" src="https://github.com/user-attachments/assets/8856a578-5908-430d-b952-abdf2bfd76e8" />

<img width="805" height="888" alt="Screenshot from 2026-06-25 18-04-34" src="https://github.com/user-attachments/assets/4430837a-d23b-4894-bfb3-b0386ea870b2" />

