### PR TITLE
test(Network peering): fix CI

### DIFF
--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -62,9 +62,17 @@ export const prepareCreateNetwork = async (
   options: NetworkOptions = {},
 ) => {
   const { hasMemberSpecificParents, networkACL, uplink, ipv4, ipv6 } = options;
-  await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Networking" }).click();
-  await page.getByRole("link", { name: "Networks", exact: true }).click();
+  const networksLink = page.getByRole("link", {
+    name: "Networks",
+    exact: true,
+  });
+
+  // If the link isn't visible, the accordion is collapsed
+  if (!(await networksLink.isVisible())) {
+    await page.getByRole("button", { name: "Networking" }).click();
+  }
+
+  await networksLink.click();
   await page.getByRole("button", { name: "Create network" }).click();
   await page.getByRole("heading", { name: "Create a network" }).click();
   await page.getByRole("button", { name: "Type" }).click();
@@ -232,7 +240,19 @@ export const getNetworkLink = async (page: Page, network: string) => {
   // network actions may result in ERR_NETWORK_CHANGED, we should wait for network to settle before checking visibility
   await page.waitForLoadState("networkidle");
   await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Networking" }).click();
+
+  // If the link isn't visible, the accordion is collapsed
+  if (
+    !(await page
+      .getByRole("link", {
+        name: "Networks",
+        exact: true,
+      })
+      .isVisible())
+  ) {
+    await page.getByRole("button", { name: "Networking" }).click();
+  }
+
   await page.getByTitle("Networks (default)").click();
   const networkLink = page.getByRole("link", { name: network, exact: true });
   return networkLink;
@@ -240,9 +260,10 @@ export const getNetworkLink = async (page: Page, network: string) => {
 
 export const submitCreateNetwork = async (page: Page, network: string) => {
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForTimeout(5000);
   const networkLink = await getNetworkLink(page, network);
   await expect(networkLink).toBeVisible();
+  const networkRow = page.getByRole("row").filter({ hasText: network });
+  await expect(networkRow.getByText("Created")).toBeVisible({ timeout: 5000 });
 };
 
 export const createNetworkLocalPeering = async (


### PR DESCRIPTION
## Done

- Fix network local peering tests
```
  2 failed
    [chromium:lxd-5.21-edge:clustered] › tests/network-local-peering-clustered.spec.ts:43:3 › Network Local Peering › Create mutual peering between two OVN networks 
    [chromium:lxd-5.21-edge:clustered] › tests/network-local-peering-clustered.spec.ts:80:3 › Network Local Peering › Create non-mutual peering between two OVN networks 
```

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI

## Screenshots

<img width="1009" height="483" alt="image" src="https://github.com/user-attachments/assets/8678500c-b0f5-49a7-841d-e668ad606265" />
