### PR TITLE
Feat: mobile & smaller screen image selector

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   CheckboxInput,
   Col,
+  Icon,
   MainTable,
   Modal,
   Notification,
@@ -12,6 +13,7 @@ import {
   Select,
   Spinner,
 } from "@canonical/react-components";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
 import type { LxdImageType, RemoteImage } from "types/image";
 import { capitalizeFirstLetter } from "util/helpers";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
@@ -53,7 +55,10 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
   const [hideRemote, setHideRemote] = useState(false);
   const [error, setError] = useState("");
   const [hideError, setHideError] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
   const { project } = useParams<{ project: string }>();
+
+  const isCardView = useIsScreenBelow(1090);
 
   const { data: settings, isLoading: isSettingsLoading } = useSettings();
   const { data: remoteImages, isLoading: isRemoteImagesLoading } =
@@ -168,6 +173,8 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
         onSelect(item, item.type ?? type);
       };
 
+      const onCellClick = isCardView ? undefined : selectImage;
+
       const displayRelease =
         item.os === "Ubuntu" &&
         item.release_title &&
@@ -226,54 +233,51 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             content: item.os,
             role: "rowheader",
             "aria-label": "Distribution",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
             content: displayRelease,
             role: "cell",
             "aria-label": "Release",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
             content: displayVariant,
             role: "cell",
             "aria-label": "Variant",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
             content: itemType,
             role: "cell",
             "aria-label": "Type",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: item.aliases.split(",").pop(),
             title: item.aliases.split(",").pop(),
             role: "cell",
             "aria-label": "Alias",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
             content: getSource(),
             role: "cell",
             "aria-label": "Source",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: item.cached ? "Cached" : "Remote",
             role: "cell",
             "aria-label": "Cached",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
           {
-            className: "u-hide--small u-hide--medium",
             content: (
               <Button
                 onClick={selectImage}
                 type="button"
-                dense
+                dense={!isCardView}
                 className="u-no-margin--bottom"
                 appearance={
                   item.cached || item.server === LOCAL_IMAGE
@@ -286,7 +290,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             ),
             role: "cell",
             "aria-label": "Action",
-            onClick: selectImage,
+            onClick: onCellClick,
           },
         ],
         sortData: {
@@ -307,21 +311,109 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
     {
       content: "Alias",
       sortKey: "alias",
-      className: "u-hide--small u-hide--medium",
     },
     {
       content: "Source",
     },
     {
-      className: "u-hide--small u-hide--medium",
       content: "Cached",
     },
     {
-      className: "u-hide--small u-hide--medium",
       content: "",
       "aria-label": "Actions",
     },
   ];
+
+  const filters = (
+    <div className="image-select-filters">
+      <Select
+        label="Distribution"
+        name="distribution"
+        onChange={(v) => {
+          setOs(v.target.value);
+          setRelease("");
+        }}
+        options={getOptionList((item: RemoteImage) => item.os)}
+        value={os}
+      />
+      <Select
+        label="Release"
+        name="release"
+        onChange={(v) => {
+          setRelease(v.target.value);
+        }}
+        options={getOptionList(
+          (item) => item.release,
+          (item) => item.os === os,
+        )}
+        value={release}
+        disabled={os === ""}
+      />
+      <Select
+        label="Variant"
+        name="variant"
+        onChange={(v) => {
+          setVariant(v.target.value);
+        }}
+        options={[
+          {
+            label: "Any",
+            value: ANY,
+          },
+        ].concat(
+          variantAll
+            .filter((item) => Boolean(item))
+            .map((item) => {
+              return {
+                label: item ?? "",
+                value: item ?? "",
+              };
+            }),
+        )}
+        value={variant}
+      />
+      <Select
+        label="Architecture"
+        name="architecture"
+        onChange={(v) => {
+          setArch(v.target.value);
+        }}
+        options={archAll.map((item) => {
+          return {
+            label: item,
+            value: item,
+          };
+        })}
+        value={arch}
+      />
+      <Select
+        label="Type"
+        name="type"
+        onChange={(v) => {
+          setType(
+            v.target.value === ANY
+              ? undefined
+              : (v.target.value as LxdImageType),
+          );
+        }}
+        options={[
+          {
+            label: "Any",
+            value: ANY,
+          },
+          ...instanceCreationTypes,
+        ]}
+        value={type ?? ""}
+      />
+      <CheckboxInput
+        checked={hideRemote}
+        label="Show only cached images"
+        onChange={() => {
+          setHideRemote((prev) => !prev);
+        }}
+      />
+    </div>
+  );
 
   return (
     <Modal
@@ -330,103 +422,10 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       className="image-select-modal"
     >
       <Row className="u-no-padding--left u-no-padding--right">
-        <Col size={3}>
-          <div className="image-select-filters">
-            <Select
-              id="imageFilterDistribution"
-              label="Distribution"
-              name="distribution"
-              onChange={(v) => {
-                setOs(v.target.value);
-                setRelease("");
-              }}
-              options={getOptionList((item: RemoteImage) => item.os)}
-              value={os}
-            />
-            <Select
-              id="imageFilterRelease"
-              label="Release"
-              name="release"
-              onChange={(v) => {
-                setRelease(v.target.value);
-              }}
-              options={getOptionList(
-                (item) => item.release,
-                (item) => item.os === os,
-              )}
-              value={release}
-              disabled={os === ""}
-            />
-            <Select
-              id="imageFilterVariant"
-              label="Variant"
-              name="variant"
-              onChange={(v) => {
-                setVariant(v.target.value);
-              }}
-              options={[
-                {
-                  label: "Any",
-                  value: ANY,
-                },
-              ].concat(
-                variantAll
-                  .filter((item) => Boolean(item))
-                  .map((item) => {
-                    return {
-                      label: item ?? "",
-                      value: item ?? "",
-                    };
-                  }),
-              )}
-              value={variant}
-            />
-            <Select
-              id="imageFilterArchitecture"
-              label="Architecture"
-              name="architecture"
-              onChange={(v) => {
-                setArch(v.target.value);
-              }}
-              options={archAll.map((item) => {
-                return {
-                  label: item,
-                  value: item,
-                };
-              })}
-              value={arch}
-            />
-            <Select
-              id="imageFilterType"
-              label="Type"
-              name="type"
-              onChange={(v) => {
-                setType(
-                  v.target.value === ANY
-                    ? undefined
-                    : (v.target.value as LxdImageType),
-                );
-              }}
-              options={[
-                {
-                  label: "Any",
-                  value: ANY,
-                },
-                ...instanceCreationTypes,
-              ]}
-              value={type ?? ""}
-            />
-            <CheckboxInput
-              aria-label="Only show cached images"
-              checked={hideRemote}
-              label="Show only cached images"
-              onChange={() => {
-                setHideRemote((prev) => !prev);
-              }}
-            />
-          </div>
+        <Col size={3} className="u-hide--small u-hide--medium">
+          {filters}
         </Col>
-        <Col size={9}>
+        <Col size={9} small={12} medium={12}>
           <div className="image-select-header">
             {error && !hideError ? (
               <Notification
@@ -454,7 +453,20 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 />
               </div>
             )}
+            <Button
+              type="button"
+              hasIcon
+              className="image-filter-toggle u-no-margin--bottom u-hide--large"
+              aria-expanded={showFilters}
+              aria-label={showFilters ? "Hide filters" : "Show filters"}
+              onClick={() => {
+                setShowFilters((prev) => !prev);
+              }}
+            >
+              <Icon name="filter" />
+            </Button>
           </div>
+          {isCardView && showFilters && filters}
           <div className="image-list">
             <ScrollableTable
               dependencies={[images]}
@@ -473,6 +485,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
                 headers={headers}
                 rows={rows}
                 paginate={null}
+                responsive
                 sortable
               />
             </ScrollableTable>

--- a/src/sass/_forms.scss
+++ b/src/sass/_forms.scss
@@ -428,18 +428,63 @@
     min-height: 100%;
   }
 
+  @include mobile {
+    .p-modal__dialog {
+      left: 0;
+      right: 0;
+    }
+  }
+
   .image-select-filters {
     height: 100%;
     margin-right: 2rem;
+
+    @include mobile-and-tablet {
+      column-gap: $sph--large;
+      display: grid;
+      height: auto;
+      margin-bottom: $spv--large;
+      margin-right: 0;
+    }
+
+    @include mobile {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    @include medium {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .image-filter-toggle {
+    flex-shrink: 0;
+    margin-left: $sph--small;
+
+    &[aria-expanded="true"] {
+      background-color: $colors--theme--background-active;
+    }
+  }
+
+  .table-image-select.p-table--mobile-card tbody {
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   }
 
   @include mobile-and-tablet {
-    .image-select-filters {
-      display: none;
+    .table-image-select td[data-heading=""] {
+      &::before,
+      &::after {
+        display: none;
+      }
+
+      button {
+        margin-top: $spv--small;
+        width: 100%;
+      }
     }
   }
 
   .image-select-header {
+    align-items: flex-start;
     display: flex;
 
     > :first-child {


### PR DESCRIPTION
## Done

- Make the image selector usable on medium, small and mobile screens by converting to a table view.
- Filters behind a toggle/button
- Search always available

Fixes usability on <1090 pixels width screens

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots

Image selector on mobile (No black bars <500px)

<img width="850" height="1376" alt="image" src="https://github.com/user-attachments/assets/cb2c17c2-0270-4315-8874-1a6d17f2586b" />

little over 500px width:

<img width="1114" height="1566" alt="image" src="https://github.com/user-attachments/assets/961ec51e-f62a-4e51-96dd-91c1b4e86915" />

Filters available behind a toggle/button:

<img width="1250" height="1604" alt="image" src="https://github.com/user-attachments/assets/8d3b5f8f-8145-4e79-bc32-be5fd79d24fe" />



792 pixels width:

<img width="1582" height="1566" alt="image" src="https://github.com/user-attachments/assets/1106c527-5f12-402b-95d6-d7fb90a1eafd" />


Previous setup at 792 pixels, only showing 5 out of 8 columns, no select button/filters:

<img width="1582" height="1566" alt="image" src="https://github.com/user-attachments/assets/4b5669d1-fc79-49e2-b4f5-9a14f0dd0a95" />
