### PR TITLE
feat(agents):  add copilot-instructions.md and AGENTS_AND_SKILLS.md

### DIFF
--- a/.github/AGENTS_AND_SKILLS.md
+++ b/.github/AGENTS_AND_SKILLS.md
@@ -1,0 +1,142 @@
+# LXD-UI Agents and Skills Guide
+
+This guide explains how to use LXD-UI agents and skills in:
+
+- VS Code Copilot Chat
+- GitHub Copilot CLI
+
+It focuses on invocation patterns that match current public docs for Agent Skills, custom agents, and plugins.
+
+## Quick Reference Table
+
+| Name                       | Type               | VS Code Invocation                           | Copilot CLI Invocation                          | When to Use                                       | Tools                                        | Handoff / Delegation                        |
+| -------------------------- | ------------------ | -------------------------------------------- | ----------------------------------------------- | ------------------------------------------------- | -------------------------------------------- | ------------------------------------------- |
+| LXD-UI Feature Planner     | Agent (plugin)     | Agent picker -> `LXD-UI Feature Planner`     | `/agent` -> select `LXD-UI Feature Planner`     | Plan implementation before coding                 | Read-only exploration/search (agent-defined) | Yes -> Feature Implementer                  |
+| LXD-UI Feature Implementer | Agent (plugin)     | Agent picker -> `LXD-UI Feature Implementer` | `/agent` -> select `LXD-UI Feature Implementer` | Implement feature end-to-end from plan/spec       | Read/edit/search/execute (agent-defined)     | Yes -> Test Writer                          |
+| LXD-UI Test Writer         | Agent (plugin)     | Agent picker -> `LXD-UI Test Writer`         | `/agent` -> select `LXD-UI Test Writer`         | Write and run unit/E2E tests                      | Read/edit/search/execute (agent-defined)     | Usually terminal step (no required handoff) |
+| code-review                | Skill (local repo) | `/code-review`                               | `/code-review`                                  | Review PR/diff for regressions, risk, and quality | Inherits active agent/session tools          | N/A                                         |
+| lxd-ui-architecture-design | Skill (plugin)     | `/lxd-dev:lxd-ui-architecture-design`        | `/lxd-dev:lxd-ui-architecture-design`           | Architecture and major refactor design            | Inherits active agent/session tools          | Feeds Planner/Implementer                   |
+| lxd-ui-qa-instructions     | Skill (plugin)     | `/lxd-dev:lxd-ui-qa-instructions`            | `/lxd-dev:lxd-ui-qa-instructions`               | Generate manual QA instructions for PRs           | Inherits active agent/session tools          | N/A                                         |
+| lxd-ui-env-setup           | Skill (plugin)     | `/lxd-dev:lxd-ui-env-setup`                  | `/lxd-dev:lxd-ui-env-setup`                     | Produce LXD environment setup for validation      | Inherits active agent/session tools          | N/A                                         |
+| lxd-ui-release-notes       | Skill (plugin)     | `/lxd-dev:lxd-ui-release-notes`              | `/lxd-dev:lxd-ui-release-notes`                 | Create release notes/changelog content            | Inherits active agent/session tools          | N/A                                         |
+
+## Big Picture
+
+There are three related concepts:
+
+- Custom instructions: always-on or file-scoped guidance (`.github/copilot-instructions.md`, `AGENTS.md`, `*.instructions.md`)
+- Skills: task-specific capabilities invoked as slash commands or auto-loaded when relevant
+- Agents: specialized personas/tool configurations selected explicitly (agent picker, `/agent`, or `--agent`)
+
+In this repo:
+
+- One local skill lives in `.github/skills/code-review/SKILL.md`
+- Additional skills and agents come from the `lxd-dev` plugin
+
+## Most Important Invocation Rules
+
+### VS Code Copilot Chat
+
+- Skills are invoked from the slash command menu. Type `/` and pick one.
+- Plugin skills can be namespaced by plugin name (for example `/lxd-dev:skill-name`).
+- Agents are selected from the agent dropdown/picker in chat.
+
+### Copilot CLI
+
+- Start with `copilot`.
+- Select an agent with `/agent`.
+- Invoke a skill by slash command (for example `/skill-name` or namespaced `/plugin-name:skill-name` when provided by a plugin).
+- Discover what is loaded with `/env`, `/skills list`, and `/skills info <name>`.
+
+## LXD-UI Inventory
+
+### Agents from plugin
+
+- `LXD-UI Feature Planner`
+- `LXD-UI Feature Implementer`
+- `LXD-UI Test Writer`
+
+Use these from:
+
+- VS Code: select from the agent picker
+- CLI: `/agent` then choose the agent.
+
+### Skills
+
+Local repo skill:
+
+- `code-review`
+
+Plugin skills:
+
+- `lxd-ui-architecture-design`
+- `lxd-ui-qa-instructions`
+- `lxd-ui-env-setup`
+- `lxd-ui-release-notes`
+
+Invocation pattern:
+
+- VS Code: type `/` and select the skill from the picker
+- CLI: type `/` and select, or run by explicit command name
+
+Namespacing note:
+
+- Plugin-provided skills may appear with plugin prefix (for example `/lxd-dev:lxd-ui-qa-instructions`).
+- Local skills are typically unprefixed (for example `/code-review`).
+- Because naming display can vary by environment/version, prefer picker-based invocation instead of memorizing strings.
+
+## Recommended Workflows
+
+### Feature delivery
+
+1. Select `LXD-UI Feature Planner`
+2. Ask for implementation plan from acceptance criteria
+3. Switch (or hand off) to `LXD-UI Feature Implementer`
+4. Use `LXD-UI Test Writer` for tests
+
+### Architecture-heavy change
+
+1. Run skill `lxd-ui-architecture-design`
+2. Use planner agent with the architecture output
+3. Implement with implementer agent
+
+### PR review
+
+1. Run `/code-review` in VS Code chat or CLI
+2. For GitHub PR UI, native Copilot review still applies repo instructions and local review guidance
+
+### QA instructions for a PR
+
+1. Run `lxd-ui-qa-instructions`
+2. Paste generated steps into the PR template
+
+## Troubleshooting Discovery and Invocation
+
+If a skill or agent is not visible:
+
+1. Confirm plugin is installed and enabled
+2. In VS Code, open chat customizations and verify the item appears
+3. In CLI, run `/env` and `/skills list`
+4. For skills, verify `name` in `SKILL.md` is lowercase kebab-case and matches its folder name
+5. If recently added, run `/skills reload` in CLI
+
+## Where These Definitions Live
+
+- Local skill: `.github/skills/code-review/SKILL.md`
+- Repo-wide instructions: `.github/copilot-instructions.md`
+- Project conventions: `agents.md`
+- This guide: `.github/AGENTS_AND_SKILLS.md`
+
+Plugin source for LXD-UI-specific plugin content:
+
+- `canonical/anbox-agent-plugins` (plugin `lxd-dev`)
+
+## Reference Links
+
+- VS Code Agent Skills: https://code.visualstudio.com/docs/agent-customization/agent-skills
+- VS Code Custom Agents: https://code.visualstudio.com/docs/agent-customization/custom-agents
+- VS Code Agent Plugins: https://code.visualstudio.com/docs/agent-customization/agent-plugins
+- GitHub Copilot CLI usage: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli
+- Copilot CLI command reference: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference
+- Copilot CLI skills: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-skills
+- Copilot CLI custom agents: https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/invoke-custom-agents

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,84 @@
+# LXD-UI Code Review & Development Instructions
+
+This file configures GitHub Copilot's behavior for code reviews and development tasks in the LXD-UI repository.
+
+## Code Review Standards
+
+When reviewing pull requests, apply these LXD-UI-specific checks:
+
+### TypeScript & Type Safety
+
+- Verify TypeScript strict mode compliance (`tsconfig.json`)
+- All function parameters and returns must be explicitly typed
+- No `any` types unless absolutely necessary with justification
+- Component props must be typed via `interface Props` or inline
+
+### React Components & Patterns
+
+- Use **functional components** (no class components)
+- Props must be properly typed: `interface ComponentProps { ... }`
+- Use React hooks for state and effects
+- Follow the side panel pattern for create/edit forms (see [`agents.md`](../agents.md))
+
+### React Query & Data Fetching
+
+- Queries use `useQuery` with typed `queryFn`
+- Mutations use `useMutation` with proper error handling
+- Cache invalidation on mutations (via `useQueryClient`)
+- Query keys follow hierarchical pattern (defined in `queryKeys.tsx`)
+- No polling; use proper cache strategies
+
+### Notification System
+
+- **Inline errors**: Use `useNotify` with `<NotificationRow />`
+- **Toast notifications**: Use `useToastNotification` for post-action feedback
+- Always clear inline notifications when closing panels
+
+### API Layer
+
+- Keep API calls in `src/api/<resource>.tsx`
+- Follow naming: `fetch<Resource>s()`, `create<Resource>()`, etc.
+- Include query params documentation
+
+### Component Organization
+
+- Colocate related components
+- Use `.spec.ts` (or `.spec.tsx` when JSX is needed) for Vitest unit tests (Playwright E2E tests live under `tests/` as `.spec.ts`)
+- Keep components modular and reusable; avoid large monolithic components
+
+### Testing
+
+- Unit tests with Vitest for utilities and complex logic
+- E2E tests with Playwright for user workflows
+- Use test helpers from `tests/helpers/`
+
+### Security
+
+- No hardcoded secrets or API keys
+- Validate user inputs before API calls
+- Sanitize rendered HTML (use React's default escaping)
+- Check OWASP Top 10 for common vulnerabilities
+
+### Code Quality
+
+- Run `yarn lint-js` before commit (TypeScript, ESLint, Prettier)
+- No circular dependencies (check with `yarn check-circular-deps`)
+- Use path aliases from `tsconfig.json` (`context/`, `api/`, etc.)
+- Comments explain _why_, not _what_
+
+## LXD-UI Project Reference
+
+See these files for detailed conventions:
+
+- [`agents.md`](../agents.md) — Complete project patterns and architecture
+- [`AGENTS_AND_SKILLS.md`](AGENTS_AND_SKILLS.md) — Agent and skill usage guide
+- `ARCHITECTURE.MD` — System architecture and setup
+
+## For Development Tasks
+
+When suggesting code or refactoring:
+
+- Follow patterns in `src/` (API → Context → Components → Pages)
+- Reference similar features (e.g., instances, networks) as templates
+- Include test suggestions
+- Validate with `yarn lint-js` requirements

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: code-review
+description: "Review a GitHub PR for the LXD-UI codebase. Checks code quality, security, and adherence to LXD-UI conventions including TypeScript, React, React Query, side panel patterns, notifications, and OWASP Top 10. For GitHub Copilot code review and VS Code Copilot Chat. Triggers on: code review, review, PR review, code quality, security review."
+---
+
+# LXD-UI Code Review
+
+Perform a thorough, actionable review of a GitHub PR for the LXD-UI project.
+
+## Setup
+
+Reference the project conventions before reviewing:
+
+- [agents.md](../../../agents.md) — LXD-UI conventions, patterns, and architecture
+- [.github/copilot-instructions.md](../../copilot-instructions.md) — Code review standards
+
+## Review Criteria
+
+When reviewing code, check each file against these criteria:
+
+### TypeScript Quality
+
+- No `any` types unless explicitly justified
+- All component props are typed via an `interface Props` or `interface ComponentProps`
+- Strict null checks respected — no unchecked optional chaining without guards
+- Path aliases used for imports (e.g. `context/...`, `api/...`, `util/...`)
+
+### React Patterns
+
+- Functional components only (no class components)
+- Hooks used correctly (no conditional hook calls, deps arrays correct)
+- Components declared as `const Component: FC = () => { ... }`
+- Side effects in `useEffect`, not in render
+- No JSX in conditional ternaries without parentheses
+
+### Data Fetching (React Query)
+
+- Query keys follow the hierarchical pattern in [src/util/queryKeys.tsx](../../../src/util/queryKeys.tsx)
+- Mutations invalidate relevant query keys on success
+- `useQuery` / `useMutation` used consistently — no raw `useEffect` for data fetching
+- Cache invalidation handled on mutations
+
+### Side Panel Pattern
+
+- New panels added to the `panels` constant in [src/util/usePanelParams.tsx](../../../src/util/usePanelParams.tsx)
+- `open*` helper added to `PanelHelper` interface and implementation
+- Panel renders `<NotificationRow />` and calls `notify.clear()` on close
+- Parent page suppresses `<NotificationRow />` when any panel is open
+
+### Notification Pattern
+
+- `useNotify` used for inline panel/form errors
+- `useToastNotification` used for post-action feedback
+- `notify.clear()` called when panels close
+- No multiple notification systems in same component
+
+### API Layer
+
+- API calls stay in [src/api/<resource>.tsx](../../../src/api/)
+- Naming convention: `fetch<Resource>s()`, `create<Resource>()`, `update<Resource>()`, `delete<Resource>()`
+- `fetch` used with proper error handling
+- Query parameters and payloads documented
+
+### Security (OWASP Top 10)
+
+- No user-supplied values interpolated directly into `dangerouslySetInnerHTML`
+- No secrets, tokens, or credentials in source or comments
+- No unvalidated data passed to `eval()` or similar
+- API calls use typed responses — no blind `JSON.parse` of arbitrary input
+- Input validation before API calls
+
+### Tests
+
+- New features include at least one E2E test in [tests/](../../../tests/)
+- New utility functions include a unit test (`.spec.ts` colocated with the source)
+- Helpers used from [tests/helpers/](../../../tests/helpers/) rather than duplicated inline
+- Aim for 80%+ coverage on critical logic
+
+### Code Quality
+
+- No circular imports introduced (`yarn check-circular-deps` would pass)
+- No commented-out code or debug `console.log` statements
+- SCSS follows BEM convention; `@canonical/react-components` preferred over custom styles
+- File names: PascalCase for components, camelCase for utilities
+- Components are modular and reusable; avoid large monolithic files
+- Comments explain _why_, not _what_
+
+### Component Organization
+
+- Related components are colocated
+- Reusable components in `src/components/`, page-specific in `src/pages/`
+
+## Review Output Format
+
+Structure reviews as:
+
+```
+## Review: PR #<number> — <title>
+
+### Summary
+<2-3 sentence overview of what the PR does and overall impression>
+
+### Critical Issues
+<Numbered list — these must be fixed before merging>
+
+### Minor Issues / Suggestions
+<Numbered list — improvements that are encouraged but not blocking>
+
+### Positives
+<Brief callout of things done well>
+```
+
+Always explicitly state: "No critical issues" if none exist.


### PR DESCRIPTION
## Done

- add copilot-instructions.md, code-review skill and AGENTS_AND_SKILLS.md


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
   - Open `.github/AGENTS_AND_SKILLS.md` and verify the quick-reference table lists all agents and skills added in this PR with correct invocation instructions
