### PR TITLE
WD-36625 - Overview projects

### DIFF
--- a/src/context/useCurrentProject.tsx
+++ b/src/context/useCurrentProject.tsx
@@ -46,7 +46,10 @@ export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
 
   const parts = url.split("/");
   const project = parts[0] === "project" ? parts[1] : "";
-  const isAllProjects = parts[0] === "all-projects" || parts[0] === "projects";
+  const isAllProjects =
+    parts[0] === "all-projects" ||
+    parts[0] === "projects" ||
+    parts[0] === "overview";
 
   const initializeProjectName = (
     isAllProjectsFromUrl: boolean,

--- a/src/pages/overview/InstancesCard.tsx
+++ b/src/pages/overview/InstancesCard.tsx
@@ -10,7 +10,6 @@ import ChartLegend from "components/ChartLegend";
 import { useInstances } from "context/useInstances";
 import InstanceEmptyState from "pages/instances/InstanceEmptyState";
 import InstancesOverviewStatus from "pages/overview/InstancesOverviewStatus";
-import type { LxdInstance } from "types/instance";
 import { pluralize } from "util/helpers";
 import {
   getInstanceDistribution,
@@ -19,8 +18,7 @@ import {
 import { ROOT_PATH } from "util/rootPath";
 
 const InstancesCard: FC = () => {
-  const { data, error, isLoading } = useInstances(null);
-  const instances: LxdInstance[] = data ?? [];
+  const { data: instances = [], error, isLoading } = useInstances(null);
 
   const {
     runningCount,

--- a/src/pages/overview/ProjectsCard.tsx
+++ b/src/pages/overview/ProjectsCard.tsx
@@ -1,8 +1,84 @@
 import type { FC } from "react";
-import { Card } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { Card, Icon, Spinner } from "@canonical/react-components";
+import { useProjects } from "context/useProjects";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
+import type { LxdProject } from "types/project";
+import { pluralize } from "util/helpers";
+import { getInstancesUsedByProject } from "util/projects";
+import { ROOT_PATH } from "util/rootPath";
 
 const ProjectsCard: FC = () => {
-  return <Card className="overview-card projects"></Card>;
+  const { data: projects = [], error, isLoading } = useProjects();
+  const PROJECTS_LIMIT = 5;
+
+  const projectsWithCounts = projects.map((project: LxdProject) => {
+    return {
+      name: project.name,
+      instanceCount: getInstancesUsedByProject(project).length,
+    };
+  });
+
+  const topProjects = projectsWithCounts
+    .sort((a, b) => b.instanceCount - a.instanceCount)
+    .slice(0, PROJECTS_LIMIT);
+
+  const cardClassName = "overview-card projects";
+  const cardTitle = (
+    <>
+      <Icon name="folder" /> Projects
+      {!isLoading && !error && projects.length > 0 && ` (${projects.length})`}
+    </>
+  );
+
+  if (isLoading) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <Spinner className="u-loader" text="Loading projects..." />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <div className="error-message">
+          <Icon name="error" className="margin-right--large" /> Error while
+          loading projects: {error.message}
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cardClassName} title={cardTitle}>
+      {!isLoading && !error && (
+        <>
+          <table className="projects-instances-ranking-table u-no-margin">
+            <tbody>
+              {topProjects.map((project) => {
+                return (
+                  <tr key={project.name}>
+                    <td>
+                      <ProjectRichChip projectName={project.name} />
+                    </td>
+                    <td className="u-align--right u-text--muted">
+                      {project.instanceCount}{" "}
+                      {pluralize("instance", project.instanceCount)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div className="card-footer">
+            <Link to={`${ROOT_PATH}/ui/projects`}>See more</Link>
+          </div>
+        </>
+      )}
+    </Card>
+  );
 };
 
 export default ProjectsCard;

--- a/src/pages/projects/NavigationProjectSelectorList.tsx
+++ b/src/pages/projects/NavigationProjectSelectorList.tsx
@@ -1,9 +1,7 @@
 import { useState, type Dispatch, type FC, type SetStateAction } from "react";
 import { Link, useLocation } from "react-router-dom";
 import type { LxdProject } from "types/project";
-import { getProjectSwitchTarget } from "util/projects";
-import { filterUsedByType } from "util/usedBy";
-import { pluralize } from "util/helpers";
+import { getInstanceCount, getProjectSwitchTarget } from "util/projects";
 
 interface Props {
   projects: LxdProject[];
@@ -18,11 +16,6 @@ const NavigationProjectSelectorList: FC<Props> = ({
   const [query, setQuery] = useState("");
 
   onMount(setQuery);
-
-  const getInstanceCount = (project: LxdProject) => {
-    const count = filterUsedByType("instance", project.used_by).length;
-    return `${count} ${pluralize("instance", count)}`;
-  };
 
   return (
     <div className="projects">

--- a/src/sass/_overview.scss
+++ b/src/sass/_overview.scss
@@ -19,6 +19,12 @@
       }
     }
 
+    .card-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: $spv--small;
+    }
+
     &.cluster,
     &.storage,
     &.memory {
@@ -78,14 +84,17 @@
         }
       }
 
-      .card-footer {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: $spv--small;
-      }
-
       @include mobile {
         min-width: 100%;
+      }
+    }
+
+    &.projects {
+      max-width: calc(50% - $sph--large / 2);
+      min-width: 20rem;
+
+      .plus-n-more {
+        margin-left: $sph--small;
       }
     }
   }

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -1,8 +1,9 @@
 import type { LxdProject, ProjectReplicaMode } from "types/project";
 import { slugify } from "./slugify";
-import { ROOT_PATH } from "util/rootPath";
 import { updateProjectReplicaMode } from "api/projects";
 import { waitForOperation } from "api/operations";
+import { pluralize } from "util/helpers";
+import { ROOT_PATH } from "util/rootPath";
 
 export const ALL_PROJECTS = "All projects";
 
@@ -93,6 +94,11 @@ export const getInstancesUsedByProject = (project: LxdProject): string[] => {
   }
 
   return project.used_by.filter((item) => item.startsWith("/1.0/instances/"));
+};
+
+export const getInstanceCount = (project: LxdProject): string => {
+  const count = getInstancesUsedByProject(project).length;
+  return `${count} ${pluralize("instance", count)}`;
 };
 
 export const updateReplicaMode = async (


### PR DESCRIPTION
## Done

- feat(Overview): Darft for Projects card in Overview page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Enable overview: in your browser console, run localStorage.setItem("lxdui_ff_OVERVIEW", "true");. Then refresh, you should see an Overview item in the Navigation.
    - Click `Overview` in the side navigation
    - Admire projects card draft

## Screenshots

<img width="765" height="432" alt="image" src="https://github.com/user-attachments/assets/86326b59-dee8-49b4-badb-72b44c2c2592" />

Loading
<img width="543" height="172" alt="image" src="https://github.com/user-attachments/assets/009cddd5-c0e8-4231-8419-6b45e6d50d23" />

Error
<img width="732" height="172" alt="image" src="https://github.com/user-attachments/assets/b5234947-46b0-4c62-9df7-03adbc16cdc2" />
