### PR TITLE
fix(modal footer): SnapshotForm

### DIFF
--- a/src/components/forms/SnapshotForm.tsx
+++ b/src/components/forms/SnapshotForm.tsx
@@ -34,12 +34,7 @@ const SnapshotForm: FC<Props> = (props) => {
       title={`${isEdit ? "Edit" : "Create"} snapshot`}
       buttonRow={
         <>
-          <Button
-            appearance="base"
-            className="u-no-margin--bottom"
-            type="button"
-            onClick={close}
-          >
+          <Button appearance="base" type="button" onClick={close}>
             Cancel
           </Button>
           <ActionButton


### PR DESCRIPTION
## Done

- Fix modal footer of SnapshotForm

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to an instance's detail page. Select "Snapshot" tab.
    - Click "Create snapshot". Make sure the buttons in the modal footer are vertically aligned.

## Screenshots

<img width="1846" height="1049" alt="Screenshot from 2026-06-30 15-41-46" src="https://github.com/user-attachments/assets/3b17275c-0b0b-4fef-ac53-0cc27647a2ed" />
