### PR TITLE
Overview - draft

### DIFF
--- a/src/components/Meter.tsx
+++ b/src/components/Meter.tsx
@@ -6,6 +6,7 @@ interface Props {
   secondaryPercentage?: number;
   text: string;
   hoverText?: string;
+  color?: string;
 }
 
 const Meter: FC<Props> = ({
@@ -13,12 +14,13 @@ const Meter: FC<Props> = ({
   secondaryPercentage = 0,
   text,
   hoverText,
+  color,
 }: Props) => {
   return (
     <>
       <div className="p-meter u-no-margin--bottom" title={hoverText}>
         <div
-          style={{ width: `max(${percentage}%, 5px)` }}
+          style={{ width: `max(${percentage}%, 5px)`, backgroundColor: color }}
           className={classnames({
             "has-next-sibling": secondaryPercentage > 0,
           })}

--- a/src/pages/instances/InstanceEmptyState.tsx
+++ b/src/pages/instances/InstanceEmptyState.tsx
@@ -10,13 +10,14 @@ import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   className?: string;
+  isAllProjects?: boolean;
 }
 
-const InstanceEmptyState: FC<Props> = ({ className }) => {
+const InstanceEmptyState: FC<Props> = ({ className, isAllProjects }) => {
   const navigate = useNavigate();
   const { canCreateInstances } = useProjectEntitlements();
-  const { project, isAllProjects } = useCurrentProject();
-  const { data: defaultProject } = useProject("default", isAllProjects);
+  const { project, isAllProjects: currentIsAllProjects } = useCurrentProject();
+  const { data: defaultProject } = useProject("default", currentIsAllProjects);
 
   const projectForCreation = isAllProjects ? defaultProject : project;
   const projectForCreationName = projectForCreation?.name ?? "default";
@@ -31,7 +32,8 @@ const InstanceEmptyState: FC<Props> = ({ className }) => {
       title="No instances found"
     >
       <p>
-        There are no instances in {isAllProjects ? "any" : "this"} project.
+        There are no instances in{" "}
+        {isAllProjects || currentIsAllProjects ? "any" : "this"} project.
         {canCreateInstances(projectForCreation)
           ? " Spin up your first instance!"
           : ""}

--- a/src/pages/overview/ClusterCard.tsx
+++ b/src/pages/overview/ClusterCard.tsx
@@ -1,8 +1,99 @@
 import type { FC } from "react";
-import { Card } from "@canonical/react-components";
+import { Card, Icon } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { useIsClustered } from "context/useIsClustered";
+import { ROOT_PATH } from "util/rootPath";
 
 const ClusterCard: FC = () => {
-  return <Card className="overview-card cluster"></Card>;
+  const isClustered = useIsClustered();
+
+  return (
+    <Card
+      className="overview-card cluster"
+      title={
+        <>
+          <Icon name="cluster-host" /> Clustering
+        </>
+      }
+    >
+      <div className="card-content">
+        <div>
+          <h5>Members (3)</h5>
+          <ul>
+            <li>
+              Leader <span className="u-text--muted">master</span>
+            </li>
+            <li>
+              <strong>2</strong> voters{" "}
+              <span className="u-text--muted">node-02, node-03</span>
+            </li>
+          </ul>
+          <p>
+            <Icon name="status-succeeded-small" /> 2 online |{" "}
+            <Icon name="status-queued-small" /> 1 offline
+          </p>
+        </div>
+        <div>
+          <div className="leaderboard-group">
+            <h5>Highest memory usage</h5>
+            <ol className="leaderboard-list">
+              <li className="critical-strain">
+                <span className="node-name">node-02</span>{" "}
+                <span className="node-value text-danger">
+                  95.4% <span className="details">(2.1 / 2.2 GiB)</span>
+                </span>
+              </li>
+              <li>
+                <span className="node-name">master</span>{" "}
+                <span className="node-value">
+                  14.0% <span className="details">(4.2 / 30.0 GiB)</span>
+                </span>
+              </li>
+              <li>
+                <span className="node-name">node-03</span>{" "}
+                <span className="node-value">
+                  10.0% <span className="details">(1.0 / 10.0 GiB)</span>
+                </span>
+              </li>
+            </ol>
+          </div>
+
+          <div className="leaderboard-group" style={{ marginTop: "1.5rem" }}>
+            <h5>Highest CPU usage</h5>
+            <ol className="leaderboard-list">
+              <li>
+                <span className="node-name">master</span>{" "}
+                <span className="node-value">78.2%</span>
+              </li>
+              <li>
+                <span className="node-name">node-02</span>{" "}
+                <span className="node-value">41.5%</span>
+              </li>
+              <li>
+                <span className="node-name u-text--muted">
+                  {" "}
+                  node-03 (Offline)
+                </span>
+                <span className="node-value u-text--muted">--</span>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+
+      <div className="card-footer">
+        <Link
+          to={
+            isClustered
+              ? `${ROOT_PATH}/ui/cluster/members`
+              : `${ROOT_PATH}/ui/cluster/server`
+          }
+        >
+          See more
+        </Link>
+      </div>
+    </Card>
+  );
 };
 
 export default ClusterCard;

--- a/src/pages/overview/InstancesCard.tsx
+++ b/src/pages/overview/InstancesCard.tsx
@@ -10,7 +10,6 @@ import ChartLegend from "components/ChartLegend";
 import { useInstances } from "context/useInstances";
 import InstanceEmptyState from "pages/instances/InstanceEmptyState";
 import InstancesOverviewStatus from "pages/overview/InstancesOverviewStatus";
-import type { LxdInstance } from "types/instance";
 import { pluralize } from "util/helpers";
 import {
   getInstanceDistribution,
@@ -19,8 +18,7 @@ import {
 import { ROOT_PATH } from "util/rootPath";
 
 const InstancesCard: FC = () => {
-  const { data, error, isLoading } = useInstances(null);
-  const instances: LxdInstance[] = data ?? [];
+  const { data: instances = [], error, isLoading } = useInstances(null);
 
   const {
     runningCount,
@@ -70,7 +68,7 @@ const InstancesCard: FC = () => {
   if (instances.length === 0) {
     return (
       <Card className={cardClassName} title={cardTitle}>
-        <InstanceEmptyState className="u-no-margin" />
+        <InstanceEmptyState className="u-no-margin" isAllProjects />
       </Card>
     );
   }

--- a/src/pages/overview/Overview.tsx
+++ b/src/pages/overview/Overview.tsx
@@ -6,6 +6,7 @@ import ProjectsCard from "pages/overview/ProjectsCard";
 import MemoryCard from "pages/overview/MemoryCard";
 import StorageCard from "pages/overview/StorageCard";
 import NetworksCard from "pages/overview/NetworksCard";
+import WarningCard from "pages/overview/WarningCard";
 
 const Overview: FC = () => {
   return (
@@ -14,15 +15,14 @@ const Overview: FC = () => {
         <InstancesCard />
         <ClusterCard />
       </Row>
-      <Row>
-        <ProjectsCard />
-      </Row>
       <Row className="overview-row">
+        <ProjectsCard />
         <StorageCard />
-        <MemoryCard />
+        {/* <MemoryCard /> */}
       </Row>
       <Row>
-        <NetworksCard />
+        {/* <NetworksCard /> */}
+        <WarningCard />
       </Row>
     </CustomLayout>
   );

--- a/src/pages/overview/ProjectsCard.tsx
+++ b/src/pages/overview/ProjectsCard.tsx
@@ -1,8 +1,84 @@
 import type { FC } from "react";
-import { Card } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { Card, Icon, Spinner } from "@canonical/react-components";
+import { useProjects } from "context/useProjects";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
+import type { LxdProject } from "types/project";
+import { pluralize } from "util/helpers";
+import { getInstancesUsedByProject } from "util/projects";
+import { ROOT_PATH } from "util/rootPath";
 
 const ProjectsCard: FC = () => {
-  return <Card className="overview-card projects"></Card>;
+  const { data: projects = [], error, isLoading } = useProjects();
+  const PROJECTS_LIMIT = 5;
+
+  const projectsWithCounts = projects.map((project: LxdProject) => {
+    return {
+      name: project.name,
+      instanceCount: getInstancesUsedByProject(project).length,
+    };
+  });
+
+  const topProjects = projectsWithCounts
+    .sort((a, b) => b.instanceCount - a.instanceCount)
+    .slice(0, PROJECTS_LIMIT);
+
+  const cardClassName = "overview-card projects";
+  const cardTitle = (
+    <>
+      <Icon name="folder" /> Projects
+      {!isLoading && !error && projects.length > 0 && ` (${projects.length})`}
+    </>
+  );
+
+  if (isLoading) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <Spinner className="u-loader" text="Loading projects..." />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <div className="error-message">
+          <Icon name="error" className="margin-right--large" /> Error while
+          loading projects: {error.message}
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overview-card projects" title={cardTitle}>
+      {!isLoading && !error && (
+        <>
+          <table className="projects-instances-ranking-table u-no-margin">
+            <tbody>
+              {topProjects.map((project) => {
+                return (
+                  <tr key={project.name}>
+                    <td>
+                      <ProjectRichChip projectName={project.name} />
+                    </td>
+                    <td className="u-align--right u-text--muted">
+                      {project.instanceCount}{" "}
+                      {pluralize("instance", project.instanceCount)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div className="card-footer">
+            <Link to={`${ROOT_PATH}/ui/projects`}>See more</Link>
+          </div>
+        </>
+      )}
+    </Card>
+  );
 };
 
 export default ProjectsCard;

--- a/src/pages/overview/ProjectsCard.tsx
+++ b/src/pages/overview/ProjectsCard.tsx
@@ -51,7 +51,7 @@ const ProjectsCard: FC = () => {
   }
 
   return (
-    <Card className="overview-card projects" title={cardTitle}>
+    <Card className={cardClassName} title={cardTitle}>
       {!isLoading && !error && (
         <>
           <table className="projects-instances-ranking-table u-no-margin">

--- a/src/pages/overview/StorageCard.tsx
+++ b/src/pages/overview/StorageCard.tsx
@@ -1,8 +1,82 @@
 import type { FC } from "react";
-import { Card } from "@canonical/react-components";
+import { Link } from "react-router-dom";
+import { Card, Icon, Spinner } from "@canonical/react-components";
+import { useStoragePools } from "context/useStoragePools";
+import StoragePoolDetails from "pages/overview/StoragePoolDetails";
+import { type LxdStoragePool } from "types/storage";
+import { ROOT_PATH } from "util/rootPath";
+import { getVolumesUsedByPool } from "util/storagePool";
+import { pluralize } from "util/helpers";
 
 const StorageCard: FC = () => {
-  return <Card className="overview-card storage"></Card>;
+  const { data: pools = [], error, isLoading } = useStoragePools();
+
+  const poolsWithVolumeCount = pools.map((pool: LxdStoragePool) => {
+    return {
+      name: pool.name,
+      volumeCount: getVolumesUsedByPool(pool).length,
+    };
+  });
+  const totalVolumeCount = poolsWithVolumeCount.reduce(
+    (acc, pool) => acc + pool.volumeCount,
+    0,
+  );
+
+  const cardClassName = "overview-card storage";
+  const cardTitle = (
+    <>
+      <Icon name="storage-pool" /> Storage
+    </>
+  );
+
+  if (isLoading) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <Spinner className="u-loader" text="Loading..." />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <div className="error-message">
+          <Icon name="error" className="margin-right--large" /> Error while
+          loading storage pools: {error.message}
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cardClassName} title={cardTitle}>
+      {!isLoading && !error && (
+        <>
+          <p>
+            {pools.length} {pluralize("pool", pools.length)}&nbsp;|&nbsp;
+            {totalVolumeCount} {pluralize("volume", totalVolumeCount)}
+          </p>
+          <div className="storage-pools-container">
+            {pools.map((pool) => (
+              <StoragePoolDetails
+                pool={pool}
+                volumeCount={
+                  poolsWithVolumeCount.find((p) => p.name === pool.name)
+                    ?.volumeCount || 0
+                }
+                key={pool.name}
+              />
+            ))}
+          </div>
+          <div className="card-footer">
+            <Link to={`${ROOT_PATH}/ui/project/default/storage/pools`}>
+              See more
+            </Link>
+          </div>
+        </>
+      )}
+    </Card>
+  );
 };
 
 export default StorageCard;

--- a/src/pages/overview/StoragePoolDetails.tsx
+++ b/src/pages/overview/StoragePoolDetails.tsx
@@ -1,0 +1,25 @@
+import StoragePoolSize from "pages/storage/StoragePoolSize";
+import { type FC } from "react";
+import type { LxdStoragePool } from "types/storage";
+import { pluralize } from "util/helpers";
+
+interface Props {
+  pool: LxdStoragePool;
+  volumeCount: number;
+}
+
+const StoragePoolDetails: FC<Props> = ({ pool, volumeCount }) => {
+  return (
+    <div className="storage-pool-details">
+      <p>
+        <b>{pool.name}</b>
+      </p>
+      <p>
+        {volumeCount} {pluralize("volume", volumeCount)}
+      </p>
+      <StoragePoolSize pool={pool} hasMeterBar displayPercentage withColor />
+    </div>
+  );
+};
+
+export default StoragePoolDetails;

--- a/src/pages/overview/WarningCard.tsx
+++ b/src/pages/overview/WarningCard.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState, type FC } from "react";
+import { Card, Icon, MainTable, Spinner } from "@canonical/react-components";
+import { Link, useSearchParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { fetchWarnings } from "api/warnings";
+import { type LxdWarningSeverity, type LxdWarningStatus } from "types/warning";
+import { isoTimeToString } from "util/helpers";
+import { queryKeys } from "util/queryKeys";
+import { ROOT_PATH } from "util/rootPath";
+import { type WarningFilters } from "util/warningFilter";
+
+const WarningCard: FC = () => {
+  const [selectedNames, setSelectedNames] = useState<string[]>([]);
+  const [searchParams] = useSearchParams();
+
+  const {
+    data: warnings = [],
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: [queryKeys.warnings],
+    queryFn: async () => fetchWarnings(),
+    retry: false, // the api returns a 403 for users with limited permissions, surface the error right away
+  });
+
+  const cardClassName = "overview-card warnings";
+  const cardTitle = (
+    <>
+      <Icon name="warning-grey" /> Warnings
+    </>
+  );
+
+  const filters: WarningFilters = {
+    queries: searchParams.getAll("query").map((value) => value.toLowerCase()),
+    statuses: searchParams.getAll("status") as LxdWarningStatus[],
+    severities: searchParams.getAll("severity") as LxdWarningSeverity[],
+  };
+
+  const filteredWarnings = warnings.filter((item) => {
+    if (
+      !filters.queries.every(
+        (q) =>
+          item.type.toLowerCase().includes(q.toLowerCase()) ||
+          item.last_message.toLowerCase().includes(q.toLowerCase()),
+      )
+    ) {
+      return false;
+    }
+    if (
+      filters.statuses.length > 0 &&
+      !filters.statuses.includes(item.status)
+    ) {
+      return false;
+    }
+    if (
+      filters.severities.length > 0 &&
+      !filters.severities.includes(item.severity)
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    const validNames = new Set(
+      filteredWarnings?.map((warning) => warning.uuid),
+    );
+    const validSelections = selectedNames.filter((name) =>
+      validNames.has(name),
+    );
+    if (validSelections.length !== selectedNames.length) {
+      setSelectedNames(validSelections);
+    }
+  }, [filteredWarnings]);
+
+  const headers = [
+    { content: "Type", sortKey: "type", className: "type" },
+    {
+      content: "Last message",
+      sortKey: "lastMessage",
+      className: "last_message",
+    },
+    { content: "Status", sortKey: "status", className: "status" },
+    { content: "Severity", sortKey: "severity", className: "severity" },
+    { content: "Count", sortKey: "count", className: "count u-align--right" },
+    { content: "Project", sortKey: "project", className: "project" },
+    { content: "First seen", sortKey: "firstSeen", className: "first_seen_at" },
+    { content: "Last seen", sortKey: "lastSeen", className: "last_seen_at" },
+  ];
+
+  const rows = filteredWarnings.map((warning) => {
+    return {
+      key: warning.uuid,
+      name: warning.uuid,
+      className: "u-row",
+      columns: [
+        {
+          content: warning.type,
+          role: "rowheader",
+          "aria-label": "Type",
+          className: "type",
+        },
+        {
+          content: warning.last_message,
+          role: "cell",
+          "aria-label": "Last message",
+          className: "last_message",
+        },
+        {
+          content: warning.status,
+          role: "cell",
+          "aria-label": "Status",
+          className: "status",
+        },
+        {
+          content: warning.severity,
+          role: "cell",
+          "aria-label": "Severity",
+          className: "severity",
+        },
+        {
+          content: warning.count,
+          role: "cell",
+          className: "count u-align--right",
+          "aria-label": "Count",
+        },
+        {
+          content: warning.project,
+          role: "cell",
+          className: "project u-align--center",
+          "aria-label": "Project",
+        },
+        {
+          content: isoTimeToString(warning.first_seen_at),
+          role: "cell",
+          "aria-label": "First seen",
+          className: "first_seen_at",
+        },
+        {
+          content: isoTimeToString(warning.last_seen_at),
+          role: "cell",
+          "aria-label": "Last seen",
+          className: "last_seen_at",
+        },
+      ],
+      sortData: {
+        type: warning.type,
+        lastMessage: warning.last_message.toLowerCase(),
+        status: warning.status,
+        severity: warning.severity,
+        count: warning.count,
+        project: warning.project.toLowerCase(),
+        firstSeen: warning.first_seen_at,
+        lastSeen: warning.last_seen_at,
+      },
+    };
+  });
+
+  if (isLoading) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <Spinner className="u-loader" text="Loading warnings..." />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className={cardClassName} title={cardTitle}>
+        <div className="error-message">
+          <Icon name="error" className="margin-right--large" /> Error while
+          loading warnings: {error.message}
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cardClassName} title={cardTitle}>
+      <MainTable
+        id="warning-table"
+        headers={headers}
+        rows={rows}
+        paginate={30}
+        sortable
+        className="warnings-table"
+        emptyStateMsg={
+          isLoading ? (
+            <Spinner className="u-loader" text="Loading warnings..." />
+          ) : (
+            "No data to display"
+          )
+        }
+        itemName="warning"
+        parentName="server"
+        selectedNames={selectedNames}
+        setSelectedNames={setSelectedNames}
+        filteredNames={rows.map((item) => item.name)}
+        disabledNames={[]}
+      />
+      <div className="card-footer">
+        <Link to={`${ROOT_PATH}/ui/warnings?status=new`}>See more</Link>
+      </div>
+    </Card>
+  );
+};
+
+export default WarningCard;

--- a/src/pages/projects/NavigationProjectSelectorList.tsx
+++ b/src/pages/projects/NavigationProjectSelectorList.tsx
@@ -1,9 +1,7 @@
 import { useState, type Dispatch, type FC, type SetStateAction } from "react";
 import { Link, useLocation } from "react-router-dom";
 import type { LxdProject } from "types/project";
-import { getProjectSwitchTarget } from "util/projects";
-import { filterUsedByType } from "util/usedBy";
-import { pluralize } from "util/helpers";
+import { getInstanceCount, getProjectSwitchTarget } from "util/projects";
 
 interface Props {
   projects: LxdProject[];
@@ -18,11 +16,6 @@ const NavigationProjectSelectorList: FC<Props> = ({
   const [query, setQuery] = useState("");
 
   onMount(setQuery);
-
-  const getInstanceCount = (project: LxdProject) => {
-    const count = filterUsedByType("instance", project.used_by).length;
-    return `${count} ${pluralize("instance", count)}`;
-  };
 
   return (
     <div className="projects">

--- a/src/pages/storage/StoragePoolSize.tsx
+++ b/src/pages/storage/StoragePoolSize.tsx
@@ -12,6 +12,8 @@ interface Props {
   hasMeterBar?: boolean;
   member?: LxdClusterMember;
   forceSingleLine?: boolean;
+  displayPercentage?: boolean;
+  withColor?: boolean;
 }
 
 const StoragePoolSize: FC<Props> = ({
@@ -19,6 +21,8 @@ const StoragePoolSize: FC<Props> = ({
   hasMeterBar,
   member,
   forceSingleLine,
+  displayPercentage,
+  withColor,
 }) => {
   // When a single member is provided, the resource usage is shown for that member only
 
@@ -27,6 +31,7 @@ const StoragePoolSize: FC<Props> = ({
     isClusterLocalDriver(pool.driver) && isClustered;
   const { data: resources } = useStoragePoolResources(pool, member);
   const resourceList = ensureArray(resources);
+
   if (
     hasMemberSpecificSize &&
     forceSingleLine &&
@@ -47,10 +52,45 @@ const StoragePoolSize: FC<Props> = ({
         const used = poolResource.space.used || 0;
         const resourceKey = poolResource.memberName || `resource-${index}`;
 
+        const usedPercentage = (100 / total) * used || 0;
+        const getMeterColor = (usedPercentage: number) => {
+          if (usedPercentage < 80) {
+            return "green";
+          } else if (usedPercentage < 95) {
+            return "orange";
+          } else {
+            return "red";
+          }
+        };
+
         if (!hasMeterBar) {
           return (
             <div key={resourceKey}>
               {`${humanFileSize(used)} of ${humanFileSize(total)} used`}
+            </div>
+          );
+        }
+
+        if (displayPercentage) {
+          return (
+            <div
+              key={resourceKey}
+              className="meter-with-percentage u-gap--small"
+            >
+              <div>
+                <Meter
+                  percentage={(100 / total) * used || 0}
+                  text={`${humanFileSize(used)} of ${humanFileSize(total)} used`}
+                  color={
+                    withColor
+                      ? getMeterColor((used * 100) / total || 0)
+                      : undefined
+                  }
+                />
+              </div>
+              <span className="percentage p-text--small">
+                {Math.round(usedPercentage)}%
+              </span>
             </div>
           );
         }
@@ -60,6 +100,9 @@ const StoragePoolSize: FC<Props> = ({
             key={resourceKey}
             percentage={(100 / total) * used || 0}
             text={`${humanFileSize(used)} of ${humanFileSize(total)} used`}
+            color={
+              withColor ? getMeterColor((used * 100) / total || 0) : undefined
+            }
           />
         );
       })}

--- a/src/sass/_meter.scss
+++ b/src/sass/_meter.scss
@@ -23,3 +23,7 @@
     opacity: 0.3;
   }
 }
+
+.meter-with-percentage {
+  display: flex;
+}

--- a/src/sass/_overview.scss
+++ b/src/sass/_overview.scss
@@ -19,6 +19,12 @@
       }
     }
 
+    .card-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: $spv--small;
+    }
+
     &.cluster,
     &.storage,
     &.memory {
@@ -78,14 +84,17 @@
         }
       }
 
-      .card-footer {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: $spv--small;
-      }
-
       @include mobile {
         min-width: 100%;
+      }
+    }
+
+    &.projects {
+      max-width: calc(50% - $sph--large / 2);
+      min-width: 20rem;
+
+      .plus-n-more {
+        margin-left: $sph--small;
       }
     }
   }

--- a/src/sass/_overview.scss
+++ b/src/sass/_overview.scss
@@ -31,6 +31,17 @@
       flex: 1;
     }
 
+    &.cluster {
+      .card-content {
+        display: flex;
+        gap: calc($sph--x-large * 2);
+
+        > div {
+          flex: 1;
+        }
+      }
+    }
+
     &.instances {
       max-width: calc(50% - $sph--large / 2);
       min-width: 20rem;
@@ -95,6 +106,32 @@
 
       .plus-n-more {
         margin-left: $sph--small;
+      }
+    }
+
+    &.storage {
+      .p-card__content {
+        .storage-pools-container {
+          display: grid;
+          gap: $sph--x-large;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+
+          @include mobile {
+            grid-template-columns: 1fr;
+          }
+
+          .storage-pool-details {
+            .meter-with-percentage {
+              .p-meter {
+                width: 8rem;
+              }
+
+              .percentage {
+                margin-top: -$spv--x-small;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/src/util/projects.tsx
+++ b/src/util/projects.tsx
@@ -1,8 +1,9 @@
 import type { LxdProject, ProjectReplicaMode } from "types/project";
 import { slugify } from "./slugify";
-import { ROOT_PATH } from "util/rootPath";
 import { updateProjectReplicaMode } from "api/projects";
 import { waitForOperation } from "api/operations";
+import { pluralize } from "util/helpers";
+import { ROOT_PATH } from "util/rootPath";
 
 export const ALL_PROJECTS = "All projects";
 
@@ -93,6 +94,11 @@ export const getInstancesUsedByProject = (project: LxdProject): string[] => {
   }
 
   return project.used_by.filter((item) => item.startsWith("/1.0/instances/"));
+};
+
+export const getInstanceCount = (project: LxdProject): string => {
+  const count = getInstancesUsedByProject(project).length;
+  return `${count} ${pluralize("instance", count)}`;
 };
 
 export const updateReplicaMode = async (

--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -16,6 +16,7 @@ import {
   pureStorage,
   zfsDriver,
 } from "util/storageOptions";
+import { LxdStoragePool } from "types/storage";
 
 export const storagePoolFormFieldToPayloadName: Record<string, string> = {
   ceph_cluster_name: "ceph.cluster_name",
@@ -236,4 +237,14 @@ export const hasSource = (
   }
 
   return driversWithSource.includes(driver);
+};
+
+export const getVolumesUsedByPool = (pool: LxdStoragePool) => {
+  if (!pool.used_by) {
+    return [];
+  }
+
+  return pool.used_by.filter((item) =>
+    item.startsWith(`/1.0/storage-pools/${pool.name}/volumes/`),
+  );
 };


### PR DESCRIPTION
## --- DO NOT MERGE ---

## Done

- Overview draft

**Note that:**
This draft is not responsive.
The calculation of volumes count is incomplete.
The Cluster card is harcoded with dummy data.
The Warnings card is the same table as the warning list page so any UX change should be reflected in both.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Enable overview: in your browser console, run `localStorage.setItem("lxdui_ff_OVERVIEW", "true");`. Then refresh, you should see an `Overview` item in the Navigation.
    - Click `Overview` in the side navigation
    - Admire draft

## Screenshots

<img width="1857" height="1056" alt="image" src="https://github.com/user-attachments/assets/11df44b5-423f-47f3-a672-34f6a5ec4b2b" />

<img width="1857" height="1056" alt="image" src="https://github.com/user-attachments/assets/bd7794f0-f168-433c-b885-279fb8348024" />