### PR TITLE
feat(File explorer): [WD-37160] Create new Directory

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -619,6 +619,25 @@ export const deleteInstanceFile = async (
   ).then(handleResponse);
 };
 
+export const createInstanceDirectory = async (
+  instance: LxdInstance,
+  path: string,
+): Promise<void> => {
+  const params = new URLSearchParams();
+  params.set("project", instance.project);
+  params.set("path", path);
+
+  await fetch(
+    `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instance.name)}/files?${params.toString()}`,
+    {
+      method: "POST",
+      headers: {
+        "X-LXD-type": "directory",
+      },
+    },
+  ).then(handleResponse);
+};
+
 export const uploadInstanceFile = async (
   instance: LxdInstance,
   path: string,

--- a/src/pages/instances/FileExplorerBreadcrumb.tsx
+++ b/src/pages/instances/FileExplorerBreadcrumb.tsx
@@ -1,7 +1,12 @@
-import type { FC } from "react";
-import { Link } from "react-router-dom";
+import { type FC, type KeyboardEvent, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button, Icon, Input } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
-import { getFileExplorerDirectoryURL } from "util/instances";
+import {
+  getFileExplorerDirectoryURL,
+  validateDirectoryPathSyntax,
+} from "util/instances";
+import { fetchInstanceDirectory } from "api/instances";
 
 interface Props {
   currentPath: string;
@@ -9,42 +14,146 @@ interface Props {
 }
 
 const FileExplorerBreadcrumb: FC<Props> = ({ currentPath, instance }) => {
-  const segments = currentPath.split("/").filter(Boolean);
+  const [isEditing, setIsEditing] = useState(false);
+  const [path, setPath] = useState(currentPath);
+  const [isNavigating, setIsNavigating] = useState(false);
+  const [inputError, setInputError] = useState<string | undefined>(undefined);
+  const navigate = useNavigate();
 
+  useEffect(() => {
+    setPath(currentPath);
+    setInputError(undefined);
+    setIsEditing(false);
+  }, [currentPath]);
+
+  const handleNavigate = async () => {
+    const trimmedPath = path.trim();
+
+    if (trimmedPath === currentPath) {
+      setInputError(undefined);
+      setIsEditing(false);
+      return;
+    }
+
+    const syntaxError = validateDirectoryPathSyntax(trimmedPath);
+    setInputError(syntaxError);
+    if (syntaxError) {
+      return;
+    }
+
+    setIsNavigating(true);
+    try {
+      await fetchInstanceDirectory(
+        instance.name,
+        instance.project,
+        trimmedPath,
+      );
+      navigate(getFileExplorerDirectoryURL(trimmedPath, instance));
+    } catch (error) {
+      setInputError(
+        "Invalid path: " +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    } finally {
+      setIsNavigating(false);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      void handleNavigate();
+    }
+    if (e.key === "Escape") {
+      setPath(currentPath);
+      setInputError(undefined);
+      setIsEditing(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <div className="file-explorer-path-editor">
+        <Input
+          type="text"
+          className="file-explorer-path-input"
+          aria-label="Search path"
+          value={path}
+          onChange={(e) => {
+            setPath(e.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          disabled={isNavigating}
+          error={inputError}
+          autoFocus
+        />
+        <div>
+          <Button
+            appearance="base"
+            onClick={() => void handleNavigate()}
+            aria-label="Go to path"
+            disabled={isNavigating}
+            hasIcon
+          >
+            <Icon name="search" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const segments = currentPath.split("/").filter(Boolean);
   const breadcrumbs = [
-    {
-      label: "root",
-      path: "/",
-    },
+    { label: "root", path: "/" },
     ...segments.map((segment, index) => ({
       label: segment,
       path: "/" + segments.slice(0, index + 1).join("/"),
     })),
   ];
-  return (
-    <nav
-      className="p-breadcrumbs p-breadcrumbs--large"
-      aria-label="File Explorer Path"
-    >
-      <ol className="p-breadcrumbs__items breadcrumb-wrapper">
-        <li className="p-heading--4 breadcrumb-header">Directory:&nbsp;</li>
-        {breadcrumbs.map((crumb, index) => {
-          const isCurrentDirectory = index === breadcrumbs.length - 1;
 
-          return (
-            <li key={crumb.path} className="p-heading--4 continuous-breadcrumb">
-              {isCurrentDirectory ? (
-                <span>{crumb.label}</span>
-              ) : (
-                <Link to={getFileExplorerDirectoryURL(crumb.path, instance)}>
-                  {crumb.label}
-                </Link>
-              )}
-            </li>
-          );
-        })}
-      </ol>
-    </nav>
+  return (
+    <div className="file-explorer-breadcrumb-bar">
+      <nav
+        className="p-breadcrumbs p-breadcrumbs--large"
+        aria-label="File Explorer Path"
+      >
+        <ol className="p-breadcrumbs__items breadcrumb-wrapper">
+          <li className="p-heading--5 breadcrumb-header">Directory:&nbsp;</li>
+          {breadcrumbs.map((crumb, index) => {
+            const isCurrentDirectory = index === breadcrumbs.length - 1;
+
+            return (
+              <li
+                key={crumb.path}
+                className="p-heading--5 continuous-breadcrumb"
+              >
+                {isCurrentDirectory ? (
+                  <span>{crumb.label}</span>
+                ) : (
+                  <Link to={getFileExplorerDirectoryURL(crumb.path, instance)}>
+                    {crumb.label}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+          <li>
+            <Button
+              appearance="base"
+              className="u-no-margin--bottom"
+              onClick={() => {
+                setPath(currentPath);
+                setIsEditing(true);
+              }}
+              title="Search path"
+              aria-label="Search path"
+              hasIcon
+            >
+              <Icon name="search" />
+            </Button>
+          </li>
+        </ol>
+      </nav>
+    </div>
   );
 };
 

--- a/src/pages/instances/FileExplorerCreateBtn.tsx
+++ b/src/pages/instances/FileExplorerCreateBtn.tsx
@@ -1,0 +1,59 @@
+import { type FC } from "react";
+import { Button, Icon, usePortal } from "@canonical/react-components";
+import type { LxdInstance } from "types/instance";
+import { useInstanceEntitlements } from "util/entitlements/instances";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
+import FileExplorerCreateModal from "./forms/FileExplorerCreateModal";
+
+interface Props {
+  instance: LxdInstance;
+  currentPath: string;
+  refreshDirectoryList: () => void;
+}
+
+const FileExplorerCreateBtn: FC<Props> = ({
+  instance,
+  currentPath,
+  refreshDirectoryList,
+}) => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal();
+  const isSmallScreen = useIsScreenBelow();
+  const { canAccessInstanceFiles } = useInstanceEntitlements();
+  const hasPermission = canAccessInstanceFiles(instance);
+
+  const handleSuccess = () => {
+    refreshDirectoryList();
+    closePortal();
+  };
+
+  return (
+    <>
+      <Button
+        onClick={openPortal}
+        hasIcon={!isSmallScreen}
+        disabled={!hasPermission || isOpen}
+        className="u-no-margin--bottom"
+        title={
+          hasPermission
+            ? "Create a new directory"
+            : "You do not have permission to manage files on this instance"
+        }
+      >
+        {!isSmallScreen && <Icon name="plus" />}
+        <span>{isSmallScreen ? "Create" : "Create directory"}</span>
+      </Button>
+      {isOpen && (
+        <Portal>
+          <FileExplorerCreateModal
+            close={closePortal}
+            instance={instance}
+            currentPath={currentPath}
+            onSuccess={handleSuccess}
+          />
+        </Portal>
+      )}
+    </>
+  );
+};
+
+export default FileExplorerCreateBtn;

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -21,7 +21,7 @@ const tabs: string[] = [
   "Overview",
   "Configuration",
   "Snapshots",
-  "File Explorer",
+  "File explorer",
   "Terminal",
   "Console",
   "Logs",

--- a/src/pages/instances/InstanceFileExplorer.tsx
+++ b/src/pages/instances/InstanceFileExplorer.tsx
@@ -12,6 +12,7 @@ import { isInstanceRunning } from "util/instanceStatus";
 import FileExplorerTable from "./FileExplorerTable";
 import FileExplorerBreadcrumb from "./FileExplorerBreadcrumb";
 import UploadFileExplorerBtn from "./UploadFileExplorerBtn";
+import FileExplorerCreateBtn from "./FileExplorerCreateBtn";
 import { fetchInstanceDirectory } from "api/instances";
 import { useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -80,14 +81,26 @@ const InstanceFileExplorer: FC<Props> = ({ instance }) => {
 
   return (
     <Row className="general">
-      <div className="file-explorer-header">
-        <FileExplorerBreadcrumb currentPath={currentPath} instance={instance} />
-        <UploadFileExplorerBtn
-          instance={instance}
-          currentPath={currentPath}
-          refreshDirectoryList={invalidateCache}
-          directoryContent={directoryContent?.metadata ?? []}
-        />
+      <div className="file-explorer-controls-bar">
+        <div className="search-box-wrapper">
+          <FileExplorerBreadcrumb
+            currentPath={currentPath}
+            instance={instance}
+          />
+        </div>
+        <div className="file-explorer-actions">
+          <FileExplorerCreateBtn
+            instance={instance}
+            currentPath={currentPath}
+            refreshDirectoryList={invalidateCache}
+          />
+          <UploadFileExplorerBtn
+            instance={instance}
+            currentPath={currentPath}
+            refreshDirectoryList={invalidateCache}
+            directoryContent={directoryContent?.metadata ?? []}
+          />
+        </div>
       </div>
       {error ? (
         <>

--- a/src/pages/instances/forms/FileExplorerCreateModal.tsx
+++ b/src/pages/instances/forms/FileExplorerCreateModal.tsx
@@ -1,0 +1,117 @@
+import { useState, type FC, type FormEvent } from "react";
+import {
+  Button,
+  Input,
+  Modal,
+  useToastNotification,
+} from "@canonical/react-components";
+import type { LxdInstance } from "types/instance";
+import { createInstanceDirectory } from "api/instances";
+import {
+  validateDirectoryPathSyntax,
+  getFileExplorerDirectoryURL,
+} from "util/instances";
+import { useNavigate } from "react-router-dom";
+
+interface Props {
+  close: () => void;
+  instance: LxdInstance;
+  currentPath: string;
+  onSuccess: () => void;
+}
+
+const FileExplorerCreateModal: FC<Props> = ({
+  close,
+  instance,
+  currentPath,
+  onSuccess,
+}) => {
+  const [directoryName, setDirectoryName] = useState("");
+  const [parentPath, setParentPath] = useState(currentPath);
+  const [isCreating, setIsCreating] = useState(false);
+  const [inputError, setInputError] = useState<string | undefined>(undefined);
+
+  const toastNotify = useToastNotification();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    const syntaxError = validateDirectoryPathSyntax(parentPath);
+    if (syntaxError) {
+      setInputError(syntaxError);
+      setIsCreating(false);
+      return;
+    }
+
+    const fullPath =
+      parentPath === "/"
+        ? `/${directoryName}`
+        : `${parentPath}/${directoryName}`;
+
+    setIsCreating(true);
+    try {
+      await createInstanceDirectory(instance, fullPath);
+      toastNotify.success(`Directory ${directoryName} created successfully.`);
+      navigate(getFileExplorerDirectoryURL(parentPath, instance));
+      onSuccess();
+    } catch (e) {
+      close();
+      toastNotify.failure("Directory creation failed", e);
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Modal
+      close={close}
+      title="Create directory"
+      className="create-directory-modal"
+      buttonRow={
+        <>
+          <Button className="u-no-margin--bottom" onClick={close}>
+            Cancel
+          </Button>
+          <Button
+            appearance="positive"
+            className="u-no-margin--bottom"
+            disabled={!directoryName.trim() || isCreating}
+            onClick={(e) => void handleSubmit(e)}
+            loading={isCreating}
+          >
+            Create
+          </Button>
+        </>
+      }
+    >
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <Input type="submit" hidden value="Hidden input" />
+        <Input
+          id="directory-name"
+          label="Directory name"
+          type="text"
+          required
+          takeFocus
+          takeFocusDelay={100}
+          value={directoryName}
+          onChange={(e) => {
+            setDirectoryName(e.target.value);
+          }}
+          placeholder="Enter new directory name"
+        />
+        <Input
+          id="parent-path"
+          label="Parent path"
+          type="text"
+          value={parentPath}
+          onChange={(e) => {
+            setParentPath(e.target.value);
+          }}
+          error={inputError}
+        />
+      </form>
+    </Modal>
+  );
+};
+
+export default FileExplorerCreateModal;

--- a/src/pages/instances/forms/FileExplorerCreateModal.tsx
+++ b/src/pages/instances/forms/FileExplorerCreateModal.tsx
@@ -1,11 +1,13 @@
-import { useState, type FC, type FormEvent } from "react";
+import { useState, type FC } from "react";
 import {
   Button,
   Input,
   Modal,
+  useNotify,
   useToastNotification,
 } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
+import NotificationRow from "components/NotificationRow";
 import { createInstanceDirectory } from "api/instances";
 import {
   validateDirectoryPathSyntax,
@@ -31,45 +33,59 @@ const FileExplorerCreateModal: FC<Props> = ({
   const [isCreating, setIsCreating] = useState(false);
   const [inputError, setInputError] = useState<string | undefined>(undefined);
 
+  const notify = useNotify();
   const toastNotify = useToastNotification();
   const navigate = useNavigate();
 
-  const handleSubmit = async (e: FormEvent) => {
+  const handleClose = () => {
+    notify.clear();
+    close();
+  };
+
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
 
-    const syntaxError = validateDirectoryPathSyntax(parentPath);
+    setInputError(undefined);
+
+    const trimmedParentPath = parentPath.trim();
+    const trimmedDirectoryName = directoryName.trim();
+
+    const fullPath = trimmedParentPath.endsWith("/")
+      ? `${trimmedParentPath}${trimmedDirectoryName}`
+      : `${trimmedParentPath}/${trimmedDirectoryName}`;
+
+    const syntaxError =
+      validateDirectoryPathSyntax(trimmedParentPath) ||
+      validateDirectoryPathSyntax(fullPath);
+
     if (syntaxError) {
       setInputError(syntaxError);
       setIsCreating(false);
       return;
     }
 
-    const fullPath =
-      parentPath === "/"
-        ? `/${directoryName}`
-        : `${parentPath}/${directoryName}`;
-
     setIsCreating(true);
     try {
       await createInstanceDirectory(instance, fullPath);
-      toastNotify.success(`Directory ${directoryName} created successfully.`);
-      navigate(getFileExplorerDirectoryURL(parentPath, instance));
+      toastNotify.success(
+        `Directory ${trimmedDirectoryName} created successfully.`,
+      );
+      navigate(getFileExplorerDirectoryURL(trimmedParentPath, instance));
       onSuccess();
     } catch (e) {
-      close();
-      toastNotify.failure("Directory creation failed", e);
+      notify.failure("Directory creation failed", e);
       setIsCreating(false);
     }
   };
 
   return (
     <Modal
-      close={close}
+      close={handleClose}
       title="Create directory"
       className="create-directory-modal"
       buttonRow={
         <>
-          <Button className="u-no-margin--bottom" onClick={close}>
+          <Button className="u-no-margin--bottom" onClick={handleClose}>
             Cancel
           </Button>
           <Button
@@ -84,6 +100,7 @@ const FileExplorerCreateModal: FC<Props> = ({
         </>
       }
     >
+      <NotificationRow />
       <form onSubmit={(e) => void handleSubmit(e)}>
         <Input type="submit" hidden value="Hidden input" />
         <Input

--- a/src/sass/_file_explorer.scss
+++ b/src/sass/_file_explorer.scss
@@ -45,6 +45,20 @@
   .p-breadcrumbs {
     overflow: hidden;
   }
+
+  .p-breadcrumbs__items {
+    list-style: none;
+
+    > li {
+      display: inline;
+    }
+  }
+
+  .continuous-breadcrumb {
+    line-height: 1.8;
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
 }
 
 .file-explorer-path-editor {

--- a/src/sass/_file_explorer.scss
+++ b/src/sass/_file_explorer.scss
@@ -1,3 +1,19 @@
+.file-explorer-controls-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  .search-box-wrapper {
+    flex: 1 1 0;
+    max-width: 45rem;
+    min-width: 0;
+  }
+}
+
+.file-explorer-actions {
+  margin-left: auto;
+}
+
 .file-explorer-item {
   align-items: center;
   display: flex;
@@ -15,12 +31,30 @@
   white-space: nowrap;
 }
 
-.breadcrumb-header {
-  display: inline-block;
-}
-
-.file-explorer-header {
+.file-explorer-breadcrumb-bar {
   align-items: center;
   display: flex;
-  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+
+  .p-breadcrumbs,
+  .p-heading--5 {
+    margin-bottom: 0;
+  }
+
+  .p-breadcrumbs {
+    overflow: hidden;
+  }
+}
+
+.file-explorer-path-editor {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  width: 100%;
+}
+
+.file-explorer-path-input {
+  min-width: 0;
+  width: 100%;
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -287,11 +287,18 @@ body.is-dark .lxd-icon {
   width: inherit;
 
   .p-breadcrumbs__items {
+    list-style: none;
     margin-bottom: 0;
 
+    > li {
+      display: inline;
+    }
+
     .continuous-breadcrumb {
-      display: inline-block;
+      line-height: 1.8;
       margin-bottom: 0 !important;
+      overflow-wrap: break-word;
+      word-break: break-all;
     }
   }
 
@@ -423,6 +430,7 @@ body.is-dark .lxd-icon {
 }
 
 .create-instance-from-snapshot-modal,
+.create-directory-modal,
 .copy-instances-modal,
 .copy-volumes-modal,
 .create-image-from-instance-modal,

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -287,18 +287,11 @@ body.is-dark .lxd-icon {
   width: inherit;
 
   .p-breadcrumbs__items {
-    list-style: none;
     margin-bottom: 0;
 
-    > li {
-      display: inline;
-    }
-
     .continuous-breadcrumb {
-      line-height: 1.8;
+      display: inline-block;
       margin-bottom: 0 !important;
-      overflow-wrap: break-word;
-      word-break: break-all;
     }
   }
 

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -111,3 +111,20 @@ export const getFileExplorerFileURL = (
 
   return `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instance.name)}/files?${params.toString()}`;
 };
+
+export const validateDirectoryPathSyntax = (
+  path: string,
+): string | undefined => {
+  if (!path.startsWith("/")) {
+    return "Path must start with /";
+  }
+
+  const segments = path.split("/").filter(Boolean);
+  for (const segment of segments) {
+    if (segment === "." || segment === "..") {
+      return "Relative path segments . and .. are not allowed.";
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Done

- [x] Creates a new directory in a specified path.
- [x] Allow traversal of directories via input

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Using a running instance, or a container, navigate to the file explorer tab.
    - Observe the "Create" button
    - Attempt to create a new directory, both within the current directory and at a specified path.

## Screenshots

<img width="1582" height="745" alt="image" src="https://github.com/user-attachments/assets/5f47c425-934a-4053-bed9-3100ba3e41f8" />
<img width="1582" height="1048" alt="image" src="https://github.com/user-attachments/assets/e604b681-1cc0-474e-99a0-cae147ba1f09" />
**Note: Modal closes after submitting to create within a dir that doesn't exist.**

Directory navigation
<img width="1561" height="472" alt="image" src="https://github.com/user-attachments/assets/4aa052ad-4ff8-4939-9c61-3bcd7c0a6cc7" />

<img width="1561" height="472" alt="image" src="https://github.com/user-attachments/assets/d69a3aef-fd5d-407c-b2ca-0e99b3f3a91c" />
