### PR TITLE
feat(a11y-accessibility-audit) - [WD-36582] Create A11y accessibility check

### DIFF
--- a/.github/actions/setup-lxd/action.yml
+++ b/.github/actions/setup-lxd/action.yml
@@ -1,0 +1,141 @@
+name: "Setup E2E Environment"
+description: "Sets up LXD, Workshop, backend, LXD-UI, Node.js, and Playwright for e2e/a11y tests"
+
+inputs:
+  lxd_channel:
+    description: "LXD snap channel to install in the VM"
+    required: false
+    default: "latest/edge"
+  deployment:
+    description: "Deployment type: unclustered, clustered, or single-node-cluster"
+    required: false
+    default: "unclustered"
+  browser:
+    description: "Browser to install for Playwright (chromium, firefox)"
+    required: false
+    default: "chromium"
+  lxd_oidc_client_id:
+    description: "OIDC client ID for LXD"
+    required: true
+  lxd_oidc_client_secret:
+    description: "OIDC client secret for LXD"
+    required: true
+  lxd_oidc_issuer:
+    description: "OIDC issuer URL"
+    required: true
+  lxd_oidc_audience:
+    description: "OIDC audience URL"
+    required: true
+  lxd_oidc_user:
+    description: "OIDC user email for e2e tests"
+    required: true
+  lxd_oidc_password:
+    description: "OIDC user password for e2e tests"
+    required: true
+  lxd_oidc_groups_claim:
+    description: "OIDC groups claim name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate SSL keys for HAProxy
+      shell: bash
+      run: |
+        mkdir -p keys
+        openssl req -x509 -newkey rsa:4096 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -days 365 -nodes -subj "/CN=localhost"
+        cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
+
+    - name: Install LXD
+      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
+      with:
+        bridges: "lxdbr0,workshopbr0"
+        channel: "latest/stable"
+
+    - name: Install Workshop
+      shell: bash
+      run: |
+        set -x
+        sudo lxd init --auto
+        sudo snap install workshop --classic
+        workshop launch --verbose
+
+    - name: Setup LXD backend (Clustered in VMs)
+      if: ${{ inputs.deployment == 'clustered' }}
+      shell: bash
+      env:
+        LXD_CHANNEL: ${{ inputs.lxd_channel }}
+      run: |
+        set -x
+        tests/scripts/start_vm_cluster.sh "$LXD_CHANNEL"
+
+    - name: Setup LXD backend (Unclustered in VM)
+      if: ${{ inputs.deployment == 'unclustered' || inputs.deployment == 'single-node-cluster' }}
+      shell: bash
+      env:
+        LXD_CHANNEL: ${{ inputs.lxd_channel }}
+      run: |
+        set -x
+        tests/scripts/start_vm_single_unclustered.sh "$LXD_CHANNEL"
+        # For LXD 5.0/edge, we need to add the certificate to the trust store as that version doesn't support login.
+        if [ "$LXD_CHANNEL" == '5.0/edge' ]; then
+          cat keys/lxd-ui.crt | sudo lxc exec vm1 -- lxc config trust add - || true
+        fi
+
+    - name: Install LXD-UI dependencies
+      shell: bash
+      run: |
+        sudo chmod 0777 ../lxd-ui
+        workshop run dev install
+
+    - name: Setup for tests
+      if: ${{ inputs.lxd_channel != '5.0/edge' }}
+      shell: bash
+      env:
+        DEPLOYMENT: ${{ inputs.deployment }}
+        LXD_OIDC_ISSUER: ${{ inputs.lxd_oidc_issuer }}
+        LXD_OIDC_CLIENT_ID: ${{ inputs.lxd_oidc_client_id }}
+        LXD_OIDC_CLIENT_SECRET: ${{ inputs.lxd_oidc_client_secret }}
+        LXD_OIDC_AUDIENCE: ${{ inputs.lxd_oidc_audience }}
+        LXD_OIDC_GROUPS_CLAIM: ${{ inputs.lxd_oidc_groups_claim }}
+        LXD_OIDC_USER: ${{ inputs.lxd_oidc_user }}
+        LXD_OIDC_PASSWORD: ${{ inputs.lxd_oidc_password }}
+      run: |
+        sudo -E ./tests/scripts/setup_test
+        {
+          echo "DEPLOYMENT=${DEPLOYMENT}"
+          echo "LXD_OIDC_ISSUER=${LXD_OIDC_ISSUER}"
+          echo "LXD_OIDC_CLIENT_ID=${LXD_OIDC_CLIENT_ID}"
+          echo "LXD_OIDC_CLIENT_SECRET=${LXD_OIDC_CLIENT_SECRET}"
+          echo "LXD_OIDC_AUDIENCE=${LXD_OIDC_AUDIENCE}"
+          echo "LXD_OIDC_GROUPS_CLAIM=${LXD_OIDC_GROUPS_CLAIM}"
+          echo "LXD_OIDC_USER=${LXD_OIDC_USER}"
+          echo "LXD_OIDC_PASSWORD=${LXD_OIDC_PASSWORD}"
+        } >> "$GITHUB_ENV"
+
+    - name: Run LXD-UI
+      shell: bash
+      env:
+        ENVIRONMENT: devel
+        PORT: 8407
+        VITE_PORT: 3000
+      run: |
+        echo "Backend configuration:"
+        if [ -f .env.local ]; then
+          cat .env.local
+        else
+          echo "Using default backend configuration"
+        fi
+        workshop run dev serve &
+        sleep 10
+        curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 24
+
+    - name: Install Playwright Browsers
+      shell: bash
+      env:
+        PW_BROWSER: ${{ inputs.browser }}
+      run: npx playwright install --with-deps "$PW_BROWSER"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,88 +87,28 @@ jobs:
   a11y-check:
     name: a11y-check
     runs-on: ubuntu-latest
-    env:
-      LXD_CHANNEL: "latest/edge"
-      DEPLOYMENT: "unclustered"
-      LXD_OIDC_CLIENT_ID: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
-      LXD_OIDC_CLIENT_SECRET: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
-      LXD_OIDC_ISSUER: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
-      LXD_OIDC_AUDIENCE: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
-      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
-      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
-      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Generate SSL keys for HAProxy
-        run: |
-          mkdir -p keys
-          openssl req -x509 -newkey rsa:4096 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -days 365 -nodes -subj "/CN=localhost"
-          cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
-
-      - name: Install LXD
-        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
+      - name: Setup LXD
+        uses: ./.github/actions/setup-lxd
         with:
-          bridges: "lxdbr0,workshopbr0"
-          channel: "latest/stable"
-
-      - name: Install Workshop
-        run: |
-          set -x
-          sudo lxd init --auto
-          sudo snap install workshop --classic
-          workshop launch --verbose
-
-      - name: Setup LXD backend (Unclustered in VM)
-        shell: bash
-        run: |
-          set -x
-          tests/scripts/start_vm_single_unclustered.sh ${{ env.LXD_CHANNEL }}
-
-
-      - name: Install LXD-UI dependencies
-        run: |
-          sudo chmod 0777 ../lxd-ui
-          workshop run dev install
-
-      - name: Setup for tests
-        shell: bash
-        env:
-          DEPLOYMENT: ${{ env.DEPLOYMENT }}
-          LXD_OIDC_ISSUER: ${{ env.LXD_OIDC_ISSUER }}
-          LXD_OIDC_CLIENT_ID: ${{ env.LXD_OIDC_CLIENT_ID }}
-          LXD_OIDC_CLIENT_SECRET: ${{ env.LXD_OIDC_CLIENT_SECRET }}
-          LXD_OIDC_AUDIENCE: ${{ env.LXD_OIDC_AUDIENCE }}
-          LXD_OIDC_GROUPS_CLAIM: ${{ env.LXD_OIDC_GROUPS_CLAIM }}
-        run: sudo -E ./tests/scripts/setup_test
-
-      - name: Run LXD-UI
-        env:
-          ENVIRONMENT: devel
-          PORT: 8407
-          VITE_PORT: 3000
-        run: |
-          echo "Backend configuration:"
-          if [ -f .env.local ]; then
-            cat .env.local
-          else
-            echo "Using default backend configuration"
-          fi
-          workshop run dev serve &
-          sleep 10
-          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
+          lxd_channel: "latest/edge"
+          deployment: "unclustered"
+          browser: "chromium"
+          lxd_oidc_client_id: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
+          lxd_oidc_client_secret: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
+          lxd_oidc_issuer: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
+          lxd_oidc_audience: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
+          lxd_oidc_user: "lxd-ui-e2e-tests@example.org"
+          lxd_oidc_password: "lxd-ui-e2e-password"
+          lxd_oidc_groups_claim: "lxd-idp-groups"
 
       - name: Install dependencies
+        shell: bash
         run: yarn install --immutable
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
 
       - name: Run a11y check
         run: npx playwright test --project a11y-audit
@@ -189,102 +129,24 @@ jobs:
             deployment: "single-node-cluster"
     outputs:
       job_status: ${{job.status}}
-    env:
-      LXD_OIDC_CLIENT_ID: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
-      LXD_OIDC_CLIENT_SECRET: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
-      LXD_OIDC_ISSUER: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
-      LXD_OIDC_AUDIENCE: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
-      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
-      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
-      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Generate SSL keys for HAProxy
-        run: |
-          mkdir -p keys
-          openssl req -x509 -newkey rsa:4096 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -days 365 -nodes -subj "/CN=localhost"
-          cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
-
-      - name: Install LXD
-        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
+      - name: Setup LXD
+        uses: ./.github/actions/setup-lxd
         with:
-          bridges: "lxdbr0,workshopbr0"
-          channel: "latest/stable"
-
-      - name: Install Workshop
-        run: |
-          set -x
-          sudo lxd init --auto
-          sudo snap install workshop --classic
-          workshop launch --verbose
-
-      - name: Setup LXD backend (Clustered in VMs)
-        if: ${{ matrix.deployment == 'clustered' }}
-        shell: bash
-        run: |
-          set -x
-          tests/scripts/start_vm_cluster.sh ${{ matrix.lxd_channel }}
-
-      - name: Setup LXD backend (Unclustered in VM)
-        if: ${{ matrix.deployment == 'unclustered' }}
-        shell: bash
-        run: |
-          set -x
-          tests/scripts/start_vm_single_unclustered.sh ${{ matrix.lxd_channel }}
-          # For LXD 5.0/edge, we need to add the certificate to the trust store as that version doesn't support login.
-          if [ "${{ matrix.lxd_channel }}" == '5.0/edge' ]; then
-            cat keys/lxd-ui.crt | sudo lxc exec vm1 -- lxc config trust add - || true
-          fi
-
-      - name: Setup LXD backend (Single-node cluster in VM) 
-        if: ${{ matrix.deployment == 'single-node-cluster' }}
-        shell: bash
-        run: |
-          set -x
-          tests/scripts/start_vm_single_unclustered.sh ${{ matrix.lxd_channel }}
-
-      - name: Install LXD-UI dependencies
-        run: |
-          sudo chmod 0777 ../lxd-ui
-          workshop run dev install
-
-      - name: Setup for tests
-        if: ${{ matrix.lxd_channel != '5.0/edge' }}
-        shell: bash
-        env:
-          DEPLOYMENT: ${{ matrix.deployment }}
-          LXD_OIDC_ISSUER: ${{ env.LXD_OIDC_ISSUER }}
-          LXD_OIDC_CLIENT_ID: ${{ env.LXD_OIDC_CLIENT_ID }}
-          LXD_OIDC_CLIENT_SECRET: ${{ env.LXD_OIDC_CLIENT_SECRET }}
-          LXD_OIDC_AUDIENCE: ${{ env.LXD_OIDC_AUDIENCE }}
-          LXD_OIDC_GROUPS_CLAIM: ${{ env.LXD_OIDC_GROUPS_CLAIM }}
-        run: sudo -E ./tests/scripts/setup_test
-
-      - name: Run LXD-UI
-        env:
-          ENVIRONMENT: devel
-          PORT: 8407
-          VITE_PORT: 3000
-        run: |
-          echo "Backend configuration:"
-          if [ -f .env.local ]; then
-            cat .env.local
-          else
-            echo "Using default backend configuration"
-          fi
-          workshop run dev serve &
-          sleep 10
-          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+          lxd_channel: ${{ matrix.lxd_channel }}
+          deployment: ${{ matrix.deployment }}
+          browser: ${{ matrix.browser }}
+          lxd_oidc_client_id: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
+          lxd_oidc_client_secret: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
+          lxd_oidc_issuer: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
+          lxd_oidc_audience: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
+          lxd_oidc_user: "lxd-ui-e2e-tests@example.org"
+          lxd_oidc_password: "lxd-ui-e2e-password"
+          lxd_oidc_groups_claim: "lxd-idp-groups"
 
       - name: Run Playwright tests
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,6 +113,14 @@ jobs:
       - name: Run a11y check
         run: npx playwright test --project a11y-audit
 
+      - name: Upload a11y report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: a11y-report
+          path: test-results
+          retention-days: 14
+
   browser-e2e-test:
     name: e2e-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,6 +84,95 @@ jobs:
             echo "No disallowed Unicode characters found."
           fi
 
+  a11y-check:
+    name: a11y-check
+    runs-on: ubuntu-latest
+    env:
+      LXD_CHANNEL: "latest/edge"
+      DEPLOYMENT: "unclustered"
+      LXD_OIDC_CLIENT_ID: "RYDnMpkygLAMfeo17lU7LYwWGxisRuRR"
+      LXD_OIDC_CLIENT_SECRET: "CNKX4UmrZKZJq5rJy5VM_JfcNPqkws1rwWWQk_q0oyZ8gABARr19ic7xrhPssGA1"
+      LXD_OIDC_ISSUER: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/"
+      LXD_OIDC_AUDIENCE: "https://dev-h6c02msuggpi6ijh.eu.auth0.com/api/v2/"
+      LXD_OIDC_USER: "lxd-ui-e2e-tests@example.org"
+      LXD_OIDC_PASSWORD: "lxd-ui-e2e-password"
+      LXD_OIDC_GROUPS_CLAIM: "lxd-idp-groups"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Generate SSL keys for HAProxy
+        run: |
+          mkdir -p keys
+          openssl req -x509 -newkey rsa:4096 -keyout keys/lxd-ui.key -out keys/lxd-ui.crt -days 365 -nodes -subj "/CN=localhost"
+          cat keys/lxd-ui.key keys/lxd-ui.crt > keys/lxd-ui.pem
+
+      - name: Install LXD
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
+        with:
+          bridges: "lxdbr0,workshopbr0"
+          channel: "latest/stable"
+
+      - name: Install Workshop
+        run: |
+          set -x
+          sudo lxd init --auto
+          sudo snap install workshop --classic
+          workshop launch --verbose
+
+      - name: Setup LXD backend (Unclustered in VM)
+        shell: bash
+        run: |
+          set -x
+          tests/scripts/start_vm_single_unclustered.sh ${{ env.LXD_CHANNEL }}
+
+
+      - name: Install LXD-UI dependencies
+        run: |
+          sudo chmod 0777 ../lxd-ui
+          workshop run dev install
+
+      - name: Setup for tests
+        shell: bash
+        env:
+          DEPLOYMENT: ${{ env.DEPLOYMENT }}
+          LXD_OIDC_ISSUER: ${{ env.LXD_OIDC_ISSUER }}
+          LXD_OIDC_CLIENT_ID: ${{ env.LXD_OIDC_CLIENT_ID }}
+          LXD_OIDC_CLIENT_SECRET: ${{ env.LXD_OIDC_CLIENT_SECRET }}
+          LXD_OIDC_AUDIENCE: ${{ env.LXD_OIDC_AUDIENCE }}
+          LXD_OIDC_GROUPS_CLAIM: ${{ env.LXD_OIDC_GROUPS_CLAIM }}
+        run: sudo -E ./tests/scripts/setup_test
+
+      - name: Run LXD-UI
+        env:
+          ENVIRONMENT: devel
+          PORT: 8407
+          VITE_PORT: 3000
+        run: |
+          echo "Backend configuration:"
+          if [ -f .env.local ]; then
+            cat .env.local
+          else
+            echo "Using default backend configuration"
+          fi
+          workshop run dev serve &
+          sleep 10
+          curl --head --fail --retry-delay 2 --retry 100 --retry-connrefused --insecure https://localhost:8407
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run a11y check
+        run: npx playwright test --project a11y-audit
+
   browser-e2e-test:
     name: e2e-tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "yup": "1.7.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
     "@babel/eslint-parser": "7.28.5",
     "@babel/preset-react": "7.28.5",
     "@babel/preset-typescript": "7.28.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -222,6 +222,25 @@ const config: PlaywrightTestConfig<TestOptions> = {
       },
       testMatch: "docs-screenshots-clustered.spec.ts",
     },
+    {
+      name: "a11y-audit",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          /* We launch chromium with the --unsafely-treat-insecure-origin-as-secure
+           * flag to simulate a secure context at least when running headed tests.
+           * In headless mode, it would not work anyway, see following bug:
+           * https://issues.chromium.org/issues/41380386 */
+          args: [
+            `--unsafely-treat-insecure-origin-as-secure=${(
+              process.env.BASE_URL ?? "https://localhost:8407"
+            ).replace(/\/$/, "")}`,
+          ],
+        },
+      },
+      dependencies: ["login-chromium"],
+      testMatch: "accessibility-audit.spec.ts",
+    },
   ],
 };
 

--- a/tests/accessibility-audit.spec.ts
+++ b/tests/accessibility-audit.spec.ts
@@ -1,0 +1,68 @@
+import { test } from "./fixtures/lxd-test";
+import { runA11yAudit } from "./helpers/a11y";
+
+test("accessibility audit for instance page", async ({ page }) => {
+  const slug = "Instances";
+  await runA11yAudit(slug, page, test.info());
+});
+
+test("accessibility audit for profile page", async ({ page }) => {
+  const slug = "Profiles";
+  await runA11yAudit(slug, page, test.info());
+});
+
+test("accessibility audit for network pages", async ({ page }) => {
+  const slug = "Networking";
+  await runA11yAudit("Networks", page, test.info(), slug);
+  await runA11yAudit("ACLs", page, test.info(), slug);
+  await runA11yAudit("IPAM", page, test.info(), slug);
+});
+
+test("accessibility audit for storage pages", async ({ page }) => {
+  const slug = "Storage";
+  await runA11yAudit("Pools", page, test.info(), slug);
+  await runA11yAudit("Volumes", page, test.info(), slug);
+  await runA11yAudit("Buckets", page, test.info(), slug);
+  await runA11yAudit("Custom ISOs", page, test.info(), slug);
+});
+
+test("accessibility audit for image page", async ({ page }) => {
+  const slug = "Images";
+  await runA11yAudit("Local images", page, test.info(), slug);
+});
+
+test("accessibility audit for project page", async ({ page }) => {
+  const slug = "Configuration";
+  await runA11yAudit(slug, page, test.info());
+});
+
+test("accessibility audit for clustering pages", async ({ page }) => {
+  const slug = "Clustering";
+  await runA11yAudit("Server", page, test.info(), slug);
+  await runA11yAudit("Groups", page, test.info(), slug);
+  await runA11yAudit("Links", page, test.info(), slug);
+  await runA11yAudit("Placement", page, test.info(), slug);
+  await runA11yAudit("Replicators", page, test.info(), slug);
+});
+
+test("accessibility audit for operations page", async ({ page }) => {
+  const slug = "Operations";
+  await runA11yAudit(slug, page, test.info());
+});
+
+test("accessibility audit for warning page", async ({ page }) => {
+  const slug = "Warnings";
+  await runA11yAudit(slug, page, test.info());
+});
+
+test("accessibility audit for permissions pages", async ({ page }) => {
+  const slug = "Permissions";
+  await runA11yAudit("Identities", page, test.info(), slug);
+  await runA11yAudit("Groups", page, test.info(), slug);
+  await runA11yAudit("IDP groups", page, test.info(), slug);
+});
+
+test("accessibility audit for settings page", async ({ page }) => {
+  const slug = "Settings";
+  await runA11yAudit(slug, page, test.info());
+});

--- a/tests/accessibility-audit.spec.ts
+++ b/tests/accessibility-audit.spec.ts
@@ -23,6 +23,18 @@ test("accessibility audit for storage pages", async ({ page }) => {
   await runA11yAudit("Pools", page, test.info(), slug);
   await runA11yAudit("Volumes", page, test.info(), slug);
   await runA11yAudit("Buckets", page, test.info(), slug);
+});
+
+test("accessibility audit for custom ISOs page", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion === "5.0-edge",
+    "Custom ISOs are not supported in lxd 5.0",
+  );
+
+  const slug = "Storage";
   await runA11yAudit("Custom ISOs", page, test.info(), slug);
 });
 
@@ -40,8 +52,20 @@ test("accessibility audit for clustering pages", async ({ page }) => {
   const slug = "Clustering";
   await runA11yAudit("Server", page, test.info(), slug);
   await runA11yAudit("Groups", page, test.info(), slug);
-  await runA11yAudit("Links", page, test.info(), slug);
   await runA11yAudit("Placement", page, test.info(), slug);
+});
+
+test("accessibility audit for replicator and cluster link pages", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion === "5.21-edge" || lxdVersion === "5.0-edge",
+    "Cluster Links & Replicators are not supported in older LXD versions",
+  );
+
+  const slug = "Clustering";
+  await runA11yAudit("Links", page, test.info(), slug);
   await runA11yAudit("Replicators", page, test.info(), slug);
 });
 
@@ -55,7 +79,15 @@ test("accessibility audit for warning page", async ({ page }) => {
   await runA11yAudit(slug, page, test.info());
 });
 
-test("accessibility audit for permissions pages", async ({ page }) => {
+test("accessibility audit for permissions pages", async ({
+  page,
+  lxdVersion,
+}) => {
+  test.skip(
+    lxdVersion === "5.0-edge",
+    "Fine grained authorisation is supported in lxd 5.21 LTS and latest/edge",
+  );
+
   const slug = "Permissions";
   await runA11yAudit("Identities", page, test.info(), slug);
   await runA11yAudit("Groups", page, test.info(), slug);

--- a/tests/helpers/a11y.ts
+++ b/tests/helpers/a11y.ts
@@ -1,48 +1,8 @@
 import { gotoURL } from "./navigate";
 import AxeBuilder from "@axe-core/playwright";
-import type { AxeResults, Result, CrossTreeSelector } from "axe-core";
+import type { AxeResults, Result } from "axe-core";
 import type { Page, TestInfo } from "@playwright/test";
 import { writeFile } from "fs/promises";
-
-interface A11yResult {
-  id: string;
-  slug: string;
-  tags: string[];
-  type: string;
-  description: string;
-  nodes: CrossTreeSelector[];
-}
-
-const generateResult = (
-  results: AxeResults,
-  type: "pass" | "violation",
-  slug: string,
-): A11yResult[] => {
-  let targetAttr: Result[];
-  if (type === "pass") targetAttr = results.passes;
-  else targetAttr = results.violations;
-
-  const result: A11yResult[] = [];
-
-  for (const instance of targetAttr) {
-    const resultObject: A11yResult = {
-      id: instance.id,
-      slug,
-      type,
-      tags: instance.tags,
-      description: instance.description,
-      nodes: [],
-    };
-    for (const node of instance.nodes) {
-      const targets = Array.isArray(node.target) ? node.target : [node.target];
-      for (const target of targets) {
-        resultObject.nodes.push(target);
-      }
-    }
-    result.push(resultObject);
-  }
-  return result;
-};
 
 const printSummary = (
   percent: number,
@@ -134,8 +94,9 @@ export const runA11yAudit = async (
   );
 
   if (results.violations.length > 0) {
-    const result = generateResult(results, "violation", slug);
-    console.log(result);
+    console.log(
+      `\n${results.violations.length} violation(s) found. Full details available in the a11y-report artifact.`,
+    );
   }
 
   try {

--- a/tests/helpers/a11y.ts
+++ b/tests/helpers/a11y.ts
@@ -1,0 +1,171 @@
+import { gotoURL } from "./navigate";
+import AxeBuilder from "@axe-core/playwright";
+import type { AxeResults, Result, CrossTreeSelector } from "axe-core";
+import type { Page, TestInfo } from "@playwright/test";
+import { writeFile } from "fs/promises";
+
+interface A11yResult {
+  id: string;
+  slug: string;
+  tags: string[];
+  type: string;
+  description: string;
+  nodes: CrossTreeSelector[];
+}
+
+const generateResult = (
+  results: AxeResults,
+  type: "pass" | "violation",
+  slug: string,
+): A11yResult[] => {
+  let targetAttr: Result[];
+  if (type === "pass") targetAttr = results.passes;
+  else targetAttr = results.violations;
+
+  const result: A11yResult[] = [];
+
+  for (const instance of targetAttr) {
+    const resultObject: A11yResult = {
+      id: instance.id,
+      slug,
+      type,
+      tags: instance.tags,
+      description: instance.description,
+      nodes: [],
+    };
+    for (const node of instance.nodes) {
+      const targets = Array.isArray(node.target) ? node.target : [node.target];
+      for (const target of targets) {
+        resultObject.nodes.push(target);
+      }
+    }
+    result.push(resultObject);
+  }
+  return result;
+};
+
+const printSummary = (
+  percent: number,
+  passed: number,
+  failed: number,
+  incomplete: number,
+  slug: string,
+  testName: string,
+  severities: Record<string, number>,
+): void => {
+  console.log("-----------------------------------------");
+  console.log("A11Y Report");
+  console.log(`Page: ${slug}`);
+  console.log(`Test: ${testName}`);
+  console.log("-----------------------------------------");
+
+  console.log("\nCoverage:");
+  console.log(`- Rules evaluated: ${passed + failed + incomplete}`);
+  console.log(`- Passing rate: ${percent.toFixed(2)}%`);
+
+  console.log("\nSummary:");
+  console.log("- Passed:", passed);
+  console.log("- Failed:", failed);
+  console.log("- Incomplete:", incomplete);
+  console.log("- Severities:", severities);
+};
+
+const countSeverities = (results: AxeResults): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  const arraysToScan: Result[][] = [
+    results.violations || [],
+    results.incomplete || [],
+  ];
+
+  for (const arr of arraysToScan) {
+    for (const rule of arr) {
+      const impact = rule.impact || "unknown";
+      counts[impact] = (counts[impact] || 0) + 1;
+    }
+  }
+
+  return counts;
+};
+
+const clickSideNavItem = async (
+  page: Page,
+  slug: string,
+  parentSlug?: string,
+): Promise<void> => {
+  await gotoURL(page, `/ui/project/default`);
+  await page.waitForLoadState("networkidle");
+
+  if (parentSlug) {
+    await page.getByRole("button", { name: parentSlug }).click();
+  }
+  await page.getByRole("link", { name: slug, exact: true }).first().click();
+  await page.waitForLoadState("networkidle");
+};
+
+export const runA11yAudit = async (
+  slug: string,
+  page: Page,
+  testInfo: TestInfo,
+  parentSlug?: string,
+): Promise<number> => {
+  await clickSideNavItem(page, slug, parentSlug);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"])
+    .analyze();
+
+  const passed = results.passes?.length ?? 0;
+  const violations = results.violations?.length ?? 0;
+  const incomplete = results.incomplete?.length ?? 0;
+  const total = passed + violations + incomplete;
+  const percent = total === 0 ? 100 : (passed / total) * 100;
+
+  const severities = countSeverities(results);
+  const testName = testInfo.title;
+
+  printSummary(
+    percent,
+    passed,
+    violations,
+    incomplete,
+    slug,
+    testName,
+    severities,
+  );
+
+  if (results.violations.length > 0) {
+    const result = generateResult(results, "violation", slug);
+    console.log(result);
+  }
+
+  try {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "_");
+
+    const report = {
+      meta: {
+        slug,
+        testName,
+        percent,
+        passed,
+        violations,
+        incomplete,
+        severities,
+        timestamp,
+      },
+      results,
+    };
+
+    const filename = `a11y-${slug.toLowerCase()}-${timestamp}.json`;
+    const outPath = testInfo.outputPath(filename);
+    await writeFile(outPath, JSON.stringify(report, null, 2), "utf8");
+
+    await testInfo.attach(filename, {
+      path: outPath,
+      contentType: "application/json",
+    });
+  } catch (err) {
+    console.error("Failed to write/attach a11y report:", err);
+  }
+
+  return percent;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,13 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@axe-core/playwright@4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.12.1.tgz#4a14cd41eecc1ff01edcdc3db12a2e88acd34180"
+  integrity sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==
+  dependencies:
+    axe-core "~4.12.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
@@ -2475,7 +2482,7 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axe-core@^4.2.0:
+axe-core@^4.2.0, axe-core@~4.12.1:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.12.1.tgz#69fe2bf6dfc0b24973af91b1d8e945f79e1b7c44"
   integrity sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==


### PR DESCRIPTION
## Done

- [x] Added accessibility-audit.spec.ts test
- [x] Added audit tests for main entity pages and subpages
- [x] Refactored the Pr.yaml workflow to reduce repetition
- [x] Add upload artefact capability to CI
- [x] Aligns tests on features that are/n't in older LXD versions. (Eg; Cluster links are not supported in LXD 5.21)

Out of scope:
- Adding accessibility tests for side-panels
- ~Adding accessibility tests to CI to be automated (next PR)~
- Addressing any of the accessibility notices from "failed" tests.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Within a local environment, run any of the tests on accessibility-audit.spec.ts and observe the output.

## Screenshots

Expected output for instances page:
<img width="563" height="266" alt="image" src="https://github.com/user-attachments/assets/69fdc90d-4ba4-4517-ba74-5a52ebcc253c" />
