### PR TITLE
feat(devices): additional disk device options

### DIFF
--- a/src/components/forms/DiskDeviceFormCustom.tsx
+++ b/src/components/forms/DiskDeviceFormCustom.tsx
@@ -1,7 +1,16 @@
 import type { FC } from "react";
-import { Button, Icon, Input, Label } from "@canonical/react-components";
+import {
+  Button,
+  Icon,
+  Input,
+  Label,
+  Select,
+} from "@canonical/react-components";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
-import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
+import type {
+  CreateInstanceFormValues,
+  EditInstanceFormValues,
+} from "types/forms/instanceAndProfile";
 import CustomVolumeSelectBtn from "pages/storage/CustomVolumeSelectBtn";
 import type {
   CustomDiskDevice,
@@ -33,11 +42,19 @@ import {
 } from "util/devices";
 import { isInstanceCreation } from "util/instanceEdit";
 import { ensureEditMode } from "util/editMode";
-import { focusField } from "util/formFields";
+import { focusField, optionRenderer } from "util/formFields";
 import AttachDiskDeviceBtn from "pages/storage/AttachDiskDeviceBtn";
 import type { LxdProfile } from "types/profile";
 import type { LxdStorageVolume } from "types/storage";
 import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
+import { optionYesNo } from "util/options";
+import {
+  getConfigFieldDefault,
+  getConfigFieldDescription,
+  toConfigFields,
+} from "util/config";
+import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
+import { useConfigOptions } from "context/useConfigOptions";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -49,6 +66,33 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
   const readOnly = (formik.values as EditInstanceFormValues).readOnly;
   const existingDeviceNames = getExistingDeviceNames(formik.values, profiles);
   const isProfile = formik.values.entityType === "profile";
+  const { data: configOptions } = useConfigOptions();
+
+  const diskOptions = configOptions?.configs?.["device-disk"];
+  const diskConfigFields = diskOptions ? toConfigFields(diskOptions) : [];
+
+  const diskFieldLabel = ({
+    id,
+    label,
+    key,
+    required = false,
+  }: {
+    id: string;
+    label: string;
+    key: string;
+    required?: boolean;
+  }) => (
+    <div className="configuration-label-with-help">
+      <Label forId={id} required={required}>
+        {label}
+      </Label>
+      <span className="configuration-help">
+        <ConfigFieldDescription
+          description={getConfigFieldDescription(diskConfigFields, key)}
+        />
+      </span>
+    </div>
+  );
 
   const getInitialDeviceName = (
     deviceType: string,
@@ -89,7 +133,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
       formik.setFieldValue(`devices.${index}.path`, "");
     }
 
-    // If path must not exist for the device, remote it even if it's set for the existing device
+    // If path must not exist for the device, remove it even if it's set for the existing device
     if (volume.content_type === "block") {
       formik.setFieldValue(`devices.${index}.path`, undefined);
     }
@@ -111,6 +155,41 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
       <Icon name="edit" />
     </Button>
   );
+
+  const readOnlyYesNoValue = (
+    fieldName: string,
+    value: string | undefined,
+    option: string,
+  ) => {
+    const displayValue =
+      value ?? getConfigFieldDefault(diskConfigFields, option);
+
+    return (
+      <div className="custom-disk-read-mode">
+        <div className="custom-disk-value">
+          <b>{optionRenderer(displayValue, optionYesNo) || "-"}</b>
+        </div>
+        {editButton(fieldName)}
+      </div>
+    );
+  };
+
+  const getYesNoOptionsWithLxdDefault = (fieldKey: string) => {
+    const defaultValue = getConfigFieldDefault(diskConfigFields, fieldKey);
+    const defaultLabel = optionRenderer(defaultValue, optionYesNo);
+    const placeholderLabel = defaultLabel
+      ? `LXD default (${defaultLabel})`
+      : "LXD default";
+
+    return optionYesNo.map((option, index) =>
+      index === 0
+        ? {
+            ...option,
+            label: placeholderLabel,
+          }
+        : option,
+    );
+  };
 
   const rows: MainTableRow[] = [];
   let customDiskDeviceCount = 0;
@@ -151,7 +230,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
       rows.push(
         getConfigurationRowBase({
           className: "no-border-top has-margin-left",
-          configuration: <div className="u-text--muted">Source</div>,
+          configuration: <div>Source</div>,
           inherited: (
             <b className="mono-font">{(item as IsoVolumeDevice).source}</b>
           ),
@@ -161,7 +240,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
       rows.push(
         getConfigurationRowBase({
           className: "no-border-top has-margin-left",
-          configuration: <div className="u-text--muted">Pool</div>,
+          configuration: <div>Pool</div>,
           inherited: (
             <StoragePoolRichChip
               poolName={(item as IsoVolumeDevice).pool}
@@ -209,9 +288,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
 
       const volumeDeviceSource = () =>
         getConfigurationRowBase({
-          className: classnames("no-border-top inherited-with-form", {
-            "device-last-row": isVolumeDevice(item) && item.path === undefined,
-          }),
+          className: classnames("no-border-top inherited-with-form"),
           configuration: (
             <Label forId={`devices.${index}.pool`} className="u-text--muted">
               Pool / volume
@@ -253,9 +330,7 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
 
       const hostDeviceSource = () =>
         getConfigurationRowBase({
-          className: classnames("no-border-top inherited-with-form", {
-            "device-last-row": !isVolumeDevice(item) && item.path === undefined,
-          }),
+          className: classnames("no-border-top inherited-with-form"),
           configuration: (
             <Label forId={`devices.${index}.source`} className="u-text--muted">
               Host path
@@ -286,20 +361,33 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
           override: "",
         });
 
+      const isContainerOrProfile =
+        isProfile ||
+        (formik.values as CreateInstanceFormValues).instanceType ===
+          "container";
+      const isVolumeBackedDisk = isVolumeDevice(item);
+      const isReadonlyDisk = item.readonly === "true";
+      const isRecursiveDisk = item.recursive === "true";
+      const showMountPointField =
+        !isVolumeBackedDisk || item.path !== undefined;
+      const showRecursiveField = !isVolumeBackedDisk;
+      const showShiftField = isContainerOrProfile && !isVolumeBackedDisk;
+      const isRequiredLastRow = !showShiftField;
+
       rows.push(
         isVolumeDevice(item) ? volumeDeviceSource() : hostDeviceSource(),
       );
 
-      if (!isVolumeDevice(item) || item.path !== undefined) {
+      if (showMountPointField) {
         const hasError = isDiskDeviceMountPointMissing(formik, index);
         rows.push(
           getConfigurationRowBase({
-            className: "no-border-top inherited-with-form device-last-row",
+            className: "no-border-top inherited-with-form",
             configuration: (
               <Label
                 forId={`devices.${index}.path`}
-                required
                 className="u-text--muted"
+                required
               >
                 Mount point
               </Label>
@@ -324,6 +412,176 @@ const DiskDeviceFormCustom: FC<Props> = ({ formik, project, profiles }) => {
                 placeholder="Enter full path (e.g. /data)"
                 className={hasError ? undefined : "u-no-margin--bottom"}
                 error={hasError ? "Path is required" : undefined}
+              />
+            ),
+            override: "",
+          }),
+        );
+      }
+
+      rows.push(
+        getConfigurationRowBase({
+          className: "no-border-top inherited-with-form",
+          configuration: diskFieldLabel({
+            id: `devices.${index}.readonly`,
+            label: "Read-only",
+            key: "readonly",
+          }),
+          inherited: readOnly ? (
+            readOnlyYesNoValue(
+              `devices.${index}.readonly`,
+              item.readonly,
+              "readonly",
+            )
+          ) : (
+            <Select
+              id={`devices.${index}.readonly`}
+              name={`devices.${index}.readonly`}
+              onBlur={formik.handleBlur}
+              onChange={(e) => {
+                ensureEditMode(formik);
+                const value = e.target.value || undefined;
+                formik.setFieldValue(`devices.${index}.readonly`, value);
+
+                // The kernel does not support recursive read-only bind mounts.
+                if (value === "true") {
+                  formik.setFieldValue(`devices.${index}.recursive`, undefined);
+                }
+              }}
+              value={item.readonly ?? ""}
+              options={getYesNoOptionsWithLxdDefault("readonly")}
+              className="u-no-margin--bottom"
+              disabled={!!formik.values.editRestriction || isRecursiveDisk}
+              title={
+                formik.values.editRestriction ??
+                (isRecursiveDisk
+                  ? "Cannot set read-only with recursive bind mounts"
+                  : undefined)
+              }
+            />
+          ),
+          override: "",
+        }),
+      );
+
+      if (showRecursiveField) {
+        rows.push(
+          getConfigurationRowBase({
+            className: "no-border-top inherited-with-form",
+            configuration: diskFieldLabel({
+              id: `devices.${index}.recursive`,
+              label: "Recursive",
+              key: "recursive",
+            }),
+            inherited: readOnly ? (
+              readOnlyYesNoValue(
+                `devices.${index}.recursive`,
+                item.recursive,
+                "recursive",
+              )
+            ) : (
+              <Select
+                id={`devices.${index}.recursive`}
+                name={`devices.${index}.recursive`}
+                onBlur={formik.handleBlur}
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  const value = e.target.value || undefined;
+                  formik.setFieldValue(`devices.${index}.recursive`, value);
+
+                  // The kernel does not support recursive read-only bind mounts.
+                  if (value === "true") {
+                    formik.setFieldValue(
+                      `devices.${index}.readonly`,
+                      undefined,
+                    );
+                  }
+                }}
+                value={item.recursive ?? ""}
+                options={getYesNoOptionsWithLxdDefault("recursive")}
+                className="u-no-margin--bottom"
+                disabled={!!formik.values.editRestriction || isReadonlyDisk}
+                title={
+                  formik.values.editRestriction ??
+                  (isReadonlyDisk
+                    ? "Recursive read-only bind mounts are not supported"
+                    : undefined)
+                }
+              />
+            ),
+            override: "",
+          }),
+        );
+      }
+
+      rows.push(
+        getConfigurationRowBase({
+          className: classnames("no-border-top inherited-with-form", {
+            "device-last-row": isRequiredLastRow,
+          }),
+          configuration: diskFieldLabel({
+            id: `devices.${index}.required`,
+            label: "Required",
+            key: "required",
+          }),
+          inherited: readOnly ? (
+            readOnlyYesNoValue(
+              `devices.${index}.required`,
+              item.required,
+              "required",
+            )
+          ) : (
+            <Select
+              id={`devices.${index}.required`}
+              name={`devices.${index}.required`}
+              onBlur={formik.handleBlur}
+              onChange={(e) => {
+                ensureEditMode(formik);
+                formik.setFieldValue(
+                  `devices.${index}.required`,
+                  e.target.value || undefined,
+                );
+              }}
+              value={item.required ?? ""}
+              options={getYesNoOptionsWithLxdDefault("required")}
+              className="u-no-margin--bottom"
+              disabled={!!formik.values.editRestriction}
+              title={formik.values.editRestriction}
+            />
+          ),
+          override: "",
+        }),
+      );
+
+      // The "shift" property cannot be used with custom storage volumes or VMs
+      if (showShiftField) {
+        rows.push(
+          getConfigurationRowBase({
+            className: "no-border-top inherited-with-form device-last-row",
+            configuration: diskFieldLabel({
+              id: `devices.${index}.shift`,
+              label: "Shift",
+              key: "shift",
+            }),
+            inherited: readOnly ? (
+              readOnlyYesNoValue(`devices.${index}.shift`, item.shift, "shift")
+            ) : (
+              <Select
+                id={`devices.${index}.shift`}
+                name={`devices.${index}.shift`}
+                onBlur={formik.handleBlur}
+                onChange={(e) => {
+                  ensureEditMode(formik);
+                  formik.setFieldValue(
+                    `devices.${index}.shift`,
+                    e.target.value || undefined,
+                  );
+                }}
+                value={item.shift ?? ""}
+                options={getYesNoOptionsWithLxdDefault("shift")}
+                className="u-no-margin--bottom"
+                disabled={!!formik.values.editRestriction}
+                title={formik.values.editRestriction}
               />
             ),
             override: "",

--- a/src/components/forms/DiskDeviceFormInherited.tsx
+++ b/src/components/forms/DiskDeviceFormInherited.tsx
@@ -2,7 +2,10 @@ import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import ConfigurationTable from "components/ConfigurationTable";
-import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
+import type {
+  CreateInstanceFormValues,
+  EditInstanceFormValues,
+} from "types/forms/instanceAndProfile";
 import { getConfigurationRowBase } from "components/ConfigurationRow";
 import type { InheritedDiskDevice } from "types/forms/configInheritance";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
@@ -18,15 +21,23 @@ import {
 } from "components/forms/InheritedDeviceRow";
 import { isInstanceCreation } from "util/instanceEdit";
 import { ensureEditMode } from "util/editMode";
+import { useConfigOptions } from "context/useConfigOptions";
+import {
+  getConfigFieldDefault,
+  getConfigFieldDescription,
+  toConfigFields,
+} from "util/config";
 import {
   getProfileFromSource,
   isHostDiskDevice,
   isIsoDiskDevice,
+  isVolumeDevice,
 } from "util/devices";
 import DeviceName from "components/forms/DeviceName";
 import { isDeviceModified } from "util/formChangeCount";
 import StoragePoolRichChip from "pages/storage/StoragePoolRichChip";
 import classnames from "classnames";
+import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -40,6 +51,21 @@ const DiskDeviceFormInherited: FC<Props> = ({
   project,
 }) => {
   const readOnly = (formik.values as EditInstanceFormValues).readOnly;
+  const { data: configOptions } = useConfigOptions();
+
+  const diskOptions = configOptions?.configs?.["device-disk"];
+  const diskConfigFields = diskOptions ? toConfigFields(diskOptions) : [];
+
+  const labelWithHelpText = (label: string, key: string) => (
+    <div className="configuration-label-with-help">
+      <span>{label}</span>
+      <span className="configuration-help">
+        <ConfigFieldDescription
+          description={getConfigFieldDescription(diskConfigFields, key)}
+        />
+      </span>
+    </div>
+  );
 
   const rows: MainTableRow[] = [];
   inheritedDiskDevices.forEach((item) => {
@@ -100,7 +126,7 @@ const DiskDeviceFormInherited: FC<Props> = ({
     if (isIsoDiskDevice(item)) {
       rows.push(
         getInheritedDeviceRow({
-          label: "Source",
+          label: labelWithHelpText("Source", "source"),
           inheritValue: item.disk.source,
           readOnly: readOnly,
           isDeactivated: isNoneDevice,
@@ -109,7 +135,7 @@ const DiskDeviceFormInherited: FC<Props> = ({
       );
       rows.push(
         getInheritedDeviceRow({
-          label: "Pool",
+          label: labelWithHelpText("Pool", "pool"),
           inheritValue: (
             <StoragePoolRichChip
               poolName={item.disk.pool ?? ""}
@@ -152,16 +178,106 @@ const DiskDeviceFormInherited: FC<Props> = ({
         );
       }
 
-      rows.push(
-        getInheritedDeviceRow({
-          label: "Mount point",
-          inheritValue: item.disk.path,
-          readOnly: readOnly,
-          isDeactivated: isNoneDevice,
-          disabledReason: formik.values.editRestriction,
-          className: "device-last-row",
-        }),
-      );
+      const isContainerOrProfile =
+        formik.values.entityType === "profile" ||
+        (formik.values as CreateInstanceFormValues).instanceType ===
+          "container";
+      const isVolumeBackedDisk = isVolumeDevice(item.disk);
+      const showMountPointField =
+        !isVolumeBackedDisk || item.disk.path !== undefined;
+      const showRecursive = !isVolumeBackedDisk;
+      const showShift = isContainerOrProfile && !isVolumeBackedDisk;
+
+      const readonlyValue =
+        item.disk.readonly ??
+        getConfigFieldDefault(diskConfigFields, "readonly");
+      const recursiveValue = showRecursive
+        ? (item.disk.recursive ??
+          getConfigFieldDefault(diskConfigFields, "recursive"))
+        : undefined;
+      const requiredValue =
+        item.disk.required ??
+        getConfigFieldDefault(diskConfigFields, "required");
+      const shiftValue = showShift
+        ? (item.disk.shift ?? getConfigFieldDefault(diskConfigFields, "shift"))
+        : undefined;
+
+      const hasReadonly = readonlyValue !== undefined;
+      const hasRecursive = recursiveValue !== undefined;
+      const hasRequired = requiredValue !== undefined;
+      const hasShift = shiftValue !== undefined;
+
+      if (showMountPointField) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: "Mount point",
+            inheritValue: item.disk.path,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+            className:
+              !hasReadonly && !hasRecursive && !hasRequired && !hasShift
+                ? "device-last-row"
+                : undefined,
+          }),
+        );
+      }
+
+      if (hasReadonly) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: labelWithHelpText("Read-only", "readonly"),
+            inheritValue: readonlyValue,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+            className:
+              !hasRecursive && !hasRequired && !hasShift
+                ? "device-last-row"
+                : undefined,
+          }),
+        );
+      }
+
+      if (hasRecursive) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: labelWithHelpText("Recursive", "recursive"),
+            inheritValue: recursiveValue,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+            className:
+              !hasRequired && !hasShift ? "device-last-row" : undefined,
+          }),
+        );
+      }
+
+      if (hasRequired) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: labelWithHelpText("Required", "required"),
+            inheritValue: requiredValue,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+            className: !hasShift ? "device-last-row" : undefined,
+          }),
+        );
+      }
+
+      if (hasShift) {
+        rows.push(
+          getInheritedDeviceRow({
+            label: labelWithHelpText("Shift", "shift"),
+            inheritValue: shiftValue,
+            readOnly: readOnly,
+            isDeactivated: isNoneDevice,
+            disabledReason: formik.values.editRestriction,
+            className: "device-last-row",
+          }),
+        );
+      }
     }
   });
 

--- a/src/components/forms/InheritedDeviceRow.tsx
+++ b/src/components/forms/InheritedDeviceRow.tsx
@@ -7,7 +7,7 @@ import ProfileRichChip from "pages/profiles/ProfileRichChip";
 
 interface Props {
   id?: string;
-  label: string;
+  label: ReactNode;
   inheritValue: ReactNode;
   inheritSource?: string;
   readOnly: boolean;
@@ -40,16 +40,14 @@ export const getInheritedDeviceRow = ({
     className: classnames("no-border-top", className),
     configuration: id ? (
       !readOnly && overrideValue ? (
-        <Label forId={id} className="u-text--muted">
-          {label}
-        </Label>
+        <Label forId={id}>{label}</Label>
       ) : (
-        <p className="p-form__label u-no-margin--bottom u-no-padding--top u-text--muted">
+        <p className="p-form__label u-no-margin--bottom u-no-padding--top">
           {label}
         </p>
       )
     ) : (
-      <div className="u-text--muted">{label}</div>
+      <div>{label}</div>
     ),
     inherited: inheritValue && (
       <div

--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
@@ -78,7 +78,7 @@ export const getNetworkDeviceRows = ({
     rows.push(
       getConfigurationRowBase({
         className: "no-border-top",
-        configuration: <div className="u-text--muted">From profile</div>,
+        configuration: <div>From profile</div>,
         inherited: sourceProfile,
         override: null,
       }),
@@ -114,7 +114,7 @@ export const getNetworkDeviceRows = ({
     rows.push(
       getConfigurationRowBase({
         className: "no-border-top",
-        configuration: <div className="u-text--muted">Network</div>,
+        configuration: <div>Network</div>,
         inherited: (
           <div>
             <NetworkRichChip
@@ -148,7 +148,7 @@ export const getNetworkDeviceRows = ({
               "device-last-row":
                 acls.length === 0 && index === activeIps.length - 1,
             }),
-            configuration: <div className="u-text--muted">{family}</div>,
+            configuration: <div>{family}</div>,
             inherited: (
               <div>
                 <b
@@ -170,9 +170,7 @@ export const getNetworkDeviceRows = ({
       rows.push(
         getConfigurationRowBase({
           className: "no-border-top",
-          configuration: (
-            <div className="u-text--muted">Access control lists</div>
-          ),
+          configuration: <div>Access control lists</div>,
           inherited: (
             <div>
               <ExpandableList
@@ -214,7 +212,7 @@ export const getNetworkDeviceRows = ({
           className: classnames("no-border-top device-last-row acl-defaults", {
             "u-text--line-through": isDetached,
           }),
-          configuration: <div className="u-text--muted"></div>,
+          configuration: <div></div>,
           inherited: (
             <div>
               <NetworkDefaultACLRead values={getDefaultEgressIngress()} />

--- a/src/components/forms/OtherDeviceForm.tsx
+++ b/src/components/forms/OtherDeviceForm.tsx
@@ -8,12 +8,9 @@ import {
   useNotify,
   Spinner,
 } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
 import type { LxdDeviceValue } from "types/device";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
-import { fetchConfigOptions } from "api/server";
-import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useConfigOptions } from "context/useConfigOptions";
 import { toConfigFields } from "util/config";
 import ConfigFieldDescription from "pages/settings/ConfigFieldDescription";
 import ScrollableForm from "components/ScrollableForm";
@@ -60,12 +57,8 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
     (formik.values as EditInstanceFormValues).instanceType ===
       "virtual-machine";
 
-  const { hasMetadataConfiguration } = useSupportedFeatures();
-
-  const { data: configOptions, isLoading: isConfigOptionsLoading } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
-  });
+  const { data: configOptions, isLoading: isConfigOptionsLoading } =
+    useConfigOptions();
 
   const {
     data: profiles = [],
@@ -234,7 +227,7 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
 
     customRows.push(
       getConfigurationRowBase({
-        className: "no-border-top inherited-with-form u-text--muted",
+        className: "no-border-top inherited-with-form",
         configuration: <Label forId={`devices.${index}.type`}>Type</Label>,
         inherited: (
           <Select
@@ -297,7 +290,7 @@ const OtherDeviceForm: FC<Props> = ({ formik, project }) => {
 
       customRows.push(
         getConfigurationRowBase({
-          className: "no-border-top inherited-with-form u-text--muted",
+          className: "no-border-top inherited-with-form",
           configuration: (
             <Label forId={key}>{deviceKeyToLabel(field.key)}</Label>
           ),

--- a/src/components/forms/ProxyDeviceForm.tsx
+++ b/src/components/forms/ProxyDeviceForm.tsx
@@ -95,7 +95,7 @@ const ProxyDeviceForm: FC<Props> = ({ formik, project }) => {
     const key = `devices.${index}.${fieldName}`;
 
     return getConfigurationRowBase({
-      className: "no-border-top inherited-with-form u-text--muted",
+      className: "no-border-top inherited-with-form",
       configuration: <Label forId={key}>{label}</Label>,
       inherited: (
         <Select

--- a/src/context/useConfigOptions.tsx
+++ b/src/context/useConfigOptions.tsx
@@ -1,0 +1,14 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { fetchConfigOptions } from "api/server";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { queryKeys } from "util/queryKeys";
+import type { LxdMetadata } from "types/config";
+
+export const useConfigOptions = (): UseQueryResult<LxdMetadata | null> => {
+  const { hasMetadataConfiguration } = useSupportedFeatures();
+
+  return useQuery({
+    queryKey: [queryKeys.configOptions],
+    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
+  });
+};

--- a/src/pages/permissions/OidcConfigurationForm.tsx
+++ b/src/pages/permissions/OidcConfigurationForm.tsx
@@ -6,15 +6,13 @@ import {
   Spinner,
   useNotify,
 } from "@canonical/react-components";
-import { useQuery } from "@tanstack/react-query";
-import { fetchConfigOptions } from "api/server";
 import NotificationRow from "components/NotificationRow";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useConfigOptions } from "context/useConfigOptions";
 import { useClusteredSettings } from "context/useClusteredSettings";
 import SsoNotification from "pages/permissions/SsoNotification";
 import { getSettingRow } from "pages/settings/SettingsRow";
 import { toConfigFields } from "util/config";
-import { queryKeys } from "util/queryKeys";
 import { getConfigFieldClusteredValue } from "util/settings";
 
 interface Props {
@@ -29,10 +27,8 @@ const OidcConfigurationForm: FC<Props> = ({ closeModal }: Props) => {
     isSettingsLoading,
     settingsError,
   } = useSupportedFeatures();
-  const { data: configOptions, isLoading: isConfigOptionsLoading } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
-  });
+  const { data: configOptions, isLoading: isConfigOptionsLoading } =
+    useConfigOptions();
   const {
     data: clusteredSettings = [],
     isLoading: isClusteredSettingsLoading,

--- a/src/pages/permissions/panels/PermissionSelector.tsx
+++ b/src/pages/permissions/panels/PermissionSelector.tsx
@@ -1,7 +1,7 @@
 import { Button, CustomSelect, useNotify } from "@canonical/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { fetchPermissions } from "api/auth-permissions";
-import { fetchConfigOptions } from "api/server";
+import { useConfigOptions } from "context/useConfigOptions";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useEffect, useRef, useState, type FC } from "react";
 import {
@@ -33,8 +33,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission, disableReason }) => {
   const [resourceType, setResourceType] = useState("");
   const [resource, setResource] = useState("");
   const [entitlement, setEntitlement] = useState("");
-  const { hasMetadataConfiguration, hasEntityTypeMetadata } =
-    useSupportedFeatures();
+  const { hasEntityTypeMetadata } = useSupportedFeatures();
   const permissionSelectorRef = useRef<HTMLDivElement>(null);
 
   // Refs for select components, these contain methods to open/close the dropdown programmatically
@@ -59,10 +58,7 @@ const PermissionSelector: FC<Props> = ({ onAddPermission, disableReason }) => {
   const imageLookup = getImageLookup(images);
   const identityNamesLookup = getIdentityNameLookup(identities);
 
-  const { data: metadata, isLoading: isMetadataLoading } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
-  });
+  const { data: metadata, isLoading: isMetadataLoading } = useConfigOptions();
 
   const isLoading = isPermissionsLoading || isMetadataLoading;
 

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -12,11 +12,10 @@ import {
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import HelpLink from "components/HelpLink";
-import { queryKeys } from "util/queryKeys";
-import { fetchConfigOptions, updateSettings } from "api/server";
-import { useQuery } from "@tanstack/react-query";
+import { updateSettings } from "api/server";
 import { toConfigFields } from "util/config";
 import PageHeader from "components/PageHeader";
+import { useConfigOptions } from "context/useConfigOptions";
 import { useSupportedFeatures } from "context/useSupportedFeatures";
 import { useServerEntitlements } from "util/entitlements/server";
 import { useClusteredSettings } from "context/useClusteredSettings";
@@ -109,10 +108,8 @@ const Settings: FC = () => {
 
   const { canEditServerConfiguration } = useServerEntitlements();
 
-  const { data: configOptions, isLoading: isConfigOptionsLoading } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
-  });
+  const { data: configOptions, isLoading: isConfigOptionsLoading } =
+    useConfigOptions();
   const { data: clusteredSettings = [], error: clusterError } =
     useClusteredSettings();
 

--- a/src/pages/storage/HostPathDeviceModal.tsx
+++ b/src/pages/storage/HostPathDeviceModal.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type FC, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type FC,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { Button, Input, Modal } from "@canonical/react-components";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
 import type { LxdDiskDevice } from "types/device";
@@ -40,6 +47,25 @@ const HostPathDeviceModal: FC<Props> = ({
     onFinish(device);
   };
 
+  const canSubmit = !!source && !!path && !formik.isSubmitting;
+
+  const handleEnterAttach = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") {
+      return;
+    }
+
+    e.preventDefault();
+
+    touchedRef.current.source = true;
+    touchedRef.current.path = true;
+
+    if (!canSubmit) {
+      return;
+    }
+
+    handleFinish();
+  };
+
   return (
     <Modal
       className="host-path-device-modal"
@@ -56,11 +82,11 @@ const HostPathDeviceModal: FC<Props> = ({
             Back
           </Button>
           <Button
-            appearance=""
+            appearance="positive"
             className="u-no-margin--bottom"
             type="button"
             loading={formik.isSubmitting}
-            disabled={!source || !path || formik.isSubmitting}
+            disabled={!canSubmit}
             onClick={handleFinish}
           >
             Attach
@@ -75,6 +101,7 @@ const HostPathDeviceModal: FC<Props> = ({
           touchedRef.current.source = true;
           setSource(e.target.value);
         }}
+        onKeyDown={handleEnterAttach}
         type="text"
         label="Host path"
         required
@@ -91,6 +118,7 @@ const HostPathDeviceModal: FC<Props> = ({
           touchedRef.current.path = true;
           setPath(e.target.value);
         }}
+        onKeyDown={handleEnterAttach}
         type="text"
         label="Mount point"
         required

--- a/src/sass/_disk_device_form.scss
+++ b/src/sass/_disk_device_form.scss
@@ -1,4 +1,17 @@
 .disk-device-form {
+  .configuration-label-with-help {
+    align-items: flex-start;
+    display: flex;
+    flex-direction: column;
+
+    .configuration-help {
+      display: block;
+      margin-bottom: 0;
+      margin-top: $sp-unit;
+      text-align: left;
+    }
+  }
+
   .custom-disk-read-mode {
     display: flex;
 

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -39,6 +39,7 @@ export interface LxdEntityEntitlements {
 export interface LxdMetadata {
   configs: {
     cluster: LxcConfigOptionCategories;
+    "device-disk": LxcConfigOptionCategories;
     instance: LxcConfigOptionCategories;
     "network-bridge": LxcConfigOptionCategories;
     "network-macvlan": LxcConfigOptionCategories;

--- a/src/types/device.d.ts
+++ b/src/types/device.d.ts
@@ -2,6 +2,10 @@ export interface LxdDiskDevice {
   name?: string;
   path?: string;
   pool?: string;
+  readonly?: string;
+  recursive?: string;
+  required?: string;
+  shift?: string;
   size?: string;
   "boot.priority"?: string;
   "size.state"?: string;

--- a/src/util/config.tsx
+++ b/src/util/config.tsx
@@ -24,6 +24,27 @@ export const toConfigFields = (
   return result;
 };
 
+export const getConfigFieldByKey = (
+  configFields: ConfigField[],
+  key: string,
+): ConfigField | undefined => {
+  return configFields.find((field) => field.key === key);
+};
+
+export const getConfigFieldDefault = (
+  configFields: ConfigField[],
+  key: string,
+): string | undefined => {
+  return getConfigFieldByKey(configFields, key)?.default || undefined;
+};
+
+export const getConfigFieldDescription = (
+  configFields: ConfigField[],
+  key: string,
+): string | undefined => {
+  return getConfigFieldByKey(configFields, key)?.shortdesc;
+};
+
 export const configDescriptionToHtml = (
   input: string,
   docBaseLink: string,

--- a/src/util/configInheritance.tsx
+++ b/src/util/configInheritance.tsx
@@ -19,10 +19,7 @@ import type {
 import type { ProjectFormValues } from "types/forms/project";
 import type { ConfigurationRowFormikValues } from "types/forms/configurationRow";
 import type { ConfigField } from "types/config";
-import { useQuery } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
-import { fetchConfigOptions } from "api/server";
-import { toConfigFields } from "util/config";
+import { getConfigFieldByKey, toConfigFields } from "util/config";
 import { getInstanceField } from "util/instanceConfigFields";
 import { useParams } from "react-router-dom";
 import { getProjectKey } from "util/projectConfigFields";
@@ -31,7 +28,7 @@ import { getVolumeKey } from "util/storageVolume";
 import { getNetworkKey, networkFormTypeToOptionKey } from "util/networks";
 import { getPoolKey, storagePoolFormDriverToOptionKey } from "./storagePool";
 import type { StoragePoolFormValues } from "types/forms/storagePool";
-import { useSupportedFeatures } from "context/useSupportedFeatures";
+import { useConfigOptions } from "context/useConfigOptions";
 import type { NetworkFormValues } from "types/forms/network";
 import { useSettings } from "context/useSettings";
 import { useProfiles } from "context/useProfiles";
@@ -74,11 +71,7 @@ export const getConfigRowMetadata = (
 };
 
 const getConfigOptions = () => {
-  const { hasMetadataConfiguration } = useSupportedFeatures();
-  const { data: configOptions } = useQuery({
-    queryKey: [queryKeys.configOptions],
-    queryFn: async () => fetchConfigOptions(hasMetadataConfiguration),
-  });
+  const { data: configOptions } = useConfigOptions();
 
   return configOptions;
 };
@@ -91,7 +84,7 @@ const getInstanceRowMetadata = (
 
   const configFields = toConfigFields(configOptions?.configs.instance ?? {});
   const configKey = getInstanceField(name);
-  const configField = configFields.find((item) => item.key === configKey);
+  const configField = getConfigFieldByKey(configFields, configKey);
 
   const { project } = useParams<{ project: string }>();
   const { data: profiles = [] } = useProfiles(project as string);
@@ -127,7 +120,7 @@ const getProjectRowMetadata = (
 
   const configFields = toConfigFields(configOptions?.configs.project ?? {});
   const configKey = getProjectKey(name);
-  const configField = configFields.find((item) => item.key === configKey);
+  const configField = getConfigFieldByKey(configFields, configKey);
 
   return getInstanceProfileProjectDefaults(values, configKey, configField);
 };
@@ -153,7 +146,7 @@ const getStorageVolumeRowMetadata = (
   const optionKey = storagePoolFormDriverToOptionKey(pool?.driver ?? "zfs");
   const configFields = toConfigFields(configOptions?.configs[optionKey] ?? {});
   const configKey = getVolumeKey(name);
-  const configField = configFields.find((item) => item.key === configKey);
+  const configField = getConfigFieldByKey(configFields, configKey);
 
   const lxdDefault = getLxdDefault(configField);
 
@@ -177,7 +170,7 @@ export const getNetworkMetadata = (
   const configFields = toConfigFields(configOptions?.configs[optionKey] ?? {});
 
   const configKey = getNetworkKey(name);
-  const configField = configFields.find((item) => item.key === configKey);
+  const configField = getConfigFieldByKey(configFields, configKey);
   const lxdDefault = getLxdDefault(configField);
   return { value: lxdDefault, source: "LXD", configField };
 };
@@ -192,7 +185,7 @@ const getStoragePoolRowMetadata = (
   const optionKey = storagePoolFormDriverToOptionKey(values.driver);
   const configFields = toConfigFields(configOptions?.configs[optionKey] ?? {});
   const configKey = getPoolKey(name);
-  const configField = configFields.find((item) => item.key === configKey);
+  const configField = getConfigFieldByKey(configFields, configKey);
 
   const lxdDefault = getLxdDefault(configField);
 

--- a/src/util/formDevices.spec.ts
+++ b/src/util/formDevices.spec.ts
@@ -22,6 +22,10 @@ const deviceYaml =
   "  root:\n" +
   "    path: /\n" +
   "    pool: big-pool\n" +
+  "    readonly: 'true'\n" +
+  "    recursive: 'false'\n" +
+  "    required: 'true'\n" +
+  "    shift: 'false'\n" +
   "    size: 10GiB\n" +
   "    type: disk\n" +
   "    size.state: 3GiB\n" +
@@ -67,6 +71,17 @@ describe("parseDevices", () => {
     expect(matchType("custom-nic").length).toBe(1);
     expect(matchType("proxy").length).toBe(2);
     expect(matchType("gpu").length).toBe(1);
+
+    const disk = matchType("disk")[0] as FormDevice & {
+      readonly?: string;
+      recursive?: string;
+      required?: string;
+      shift?: string;
+    };
+    expect(disk.readonly).toBe("true");
+    expect(disk.recursive).toBe("false");
+    expect(disk.required).toBe("true");
+    expect(disk.shift).toBe("false");
   });
 });
 

--- a/src/util/formDevices.tsx
+++ b/src/util/formDevices.tsx
@@ -61,6 +61,10 @@ export const parseDevices = (devices: LxdDevices): FormDevice[] => {
           pool: item.pool,
           source: "source" in item ? item.source : undefined,
           size: "size" in item ? item.size : undefined,
+          readonly: "readonly" in item ? item.readonly : undefined,
+          recursive: "recursive" in item ? item.recursive : undefined,
+          required: "required" in item ? item.required : undefined,
+          shift: "shift" in item ? item.shift : undefined,
           type: "disk",
           bare: item,
         };

--- a/src/util/instanceAndProfilePayloads.spec.ts
+++ b/src/util/instanceAndProfilePayloads.spec.ts
@@ -176,6 +176,10 @@ const deviceYaml =
   "  root:\n" +
   "    path: /\n" +
   "    pool: big-pool\n" +
+  "    readonly: 'true'\n" +
+  "    recursive: 'false'\n" +
+  "    required: 'true'\n" +
+  "    shift: 'false'\n" +
   "    size: 10GiB\n" +
   "    type: disk\n" +
   "    size.state: 3GiB\n" +

--- a/src/util/permissions.spec.ts
+++ b/src/util/permissions.spec.ts
@@ -118,6 +118,7 @@ describe("General util functions for permissions feature", () => {
       const metadata: LxdMetadata = {
         configs: {
           cluster: {},
+          "device-disk": {},
           instance: {},
           "network-bridge": {},
           "network-macvlan": {},

--- a/src/util/proxyDevices.tsx
+++ b/src/util/proxyDevices.tsx
@@ -23,7 +23,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form p-heading--6 u-text--muted",
+      className: "no-border-top inherited-with-form p-heading--6",
       configuration: headingTitle,
       inherited: "",
       override: "",
@@ -32,7 +32,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form u-text--muted",
+      className: "no-border-top inherited-with-form",
       configuration: (
         <Label forId={`devices.${index}.${connectionType}`}>Type</Label>
       ),
@@ -81,7 +81,7 @@ export const getProxyAddress = (
 
   customRows.push(
     getConfigurationRowBase({
-      className: "no-border-top inherited-with-form u-text--muted",
+      className: "no-border-top inherited-with-form",
       configuration:
         deviceType === "unix" ? (
           <Label
@@ -140,7 +140,7 @@ export const getProxyAddress = (
   if (deviceType !== "unix") {
     customRows.push(
       getConfigurationRowBase({
-        className: "no-border-top inherited-with-form u-text--muted",
+        className: "no-border-top inherited-with-form",
         configuration: (
           <Label forId={`devices.${index}.${connectionType}.port`} required>
             Port


### PR DESCRIPTION
## Done

- additional disk device options WD-37536


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
   1. Add a read-only host bind-mount disk to a container
      - Navigate to Instances → select or create a **container** → Configuration → Disk devices tab.
      - Add a disk device using a host path (not a storage volume).
      - Set **Read-only** to `yes`.
      - Verify the **Recursive** field is disabled and its tooltip explains the conflict.
      - Save and confirm the instance config reflects `readonly: "true"` and no `recursive` key.
   2. Add a recursive host bind-mount disk to a container
      - On the same or a new container, add a host path disk device.
      - Set **Recursive** to `yes`.
      - Verify the **Read-only** field is disabled with a matching tooltip.
      - Save and confirm `recursive: "true"` is present and `readonly` is absent in the config.
   3. Volume-backed disk does not show Recursive or Shift
      - Add a disk device backed by a **custom storage volume** to a container.
      - Verify the **Recursive** and **Shift** fields are **not** present in the form.
      - Verify **Read-only** and **Required** are still visible.
      - Save successfully.
   6. VM disk device does not show Shift
      - Navigate to a **virtual machine** → Configuration → Disk devices tab.
      - Add a disk device (host path or volume).
      - Verify the **Shift** field is **not** present.
      - Verify **Read-only** and **Required** are visible.
   7. Shift field visible for container and profile disk devices
      - On a **container**, add a host bind-mount disk device.
      - Verify the **Shift** field is present; set it to `yes` and save.
      - Navigate to **Profiles** → Configuration→ Disk devices → add a host path disk.
      - Verify **Shift** is also present on the profile form.
   8. Inherited disk device displays the new properties
      - Apply a profile to a container where the profile's disk device has `readonly`, `recursive`, `required`, or `shift` set.
      - Edit the container → Disk devices tab.
      - Verify the inherited disk device row shows the correct labels and values for each property that is set.

## Screenshots

<img width="1824" height="1090" alt="image" src="https://github.com/user-attachments/assets/5cb510d7-57d7-4142-ac8d-456105998d87" />

<img width="1824" height="1090" alt="image" src="https://github.com/user-attachments/assets/b489c83e-89e2-4b2a-a0bc-e7d34c2f4ab1" />
