### PR TITLE
fix(EditProfile): add NotificationRow

### DIFF
--- a/src/pages/profiles/EditProfile.tsx
+++ b/src/pages/profiles/EditProfile.tsx
@@ -51,6 +51,7 @@ import YamlSwitch from "components/forms/YamlSwitch";
 import YamlNotification from "components/forms/YamlNotification";
 import ProxyDeviceForm from "components/forms/ProxyDeviceForm";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
+import NotificationRow from "components/NotificationRow";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
 import BootForm from "components/forms/BootForm";
 import { useProfileEntitlements } from "util/entitlements/profiles";
@@ -158,7 +159,10 @@ const EditProfile: FC<Props> = ({ profile }) => {
             handleFinish();
           }
         })
-        .catch(handleFailure);
+        .catch((e: Error) => {
+          handleFailure(e);
+          formik.setSubmitting(false);
+        });
     },
   });
 
@@ -196,6 +200,8 @@ const EditProfile: FC<Props> = ({ profile }) => {
         )}
         <Row className="form-contents" key={section}>
           <Col size={12}>
+            {!panelParams.panel && <NotificationRow />}
+
             {(section === slugify(MAIN_CONFIGURATION) || !section) && (
               <ProfileDetailsForm
                 formik={formik}


### PR DESCRIPTION
## Done

- fix(EditProfile): add NotificationRow

Fixes #2107

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a profile's configuration and switch to YAML
    - In a device, add `readonly: true` and click "Save". Make sure an error is displayed in the screen and the "Save" button is enabled.
    - In a device, add `foo: bar` and click "Save". Make sure an error is displayed in the screen and the "Save" button is enabled.

## Screenshots

<img width="1858" height="1059" alt="image" src="https://github.com/user-attachments/assets/59f66d93-09a7-4bb6-a21f-24ecc0245a50" />

<img width="1858" height="1059" alt="image" src="https://github.com/user-attachments/assets/5f6bc9f2-e240-4902-8ece-72c834ee98c3" />
