### PR TITLE
feat(IDP groups): make info notification dismissable

### DIFF
--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -45,6 +45,7 @@ const PermissionIdpGroups: FC = () => {
   const { canCreateIdpGroups } = useServerEntitlements();
   const { canEditIdpGroup } = useIdpGroupEntitlements();
   const isSmallScreen = useIsScreenBelow();
+  const [isNotification, setIsNotification] = useState(true);
 
   if (error) {
     notify.failure("Loading provider groups failed", error);
@@ -221,7 +222,16 @@ const PermissionIdpGroups: FC = () => {
 
   const content = hasGroups ? (
     <>
-      <Notification severity="information">{idpGroupsInfo}</Notification>
+      {isNotification && (
+        <Notification
+          severity="information"
+          onDismiss={() => {
+            setIsNotification(false);
+          }}
+        >
+          {idpGroupsInfo}
+        </Notification>
+      )}
       <ScrollableTable
         dependencies={[groups]}
         tableId="idp-groups-table"


### PR DESCRIPTION
## Done

- feat(IDP groups): make information notification dismissable

Fixes #2121

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions > IDP groups.
    - Make sure the information notification is dismissable.
    - Refresh page, the notification should be visible again.

## Screenshots

<img width="1856" height="1058" alt="image" src="https://github.com/user-attachments/assets/4b1184c6-ff3f-4a07-9c89-8ead7ffbba56" />

After notification close
<img width="1856" height="1058" alt="image" src="https://github.com/user-attachments/assets/424be01b-ed66-49ac-aa4e-ae1d9b62055b" />
