### PR TITLE
fix(Navigation): highlight "Networks" for unmanaged networks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import { setFavicon } from "util/favicon";
+import { unmanagedNetworkDetailRoute } from "util/networks";
 import { ALL_PROJECTS } from "util/projects";
 import { AUTH_METHOD } from "util/authentication";
 
@@ -333,7 +334,7 @@ const App: FC = () => {
           }
         />
         <Route
-          path={`${ROOT_PATH}/ui/project/:project/member/:member/network/:name`}
+          path={unmanagedNetworkDetailRoute}
           element={
             <ProtectedRoute
               outlet={<ProjectLoader outlet={<NetworkDetail />} />}

--- a/src/components/NavAccordion.tsx
+++ b/src/components/NavAccordion.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@canonical/react-components";
 import type { FC, ReactNode } from "react";
-import { useLocation } from "react-router-dom";
+import { matchPath, useLocation } from "react-router-dom";
 import classnames from "classnames";
 
 export type AccordionNavMenu =
@@ -32,8 +32,10 @@ const NavAccordion: FC<Props> = ({
   disabled,
 }) => {
   const location = useLocation();
-  const isActive = baseUrls.some((baseUrl) =>
-    location.pathname.includes(baseUrl),
+  const isActive = baseUrls.some(
+    (baseUrl) =>
+      location.pathname.includes(baseUrl) ||
+      Boolean(matchPath({ path: baseUrl, end: false }, location.pathname)),
   );
 
   return (

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,5 +1,5 @@
 import type { FC, LinkHTMLAttributes, ReactNode } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, matchPath, useLocation } from "react-router-dom";
 import classnames from "classnames";
 
 interface Props {
@@ -30,7 +30,10 @@ const NavLink: FC<Props & LinkHTMLAttributes<HTMLElement>> = ({
 
   // this caters for more custom url matches for link to be active e.g. /identities & /identity/oidc etc
   for (const match of activeUrlMatches) {
-    if (location.pathname.includes(match)) {
+    if (
+      location.pathname.includes(match) ||
+      matchPath({ path: match, end: false }, location.pathname)
+    ) {
       isActive = true;
     }
   }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -28,11 +28,12 @@ import { useLoggedInUser } from "context/useLoggedInUser";
 import { useSettings } from "context/useSettings";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import { useIsClustered } from "context/useIsClustered";
-import { getReportBugURL } from "util/reportBug";
 import { AUTH_METHOD, authIcon } from "util/authentication";
+import { unmanagedNetworkDetailRoute } from "util/networks";
+import { ALL_PROJECTS } from "util/projects";
+import { getReportBugURL } from "util/reportBug";
 import DocLink from "components/DocLink";
 import AuthenticationTlsStepper from "./AuthenticationTlsStepper";
-import { ALL_PROJECTS } from "util/projects";
 
 const initialiseOpenNavMenus = (location: Location) => {
   const openPermissions = location.pathname.includes("/permissions/");
@@ -313,6 +314,7 @@ const Navigation: FC = () => {
                         <NavAccordion
                           baseUrls={[
                             `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network`,
+                            unmanagedNetworkDetailRoute,
                           ]}
                           title={getNavTitle("networking")}
                           disabled={isAllProjects}
@@ -335,6 +337,7 @@ const Navigation: FC = () => {
                                 title={`Networks (${projectName})`}
                                 onClick={softToggleMenu}
                                 className="accordion-nav-secondary"
+                                activeUrlMatches={[unmanagedNetworkDetailRoute]}
                                 ignoreUrlMatches={[
                                   "network-acl",
                                   "network-acls",

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -1,3 +1,5 @@
+import type { useNotify } from "@canonical/react-components";
+import type { IpAddressFamily } from "types/forms/network";
 import type { IpAddress, IpFamily, LxdInstance } from "types/instance";
 import type {
   LxdNetwork,
@@ -7,11 +9,16 @@ import type {
   LXDNetworkOnClusterMemberFulfilled,
 } from "types/network";
 import type { LxdConfigOptionsKeys } from "types/config";
-import { capitalizeFirstLetter, constructMemberError } from "util/helpers";
+import {
+  capitalizeFirstLetter,
+  checkDuplicateName,
+  constructMemberError,
+  type AbortControllerState,
+} from "util/helpers";
+import { ROOT_PATH } from "util/rootPath";
 import type { AnyObject, TestFunction } from "yup";
-import { checkDuplicateName, type AbortControllerState } from "./helpers";
-import type { useNotify } from "@canonical/react-components";
-import type { IpAddressFamily } from "types/forms/network";
+
+export const unmanagedNetworkDetailRoute = `${ROOT_PATH}/ui/project/:project/member/:member/network/:name`;
 
 export const bridgeType = "bridge";
 export const macvlanType = "macvlan";


### PR DESCRIPTION
## Done

- fix(Navigation): highlight "Networks" for unmanaged networks

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to the networks list page.
    - Click on an unmanaged network name (column Managed = No). Once on the detail page of an unmanaged network, "Networks" in the side navigation should be highlighted and the accordion open.
    - Make sure it's not broken for managed networks.

## Screenshots

Unmanaged
<img width="1846" height="1051" alt="image" src="https://github.com/user-attachments/assets/d6f3cb2e-f4a5-403f-b7a0-1c0c484a0a74" />

Managed
<img width="1846" height="1051" alt="image" src="https://github.com/user-attachments/assets/8cb1c91f-a08a-4a6e-b9da-cee25cd4e042" />
