### PR TITLE
feat(Identities): group selection for token bearer identities

### DIFF
--- a/src/components/IdentityResource.tsx
+++ b/src/components/IdentityResource.tsx
@@ -1,26 +1,37 @@
 import type { FC } from "react";
+import ResourceLabel from "components/ResourceLabel";
+import ResourceLink from "components/ResourceLink";
 import type { LxdIdentity } from "types/permissions";
-import ResourceLabel from "./ResourceLabel";
-import { AUTH_METHOD } from "util/authentication";
+import { getIdentityIconType } from "util/permissionIdentities";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   identity: LxdIdentity;
-  truncate?: boolean;
-  bold?: boolean;
+  variant?: "link" | "label";
 }
 
-const IdentityResource: FC<Props> = ({ identity, truncate, bold }) => {
-  const identityIconType =
-    identity.authentication_method == AUTH_METHOD.TLS
-      ? "certificate"
-      : "oidc-identity";
+const IdentityResource: FC<Props> = ({ identity, variant = "link" }) => {
+  const name = identity.name?.trim();
+  const label = name
+    ? `${name} (${identity.type}, ${identity.id})`
+    : `${identity.id} (${identity.type})`;
+
+  if (variant === "label") {
+    return (
+      <ResourceLabel
+        type={getIdentityIconType(identity.type)}
+        value={label}
+        bold
+        truncate
+      />
+    );
+  }
 
   return (
-    <ResourceLabel
-      type={identityIconType}
-      value={identity.type}
-      truncate={truncate}
-      bold={bold}
+    <ResourceLink
+      type={getIdentityIconType(identity.type)}
+      value={label}
+      to={`${ROOT_PATH}/ui/permissions/identities`}
     />
   );
 };

--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -32,7 +32,8 @@ export type ResourceIconType =
   | "device"
   | "setting"
   | "peering"
-  | "replicator";
+  | "replicator"
+  | "token-bearer";
 
 const resourceIcons: Record<ResourceIconType, string> = {
   container: "pods",
@@ -66,6 +67,7 @@ const resourceIcons: Record<ResourceIconType, string> = {
   metric: "statistics",
   "placement-group": "repository",
   replicator: "change-version",
+  "token-bearer": "private-key",
 };
 
 interface Props {

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -34,11 +34,13 @@ import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { isUnrestricted, pluralize } from "util/helpers";
 import { useIdentities } from "context/useIdentities";
 import { useIdentityEntitlements } from "util/entitlements/identities";
-import { getIdentityName } from "util/permissionIdentities";
+import {
+  getIdentityIconType,
+  getIdentityName,
+} from "util/permissionIdentities";
 import CreateTLSIdentity from "pages/permissions/CreateTLSIdentity";
 import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesActions";
 import ResourceLabel from "components/ResourceLabel";
-import type { ResourceIconType } from "components/ResourceIcon";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -141,22 +143,6 @@ const PermissionIdentities: FC = () => {
     };
     const name = getIdentityName(identity);
 
-    const getType = (): ResourceIconType => {
-      if (identity.type.startsWith("Client certificate")) {
-        return "certificate";
-      }
-      if (identity.type.startsWith("OIDC client")) {
-        return "oidc-identity";
-      }
-      if (identity.type.startsWith("Server certificate")) {
-        return "cluster-member";
-      }
-      if (identity.type.startsWith("Metrics certificate")) {
-        return "metric";
-      }
-      return "certificate";
-    };
-
     return {
       key: identity.id,
       name: isUnrestricted(identity) ? "" : identity.id,
@@ -165,7 +151,10 @@ const PermissionIdentities: FC = () => {
         {
           content: (
             <>
-              <ResourceLabel type={getType()} value={name} />{" "}
+              <ResourceLabel
+                type={getIdentityIconType(identity.type)}
+                value={name}
+              />{" "}
               <Tag isVisible={isLoggedInIdentity}>You</Tag>
             </>
           ),

--- a/src/pages/permissions/actions/DeleteIdentityBtn.tsx
+++ b/src/pages/permissions/actions/DeleteIdentityBtn.tsx
@@ -9,13 +9,13 @@ import {
 } from "@canonical/react-components";
 import type { LxdIdentity } from "types/permissions";
 import { deleteIdentity } from "api/auth-identities";
-import { useIdentityEntitlements } from "util/entitlements/identities";
 import LoggedInUserNotification from "pages/permissions/panels/LoggedInUserNotification";
+import IdentityResource from "components/IdentityResource";
 import { useSettings } from "context/useSettings";
-import { logoutOidc } from "util/helpers";
-import ResourceLabel from "components/ResourceLabel";
-import { AUTH_METHOD } from "util/authentication";
 import { useAuth } from "context/auth";
+import { AUTH_METHOD } from "util/authentication";
+import { useIdentityEntitlements } from "util/entitlements/identities";
+import { logoutOidc } from "util/helpers";
 
 interface Props {
   identity: LxdIdentity;
@@ -53,13 +53,7 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
         });
         toastNotify.success(
           <>
-            Identity{" "}
-            <ResourceLabel
-              type="certificate"
-              value={identity.name}
-              bold
-              truncate
-            />{" "}
+            Identity <IdentityResource identity={identity} variant="label" />{" "}
             deleted.
           </>,
         );
@@ -71,12 +65,7 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
         notify.failure(
           `Identity deletion failed`,
           e,
-          <ResourceLabel
-            type="certificate"
-            value={identity.name}
-            bold
-            truncate
-          />,
+          <IdentityResource identity={identity} variant="label" />,
         );
       });
   };
@@ -98,7 +87,7 @@ const DeleteIdentityBtn: FC<Props> = ({ identity }) => {
             <LoggedInUserNotification isVisible={isSelf} />
             <p>
               This will permanently delete identity{" "}
-              <ResourceLabel type="certificate" value={identity.name} bold />
+              <IdentityResource identity={identity} variant="label" />
               .
               <br />
               This action cannot be undone, and can result in data loss.

--- a/src/pages/permissions/panels/IdentityGroupsPanelConfirmModal.tsx
+++ b/src/pages/permissions/panels/IdentityGroupsPanelConfirmModal.tsx
@@ -14,9 +14,8 @@ import GroupsOrIdentityChangesTable from "./GroupOrIdentityChangesTable";
 import { updateIdentities } from "api/auth-identities";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
+import IdentityResource from "components/IdentityResource";
 import usePanelParams from "util/usePanelParams";
-import ResourceLink from "components/ResourceLink";
-import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   onConfirm: () => void;
@@ -74,21 +73,27 @@ const IdentityGroupsPanelConfirmModal: FC<Props> = ({
           },
         });
 
-        const modifiedGroupNames = Object.keys(identityGroupsChangeSummary);
-        const successMessage =
-          modifiedGroupNames.length > 1 ? (
-            `Updated groups for ${modifiedGroupNames.length} identities.`
-          ) : (
-            <>
-              Updated groups for{" "}
-              <ResourceLink
-                type="oidc-identity"
-                value={modifiedGroupNames[0]}
-                to={`${ROOT_PATH}/ui/permissions/identities`}
-              />
-              .
-            </>
-          );
+        const modifiedIdentityIds = Object.keys(identityGroupsChangeSummary);
+        const isMultiple = modifiedIdentityIds.length > 1;
+        const [firstId, firstData] =
+          Object.entries(identityGroupsChangeSummary)[0] || [];
+        const firstIdentityDetails = selectedIdentities.find(
+          (id) => id.id === firstId,
+        );
+
+        const successMessage = isMultiple ? (
+          `Updated groups for ${modifiedIdentityIds.length} identities.`
+        ) : (
+          <>
+            Updated groups for{" "}
+            {firstIdentityDetails ? (
+              <IdentityResource identity={firstIdentityDetails} />
+            ) : (
+              firstData?.name?.trim() || firstId
+            )}
+            .
+          </>
+        );
 
         toastNotify.success(successMessage);
         panelParams.clear();

--- a/src/types/permissions.d.ts
+++ b/src/types/permissions.d.ts
@@ -10,9 +10,14 @@ export interface LxdIdentity {
     | "Cluster link certificate (pending)"
     | "Metrics certificate (unrestricted)"
     | "OIDC client"
-    | "Server certificate";
+    | "Client token bearer"
+    | "Server certificate"
+    | "DevLXD token bearer";
   name: string;
-  authentication_method: typeof AUTH_METHOD.TLS | typeof AUTH_METHOD.OIDC;
+  authentication_method:
+    | typeof AUTH_METHOD.TLS
+    | typeof AUTH_METHOD.OIDC
+    | typeof AUTH_METHOD.BEARER;
   tls_certificate: string;
   groups?: string[] | null;
   effective_groups?: string[];
@@ -27,6 +32,7 @@ export interface LxdAuthGroup {
   description: string;
   permissions?: LxdPermission[];
   identities?: {
+    bearer?: string[];
     oidc?: string[];
     tls?: string[];
   };

--- a/src/util/permissionIdentities.spec.ts
+++ b/src/util/permissionIdentities.spec.ts
@@ -11,21 +11,27 @@ describe("Permissions util functions for identities page", () => {
     const groups = [
       {
         name: "group-1",
+        description: "",
         identities: {
+          bearer: [],
           oidc: ["user-1"],
           tls: ["user-2"],
         },
       },
       {
         name: "group-2",
+        description: "",
         identities: {
+          bearer: ["user-4"],
           oidc: ["user-1", "user-3"],
           tls: ["user-2"],
         },
       },
       {
         name: "group-3",
+        description: "",
         identities: {
+          bearer: [],
           oidc: [],
           tls: [],
         },
@@ -53,6 +59,46 @@ describe("Permissions util functions for identities page", () => {
     expect(groupsForAllIdentities).toEqual(["group-2"]);
     expect(groupsForSomeIdentities).toEqual(["group-1"]);
     expect(groupsForNoIdentities).toEqual(["group-3"]);
+  });
+
+  it("getGroupsForIdentities includes bearer identities", () => {
+    const groups = [
+      {
+        name: "admins",
+        description: "",
+        identities: {
+          bearer: ["token-user"],
+          oidc: [],
+          tls: [],
+        },
+      },
+      {
+        name: "viewers",
+        description: "",
+        identities: {
+          bearer: [],
+          oidc: [],
+          tls: [],
+        },
+      },
+    ] as LxdAuthGroup[];
+
+    const identities = [
+      {
+        id: "token-user",
+        authentication_method: "bearer",
+      },
+    ] as LxdIdentity[];
+
+    const {
+      groupsForAllIdentities,
+      groupsForSomeIdentities,
+      groupsForNoIdentities,
+    } = getGroupsForIdentities(groups, identities);
+
+    expect(groupsForAllIdentities).toEqual(["admins"]);
+    expect(groupsForSomeIdentities).toEqual([]);
+    expect(groupsForNoIdentities).toEqual(["viewers"]);
   });
 
   it("generateGroupAllocationsForIdentities", () => {

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -1,3 +1,4 @@
+import type { ResourceIconType } from "components/ResourceIcon";
 import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
 
 export type ChangeSummary = Record<
@@ -6,9 +7,10 @@ export type ChangeSummary = Record<
 >;
 
 export const getIdentityIdsForGroup = (group?: LxdAuthGroup): string[] => {
+  const bearerIdentityIds = group?.identities?.bearer || [];
   const oidcIdentityIds = group?.identities?.oidc || [];
   const tlsIdentityIds = group?.identities?.tls || [];
-  return [...oidcIdentityIds, ...tlsIdentityIds];
+  return [...bearerIdentityIds, ...oidcIdentityIds, ...tlsIdentityIds];
 };
 
 // Given a set of lxd groups and some identities
@@ -179,4 +181,30 @@ export const getIdentityName = (identity?: LxdIdentity): string => {
     return "";
   }
   return identity.name.length > 0 ? identity.name : identity.id;
+};
+
+export const getIdentityIconType = (
+  identityType: LxdIdentity["type"],
+): ResourceIconType => {
+  if (identityType.startsWith("Server certificate")) {
+    return "cluster-member";
+  }
+
+  if (identityType.startsWith("Cluster link certificate")) {
+    return "cluster-link";
+  }
+
+  if (identityType.startsWith("Metrics certificate")) {
+    return "metric";
+  }
+
+  if (identityType.startsWith("OIDC client")) {
+    return "oidc-identity";
+  }
+
+  if (identityType.toLowerCase().includes("token bearer")) {
+    return "token-bearer";
+  }
+
+  return "certificate";
 };

--- a/tests/permission-identities.spec.ts
+++ b/tests/permission-identities.spec.ts
@@ -47,7 +47,10 @@ test("manage groups for single identity", async ({ page, lxdVersion }) => {
     "added",
   );
   await page.getByRole("button", { name: "Confirm changes" }).click();
-  await dismissNotification(page, `Updated groups for ${identityBar}.`);
+  await dismissNotification(
+    page,
+    `Updated groups for bar (OIDC client, ${identityBar}).`,
+  );
   await page
     .getByRole("row", { name: `Select ${identityBar} Name ID` })
     .getByLabel("Manage groups")


### PR DESCRIPTION
## Done

- feat(Identities): group selection for token bearer identities
- Update success notification after updating the groups to display the name of the identity, the type and the ID.
- Update modal and success notification when deleting an identity to display the name of the identity, the type and the ID.
- 
## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create two identities with the CLI
    ```
    lxc auth identity create devlxd/csi-driver --group admins
    lxc auth identity show bearer/terraform-bot
    ```
    - Go to Permissions > Identities. Make sure the two identities are correctly shown in the table, with the correct group count.
    - Click on the group icon to open the side panel. Make sure "admins" is selected.
    - Remove and/or add groups and save. Make sure the success notification displays the name of the identity, the type and the ID.
    - Make sure the identity is saved correctly. You can double check with the CLI `lxc auth identity show bearer/terraform-bot`

## Screenshots

<img width="1577" height="1054" alt="image" src="https://github.com/user-attachments/assets/d5b91b02-165b-4828-b155-740e3af1edb4" />

After adding a group to csi-driver
<img width="1580" height="281" alt="image" src="https://github.com/user-attachments/assets/175a01f5-9319-45f9-927e-85d19ea4ecca" />
<img width="1580" height="76" alt="image" src="https://github.com/user-attachments/assets/c6c06fa3-9b29-4ed1-9792-609f4c9ffbc3" />

Success notification
<img width="833" height="274" alt="image" src="https://github.com/user-attachments/assets/40ccacbd-8ee4-4ac7-bce3-1092d268603e" />

Delete modal
<img width="838" height="312" alt="image" src="https://github.com/user-attachments/assets/09b7d653-7135-4af8-9f34-fe0a8a72157f" />

Success notification of deletion
<img width="815" height="266" alt="image" src="https://github.com/user-attachments/assets/ccc9080b-820c-402b-8bdf-37d11a96a1a8" />
