### PR TITLE
refactor: extract common install deps into shared script

### DIFF
--- a/.workshop/run-lxd-ui/hooks/setup-project
+++ b/.workshop/run-lxd-ui/hooks/setup-project
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+sudo /project/tests/scripts/install-common-deps.sh
+
+# copy nvm and npm to workshop user
+sudo cp -R /root/.nvm /home/workshop/.nvm
+sudo chown -R workshop:workshop /home/workshop/.nvm
+sudo cp -R /root/.npm /home/workshop/.npm
+sudo chown -R workshop:workshop /home/workshop/.npm
+

--- a/tests/scripts/install-common-deps.sh
+++ b/tests/scripts/install-common-deps.sh
@@ -13,9 +13,3 @@ nvm install --lts
 # install global npm packages
 npm install --global serve
 npm install --global yarn
-
-# copy nvm and npm to workshop user
-cp -R /root/.nvm /home/workshop/.nvm
-chown -R workshop:workshop /home/workshop/.nvm
-cp -R /root/.npm /home/workshop/.npm
-chown -R workshop:workshop /home/workshop/.npm


### PR DESCRIPTION
## Done


- Extracts the haproxy/nvm/npm install steps from the `.workshop/run-lxd-ui/hooks/setup-base` hook into a standalone `tests/scripts/install-common-deps.sh` script.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
