### PR TITLE
feat(projects): Create projects list page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ const ProfileList = lazy(async () => import("pages/profiles/ProfileList"));
 const ProjectConfig = lazy(
   async () => import("pages/projects/ProjectConfiguration"),
 );
+const ProjectList = lazy(async () => import("pages/projects/ProjectList"));
 const ProtectedRoute = lazy(async () => import("components/ProtectedRoute"));
 const ReplicatorDetail = lazy(
   async () => import("pages/cluster/ReplicatorDetail"),
@@ -452,6 +453,10 @@ const App: FC = () => {
               outlet={<ProjectLoader outlet={<ProjectConfig />} />}
             />
           }
+        />
+        <Route
+          path={`${ROOT_PATH}/ui/projects`}
+          element={<ProtectedRoute outlet={<ProjectList />} />}
         />
         <Route
           path={`${ROOT_PATH}/ui/projects/create`}

--- a/src/context/useCurrentProject.tsx
+++ b/src/context/useCurrentProject.tsx
@@ -46,7 +46,7 @@ export const ProjectProvider: FC<ProviderProps> = ({ children }) => {
 
   const parts = url.split("/");
   const project = parts[0] === "project" ? parts[1] : "";
-  const isAllProjects = parts[0] === "all-projects";
+  const isAllProjects = parts[0] === "all-projects" || parts[0] === "projects";
 
   const initializeProjectName = (
     isAllProjectsFromUrl: boolean,

--- a/src/pages/cluster/ClusterMemberRichTooltip.tsx
+++ b/src/pages/cluster/ClusterMemberRichTooltip.tsx
@@ -100,11 +100,11 @@ const ClusterMemberRichTooltip: FC<Props> = ({ clusterMember }) => {
       value: state?.sysinfo.uptime ? formatSeconds(state?.sysinfo.uptime) : "-",
     },
     {
-      title: "Memory Usage",
+      title: "Memory usage",
       value: member ? <ClusterMemberMemoryUsage member={member} /> : "-",
     },
     {
-      title: "Load Average",
+      title: "Load average",
       value: state?.sysinfo.load_averages.join(" "),
     },
   ];

--- a/src/pages/overview/InstancesCard.tsx
+++ b/src/pages/overview/InstancesCard.tsx
@@ -1,9 +1,9 @@
 import { useMemo, type FC } from "react";
+import { Link } from "react-router-dom";
 import {
   Card,
   DoughnutChart,
   Icon,
-  Link,
   Spinner,
 } from "@canonical/react-components";
 import ChartLegend from "components/ChartLegend";
@@ -123,7 +123,7 @@ const InstancesCard: FC = () => {
       </div>
 
       <div className="card-footer">
-        <Link href={`${ROOT_PATH}/ui/all-projects/instances`}>See more</Link>
+        <Link to={`${ROOT_PATH}/ui/all-projects/instances`}>See more</Link>
       </div>
     </Card>
   );

--- a/src/pages/overview/InstancesOverviewStatus.tsx
+++ b/src/pages/overview/InstancesOverviewStatus.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { Link } from "@canonical/react-components";
+import { Link } from "react-router-dom";
 import { capitalizeFirstLetter } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import { type LxdInstanceStatus } from "types/instance";
@@ -22,11 +22,10 @@ const InstancesOverviewStatus: FC<Props> = ({ status, count }) => {
         {capitalizeFirstLetter(status)}
       </p>
       <Link
-        className="status-link"
-        href={getStatusFilterHref(
+        className="status-link p-link--soft"
+        to={getStatusFilterHref(
           capitalizeFirstLetter(status) as LxdInstanceStatus,
         )}
-        soft
       >
         <strong className="status-count">{count}</strong>
       </Link>

--- a/src/pages/projects/NavigationProjectSelector.tsx
+++ b/src/pages/projects/NavigationProjectSelector.tsx
@@ -67,12 +67,23 @@ const NavigationProjectSelector: FC<Props> = ({
             onClick={() => {
               navigate(`${ROOT_PATH}/ui/all-projects/instances`);
             }}
+            className="p-contextual-menu__link all-instances"
+            hasIcon
+          >
+            <Icon name="pods" light />
+            <span>All instances</span>
+          </Button>
+          <Button
+            onClick={() => {
+              navigate(`${ROOT_PATH}/ui/projects`);
+            }}
             className="p-contextual-menu__link all-projects"
             hasIcon
           >
             <Icon name="folder" light />
             <span>All projects</span>
           </Button>
+          <hr className="is-dark" />
           <NavigationProjectSelectorList
             projects={projects}
             onMount={onChildMount}

--- a/src/pages/projects/ProjectList.tsx
+++ b/src/pages/projects/ProjectList.tsx
@@ -1,0 +1,229 @@
+import { useState, type FC } from "react";
+import { Link } from "react-router-dom";
+import {
+  Col,
+  CustomLayout,
+  Icon,
+  MainTable,
+  Row,
+  ScrollableTable,
+  SearchBox,
+  Spinner,
+  TablePagination,
+  useNotify,
+} from "@canonical/react-components";
+import classnames from "classnames";
+import NotificationRow from "components/NotificationRow";
+import HelpLink from "components/HelpLink";
+import PageHeader from "components/PageHeader";
+import { useIsScreenBelow } from "context/useIsScreenBelow";
+import { useProjects } from "context/useProjects";
+import { useServerEntitlements } from "util/entitlements/server";
+import { defaultFirst } from "util/helpers";
+import { getInstancesUsedByProject } from "util/projects";
+import { ROOT_PATH } from "util/rootPath";
+import useSortTableData from "util/useSortTableData";
+
+const ProjectList: FC = () => {
+  const notify = useNotify();
+  const [query, setQuery] = useState<string>("");
+  const isSmallScreen = useIsScreenBelow();
+  const { canCreateProjects } = useServerEntitlements();
+  const { data: projects = [], error, isLoading } = useProjects();
+
+  if (error) {
+    notify.failure("Loading projects failed", error);
+  }
+
+  const filteredProjects = [...projects]
+    .sort(defaultFirst)
+    .filter((project) => {
+      if (!query) {
+        return true;
+      }
+      const q = query.toLowerCase();
+      return (
+        project.name.toLowerCase().includes(q) ||
+        project.description.toLowerCase().includes(q)
+      );
+    });
+
+  const headers = [
+    { content: "Name", sortKey: "name" },
+    {
+      content: "Description",
+      sortKey: "description",
+      className: "u-hide--small",
+    },
+    { content: "CPU limit", sortKey: "cpuLimit", className: "u-hide--small" },
+    {
+      content: "Memory limit",
+      sortKey: "memoryLimit",
+      className: "u-hide--small",
+    },
+    { content: "Disk limit", sortKey: "diskLimit", className: "u-hide--small" },
+    { content: "Instances", sortKey: "instances" },
+  ];
+
+  const rows = filteredProjects.map((project) => {
+    const instanceCount = getInstancesUsedByProject(project).length;
+    const projectInstancesPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project.name)}/instances`;
+    const projectConfigPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(project.name)}/configuration`;
+    const cpuLimit = project.config["limits.cpu"] || "-";
+    const memoryLimit = project.config["limits.memory"] || "-";
+    const diskLimit = project.config["limits.disk"] || "-";
+
+    return {
+      key: project.name,
+      className: "u-row",
+      columns: [
+        {
+          content: (
+            <Link
+              to={projectConfigPath}
+              className="u-truncate"
+              title={project.name}
+            >
+              {project.name}
+            </Link>
+          ),
+          role: "rowheader",
+          "aria-label": "Name",
+        },
+        {
+          content: (
+            <div className="table-description" title={project.description}>
+              {project.description || "-"}
+            </div>
+          ),
+          role: "cell",
+          "aria-label": "Description",
+          className: "u-hide--small",
+        },
+        {
+          content: cpuLimit,
+          role: "cell",
+          "aria-label": "CPU limit",
+          className: "u-hide--small",
+        },
+        {
+          content: memoryLimit,
+          role: "cell",
+          "aria-label": "Memory limit",
+          className: "u-hide--small",
+        },
+        {
+          content: diskLimit,
+          role: "cell",
+          "aria-label": "Disk limit",
+          className: "u-hide--small",
+        },
+        {
+          content: (
+            <Link
+              to={projectInstancesPath}
+              className="u-truncate"
+              title={project.name}
+            >
+              {instanceCount}
+            </Link>
+          ),
+          role: "cell",
+          "aria-label": "Instances",
+        },
+      ],
+      sortData: {
+        name: project.name.toLowerCase(),
+        description: project.description.toLowerCase(),
+        instances: instanceCount,
+        cpuLimit,
+        memoryLimit,
+        diskLimit,
+      },
+    };
+  });
+
+  const { rows: sortedRows, updateSort } = useSortTableData({ rows });
+
+  if (isLoading) {
+    return <Spinner className="u-loader" text="Loading..." isMainComponent />;
+  }
+
+  return (
+    <CustomLayout
+      header={
+        <PageHeader>
+          <PageHeader.Left>
+            <PageHeader.Title>
+              <HelpLink docPath="/projects/" title="Learn more about projects">
+                Projects
+              </HelpLink>
+            </PageHeader.Title>
+            <PageHeader.Search>
+              <SearchBox
+                className="search-box margin-right--large u-no-margin--bottom"
+                id="search-project"
+                name="search-project"
+                type="text"
+                onChange={(value: string) => {
+                  setQuery(value);
+                }}
+                placeholder="Search"
+                value={query}
+                aria-label="Search"
+              />
+            </PageHeader.Search>
+          </PageHeader.Left>
+          <PageHeader.BaseActions>
+            <Link
+              className={classnames("p-button--positive u-no-margin--bottom", {
+                "is-disabled": !canCreateProjects(),
+                "has-icon": !isSmallScreen,
+              })}
+              to={`${ROOT_PATH}/ui/projects/create`}
+              title={
+                canCreateProjects()
+                  ? ""
+                  : "You do not have permission to create projects"
+              }
+              key="create-project"
+            >
+              <Icon name="plus" light className="u-hide--small" />
+              <span>Create project</span>
+            </Link>
+          </PageHeader.BaseActions>
+        </PageHeader>
+      }
+    >
+      <NotificationRow />
+      <Row>
+        <Col size={12}>
+          <ScrollableTable
+            dependencies={[filteredProjects, notify.notification]}
+            tableId="project-table"
+            belowIds={["status-bar"]}
+          >
+            <TablePagination
+              id="pagination"
+              data={sortedRows}
+              itemName="project"
+              className="u-no-margin--top"
+              aria-label="Table pagination control"
+            >
+              <MainTable
+                id="project-table"
+                className="project-table"
+                headers={headers}
+                sortable
+                emptyStateMsg="No project found matching this search"
+                onUpdateSort={updateSort}
+              />
+            </TablePagination>
+          </ScrollableTable>
+        </Col>
+      </Row>
+    </CustomLayout>
+  );
+};
+
+export default ProjectList;

--- a/src/sass/_project_select.scss
+++ b/src/sass/_project_select.scss
@@ -40,7 +40,8 @@
     padding: 1rem;
     width: 21rem;
 
-    .all-projects {
+    .all-projects,
+    .all-instances {
       margin-bottom: $spv--small;
     }
 


### PR DESCRIPTION
## Done

- Create projects list page
- Update NavigationProjectSelector: 
    - change existing "All projects" link into "All instances"
    - add "All projects" link to project list page
    - add `hr` and make them visible
- Add "Projects" link on instance list page for all projects

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to `/ui/projects`
    - Make sure "All projects" is selected in the Navigation project selector.
    - Make sure the full list of projects is displayed.
    - Make sure you can create a project from this page.
    - Make sure you can search for a project.
    - Make sure the documentation link in the header is correct.
    - Click on a project name, it should take you to the project's configuration.
    - Click on a project instance count, it should take you to the instance list of this project.
    - Click on "Instances", it should take you to the instance list of all projects. You should be able to go back to the project list page by clicking "Projects".

## Screenshots

<img width="1853" height="1056" alt="image" src="https://github.com/user-attachments/assets/8b80b065-d5e9-481a-b594-4abda1b2ad75" />

<img width="506" height="904" alt="Screenshot from 2026-07-15 13-21-23" src="https://github.com/user-attachments/assets/8e2b9557-61f8-4698-8fd0-0d2bfbc90d20" />

