### PR TITLE
feat(explanation-tooltip) - [WD-36581] Implement ExplanationTooltip for different entities

### DIFF
--- a/src/components/ExplanationTooltip.tsx
+++ b/src/components/ExplanationTooltip.tsx
@@ -1,4 +1,5 @@
-import { type FC } from "react";
+import { type FC, type ReactNode } from "react";
+import classNames from "classnames";
 import { Icon, Tooltip } from "@canonical/react-components";
 import DocLink from "components/DocLink";
 
@@ -6,12 +7,16 @@ interface Props {
   explanation: string;
   docPath: string;
   docLabel?: string;
+  className?: string;
+  children?: ReactNode;
 }
 
 const ExplanationTooltip: FC<Props> = ({
   explanation,
   docPath,
   docLabel = "Learn more",
+  className,
+  children,
 }) => {
   const tooltip = (
     <Tooltip
@@ -31,7 +36,12 @@ const ExplanationTooltip: FC<Props> = ({
     </Tooltip>
   );
 
-  return tooltip;
+  return (
+    <span className={classNames("explanation-tooltip-wrapper", className)}>
+      {children}
+      {tooltip}
+    </span>
+  );
 };
 
 export default ExplanationTooltip;

--- a/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ClusterGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <ExplanationTooltip
+      explanation="Group cluster members together to assist with instance placement."
+      docPath="/explanation/clustering/#cluster-groups"
+    >
+      {children}
+    </ExplanationTooltip>
+  );
+};
+
+export default ClusterGroupExplanationTooltip;

--- a/src/pages/cluster/ClusterGroupList.tsx
+++ b/src/pages/cluster/ClusterGroupList.tsx
@@ -13,7 +13,7 @@ import EditClusterGroupBtn from "pages/cluster/actions/EditClusterGroupBtn";
 import DeleteClusterGroupBtn from "pages/cluster/actions/DeleteClusterGroupBtn";
 import NotificationRow from "components/NotificationRow";
 import BaseLayout from "components/BaseLayout";
-import HelpLink from "components/HelpLink";
+import ClusterGroupExplanationTooltip from "pages/cluster/ClusterGroupExplanationTooltip";
 import useSortTableData from "util/useSortTableData";
 import CreateClusterGroupBtn from "pages/cluster/actions/CreateClusterGroupBtn";
 import { useClusterGroups } from "context/useClusterGroups";
@@ -136,12 +136,9 @@ const ClusterGroupList: FC = () => {
     <BaseLayout
       mainClassName="cluster-list"
       title={
-        <HelpLink
-          docPath="/explanation/clustering/#cluster-groups"
-          title="Learn more about cluster groups"
-        >
+        <ClusterGroupExplanationTooltip>
           Cluster groups
-        </HelpLink>
+        </ClusterGroupExplanationTooltip>
       }
       controls={isClustered && <CreateClusterGroupBtn />}
     >

--- a/src/pages/cluster/ClusterLinkExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterLinkExplanationTooltip.tsx
@@ -1,12 +1,12 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const ServerExplanationTooltip: FC<{ children?: ReactNode }> = ({
+const ClusterLinkExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
     <ExplanationTooltip
-      explanation="Monitor server information, status, and resource usage."
+      explanation="Connect and manage links between clusters to share entities."
       docPath="/explanation/clustering/"
     >
       {children}
@@ -14,4 +14,4 @@ const ServerExplanationTooltip: FC<{ children?: ReactNode }> = ({
   );
 };
 
-export default ServerExplanationTooltip;
+export default ClusterLinkExplanationTooltip;

--- a/src/pages/cluster/ClusterLinkList.tsx
+++ b/src/pages/cluster/ClusterLinkList.tsx
@@ -13,7 +13,7 @@ import {
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import BaseLayout from "components/BaseLayout";
-import HelpLink from "components/HelpLink";
+import ClusterLinkExplanationTooltip from "pages/cluster/ClusterLinkExplanationTooltip";
 import { useDocs } from "context/useDocs";
 import useSortTableData from "util/useSortTableData";
 import CreateClusterLinkBtn from "pages/cluster/actions/CreateClusterLinkBtn";
@@ -167,12 +167,9 @@ const ClusterLinkList: FC = () => {
     <>
       <BaseLayout
         title={
-          <HelpLink
-            docPath="/explanation/clustering/"
-            title="Learn more about clustering"
-          >
+          <ClusterLinkExplanationTooltip>
             Cluster links
-          </HelpLink>
+          </ClusterLinkExplanationTooltip>
         }
         controls={!isEmptyState && <CreateClusterLinkBtn />}
       >

--- a/src/pages/cluster/ClusterMemberExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterMemberExplanationTooltip.tsx
@@ -1,12 +1,12 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const ServerExplanationTooltip: FC<{ children?: ReactNode }> = ({
+const ClusterMemberExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
     <ExplanationTooltip
-      explanation="Monitor server information, status, and resource usage."
+      explanation="View and manage the individual members that make up your LXD cluster."
       docPath="/explanation/clustering/"
     >
       {children}
@@ -14,4 +14,4 @@ const ServerExplanationTooltip: FC<{ children?: ReactNode }> = ({
   );
 };
 
-export default ServerExplanationTooltip;
+export default ClusterMemberExplanationTooltip;

--- a/src/pages/cluster/ClusterMemberList.tsx
+++ b/src/pages/cluster/ClusterMemberList.tsx
@@ -11,7 +11,7 @@ import {
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
 import BaseLayout from "components/BaseLayout";
-import HelpLink from "components/HelpLink";
+import ClusterMemberExplanationTooltip from "pages/cluster/ClusterMemberExplanationTooltip";
 import { useMemberLoading } from "context/memberLoading";
 import { useClusterMembers } from "context/useClusterMembers";
 import { useIsClustered } from "context/useIsClustered";
@@ -163,12 +163,9 @@ const ClusterMemberList: FC = () => {
     <BaseLayout
       mainClassName="cluster-list"
       title={
-        <HelpLink
-          docPath="/explanation/clustering/"
-          title="Learn more about clustering"
-        >
+        <ClusterMemberExplanationTooltip>
           Cluster members
-        </HelpLink>
+        </ClusterMemberExplanationTooltip>
       }
     >
       <NotificationRow />

--- a/src/pages/cluster/ClusterServer.tsx
+++ b/src/pages/cluster/ClusterServer.tsx
@@ -2,7 +2,7 @@ import { useState, type FC } from "react";
 import { Notification, Row } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
 import DocLink from "components/DocLink";
-import HelpLink from "components/HelpLink";
+import ServerExplanationTooltip from "pages/cluster/ServerExplanationTooltip";
 import EnableClusteringBtn from "pages/cluster/actions/EnableClusteringBtn";
 import ClusterMemberHardware from "pages/cluster/ClusterMemberHardware";
 
@@ -12,14 +12,7 @@ const ClusterServer: FC = () => {
   return (
     <BaseLayout
       mainClassName="cluster-server"
-      title={
-        <HelpLink
-          docPath="/explanation/clustering/"
-          title="Learn more about clustering"
-        >
-          Server
-        </HelpLink>
-      }
+      title={<ServerExplanationTooltip>Server</ServerExplanationTooltip>}
     >
       <Row>
         {showNotification && (

--- a/src/pages/cluster/ReplicatorExplanationTooltip.tsx
+++ b/src/pages/cluster/ReplicatorExplanationTooltip.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ReplicatorExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <ExplanationTooltip
+      explanation="Configure and manage replication of instances across cluster links."
+      docPath="/explanation/replicators/"
+    >
+      {children}
+    </ExplanationTooltip>
+  );
+};
+
+export default ReplicatorExplanationTooltip;

--- a/src/pages/cluster/ReplicatorList.tsx
+++ b/src/pages/cluster/ReplicatorList.tsx
@@ -11,7 +11,7 @@ import {
   Row,
 } from "@canonical/react-components";
 import BaseLayout from "components/BaseLayout";
-import HelpLink from "components/HelpLink";
+import ReplicatorExplanationTooltip from "pages/cluster/ReplicatorExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import { useClusterLinks } from "context/useClusterLinks";
 import { useReplicators } from "context/useReplicators";
@@ -250,12 +250,9 @@ const ReplicatorList: FC<Props> = ({ variant = "main", project, cluster }) => {
     return (
       <BaseLayout
         title={
-          <HelpLink
-            docPath="/explanation/replicators/"
-            title="Learn more about replicators"
-          >
+          <ReplicatorExplanationTooltip>
             Replicators
-          </HelpLink>
+          </ReplicatorExplanationTooltip>
         }
         controls={
           !isEmptyState && (

--- a/src/pages/cluster/ServerExplanationTooltip.tsx
+++ b/src/pages/cluster/ServerExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ServerExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Monitor server information, status, and resource usage."
+        docPath="/explanation/clustering/"
+      />
+    </span>
+  );
+};
+
+export default ServerExplanationTooltip;

--- a/src/pages/images/ImageRegistriesList.tsx
+++ b/src/pages/images/ImageRegistriesList.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import useSortTableData from "util/useSortTableData";
 import { useImageRegistries } from "context/useImageRegistries";
-import HelpLink from "components/HelpLink";
+import ImageRegistryExplanationTooltip from "pages/images/ImageRegistryExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import PageHeader from "components/PageHeader";
 import ImageRegistriesSearchFilter, {
@@ -192,12 +192,9 @@ const ImageRegistriesList: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/image-handling/"
-                  title="Learn more about image registries"
-                >
+                <ImageRegistryExplanationTooltip>
                   Image registries
-                </HelpLink>
+                </ImageRegistryExplanationTooltip>
               </PageHeader.Title>
               {imageRegistries.length > 0 && (
                 <PageHeader.Search>

--- a/src/pages/images/ImageRegistryExplanationTooltip.tsx
+++ b/src/pages/images/ImageRegistryExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ImageRegistryExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Configure external image sources for importing images."
+        docPath="/image-handling/"
+      />
+    </span>
+  );
+};
+
+export default ImageRegistryExplanationTooltip;

--- a/src/pages/images/ImageRegistryExplanationTooltip.tsx
+++ b/src/pages/images/ImageRegistryExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const ImageRegistryExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Configure external image sources for importing images."
+      docPath="/image-handling/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Configure external image sources for importing images."
-        docPath="/image-handling/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/images/LocalImageExplanationTooltip.tsx
+++ b/src/pages/images/LocalImageExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const LocalImageExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="View and manage images stored locally on the LXD server."
+        docPath="/image-handling/"
+      />
+    </span>
+  );
+};
+
+export default LocalImageExplanationTooltip;

--- a/src/pages/images/LocalImageExplanationTooltip.tsx
+++ b/src/pages/images/LocalImageExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const LocalImageExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="View and manage images stored locally on the LXD server."
+      docPath="/image-handling/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="View and manage images stored locally on the LXD server."
-        docPath="/image-handling/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/images/LocalImageList.tsx
+++ b/src/pages/images/LocalImageList.tsx
@@ -25,7 +25,7 @@ import useSortTableData from "util/useSortTableData";
 import SelectableMainTable from "components/SelectableMainTable";
 import BulkDeleteImageBtn from "pages/images/actions/BulkDeleteImageBtn";
 import ExpandableList from "components/ExpandableList";
-import HelpLink from "components/HelpLink";
+import LocalImageExplanationTooltip from "pages/images/LocalImageExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import PageHeader from "components/PageHeader";
 import SelectedTableNotification from "components/SelectedTableNotification";
@@ -225,12 +225,9 @@ const LocalImageList: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/image-handling/"
-                title="Learn more about local images"
-              >
+              <LocalImageExplanationTooltip>
                 Local images
-              </HelpLink>
+              </LocalImageExplanationTooltip>
             </PageHeader.Title>
             {selectedNames.length === 0 && images.length > 0 && (
               <PageHeader.Search>

--- a/src/pages/instances/InstanceExplanationTooltip.tsx
+++ b/src/pages/instances/InstanceExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const InstanceExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Manage and monitor virtual machines and containers."
+      docPath="/explanation/instances/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Manage and monitor virtual machines and containers running on the LXD server."
-        docPath="/explanation/instances/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/networks/NetworkAclExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkAclExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const NetworkAclExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Define network access control rules to control traffic on your networks."
+        docPath="/howto/network_acls/"
+      />
+    </span>
+  );
+};
+
+export default NetworkAclExplanationTooltip;

--- a/src/pages/networks/NetworkAclExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkAclExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const NetworkAclExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Define network access control rules to direct traffic on your networks."
+      docPath="/howto/network_acls/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Define network access control rules to control traffic on your networks."
-        docPath="/howto/network_acls/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/networks/NetworkAclList.tsx
+++ b/src/pages/networks/NetworkAclList.tsx
@@ -11,7 +11,7 @@ import {
 } from "@canonical/react-components";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import NetworkAclExplanationTooltip from "pages/networks/NetworkAclExplanationTooltip";
 import PageHeader from "components/PageHeader";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { useCurrentProject } from "context/useCurrentProject";
@@ -131,12 +131,9 @@ const NetworkAclList: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/howto/network_acls/"
-                title="Learn more about network access control lists"
-              >
+              <NetworkAclExplanationTooltip>
                 Network Access Control Lists
-              </HelpLink>
+              </NetworkAclExplanationTooltip>
             </PageHeader.Title>
           </PageHeader.Left>
           <PageHeader.BaseActions>

--- a/src/pages/networks/NetworkExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const NetworkExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Configure and manage virtual and physical networks to connect instances."
+        docPath="/explanation/networks/"
+      />
+    </span>
+  );
+};
+
+export default NetworkExplanationTooltip;

--- a/src/pages/networks/NetworkExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const NetworkExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Configure and manage virtual and physical networks to connect instances."
+      docPath="/explanation/networks/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Configure and manage virtual and physical networks to connect instances."
-        docPath="/explanation/networks/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/networks/NetworkIPAM.tsx
+++ b/src/pages/networks/NetworkIPAM.tsx
@@ -11,7 +11,7 @@ import {
 } from "@canonical/react-components";
 import { useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import NetworkIPAMExplanationTooltip from "pages/networks/NetworkIPAMExplanationTooltip";
 import PageHeader from "components/PageHeader";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
@@ -164,12 +164,9 @@ const NetworkIPAM: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/howto/network_ipam/"
-                title="Learn more about IPAM"
-              >
+              <NetworkIPAMExplanationTooltip>
                 IP Address Management
-              </HelpLink>
+              </NetworkIPAMExplanationTooltip>
             </PageHeader.Title>
           </PageHeader.Left>
         </PageHeader>

--- a/src/pages/networks/NetworkIPAMExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkIPAMExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const NetworkIPAMExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="View IP address allocation and tracking across LXD networks."
+        docPath="/howto/network_ipam/"
+      />
+    </span>
+  );
+};
+
+export default NetworkIPAMExplanationTooltip;

--- a/src/pages/networks/NetworkIPAMExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkIPAMExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const NetworkIPAMExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="View IP address allocation across LXD networks."
+      docPath="/howto/network_ipam/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="View IP address allocation and tracking across LXD networks."
-        docPath="/howto/network_ipam/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/networks/NetworkList.tsx
+++ b/src/pages/networks/NetworkList.tsx
@@ -16,7 +16,7 @@ import {
   useSearchParams,
 } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import NetworkExplanationTooltip from "pages/networks/NetworkExplanationTooltip";
 import NetworkForwardCount from "pages/networks/NetworkForwardCount";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
 import {
@@ -285,12 +285,7 @@ const NetworkList: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/explanation/networks/"
-                title="Learn more about networking"
-              >
-                Networks
-              </HelpLink>
+              <NetworkExplanationTooltip>Networks</NetworkExplanationTooltip>
             </PageHeader.Title>
             <PageHeader.Search>
               <NetworkSearchFilter key={searchParams.get("search")} />

--- a/src/pages/operations/OperationExplanationTooltip.tsx
+++ b/src/pages/operations/OperationExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const OperationExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Track background tasks performed by LXD."
+        docPath="/rest-api/#/operations"
+      />
+    </span>
+  );
+};
+
+export default OperationExplanationTooltip;

--- a/src/pages/operations/OperationExplanationTooltip.tsx
+++ b/src/pages/operations/OperationExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const OperationExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Track background tasks performed by LXD."
+      docPath="/events/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Track background tasks performed by LXD."
-        docPath="/rest-api/#/operations"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -12,6 +12,7 @@ import {
   CustomLayout,
 } from "@canonical/react-components";
 import { useOperationsWithChildren } from "context/operationsProvider";
+import OperationExplanationTooltip from "pages/operations/OperationExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import PageHeader from "components/PageHeader";
 import ChildOperationTrigger from "pages/operations/ChildOperationTrigger";
@@ -231,7 +232,11 @@ const OperationList: FC = () => {
         header={
           <PageHeader>
             <PageHeader.Left>
-              <PageHeader.Title>Ongoing operations</PageHeader.Title>
+              <PageHeader.Title>
+                <OperationExplanationTooltip>
+                  Ongoing operations
+                </OperationExplanationTooltip>
+              </PageHeader.Title>
               {operations.length > 0 && (
                 <PageHeader.Search>
                   <SearchBox

--- a/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const PermissionGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Organise identities into groups to facilitate permission management."
+        docPath="/explanation/authorization"
+      />
+    </span>
+  );
+};
+
+export default PermissionGroupExplanationTooltip;

--- a/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const PermissionGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Organise identities into groups to manage permissions."
+      docPath="/explanation/authorization"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Organise identities into groups to facilitate permission management."
-        docPath="/explanation/authorization"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -17,7 +17,7 @@ import { getIdentityIdsForGroup } from "util/permissionIdentities";
 import usePanelParams, { panels } from "util/usePanelParams";
 import PageHeader from "components/PageHeader";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import PermissionGroupExplanationTooltip from "pages/permissions/PermissionGroupExplanationTooltip";
 import GroupActions from "./actions/GroupActions";
 import CreateGroupPanel from "./panels/CreateGroupPanel";
 import EditGroupPanel from "./panels/EditGroupPanel";
@@ -262,12 +262,9 @@ const PermissionGroups: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/explanation/authorization"
-                  title="Learn more about permissions"
-                >
+                <PermissionGroupExplanationTooltip>
                   Auth groups
-                </HelpLink>
+                </PermissionGroupExplanationTooltip>
               </PageHeader.Title>
               {!selectedGroupNames.length && hasGroups && (
                 <PageHeader.Search>

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -25,8 +25,9 @@ import PermissionIdentitiesFilter, {
 import { useSettings } from "context/useSettings";
 import usePanelParams, { panels } from "util/usePanelParams";
 import PageHeader from "components/PageHeader";
-import HelpLink from "components/HelpLink";
 import EditIdentityPanel from "./panels/EditIdentityPanel";
+import PermissionIdentityExplanationTooltip from "pages/permissions/PermissionIdentityExplanationTooltip";
+import EditIdentityGroupsPanel from "./panels/EditIdentityGroupsPanel";
 import Tag from "components/Tag";
 import BulkDeleteIdentitiesBtn from "./actions/BulkDeleteIdentitiesBtn";
 import DeleteIdentityBtn from "./actions/DeleteIdentityBtn";
@@ -42,7 +43,6 @@ import CreateIdentity from "pages/permissions/CreateIdentity";
 import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesActions";
 import ResourceLabel from "components/ResourceLabel";
 import IdentityExpiration from "pages/permissions/IdentityExpiration";
-import EditIdentityGroupsPanel from "./panels/EditIdentityGroupsPanel";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -286,12 +286,9 @@ const PermissionIdentities: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/explanation/authorization"
-                  title="Learn more about permissions"
-                >
+                <PermissionIdentityExplanationTooltip>
                   Identities
-                </HelpLink>
+                </PermissionIdentityExplanationTooltip>
               </PageHeader.Title>
               {!selectedIdentityIds.length && !panelParams.panel && (
                 <PageHeader.Search>

--- a/src/pages/permissions/PermissionIdentityExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionIdentityExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const PermissionIdentityExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Manage users, service accounts, and authentication identities."
+        docPath="/explanation/authorization"
+      />
+    </span>
+  );
+};
+
+export default PermissionIdentityExplanationTooltip;

--- a/src/pages/permissions/PermissionIdentityExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionIdentityExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const PermissionIdentityExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Manage users, service accounts, and API keys."
+      docPath="/explanation/authorization"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Manage users, service accounts, and authentication identities."
-        docPath="/explanation/authorization"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/permissions/PermissionIdpGroupExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionIdpGroupExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const PermissionIdpGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Map identity provider groups to LXD groups."
+        docPath="/explanation/authorization"
+      />
+    </span>
+  );
+};
+
+export default PermissionIdpGroupExplanationTooltip;

--- a/src/pages/permissions/PermissionIdpGroupExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionIdpGroupExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const PermissionIdpGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Map identity provider groups to LXD groups."
+      docPath="/explanation/authorization/#use-groups-defined-by-the-identity-provider"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Map identity provider groups to LXD groups."
-        docPath="/explanation/authorization"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -18,7 +18,7 @@ import useSortTableData from "util/useSortTableData";
 import usePanelParams, { panels } from "util/usePanelParams";
 import PageHeader from "components/PageHeader";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import PermissionIdpGroupExplanationTooltip from "pages/permissions/PermissionIdpGroupExplanationTooltip";
 import PermissionGroupsFilter from "./PermissionGroupsFilter";
 import CreateIdpGroupPanel from "./panels/CreateIdpGroupPanel";
 import BulkDeleteIdpGroupsBtn from "./actions/BulkDeleteIdpGroupsBtn";
@@ -298,12 +298,9 @@ const PermissionIdpGroups: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/explanation/authorization"
-                  title="Learn more about permissions"
-                >
+                <PermissionIdpGroupExplanationTooltip>
                   IDP&nbsp;groups
-                </HelpLink>
+                </PermissionIdpGroupExplanationTooltip>
               </PageHeader.Title>
               {!selectedGroupNames.length && hasGroups ? (
                 <PageHeader.Search>

--- a/src/pages/placement-groups/PlacementGroupExplanationTooltip.tsx
+++ b/src/pages/placement-groups/PlacementGroupExplanationTooltip.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const PlacementGroupExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <ExplanationTooltip
+      explanation="Define rules to spread or compact instances across cluster members."
+      docPath="/howto/cluster_placement_groups/"
+    >
+      {children}
+    </ExplanationTooltip>
+  );
+};
+
+export default PlacementGroupExplanationTooltip;

--- a/src/pages/placement-groups/PlacementGroupList.tsx
+++ b/src/pages/placement-groups/PlacementGroupList.tsx
@@ -14,7 +14,7 @@ import {
 } from "@canonical/react-components";
 import { useParams } from "react-router-dom";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import PlacementGroupExplanationTooltip from "pages/placement-groups/PlacementGroupExplanationTooltip";
 import BaseLayout from "components/BaseLayout";
 import DocLink from "components/DocLink";
 import { useIsClustered } from "context/useIsClustered";
@@ -150,12 +150,9 @@ const PlacementGroupList: FC = () => {
       <BaseLayout
         mainClassName="placement-groups-list"
         title={
-          <HelpLink
-            docPath="/howto/cluster_placement_groups/"
-            title="Learn how to use placement groups"
-          >
+          <PlacementGroupExplanationTooltip>
             Placement groups
-          </HelpLink>
+          </PlacementGroupExplanationTooltip>
         }
         controls={
           isClustered &&

--- a/src/pages/profiles/ProfileExplanationTooltip.tsx
+++ b/src/pages/profiles/ProfileExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ProfileExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Create and manage reusable configuration templates that can be applied to instances."
+        docPath="/profiles/"
+      />
+    </span>
+  );
+};
+
+export default ProfileExplanationTooltip;

--- a/src/pages/profiles/ProfileList.tsx
+++ b/src/pages/profiles/ProfileList.tsx
@@ -23,7 +23,7 @@ import ProfileLink from "./ProfileLink";
 import { isProjectWithProfiles } from "util/projects";
 import { useCurrentProject } from "context/useCurrentProject";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import ProfileExplanationTooltip from "pages/profiles/ProfileExplanationTooltip";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
 import ProfileDetailPanel from "./ProfileDetailPanel";
@@ -180,12 +180,7 @@ const ProfileList: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/profiles/"
-                  title="Learn how to use profiles"
-                >
-                  Profiles
-                </HelpLink>
+                <ProfileExplanationTooltip>Profiles</ProfileExplanationTooltip>
               </PageHeader.Title>
               {profiles.length > 0 && (
                 <PageHeader.Search>

--- a/src/pages/projects/ProjectConfigurationExplanationTooltip.tsx
+++ b/src/pages/projects/ProjectConfigurationExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const ProjectConfigurationExplanationTooltip: FC<{
+  children?: ReactNode;
+}> = ({ children }) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="View and manage project-level configuration settings and resources."
+        docPath="/reference/projects/"
+      />
+    </span>
+  );
+};
+
+export default ProjectConfigurationExplanationTooltip;

--- a/src/pages/projects/ProjectConfigurationExplanationTooltip.tsx
+++ b/src/pages/projects/ProjectConfigurationExplanationTooltip.tsx
@@ -5,13 +5,13 @@ const ProjectConfigurationExplanationTooltip: FC<{
   children?: ReactNode;
 }> = ({ children }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      className="explanation-tooltip-wrapper--breadcrumb"
+      explanation="View and manage project-level configuration settings and resources."
+      docPath="/reference/projects/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="View and manage project-level configuration settings and resources."
-        docPath="/reference/projects/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -8,7 +8,7 @@ import { useFormik } from "formik";
 import { checkDuplicateName } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import DeleteProjectBtn from "./actions/DeleteProjectBtn";
-import HelpLink from "components/HelpLink";
+import ProjectConfigurationExplanationTooltip from "pages/projects/ProjectConfigurationExplanationTooltip";
 import { useEventQueue } from "context/eventQueue";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
@@ -124,13 +124,9 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
     <RenameHeader
       name={project.name}
       parentItems={[
-        <HelpLink
-          key="project-configuration"
-          docPath="/reference/projects/"
-          title="Learn more about project configuration"
-        >
+        <ProjectConfigurationExplanationTooltip key="project-configuration">
           Project configuration
-        </HelpLink>,
+        </ProjectConfigurationExplanationTooltip>,
       ]}
       renameDisabledReason={getRenameDisabledReason()}
       controls={<DeleteProjectBtn project={project} />}

--- a/src/pages/projects/ProjectExplanationTooltip.tsx
+++ b/src/pages/projects/ProjectExplanationTooltip.tsx
@@ -1,17 +1,17 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const ProfileExplanationTooltip: FC<{ children?: ReactNode }> = ({
+const ProjectExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
     <ExplanationTooltip
-      explanation="Create and manage configuration templates for instances."
-      docPath="/profiles/"
+      explanation="Organise and isolate entities and tenants into separate groups."
+      docPath="/projects/"
     >
       {children}
     </ExplanationTooltip>
   );
 };
 
-export default ProfileExplanationTooltip;
+export default ProjectExplanationTooltip;

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -11,7 +11,7 @@ import {
   useToastNotification,
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import SettingsExplanationTooltip from "pages/settings/SettingsExplanationTooltip";
 import { updateSettings } from "api/server";
 import { toConfigFields } from "util/config";
 import PageHeader from "components/PageHeader";
@@ -178,12 +178,9 @@ const Settings: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/server/"
-                  title="Learn more about server configuration"
-                >
+                <SettingsExplanationTooltip>
                   Settings
-                </HelpLink>
+                </SettingsExplanationTooltip>
               </PageHeader.Title>
               <PageHeader.Search>
                 <SearchBox

--- a/src/pages/settings/SettingsExplanationTooltip.tsx
+++ b/src/pages/settings/SettingsExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const SettingsExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="View and manage global LXD configuration settings and resources."
+        docPath="/server/"
+      />
+    </span>
+  );
+};
+
+export default SettingsExplanationTooltip;

--- a/src/pages/settings/SettingsExplanationTooltip.tsx
+++ b/src/pages/settings/SettingsExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const SettingsExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="View and manage global LXD configuration settings and resources."
+      docPath="/server/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="View and manage global LXD configuration settings and resources."
-        docPath="/server/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/storage/CustomIsoExplanationTooltip.tsx
+++ b/src/pages/storage/CustomIsoExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const CustomIsoExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Upload and manage custom ISO images for instance creation and installation."
+        docPath="/howto/instances_create/#instances-create-iso"
+      />
+    </span>
+  );
+};
+
+export default CustomIsoExplanationTooltip;

--- a/src/pages/storage/CustomIsoExplanationTooltip.tsx
+++ b/src/pages/storage/CustomIsoExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const CustomIsoExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Upload and manage custom ISO images for instance creation and installation."
+      docPath="/howto/instances_create/#instances-create-iso"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Upload and manage custom ISO images for instance creation and installation."
-        docPath="/howto/instances_create/#instances-create-iso"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/storage/CustomIsoList.tsx
+++ b/src/pages/storage/CustomIsoList.tsx
@@ -20,7 +20,7 @@ import UploadCustomIsoBtn from "pages/images/actions/UploadCustomIsoBtn";
 import { Link, useParams } from "react-router-dom";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
-import HelpLink from "components/HelpLink";
+import CustomIsoExplanationTooltip from "pages/storage/CustomIsoExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import ResourceLabel from "components/ResourceLabel";
 import { useLoadIsoVolumes } from "context/useVolumes";
@@ -208,12 +208,9 @@ const CustomIsoList: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/howto/instances_create/#instances-create-iso"
-                title="Learn how to create a VM that boots from an ISO"
-              >
+              <CustomIsoExplanationTooltip>
                 Custom ISOs
-              </HelpLink>
+              </CustomIsoExplanationTooltip>
             </PageHeader.Title>
             {hasImages && (
               <PageHeader.Search>

--- a/src/pages/storage/StorageBucketExplanationTooltip.tsx
+++ b/src/pages/storage/StorageBucketExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const StorageBucketExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Manage object storage buckets for storing and accessing unstructured data."
+        docPath="/explanation/storage/#storage-buckets"
+      />
+    </span>
+  );
+};
+
+export default StorageBucketExplanationTooltip;

--- a/src/pages/storage/StorageBucketExplanationTooltip.tsx
+++ b/src/pages/storage/StorageBucketExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const StorageBucketExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Manage object storage buckets for storing and accessing unstructured data."
+      docPath="/explanation/storage/#storage-buckets"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Manage object storage buckets for storing and accessing unstructured data."
-        docPath="/explanation/storage/#storage-buckets"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/storage/StorageBuckets.tsx
+++ b/src/pages/storage/StorageBuckets.tsx
@@ -26,7 +26,7 @@ import {
 } from "util/storageBucketTable";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
-import HelpLink from "components/HelpLink";
+import StorageBucketExplanationTooltip from "pages/storage/StorageBucketExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import { useBuckets } from "context/useBuckets";
 import type { StorageBucketsFilterType } from "./StorageBucketsFilter";
@@ -310,12 +310,9 @@ const StorageBuckets: FC = () => {
           <PageHeader>
             <PageHeader.Left>
               <PageHeader.Title>
-                <HelpLink
-                  docPath="/explanation/storage/#storage-buckets"
-                  title="Learn more about storage buckets"
-                >
+                <StorageBucketExplanationTooltip>
                   Buckets
-                </HelpLink>
+                </StorageBucketExplanationTooltip>
               </PageHeader.Title>
               {!selectedNames.length && !panelParams.panel && hasBuckets && (
                 <PageHeader.Search>

--- a/src/pages/storage/StoragePoolExplanationTooltip.tsx
+++ b/src/pages/storage/StoragePoolExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const StoragePoolExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Create and manage storage backends used to host instance and image data."
+        docPath="/explanation/storage/"
+      />
+    </span>
+  );
+};
+
+export default StoragePoolExplanationTooltip;

--- a/src/pages/storage/StoragePoolExplanationTooltip.tsx
+++ b/src/pages/storage/StoragePoolExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const StoragePoolExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Create and manage storage backends used to host instance and image data."
+      docPath="/explanation/storage/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Create and manage storage backends used to host instance and image data."
-        docPath="/explanation/storage/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/storage/StoragePools.tsx
+++ b/src/pages/storage/StoragePools.tsx
@@ -13,7 +13,7 @@ import { Link, useParams } from "react-router-dom";
 import DeleteStoragePoolBtn from "pages/storage/actions/DeleteStoragePoolBtn";
 import StoragePoolSize from "pages/storage/StoragePoolSize";
 import CreateStoragePoolBtn from "pages/storage/actions/CreateStoragePoolBtn";
-import HelpLink from "components/HelpLink";
+import StoragePoolExplanationTooltip from "pages/storage/StoragePoolExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import PageHeader from "components/PageHeader";
 import { useStoragePools } from "context/useStoragePools";
@@ -176,12 +176,9 @@ const StoragePools: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/explanation/storage/"
-                title="Learn more about storage pools, volumes and buckets"
-              >
+              <StoragePoolExplanationTooltip>
                 Pools
-              </HelpLink>
+              </StoragePoolExplanationTooltip>
             </PageHeader.Title>
           </PageHeader.Left>
           <PageHeader.BaseActions>

--- a/src/pages/storage/StorageVolumeExplanationTooltip.tsx
+++ b/src/pages/storage/StorageVolumeExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const StorageVolumeExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Provision and manage storage volumes for use by instances."
+        docPath="/explanation/storage/#storage-volumes"
+      />
+    </span>
+  );
+};
+
+export default StorageVolumeExplanationTooltip;

--- a/src/pages/storage/StorageVolumeExplanationTooltip.tsx
+++ b/src/pages/storage/StorageVolumeExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const StorageVolumeExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Provision and manage storage volumes used by instances."
+      docPath="/explanation/storage/#storage-volumes"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Provision and manage storage volumes for use by instances."
-        docPath="/explanation/storage/#storage-volumes"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/storage/StorageVolumes.tsx
+++ b/src/pages/storage/StorageVolumes.tsx
@@ -47,7 +47,7 @@ import StorageVolumeNameLink from "./StorageVolumeNameLink";
 import CustomStorageVolumeActions from "./actions/CustomStorageVolumeActions";
 import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
-import HelpLink from "components/HelpLink";
+import StorageVolumeExplanationTooltip from "pages/storage/StorageVolumeExplanationTooltip";
 import NotificationRow from "components/NotificationRow";
 import { useLoadVolumes } from "context/useVolumes";
 import { useIsClustered } from "context/useIsClustered";
@@ -490,12 +490,9 @@ const StorageVolumes: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/explanation/storage/#storage-volumes"
-                title="Learn more about storage volumes"
-              >
+              <StorageVolumeExplanationTooltip>
                 Volumes
-              </HelpLink>
+              </StorageVolumeExplanationTooltip>
             </PageHeader.Title>
             {!selectedNames.length && hasVolumes && (
               <PageHeader.Search>

--- a/src/pages/warnings/WarningExplanationTooltip.tsx
+++ b/src/pages/warnings/WarningExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const WarningExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <span className="explanation-tooltip-wrapper">
+      {children}
+      <ExplanationTooltip
+        explanation="Review system warnings and issues that may require attention."
+        docPath="/howto/troubleshoot/"
+      />
+    </span>
+  );
+};
+
+export default WarningExplanationTooltip;

--- a/src/pages/warnings/WarningExplanationTooltip.tsx
+++ b/src/pages/warnings/WarningExplanationTooltip.tsx
@@ -5,13 +5,12 @@ const WarningExplanationTooltip: FC<{ children?: ReactNode }> = ({
   children,
 }) => {
   return (
-    <span className="explanation-tooltip-wrapper">
+    <ExplanationTooltip
+      explanation="Review system warnings and issues that may require attention."
+      docPath="/howto/troubleshoot/"
+    >
       {children}
-      <ExplanationTooltip
-        explanation="Review system warnings and issues that may require attention."
-        docPath="/howto/troubleshoot/"
-      />
-    </span>
+    </ExplanationTooltip>
   );
 };
 

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -11,7 +11,7 @@ import { isoTimeToString } from "util/helpers";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import NotificationRow from "components/NotificationRow";
-import HelpLink from "components/HelpLink";
+import WarningExplanationTooltip from "pages/warnings/WarningExplanationTooltip";
 import BulkDeleteWarningBtn from "pages/warnings/actions/BulkDeleteWarningBtn";
 import SelectableMainTable from "components/SelectableMainTable";
 import PageHeader from "components/PageHeader";
@@ -176,12 +176,7 @@ const WarningList: FC = () => {
         <PageHeader>
           <PageHeader.Left>
             <PageHeader.Title>
-              <HelpLink
-                docPath="/howto/troubleshoot/"
-                title="Learn more about troubleshooting"
-              >
-                Warnings
-              </HelpLink>
+              <WarningExplanationTooltip>Warnings</WarningExplanationTooltip>
             </PageHeader.Title>
             {hasWarnings && selectedNames.length === 0 && (
               <PageHeader.Search>

--- a/src/sass/_explanation_tooltip.scss
+++ b/src/sass/_explanation_tooltip.scss
@@ -9,6 +9,11 @@
   width: 1rem !important;
 }
 
+.explanation-tooltip-wrapper--breadcrumb {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
 .explanation-tooltip {
   display: flex;
   flex-direction: column;

--- a/tests/helpers/permission-groups.ts
+++ b/tests/helpers/permission-groups.ts
@@ -12,9 +12,7 @@ export const visitGroups = async (page: Page) => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Permissions" }).click();
   await page.getByRole("link", { name: "Groups", exact: true }).click();
-  await expect(
-    page.getByRole("heading", { name: "Groups" }).locator("div"),
-  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Groups" })).toBeVisible();
 };
 
 export const renameGroup = async (

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -17,9 +17,7 @@ export const visitIdentities = async (page: Page) => {
   await gotoURL(page, "/ui/");
   await page.getByRole("button", { name: "Permissions" }).click();
   await page.getByRole("link", { name: "Identities" }).click();
-  await expect(
-    page.getByRole("heading", { name: "Identities" }).locator("div"),
-  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Identities" })).toBeVisible();
 };
 
 export const toggleGroupsForIdentities = async (

--- a/tests/helpers/placement-groups.ts
+++ b/tests/helpers/placement-groups.ts
@@ -65,6 +65,6 @@ export const visitPlacementGroups = async (page: Page) => {
   await page.getByRole("button", { name: "Clustering" }).click();
   await page.getByRole("link", { name: "Placement" }).click();
   await expect(
-    page.getByRole("heading", { name: "Placement groups" }).locator("div"),
+    page.getByRole("heading", { name: "Placement groups" }),
   ).toBeVisible();
 };

--- a/tests/permission-groups.spec.ts
+++ b/tests/permission-groups.spec.ts
@@ -8,7 +8,6 @@ import {
   randomGroupName,
   removePermission,
   restorePermission,
-  visitGroups,
   selectGroupsToModify,
   assertGroupPermissionsCount,
   openEditGroupPanel,
@@ -24,7 +23,6 @@ import { dismissNotification } from "./helpers/notification";
 test("create and delete group", async ({ page, lxdVersion }) => {
   skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
   const group = randomGroupName();
-  await visitGroups(page);
   await createGroup(page, group, `${group}-desc`);
   await deleteGroup(page, group);
 });
@@ -162,7 +160,6 @@ test("bulk delete groups", async ({ page, lxdVersion }) => {
 test("create group with permissions", async ({ page, lxdVersion }) => {
   skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
   const group = randomGroupName();
-  await visitGroups(page);
   const withPermission = true;
   await createGroup(page, group, `${group}-desc`, withPermission);
   await deleteGroup(page, group);


### PR DESCRIPTION
## Done

- [x] Added first set of entity explanation tooltips in accordance with the [CopyDoc](https://docs.google.com/document/d/1vDmemn4eQm0Zr3szBRzGtWdZqGNayqHkUmtC8oZ0jNA/edit?tab=t.0)
- [x] Implemented these in their relevant webpages.
- [x] Secondary entities still require helplinks to be replace with ExplanationTooltips.
- [x] Added Projects ET to the Overview page.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Navigate to any major entity and observe the ExplanationTooltip in place of the HelpLink.

## Screenshots
Example of explanation tooltips in entity headers:
<img width="1357" height="261" alt="image" src="https://github.com/user-attachments/assets/9eca2c55-b0a3-48c3-a809-865aa8553638" />
<img width="926" height="151" alt="image" src="https://github.com/user-attachments/assets/1a5a9ce7-9423-4d59-8211-119a4f8baa03" />
<img width="926" height="151" alt="image" src="https://github.com/user-attachments/assets/1e330ce0-2f49-476b-8825-33d65892aae4" />
<img width="1562" height="842" alt="image" src="https://github.com/user-attachments/assets/123ac316-786b-4b50-80b3-b769b533a44d" />
