### PR TITLE
test(replicator): fix e2e test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,7 +40,7 @@ const config: PlaywrightTestConfig<TestOptions> = {
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
+    actionTimeout: 120_000,
     baseURL: "https://localhost:8407/",
     ignoreHTTPSErrors: true,
     video: "retain-on-failure",

--- a/tests/helpers/instance-file-explorer.ts
+++ b/tests/helpers/instance-file-explorer.ts
@@ -1,9 +1,16 @@
 import type { Page } from "@playwright/test";
-import { expect } from "../fixtures/lxd-test";
+import { expect, test, type LxdVersions } from "../fixtures/lxd-test";
 import { dismissNotification } from "./notification";
 import { assertTextVisible } from "./permissions";
 import { visitInstance } from "./instances";
 import { randomNameSuffix } from "./name";
+
+export const skipIfFileExplorerNotSupported = (lxdVersion: LxdVersions) => {
+  test.skip(
+    lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge",
+    "File Explorer not supported for lxd 5.0 and 5.21",
+  );
+};
 
 export const randomFileName = (): string => {
   return `playwright-file-${randomNameSuffix()}`;

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -63,7 +63,7 @@ export const createInstance = async (
 
   await page.getByRole("button", { name: "Create" }).first().click();
 
-  await page.getByText(`Created instance ${instance}.`).waitFor();
+  await dismissNotification(page, `Created instance ${instance}.`);
 };
 
 export const visitInstance = async (

--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -240,7 +240,7 @@ export const getNetworkLink = async (page: Page, network: string) => {
 
 export const submitCreateNetwork = async (page: Page, network: string) => {
   await page.getByRole("button", { name: "Create", exact: true }).click();
-  await page.waitForTimeout(5000);
+  await page.waitForTimeout(10000);
   const networkLink = await getNetworkLink(page, network);
   await expect(networkLink).toBeVisible();
 };

--- a/tests/helpers/notification.ts
+++ b/tests/helpers/notification.ts
@@ -11,8 +11,10 @@ export const checkNotificationHidden = async (page: Page) => {
 };
 
 export const dismissNotification = async (page: Page, caption: string) => {
-  await page.getByText(caption).waitFor();
-  const notification = page.locator(".toast-notification");
+  const notification = page.locator(".toast-notification", {
+    hasText: caption,
+  });
+  await notification.waitFor({ state: "visible" });
   await notification
     .getByRole("button", { name: "Close notification" })
     .click();

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -25,6 +25,7 @@ import {
   downloadFile,
   uploadFile,
   createFile,
+  skipIfFileExplorerNotSupported,
 } from "./helpers/instance-file-explorer";
 import {
   assertCode,
@@ -506,7 +507,10 @@ test("navigate with breadcrumb navigation", async ({ page }) => {
 
 test("upload, download, and delete file from file explorer", async ({
   page,
+  lxdVersion,
 }, testInfo) => {
+  skipIfFileExplorerNotSupported(lxdVersion);
+
   await visitAndStartInstance(page, instance);
   await visitFileExplorer(page, instance);
 

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -7,14 +7,12 @@ import {
   visitAndStopInstance,
 } from "./helpers/instances";
 import { validateOperation } from "./helpers/operations";
-import { dismissNotification } from "./helpers/notification";
 
 test("instance operations are recognised on the Operations page", async ({
   page,
 }) => {
   const instance = randomInstanceName();
   await createInstance(page, instance);
-  await dismissNotification(page, `Created instance ${instance}.`);
   await validateOperation(page, `Creating instance${instance}`);
 
   // start instance and wait for the notification instance was started

--- a/tests/replicators-clustered.spec.ts
+++ b/tests/replicators-clustered.spec.ts
@@ -29,7 +29,13 @@ test("Replicator", async ({ page, lxdVersion }, testInfo) => {
   await createReplicator(page, replicator, clusterLink, project);
 
   const replicatorRow = page.getByRole("row").filter({ hasText: replicator });
-  await replicatorRow.getByRole("link", { name: replicator }).click();
+  const replicatorLink = replicatorRow.getByRole("link", { name: replicator });
+  await expect(replicatorLink).toBeVisible();
+  const replicatorHref = await replicatorLink.getAttribute("href");
+  if (!replicatorHref) {
+    throw new Error("Replicator detail link href is missing");
+  }
+  await page.goto(replicatorHref);
   await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Target" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Sync" })).toBeVisible();


### PR DESCRIPTION
## Done

- Fix replicator e2e test: add `pointer-events: none` to the description
- Skip file explorer test for 5.0 and 5.21
- Increase timeout for network

Fixes https://warthogs.atlassian.net/browse/WD-37781

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Rely on CI

## Screenshots

<img width="1025" height="570" alt="image" src="https://github.com/user-attachments/assets/a2a8e381-f6b6-4a33-b542-f5d8cbecaeb8" />
