### PR TITLE
Feat: mobile config navigation

### DIFF
--- a/src/pages/instances/forms/InstanceFormMenu.tsx
+++ b/src/pages/instances/forms/InstanceFormMenu.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useState, type FC } from "react";
 import MenuItem from "components/forms/FormMenuItem";
-import { Button, useListener, useNotify } from "@canonical/react-components";
+import {
+  Button,
+  Icon,
+  useListener,
+  useNotify,
+} from "@canonical/react-components";
+import classnames from "classnames";
 import { updateMaxHeight } from "util/updateMaxHeight";
+import {
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import { hasPrefixValue } from "util/formFields";
@@ -47,6 +57,12 @@ const InstanceFormMenu: FC<Props> = ({
   const notify = useNotify();
   const [isDeviceExpanded, setDeviceExpanded] = useState(true);
   const { hasMetadataConfiguration } = useSupportedFeatures();
+  const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
+  const [isMenuExpanded, setMenuExpanded] = useState(!isMediumScreen);
+
+  useEffect(() => {
+    setMenuExpanded(!isMediumScreen);
+  }, [isMediumScreen]);
 
   const disableReason = isDisabled
     ? "Please select an image before adding custom configuration"
@@ -54,7 +70,12 @@ const InstanceFormMenu: FC<Props> = ({
 
   const menuItemProps = {
     active,
-    setActive,
+    setActive: (val: string) => {
+      setActive(val);
+      if (isMediumScreen) {
+        setMenuExpanded(false);
+      }
+    },
     disableReason,
   };
 
@@ -65,103 +86,123 @@ const InstanceFormMenu: FC<Props> = ({
   useListener(window, resize, "resize", true);
 
   return (
-    <div className="p-side-navigation--accordion form-navigation">
-      <nav aria-label="Instance form navigation">
-        <ul className="p-side-navigation__list">
-          <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
-          <li className="p-side-navigation__item">
-            <Button
-              type="button"
-              className="p-side-navigation__accordion-button"
-              aria-expanded={isDeviceExpanded ? "true" : "false"}
-              onClick={() => {
-                if (!isDisabled) {
-                  setDeviceExpanded(!isDeviceExpanded);
-                }
-              }}
-              disabled={isDisabled}
-              title={disableReason}
-            >
-              {formik.values.devices.length > 0 ? (
-                <strong>Devices</strong>
-              ) : (
-                "Devices"
-              )}
-            </Button>
-            <ul
-              className="p-side-navigation__list"
-              aria-expanded={isDeviceExpanded ? "true" : "false"}
-            >
-              <MenuItem
-                label={DISK_DEVICES}
-                hasError={hasDiskError}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isDiskDevice)}
-              />
-              <MenuItem
-                label={NETWORK_DEVICES}
-                hasError={hasNetworkError}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isNicDevice)}
-              />
-              <MenuItem
-                label={GPU_DEVICES}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isGPUDevice)}
-              />
-              <MenuItem
-                label={PROXY_DEVICES}
-                {...menuItemProps}
-                isBold={formik.values.devices.some(isProxyDevice)}
-              />
-              {hasMetadataConfiguration && (
+    <div
+      className={classnames("p-side-navigation--accordion form-navigation", {
+        "is-collapsed": isMediumScreen && !isMenuExpanded,
+      })}
+    >
+      {isMediumScreen && (
+        <Button
+          type="button"
+          appearance="base"
+          className="instance-form-menu-toggle"
+          aria-label={isMenuExpanded ? "Collapse menu" : "Open menu"}
+          aria-expanded={isMenuExpanded ? "true" : "false"}
+          onClick={() => {
+            setMenuExpanded(!isMenuExpanded);
+          }}
+        >
+          <Icon name={isMenuExpanded ? "chevron-left" : "chevron-right"} />
+        </Button>
+      )}
+      {(!isMediumScreen || isMenuExpanded) && (
+        <nav aria-label="Instance form navigation">
+          <ul className="p-side-navigation__list">
+            <MenuItem label={MAIN_CONFIGURATION} {...menuItemProps} isBold />
+            <li className="p-side-navigation__item">
+              <Button
+                type="button"
+                className="p-side-navigation__accordion-button"
+                aria-expanded={isDeviceExpanded ? "true" : "false"}
+                onClick={() => {
+                  if (!isDisabled) {
+                    setDeviceExpanded(!isDeviceExpanded);
+                  }
+                }}
+                disabled={isDisabled}
+                title={disableReason}
+              >
+                {formik.values.devices.length > 0 ? (
+                  <strong>Devices</strong>
+                ) : (
+                  "Devices"
+                )}
+              </Button>
+              <ul
+                className="p-side-navigation__list"
+                aria-expanded={isDeviceExpanded ? "true" : "false"}
+              >
                 <MenuItem
-                  label={OTHER_DEVICES}
+                  label={DISK_DEVICES}
+                  hasError={hasDiskError}
                   {...menuItemProps}
-                  isBold={formik.values.devices.some(isOtherDevice)}
+                  isBold={formik.values.devices.some(isDiskDevice)}
                 />
+                <MenuItem
+                  label={NETWORK_DEVICES}
+                  hasError={hasNetworkError}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isNicDevice)}
+                />
+                <MenuItem
+                  label={GPU_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isGPUDevice)}
+                />
+                <MenuItem
+                  label={PROXY_DEVICES}
+                  {...menuItemProps}
+                  isBold={formik.values.devices.some(isProxyDevice)}
+                />
+                {hasMetadataConfiguration && (
+                  <MenuItem
+                    label={OTHER_DEVICES}
+                    {...menuItemProps}
+                    isBold={formik.values.devices.some(isOtherDevice)}
+                  />
+                )}
+              </ul>
+            </li>
+            <MenuItem
+              label={RESOURCE_LIMITS}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "limits_")}
+            />
+            <MenuItem
+              label={SECURITY_POLICIES}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "security_")}
+            />
+            <MenuItem
+              label={SNAPSHOTS}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "snapshots_")}
+            />
+            <MenuItem
+              label={MIGRATION}
+              {...menuItemProps}
+              isBold={
+                hasPrefixValue(formik, "migration_") ||
+                hasPrefixValue(formik, "cluster_")
+              }
+            />
+            <MenuItem
+              label={BOOT}
+              {...menuItemProps}
+              isBold={hasPrefixValue(formik, "boot_")}
+            />
+            <MenuItem
+              label={CLOUD_INIT}
+              {...menuItemProps}
+              isBold={hasPrefixValue(
+                formik,
+                "cloud_init_",
+                "cloud_init_ssh_keys",
               )}
-            </ul>
-          </li>
-          <MenuItem
-            label={RESOURCE_LIMITS}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "limits_")}
-          />
-          <MenuItem
-            label={SECURITY_POLICIES}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "security_")}
-          />
-          <MenuItem
-            label={SNAPSHOTS}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "snapshots_")}
-          />
-          <MenuItem
-            label={MIGRATION}
-            {...menuItemProps}
-            isBold={
-              hasPrefixValue(formik, "migration_") ||
-              hasPrefixValue(formik, "cluster_")
-            }
-          />
-          <MenuItem
-            label={BOOT}
-            {...menuItemProps}
-            isBold={hasPrefixValue(formik, "boot_")}
-          />
-          <MenuItem
-            label={CLOUD_INIT}
-            {...menuItemProps}
-            isBold={hasPrefixValue(
-              formik,
-              "cloud_init_",
-              "cloud_init_ssh_keys",
-            )}
-          />
-        </ul>
-      </nav>
+            />
+          </ul>
+        </nav>
+      )}
     </div>
   );
 };

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -45,6 +45,10 @@
         top: 0.3rem;
         z-index: 1;
       }
+
+      .instance-form-menu-toggle {
+        min-width: auto;
+      }
     }
 
     .form-contents {
@@ -113,6 +117,16 @@
   @include mobile-and-tablet {
     .form {
       margin-top: 13px;
+
+      .form-navigation.is-collapsed {
+        min-width: auto;
+        overflow: visible;
+      }
+
+      .instance-form-menu-toggle {
+        padding-left: 0;
+        padding-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Display instance configuration side-navigation as a dropdown on mobile

Fixes instance configuration navigation on mobile

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate the configuration page for both create and edit instances on **mobile**, **small**, **medium** and **large** views
    - The devices collapse should not work when in dropdown view.

## Screenshots
<img width="850" height="1376" alt="image" src="https://github.com/user-attachments/assets/26773c72-b3cc-4fd1-9345-4b00582ce714" />

<img width="850" height="1376" alt="image" src="https://github.com/user-attachments/assets/8fe391e8-ca7d-42c5-a7b1-951257ac15b1" />
