### PR TITLE
fix(symlinks): [WD-37466] Fix Symlinks behaviour

### DIFF
--- a/src/api/instances.tsx
+++ b/src/api/instances.tsx
@@ -562,7 +562,8 @@ export const fetchInstanceDirectory = async (
 ): Promise<LxdFileExplorerItem> => {
   const params = new URLSearchParams();
   params.set("project", project);
-  params.set("path", path);
+  const normalizedPath = path.endsWith("/") ? path : path + "/";
+  params.set("path", normalizedPath);
 
   return fetch(
     `${ROOT_PATH}/1.0/instances/${encodeURIComponent(name)}/files?${params.toString()}`,
@@ -601,6 +602,23 @@ export const fetchInstanceFileHeader = async (
       modified: response.headers.get("x-lxd-modified") ?? "-",
     };
   });
+};
+
+export const fetchSymlinkContent = async (
+  instanceName: string,
+  project: string,
+  path: string,
+): Promise<string> => {
+  const params = new URLSearchParams();
+  params.set("project", project);
+  params.set("path", path);
+
+  return fetch(
+    `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instanceName)}/files?${params.toString()}`,
+    {
+      method: "GET",
+    },
+  ).then(handleTextResponse);
 };
 
 export const deleteInstanceFile = async (

--- a/src/pages/instances/FileExplorerDirectory.tsx
+++ b/src/pages/instances/FileExplorerDirectory.tsx
@@ -2,15 +2,14 @@ import { Icon } from "@canonical/react-components";
 import type { FC } from "react";
 import { Link } from "react-router-dom";
 import type { LxdInstance } from "types/instance";
-import { getFileExplorerDirectoryURL } from "util/instances";
+import { getFileExplorerDirectoryURL, getFullPath } from "util/instances";
 
 const FileExplorerDirectory: FC<{
   dirName: string;
   parentPath: string;
   instance: LxdInstance;
 }> = ({ dirName, parentPath, instance }) => {
-  const fullPath =
-    parentPath === "/" ? `/${dirName}` : `${parentPath}/${dirName}`;
+  const fullPath = getFullPath(parentPath, dirName);
 
   return (
     <Link

--- a/src/pages/instances/FileExplorerFile.tsx
+++ b/src/pages/instances/FileExplorerFile.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Icon } from "@canonical/react-components";
-import { getFileExplorerFileURL } from "util/instances";
+import { getFileExplorerURL } from "util/instances";
 import type { LxdInstance } from "types/instance";
 
 const FileExplorerFile: FC<{
@@ -11,7 +11,7 @@ const FileExplorerFile: FC<{
 }> = ({ fileName, parentPath, instance, icon }) => {
   return (
     <a
-      href={getFileExplorerFileURL(parentPath, fileName, instance)}
+      href={getFileExplorerURL(parentPath, fileName, instance)}
       download={fileName}
       className="file-explorer-item"
     >

--- a/src/pages/instances/FileExplorerSymlink.tsx
+++ b/src/pages/instances/FileExplorerSymlink.tsx
@@ -1,0 +1,117 @@
+import { type FC, useState } from "react";
+import {
+  Button,
+  Icon,
+  Spinner,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useNavigate } from "react-router-dom";
+import type { LxdInstance } from "types/instance";
+import { fetchSymlinkContent, fetchInstanceFileHeader } from "api/instances";
+import {
+  getFileExplorerDirectoryURL,
+  getFileExplorerURL,
+  getFullPath,
+  resolveSymlinkTarget,
+} from "util/instances";
+
+const MAX_SYMLINK_DEPTH = 10;
+
+interface Props {
+  fileName: string;
+  parentPath: string;
+  instance: LxdInstance;
+}
+
+const isValidSymlinkTarget = (target: string): boolean => {
+  return target.length > 0 && target.length <= 4096 && !target.includes("\0");
+};
+
+const FileExplorerSymlink: FC<Props> = ({ fileName, parentPath, instance }) => {
+  const navigate = useNavigate();
+  const toastNotify = useToastNotification();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fullPath = getFullPath(parentPath, fileName);
+
+  const handleSymlink = async (
+    path: string,
+    depth = 0,
+    originalPath?: string,
+  ) => {
+    const navigatePath = originalPath ?? path;
+    if (depth >= MAX_SYMLINK_DEPTH) {
+      toastNotify.failure(
+        "Symlink resolution failed",
+        new Error("Too many levels of symbolic link nesting"),
+      );
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const target = await fetchSymlinkContent(
+        instance.name,
+        instance.project,
+        path,
+      );
+
+      const trimmedTarget = target.trim();
+
+      if (!isValidSymlinkTarget(trimmedTarget)) {
+        toastNotify.failure(
+          "Symlink resolution failed",
+          new Error("Invalid symlink target"),
+        );
+        return;
+      }
+
+      const resolvedTarget = resolveSymlinkTarget(trimmedTarget, path);
+      const metadata = await fetchInstanceFileHeader(
+        instance.name,
+        instance.project,
+        resolvedTarget,
+      );
+
+      if (metadata.type === "directory") {
+        navigate(getFileExplorerDirectoryURL(navigatePath, instance));
+      } else if (metadata.type === "symlink") {
+        await handleSymlink(resolvedTarget, depth + 1, navigatePath);
+      } else {
+        const url = getFileExplorerURL(resolvedTarget, undefined, instance);
+
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      }
+    } catch (error) {
+      toastNotify.failure(
+        "Symlink resolution failed",
+        error instanceof Error ? error : new Error("Failed to resolve symlink"),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      className="file-explorer-item u-no-margin--bottom"
+      appearance="link"
+      onClick={() => {
+        void handleSymlink(fullPath);
+      }}
+      disabled={isLoading}
+    >
+      {isLoading ? <Spinner /> : <Icon name="connected" />}
+      <span className="file-explorer-item__name" title={fileName}>
+        {fileName}
+      </span>
+    </Button>
+  );
+};
+
+export default FileExplorerSymlink;

--- a/src/pages/instances/getFileExplorerTableRow.tsx
+++ b/src/pages/instances/getFileExplorerTableRow.tsx
@@ -2,6 +2,7 @@ import { isoTimeToString } from "util/helpers";
 import { fetchInstanceFileHeader } from "api/instances";
 import FileExplorerDirectory from "./FileExplorerDirectory";
 import FileExplorerFile from "./FileExplorerFile";
+import FileExplorerSymlink from "./FileExplorerSymlink";
 import FileExplorerActions from "./actions/FileExplorerActions";
 import type { LxdInstance } from "types/instance";
 import { useQuery } from "@tanstack/react-query";
@@ -28,9 +29,9 @@ const getFileExplorerTableRow = (
       fetchInstanceFileHeader(instance.name, instance.project, fullPath),
   });
 
-  const isDirectory = metadata?.type === "directory";
-  const isFile = metadata?.type === "file";
   const fileType = metadata?.type ?? "-";
+  const isDirectory = fileType === "directory";
+  const isSymlink = fileType === "symlink";
   const fileModified = metadata?.modified
     ? isoTimeToString(metadata.modified)
     : "-";
@@ -45,12 +46,18 @@ const getFileExplorerTableRow = (
             parentPath={parentPath}
             instance={instance}
           />
+        ) : isSymlink ? (
+          <FileExplorerSymlink
+            fileName={fileName}
+            parentPath={parentPath}
+            instance={instance}
+          />
         ) : (
           <FileExplorerFile
             fileName={fileName}
             parentPath={parentPath}
             instance={instance}
-            icon={isFile ? "file-blank" : "pods"}
+            icon="file-blank"
           />
         ),
         role: "rowheader",

--- a/src/util/instances.tsx
+++ b/src/util/instances.tsx
@@ -97,18 +97,21 @@ export const getFileExplorerDirectoryURL = (
   return `${ROOT_PATH}/ui/project/${encodeURIComponent(instance.project)}/instance/${encodeURIComponent(instance.name)}/file-explorer?${params.toString()}`;
 };
 
-export const getFileExplorerFileURL = (
+export const getFileExplorerURL = (
   parentPath: string,
-  fileName: string,
+  fileName: string | undefined,
   instance: LxdInstance,
 ) => {
   const params = new URLSearchParams();
   params.set("project", instance.project);
-  params.set(
-    "path",
-    parentPath === "/" ? `/${fileName}` : `${parentPath}/${fileName}`,
-  );
 
+  if (!fileName) {
+    params.set("path", parentPath);
+    return `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instance.name)}/files?${params.toString()}`;
+  }
+
+  const path = getFullPath(parentPath, fileName);
+  params.set("path", path);
   return `${ROOT_PATH}/1.0/instances/${encodeURIComponent(instance.name)}/files?${params.toString()}`;
 };
 
@@ -127,4 +130,30 @@ export const validateDirectoryPathSyntax = (
   }
 
   return undefined;
+};
+
+export const getFullPath = (parentPath: string, fileName: string): string => {
+  return parentPath === "/" ? `/${fileName}` : `${parentPath}/${fileName}`;
+};
+
+export const resolveSymlinkTarget = (
+  target: string,
+  currentPath: string,
+): string => {
+  if (target.startsWith("/")) {
+    return target;
+  }
+  const parentDir =
+    currentPath.substring(0, currentPath.lastIndexOf("/")) || "/";
+  const combined = getFullPath(parentDir, target);
+  const parts = combined.split("/");
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === "..") {
+      resolved.pop();
+    } else if (part !== "." && part !== "") {
+      resolved.push(part);
+    }
+  }
+  return "/" + resolved.join("/");
 };


### PR DESCRIPTION
## Done

- [x] Introduces new Symlinks component
- [x] Symlinks should now be recursive and clicking on them should redirect to the folder. Note that some symlinks redirect to files.
  - For me, root/dev/fd is a symlink that redirects
  - Root/lib/libc.musl-x86_64.so.1 is a symlink that downloads a file 
- [x] Max depth of symlinks included
- [x] Error cases and validation included
- [x] Consistent styling (links, icons)

**PR Still in progress but early insights would be appreciated**

Fixes: https://github.com/canonical/lxd-ui/issues/2109

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Observe new Symlink functionality, including icons and redirection for directories and downloads for symlinks referring to files.

## Screenshots

<img width="1561" height="309" alt="image" src="https://github.com/user-attachments/assets/358a5316-eb2b-436d-af6f-c76156964169" />