### PR TITLE
feat(contextual-help): [WD-36580] Create reusable docslink component

### DIFF
--- a/src/components/ExplanationTooltip.tsx
+++ b/src/components/ExplanationTooltip.tsx
@@ -1,0 +1,37 @@
+import { type FC } from "react";
+import { Icon, Tooltip } from "@canonical/react-components";
+import DocLink from "components/DocLink";
+
+interface Props {
+  explanation: string;
+  docPath: string;
+  docLabel?: string;
+}
+
+const ExplanationTooltip: FC<Props> = ({
+  explanation,
+  docPath,
+  docLabel = "Learn more",
+}) => {
+  const tooltip = (
+    <Tooltip
+      zIndex={1000}
+      tooltipClassName="explanation-tooltip-portal"
+      position="btm-right"
+      message={
+        <span className="explanation-tooltip">
+          <span>{explanation}</span>
+          <DocLink docPath={docPath} hasExternalIcon>
+            {docLabel}
+          </DocLink>
+        </span>
+      }
+    >
+      <Icon name="information" className="explanation-tooltip-icon" />
+    </Tooltip>
+  );
+
+  return tooltip;
+};
+
+export default ExplanationTooltip;

--- a/src/pages/instances/InstanceExplanationTooltip.tsx
+++ b/src/pages/instances/InstanceExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const InstanceExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Manage and monitor virtual machines and containers running on the LXD server."
+        docPath="/explanation/instances/"
+      />
+    </span>
+  );
+};
+
+export default InstanceExplanationTooltip;

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -60,7 +60,7 @@ import {
 } from "util/operations";
 import NotificationRow from "components/NotificationRow";
 import SelectedTableNotification from "components/SelectedTableNotification";
-import HelpLink from "components/HelpLink";
+import InstanceExplanationTooltip from "pages/instances/InstanceExplanationTooltip";
 import type { LxdInstanceStatus } from "types/instance";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
@@ -661,12 +661,9 @@ const InstanceList: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/explanation/instances/#expl-instances"
-                  title="Learn more about instances"
-                >
+                <InstanceExplanationTooltip>
                   Instances
-                </HelpLink>
+                </InstanceExplanationTooltip>
               </PageHeader.Title>
               {hasInstances && selectedNames.length === 0 && (
                 <PageHeader.Search>

--- a/src/sass/_explanation_tooltip.scss
+++ b/src/sass/_explanation_tooltip.scss
@@ -1,0 +1,23 @@
+.explanation-tooltip-wrapper {
+  align-items: center;
+  display: flex;
+  gap: $spv--small;
+}
+
+.explanation-tooltip-icon {
+  height: 1rem !important;
+  width: 1rem !important;
+}
+
+.explanation-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: $spv--small;
+}
+
+.explanation-tooltip-portal .p-tooltip__message {
+  margin: 0 1rem 0 0;
+  max-width: calc(60vw - 2rem);
+  white-space: normal;
+  width: max-content;
+}

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -102,6 +102,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "device_detail_list";
 @import "empty_state";
 @import "error_page";
+@import "explanation_tooltip";
 @import "file_explorer";
 @import "file_row";
 @import "form-link";


### PR DESCRIPTION
## Done

- Introduced Explanation Tooltip + Styling
- Created InstanceExplanationTooltip
- Replaced the HelpLink in the InstanceList with InstanceExplanationTooltip

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Hover over the InstanceExplanationTooltip in the instance list page and ensure it behaves normally and responsively.
    - Double check the link it goes to, and the copy. Taken from the [contextual help copy doc](https://docs.google.com/document/d/1vDmemn4eQm0Zr3szBRzGtWdZqGNayqHkUmtC8oZ0jNA/edit?tab=t.0) that was previously created.

## Screenshots

<img width="964" height="239" alt="image" src="https://github.com/user-attachments/assets/b060630f-3429-4eda-97df-22bfa8b39015" />