### PR TITLE
fix(isServerClustered): fix after unifying clustered and unclustered

### DIFF
--- a/tests/helpers/cluster-groups.ts
+++ b/tests/helpers/cluster-groups.ts
@@ -17,8 +17,9 @@ export const skipIfClusteringNotSupported = (lxdVersion: LxdVersions) => {
 
 export const isServerClustered = async (page: Page) => {
   await gotoURL(page, "/ui/");
+  await page.getByRole("button", { name: "Clustering", exact: true }).click();
 
-  if ((await page.getByRole("button", { name: "Clustering" }).count()) === 0) {
+  if ((await page.getByRole("link", { name: "Members" }).count()) === 0) {
     return false;
   } else {
     return true;


### PR DESCRIPTION
## Done

- fix(isServerClustered): fix after unifying clustered and unclustered

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI
