### PR TITLE
fix(replicators): failure notification when running

### DIFF
--- a/src/pages/cluster/actions/RunReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/RunReplicatorBtn.tsx
@@ -126,7 +126,7 @@ const RunReplicatorBtn: FC<Props> = ({
     replicatorLoading.setLastRunError(replicator, msg);
     invalidateCache();
     toastNotify.failure(
-      `Replicator${replicator.name} failed while running`,
+      `Replicator ${replicator.name} failed while running`,
       new Error(msg),
     );
   };

--- a/tests/replicators-clustered.spec.ts
+++ b/tests/replicators-clustered.spec.ts
@@ -29,13 +29,7 @@ test("Replicator", async ({ page, lxdVersion }, testInfo) => {
   await createReplicator(page, replicator, clusterLink, project);
 
   const replicatorRow = page.getByRole("row").filter({ hasText: replicator });
-  const replicatorLink = replicatorRow.getByRole("link", { name: replicator });
-  await expect(replicatorLink).toBeVisible();
-  const replicatorHref = await replicatorLink.getAttribute("href");
-  if (!replicatorHref) {
-    throw new Error("Replicator detail link href is missing");
-  }
-  await page.goto(replicatorHref);
+  await replicatorRow.getByRole("link", { name: replicator }).click();
   await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Target" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Sync" })).toBeVisible();


### PR DESCRIPTION
## Done

- fix(replicators): failure notification when running

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Run a replicator and induce error
    - Make sure the notification has a space before the replicator name

## Screenshots
