### PR TITLE
fix(project config): responsiveness for replication tab

### DIFF
--- a/src/pages/projects/actions/ClearProjectReplicaModeBtn.tsx
+++ b/src/pages/projects/actions/ClearProjectReplicaModeBtn.tsx
@@ -61,7 +61,6 @@ const ClearProjectReplicaModeBtn: FC<Props> = ({ project, isEdit }: Props) => {
       appearance="base"
       onClick={clearReplicaMode}
       loading={isClearing}
-      className="u-no-margin--bottom"
       title={disabledReason() ?? "Clear replica mode for project."}
       disabled={Boolean(disabledReason())}
     >

--- a/src/pages/projects/actions/DemoteProjectBtn.tsx
+++ b/src/pages/projects/actions/DemoteProjectBtn.tsx
@@ -70,7 +70,6 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
         disabledReason() ??
         "Project will become the read-only replication target."
       }
-      className="u-no-margin--bottom"
       disabled={Boolean(disabledReason())}
       confirmationModalProps={{
         title: "Confirm demote",

--- a/src/pages/projects/actions/PromoteProjectBtn.tsx
+++ b/src/pages/projects/actions/PromoteProjectBtn.tsx
@@ -69,7 +69,6 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
       onHoverText={
         disabledReason() ?? "Project will become the active replication source."
       }
-      className="u-no-margin--bottom"
       disabled={Boolean(disabledReason())}
       confirmationModalProps={{
         title: "Confirm promote",

--- a/src/pages/projects/forms/ProjectReplicaForm.tsx
+++ b/src/pages/projects/forms/ProjectReplicaForm.tsx
@@ -1,18 +1,23 @@
 import { type FC } from "react";
-import { Col, Field, Notification, Row } from "@canonical/react-components";
+import {
+  Col,
+  Notification,
+  OutputField,
+  Row,
+} from "@canonical/react-components";
 import ScrollableForm from "components/ScrollableForm";
 import type { FormikProps } from "formik/dist/types";
 import ClusterLinkSelector from "pages/cluster/ClusterLinkSelector";
 import ReplicatorList from "pages/cluster/ReplicatorList";
-import PromoteProjectBtn from "pages/projects/actions/PromoteProjectBtn";
+import ClearProjectReplicaModeBtn from "pages/projects/actions/ClearProjectReplicaModeBtn";
 import DemoteProjectBtn from "pages/projects/actions/DemoteProjectBtn";
+import PromoteProjectBtn from "pages/projects/actions/PromoteProjectBtn";
 import type { LxdConfigPair } from "types/config";
 import type {
   ProjectFormValues,
   ProjectReplicaFormValues,
 } from "types/forms/project";
 import { ensureEditMode } from "util/editMode";
-import ClearProjectReplicaModeBtn from "../actions/ClearProjectReplicaModeBtn";
 
 export const replicaPayload = (
   values: ProjectReplicaFormValues,
@@ -105,24 +110,16 @@ const ProjectReplicaForm: FC<Props> = ({ formik, isEdit }) => {
   return (
     <ScrollableForm className="project-replica-form">
       <Row>
-        <Col size={12}>
-          <Field
-            forId="replica_mode"
+        <Col size={12} className="replica-mode-container">
+          <OutputField
+            id="replica_mode"
             label="Replica mode"
+            value={formik.values.replica_mode || "None"}
             help={getModeDescription(formik.values.replica_mode || "")}
-            labelClassName="u-no-margin--bottom"
-            className="replica-mode-field"
-          >
-            <div className="replica-mode-output-wrapper">
-              <output id="replica_mode" className="mono-font u-sv2">
-                <b>{formik.values.replica_mode || "None"}</b>
-              </output>
-
-              <div className="replica-mode-action-buttons">
-                {getModeActionButtons(formik.values.replica_mode)}
-              </div>
-            </div>
-          </Field>
+          />
+          <div className="replica-mode-action-buttons">
+            {getModeActionButtons(formik.values.replica_mode)}
+          </div>
         </Col>
       </Row>
 

--- a/src/sass/_project_configuration.scss
+++ b/src/sass/_project_configuration.scss
@@ -48,19 +48,29 @@
 }
 
 .project-replica-form {
-  .replica-mode-field {
-    .replica-mode-output-wrapper {
-      align-items: baseline;
-      display: flex;
-      gap: $sph--large;
+  .replica-mode-container {
+    position: relative;
 
-      output.mono-font {
-        width: 15rem;
+    .replica-mode-action-buttons {
+      left: unset;
+      margin-bottom: $spv--small;
+      position: unset;
+      top: unset;
+
+      > .p-action-button {
+        margin-bottom: $spv--small;
       }
-    }
 
-    .p-form-help-text {
-      max-width: 15rem;
+      @media screen and (width >= 1200px) {
+        left: 16rem;
+        margin-bottom: 0;
+        position: absolute;
+        top: calc(1.5rem + 0.375rem);
+
+        > .p-button--default.p-action-button {
+          margin-bottom: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Fix responsiveness for project configuration's replication tab

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a project's configuration. Open ""Replication" tab.
    - Make sure the actions buttons (Promote, Demote and Clear) are correctly displayed for all screen widths.

## Screenshots

Screen > 1200px
<img width="1852" height="1058" alt="image" src="https://github.com/user-attachments/assets/38372990-e9d2-47d0-b6c9-31026abde019" />

Screen = 990px
<img width="1237" height="1058" alt="image" src="https://github.com/user-attachments/assets/2e1d18f3-22ec-4df2-8894-5dcac7d3bfc5" />

Screen = 887px (buttons wrap)
<img width="1111" height="1058" alt="image" src="https://github.com/user-attachments/assets/33a1b11c-f8c6-4377-8ad1-69bf45b17876" />

Screen < 620px (mobile)
<img width="726" height="1058" alt="image" src="https://github.com/user-attachments/assets/854b7c65-20f2-46f0-8b7e-452159fcaee5" />
