### PR TITLE
feat(identtiy): edit bearer identities WD-37701

### DIFF
--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -6,8 +6,8 @@ import {
 import type { LxdApiResponse } from "types/apiResponse";
 import type { LxdIdentity, TlsIdentityTokenDetail } from "types/permissions";
 import { addEntitlements } from "util/entitlements/api";
-import type { BearerIdentityType } from "util/permissionIdentities";
 import { AUTH_METHOD } from "util/authentication";
+import type { BearerIdentityType } from "util/permissionIdentities";
 import { ROOT_PATH } from "util/rootPath";
 
 export const identitiesEntitlements = ["can_delete", "can_edit"];
@@ -131,7 +131,7 @@ const createBearerIdentity = async (
   }).then(handleResponse);
 };
 
-const issueBearerToken = async (
+export const issueBearerToken = async (
   name: string,
   expiry: string,
 ): Promise<{

--- a/src/context/useAuthGroups.tsx
+++ b/src/context/useAuthGroups.tsx
@@ -4,11 +4,13 @@ import { useAuth } from "./auth";
 import type { LxdAuthGroup } from "types/permissions";
 import { fetchGroups } from "api/auth-groups";
 
-export const useAuthGroups = (): UseQueryResult<LxdAuthGroup[]> => {
+export const useAuthGroups = (
+  enabled = true,
+): UseQueryResult<LxdAuthGroup[]> => {
   const { isFineGrained } = useAuth();
   return useQuery({
     queryKey: [queryKeys.authGroups],
     queryFn: async () => fetchGroups(isFineGrained),
-    enabled: isFineGrained !== null,
+    enabled: enabled && isFineGrained !== null,
   });
 };

--- a/src/pages/permissions/CreateIdentity.tsx
+++ b/src/pages/permissions/CreateIdentity.tsx
@@ -1,14 +1,11 @@
 import { useState, type FC } from "react";
 import { useNotify, usePortal } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
-import CreateIdentityModal from "pages/permissions/CreateIdentityModal";
+import IdentityTokenModal from "pages/permissions/IdentityTokenModal";
 import CreateIdentityPanel from "pages/permissions/panels/CreateIdentityPanel";
 import type { IdentityFormValues } from "types/forms/identity";
 import usePanelParams, { panels } from "util/usePanelParams";
-import {
-  CREATE_IDENTITY_MODAL_TEXT,
-  IDENTITY_TYPE,
-} from "util/permissionIdentities";
+import { IDENTITY_MODAL_TEXT, IDENTITY_TYPE } from "util/permissionIdentities";
 import { queryKeys } from "util/queryKeys";
 
 const CreateIdentity: FC = () => {
@@ -26,14 +23,13 @@ const CreateIdentity: FC = () => {
     expiry: "",
     isCustomExpiry: false,
   });
-  const identityModalCaptions =
-    CREATE_IDENTITY_MODAL_TEXT[identity.identityType];
+  const identityModalCaptions = IDENTITY_MODAL_TEXT[identity.identityType];
 
   return (
     <>
       {isOpen && (
         <Portal>
-          <CreateIdentityModal
+          <IdentityTokenModal
             onClose={closePortal}
             token={token}
             identity={identity}

--- a/src/pages/permissions/IdentityTokenModal.tsx
+++ b/src/pages/permissions/IdentityTokenModal.tsx
@@ -21,9 +21,10 @@ interface Props {
   notification: string;
   howToUseCli?: ReactNode;
   howToUseUi?: ReactNode;
+  titleSuffix?: string;
 }
 
-const CreateIdentityModal: FC<Props> = ({
+const IdentityTokenModal: FC<Props> = ({
   onClose,
   token,
   identity,
@@ -31,13 +32,14 @@ const CreateIdentityModal: FC<Props> = ({
   notification,
   howToUseCli,
   howToUseUi,
+  titleSuffix = "created successfully",
 }) => {
   const [isConfirmed, setConfirmed] = useState(false);
   const [howToUseActiveTab, setHowToUseActiveTab] = useState("ui-tab");
 
   return (
     <Modal
-      className="create-tls-identity"
+      className="identity-token-modal"
       title={
         <>
           Identity{" "}
@@ -49,7 +51,7 @@ const CreateIdentityModal: FC<Props> = ({
             bold
             truncate
           />{" "}
-          created successfully
+          {titleSuffix}
         </>
       }
       buttonRow={[
@@ -124,4 +126,4 @@ const CreateIdentityModal: FC<Props> = ({
   );
 };
 
-export default CreateIdentityModal;
+export default IdentityTokenModal;

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -9,6 +9,7 @@ import {
   CustomLayout,
   NotificationConsumer,
 } from "@canonical/react-components";
+import EditIdentityGroupsBtn from "./actions/EditIdentityGroupsBtn";
 import SelectableMainTable from "components/SelectableMainTable";
 import SelectedTableNotification from "components/SelectedTableNotification";
 import { useEffect, useState, type FC } from "react";
@@ -22,11 +23,10 @@ import PermissionIdentitiesFilter, {
   type PermissionIdentitiesFilterType,
 } from "./PermissionIdentitiesFilter";
 import { useSettings } from "context/useSettings";
-import EditIdentityGroupsBtn from "./actions/EditIdentityGroupsBtn";
 import usePanelParams, { panels } from "util/usePanelParams";
 import PageHeader from "components/PageHeader";
 import HelpLink from "components/HelpLink";
-import EditIdentityGroupsPanel from "./panels/EditIdentityGroupsPanel";
+import EditIdentityPanel from "./panels/EditIdentityPanel";
 import Tag from "components/Tag";
 import BulkDeleteIdentitiesBtn from "./actions/BulkDeleteIdentitiesBtn";
 import DeleteIdentityBtn from "./actions/DeleteIdentityBtn";
@@ -41,6 +41,7 @@ import {
 import CreateIdentity from "pages/permissions/CreateIdentity";
 import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesActions";
 import ResourceLabel from "components/ResourceLabel";
+import EditIdentityGroupsPanel from "./panels/EditIdentityGroupsPanel";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -118,15 +119,15 @@ const PermissionIdentities: FC = () => {
 
   const rows = filteredIdentities.map((identity) => {
     const isLoggedInIdentity = settings?.auth_user_name === identity.id;
-    const openGroupPanelForIdentity = () => {
-      panelParams.openIdentityGroups(identity.id);
+    const openEditIdentityPanel = () => {
+      panelParams.openEditIdentity(identity.id);
       setSelectedIdentityIds([identity.id]);
     };
 
     const getGroupLink = () => {
       if (canEditIdentity(identity)) {
         return (
-          <Button appearance="link" dense onClick={openGroupPanelForIdentity}>
+          <Button appearance="link" dense onClick={openEditIdentityPanel}>
             {identity.groups?.length || 0}
           </Button>
         );
@@ -196,17 +197,17 @@ const PermissionIdentities: FC = () => {
                 className="u-no-margin--bottom"
                 hasIcon
                 dense
-                onClick={openGroupPanelForIdentity}
+                onClick={openEditIdentityPanel}
                 type="button"
-                aria-label="Manage groups"
+                aria-label="Edit identity"
                 title={
-                  canEditIdentity()
-                    ? "Manage groups"
+                  canEditIdentity(identity)
+                    ? "Edit identity"
                     : "You do not have permission to modify this identity"
                 }
                 disabled={!canEditIdentity(identity)}
               >
-                <Icon name="user-group" />
+                <Icon name="edit" />
               </Button>
               {hasAccessManagementTLS && (
                 <DeleteIdentityBtn identity={identity} />
@@ -240,6 +241,10 @@ const PermissionIdentities: FC = () => {
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading..." isMainComponent />;
   }
+
+  const editedIdentity = identities.find(
+    (identity) => identity.id === panelParams.identity,
+  );
 
   const getTablePaginationDescription = () => {
     // This is needed because TablePagination does not cater for plural identity
@@ -351,6 +356,14 @@ const PermissionIdentities: FC = () => {
       {panelParams.panel === panels.identityGroups && (
         <EditIdentityGroupsPanel
           identities={selectedIdentities}
+          onClose={() => {
+            setSelectedIdentityIds([]);
+          }}
+        />
+      )}
+      {panelParams.panel === panels.editIdentity && editedIdentity && (
+        <EditIdentityPanel
+          identity={editedIdentity}
           onClose={() => {
             setSelectedIdentityIds([]);
           }}

--- a/src/pages/permissions/actions/GroupSelectionActions.tsx
+++ b/src/pages/permissions/actions/GroupSelectionActions.tsx
@@ -5,9 +5,9 @@ import { pluralize } from "util/helpers";
 
 interface Props {
   modifiedGroups: Set<string>;
-  undoChange: () => void;
   closePanel: () => void;
   onSubmit: () => void;
+  undoChange?: () => void;
   loading?: boolean;
   disabled?: boolean;
   actionText?: string;
@@ -30,7 +30,7 @@ const GroupSelectionActions: FC<Props> = ({
 
   return (
     <>
-      {isEdit && modifiedGroups.size ? (
+      {isEdit && modifiedGroups.size && undoChange ? (
         <ModifiedStatusAction
           modifiedCount={modifiedGroups.size}
           onUndoChange={undoChange}

--- a/src/pages/permissions/panels/CreateIdentityPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdentityPanel.tsx
@@ -1,8 +1,6 @@
 import {
   ActionButton,
   Button,
-  Input,
-  RadioInput,
   ScrollableContainer,
   SidePanel,
   useNotify,
@@ -21,10 +19,12 @@ import {
   createFineGrainedTlsIdentity,
 } from "api/auth-identities";
 import NameWithGroupForm from "pages/permissions/forms/NameWithGroupForm";
+import TokenExpirySelector from "pages/permissions/panels/TokenExpirySelector";
 import GroupSelection from "pages/permissions/panels/GroupSelection";
 import { base64EncodeObject } from "util/helpers";
 import {
   BEARER_EXPIRY_PATTERN,
+  BEARER_EXPIRY_VALIDATION_TEXT,
   IDENTITY_TYPE,
   IDENTITY_TYPE_HELP_TEXT,
   IDENTITY_TYPES_WITH_EXPIRY,
@@ -153,7 +153,7 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
       then: (schema) =>
         schema.test(
           "valid-expiry-format",
-          "Use format like 1d 3H 5M with units y, m, w, d, H, M, or S",
+          BEARER_EXPIRY_VALIDATION_TEXT,
           (value) => !value || BEARER_EXPIRY_PATTERN.test(value.trim()),
         ),
       otherwise: (schema) => schema.notRequired(),
@@ -264,54 +264,30 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
             {IDENTITY_TYPES_WITH_EXPIRY.includes(
               formik.values.identityType,
             ) && (
-              <div className="create-identity-panel-token-expiry u-sv1">
-                <label id="token-expiry-label" htmlFor="expiry">
-                  Token expiry
-                </label>
-                <RadioInput
-                  label="Default (10 years)"
-                  checked={!formik.values.isCustomExpiry}
-                  disabled={isNameInvalid}
-                  onChange={() => {
-                    formik.setFieldValue("isCustomExpiry", false);
+              <TokenExpirySelector
+                isCustomExpiry={!!formik.values.isCustomExpiry}
+                expiry={formik.values.expiry}
+                disabled={isNameInvalid}
+                error={
+                  formik.values.isCustomExpiry &&
+                  formik.touched.expiry &&
+                  formik.errors.expiry
+                    ? formik.errors.expiry
+                    : undefined
+                }
+                onIsCustomExpiryChange={(isCustom) => {
+                  formik.setFieldValue("isCustomExpiry", isCustom);
+                  if (!isCustom) {
                     formik.setFieldValue("expiry", "");
-                  }}
-                />
-                <div className="create-identity-panel-token-expiry-custom-container">
-                  <RadioInput
-                    label="Custom"
-                    checked={formik.values.isCustomExpiry}
-                    disabled={isNameInvalid}
-                    onChange={() => {
-                      formik.setFieldValue("isCustomExpiry", true);
-                    }}
-                  />
-                  <Input
-                    type="text"
-                    id="expiry"
-                    name="expiry"
-                    onChange={formik.handleChange}
-                    value={
-                      formik.values.isCustomExpiry ? formik.values.expiry : ""
-                    }
-                    error={
-                      formik.values.isCustomExpiry &&
-                      formik.touched.expiry &&
-                      formik.errors.expiry
-                        ? formik.errors.expiry
-                        : undefined
-                    }
-                    placeholder="e.g. 1d 3H 5M"
-                    disabled={isNameInvalid || !formik.values.isCustomExpiry}
-                    help={
-                      <>
-                        Space-separated durations: {"<number><unit>"} <br />
-                        Units are case-sensitive: y, m, w, d, H, M, S
-                      </>
-                    }
-                  />
-                </div>
-              </div>
+                  }
+                }}
+                onExpiryChange={(value) => {
+                  formik.setFieldValue("expiry", value);
+                }}
+                onExpiryBlur={() => {
+                  formik.setFieldTouched("expiry", true);
+                }}
+              />
             )}
             <label htmlFor="group-selection-table">Auth groups</label>
             <GroupSelection
@@ -364,9 +340,17 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
                 onClick={() => void formik.submitForm()}
                 className="u-no-margin--bottom"
                 disabled={
-                  !formik.isValid || formik.isSubmitting || !formik.values.name
+                  !formik.isValid ||
+                  formik.isSubmitting ||
+                  !formik.values.name ||
+                  (formik.values.isCustomExpiry && !formik.values.expiry)
                 }
                 loading={formik.isSubmitting}
+                title={
+                  formik.values.isCustomExpiry && !formik.values.expiry
+                    ? "Please provide a valid expiry date"
+                    : undefined
+                }
               >
                 Create identity
               </ActionButton>

--- a/src/pages/permissions/panels/EditIdentityGroupsSection.tsx
+++ b/src/pages/permissions/panels/EditIdentityGroupsSection.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState, type FC } from "react";
+import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
+import GroupSelection from "./GroupSelection";
+
+export interface IdentityGroupChanges {
+  currentGroups: Set<string>;
+  addedGroups: Set<string>;
+  removedGroups: Set<string>;
+}
+
+interface Props {
+  identity?: LxdIdentity;
+  groups: LxdAuthGroup[];
+  canEdit: boolean;
+  onChange: (
+    changes: IdentityGroupChanges,
+    modifiedGroups: Set<string>,
+  ) => void;
+}
+
+const EditIdentityGroupsSection: FC<Props> = ({
+  identity,
+  groups,
+  canEdit,
+  onChange,
+}) => {
+  const identityId = identity?.id ?? "";
+
+  const [selectedGroups, setSelectedGroupsState] = useState<Set<string> | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!identity) {
+      setSelectedGroupsState(null);
+      return;
+    }
+
+    const initialGroups = new Set(identity.groups ?? []);
+    setSelectedGroupsState(initialGroups);
+    onChange(
+      {
+        currentGroups: initialGroups,
+        addedGroups: new Set<string>(),
+        removedGroups: new Set<string>(),
+      },
+      new Set<string>(),
+    );
+  }, [identityId]);
+
+  const originalGroups = new Set(identity?.groups ?? []);
+  const groupSelection = selectedGroups ?? originalGroups;
+
+  const getGroupChanges = (currentGroups: Set<string>) => {
+    const modifiedGroups = new Set<string>();
+    for (const group of groups) {
+      const isSelected = currentGroups.has(group.name);
+      const wasSelected = originalGroups.has(group.name);
+      if (isSelected !== wasSelected) {
+        modifiedGroups.add(group.name);
+      }
+    }
+
+    const addedGroups = new Set(
+      Array.from(modifiedGroups).filter((group) => currentGroups.has(group)),
+    );
+    const removedGroups = new Set(
+      Array.from(modifiedGroups).filter((group) => !currentGroups.has(group)),
+    );
+
+    return {
+      modifiedGroups,
+      changes: {
+        currentGroups,
+        addedGroups,
+        removedGroups,
+      },
+    };
+  };
+
+  const { modifiedGroups } = getGroupChanges(groupSelection);
+
+  const updateSelection = (currentGroups: Set<string>) => {
+    setSelectedGroupsState(currentGroups);
+    const { changes, modifiedGroups } = getGroupChanges(currentGroups);
+    onChange(changes, modifiedGroups);
+  };
+
+  const toggleGroup = (groupName: string) => {
+    if (!canEdit) {
+      return;
+    }
+    const newSelection = new Set(groupSelection);
+    if (newSelection.has(groupName)) {
+      newSelection.delete(groupName);
+    } else {
+      newSelection.add(groupName);
+    }
+    updateSelection(newSelection);
+  };
+
+  const setSelectedGroups = (
+    newSelectedGroups: string[],
+    isUnselectAll?: boolean,
+  ) => {
+    if (!canEdit) {
+      return;
+    }
+    if (isUnselectAll) {
+      updateSelection(new Set());
+    } else {
+      updateSelection(new Set(newSelectedGroups));
+    }
+  };
+
+  return (
+    <>
+      {identity && (
+        <>
+          <label htmlFor="group-selection-table">Auth groups</label>
+          <GroupSelection
+            groups={groups}
+            modifiedGroups={modifiedGroups}
+            parentItemName="identity"
+            parentItems={[identity]}
+            selectedGroups={groupSelection}
+            setSelectedGroups={setSelectedGroups}
+            toggleGroup={toggleGroup}
+            scrollDependencies={[groups, modifiedGroups.size, identity]}
+            disabled={!canEdit}
+            hasScrollableTable={false}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default EditIdentityGroupsSection;

--- a/src/pages/permissions/panels/EditIdentityPanel.tsx
+++ b/src/pages/permissions/panels/EditIdentityPanel.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState, type FC } from "react";
+import {
+  ConfirmationModal,
+  ScrollableContainer,
+  SidePanel,
+  useNotify,
+  useToastNotification,
+} from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import usePanelParams from "util/usePanelParams";
+import NotificationRow from "components/NotificationRow";
+import { useAuthGroups } from "context/useAuthGroups";
+import { updateIdentity } from "api/auth-identities";
+import { queryKeys } from "util/queryKeys";
+import { useIdentityEntitlements } from "util/entitlements/identities";
+import IdentityResource from "components/IdentityResource";
+import GroupsOrIdentityChangesTable from "./GroupOrIdentityChangesTable";
+import {
+  getChangesInGroupsForIdentities,
+  pivotIdentityGroupsChangeSummary,
+} from "util/permissionIdentities";
+import { type IdentityGroupChanges } from "./EditIdentityGroupsSection";
+import EditIdentityPanelContent from "./EditIdentityPanelContent";
+import GroupSelectionActions from "../actions/GroupSelectionActions";
+import type { LxdIdentity } from "types/permissions";
+
+interface Props {
+  identity: LxdIdentity;
+  onClose: () => void;
+}
+
+const EditIdentityPanel: FC<Props> = ({ identity, onClose }) => {
+  const panelParams = usePanelParams();
+  const notify = useNotify();
+  const toastNotify = useToastNotification();
+  const queryClient = useQueryClient();
+  const { canEditIdentity } = useIdentityEntitlements();
+
+  const {
+    data: groups = [],
+    error: groupsError,
+    isLoading: isGroupLoading,
+  } = useAuthGroups();
+
+  useEffect(() => {
+    if (groupsError) {
+      notify.failure("Loading panel details failed", groupsError);
+    }
+  }, [groupsError]);
+
+  const [confirmingGroups, setConfirmingGroups] = useState(false);
+  const [pendingGroupChanges, setPendingGroupChanges] =
+    useState<IdentityGroupChanges | null>(null);
+  const [savingGroups, setSavingGroups] = useState(false);
+  const [currentGroupChanges, setCurrentGroupChanges] =
+    useState<IdentityGroupChanges | null>(null);
+  const [modifiedGroups, setModifiedGroups] = useState<Set<string>>(new Set());
+
+  const closePanel = () => {
+    panelParams.clear();
+    notify.clear();
+    setPendingGroupChanges(null);
+    setCurrentGroupChanges(null);
+    setModifiedGroups(new Set());
+    onClose();
+  };
+
+  const canEdit = canEditIdentity(identity);
+  const addedGroups = pendingGroupChanges?.addedGroups ?? new Set<string>();
+  const removedGroups = pendingGroupChanges?.removedGroups ?? new Set<string>();
+
+  const identityGroupsChangeSummary = getChangesInGroupsForIdentities(
+    [identity],
+    addedGroups,
+    removedGroups,
+  );
+  const groupIdentitiesChangeSummary = pivotIdentityGroupsChangeSummary(
+    identityGroupsChangeSummary,
+  );
+
+  const closeGroupsConfirmModal = () => {
+    setConfirmingGroups(false);
+    setPendingGroupChanges(null);
+  };
+
+  const handleSaveGroups = () => {
+    if (!pendingGroupChanges) {
+      notify.failure(
+        "Update groups failed",
+        new Error("No pending group changes are available"),
+      );
+      return;
+    }
+
+    setSavingGroups(true);
+    updateIdentity({
+      ...identity,
+      groups: Array.from(pendingGroupChanges.currentGroups),
+    })
+      .then(() => {
+        queryClient.invalidateQueries({
+          predicate: (query) => {
+            return [queryKeys.identities, queryKeys.authGroups].includes(
+              query.queryKey[0] as string,
+            );
+          },
+        });
+        toastNotify.success(
+          <>
+            Updated groups for{" "}
+            <IdentityResource identity={identity} variant="label" />.
+          </>,
+        );
+        closePanel();
+      })
+      .catch((e) => {
+        notify.failure("Update groups failed", e);
+      })
+      .finally(() => {
+        setSavingGroups(false);
+      });
+  };
+
+  const openGroupsConfirmModal = () => {
+    if (!currentGroupChanges) {
+      return;
+    }
+
+    setPendingGroupChanges(currentGroupChanges);
+    setConfirmingGroups(true);
+  };
+
+  return (
+    <>
+      <SidePanel className="edit-identity-panel">
+        <SidePanel.Header>
+          <SidePanel.HeaderTitle>Edit identity</SidePanel.HeaderTitle>
+        </SidePanel.Header>
+        <NotificationRow className="u-no-padding" />
+        <SidePanel.Content className="u-no-padding">
+          <ScrollableContainer
+            dependencies={[
+              notify.notification,
+              identity,
+              groups,
+              modifiedGroups.size,
+            ]}
+            belowIds={["panel-footer"]}
+          >
+            <EditIdentityPanelContent
+              canEdit={canEdit}
+              groups={groups}
+              identity={identity}
+              onGroupChanges={(changes, nextModifiedGroups) => {
+                setCurrentGroupChanges(changes);
+                setModifiedGroups(nextModifiedGroups);
+              }}
+            />
+          </ScrollableContainer>
+        </SidePanel.Content>
+        <SidePanel.Footer className="u-align--right">
+          <div id="panel-footer">
+            <GroupSelectionActions
+              modifiedGroups={modifiedGroups}
+              closePanel={closePanel}
+              onSubmit={openGroupsConfirmModal}
+              disabled={
+                modifiedGroups.size === 0 ||
+                !canEdit ||
+                isGroupLoading ||
+                !!groupsError
+              }
+            />
+          </div>
+        </SidePanel.Footer>
+      </SidePanel>
+
+      {confirmingGroups && pendingGroupChanges && (
+        <ConfirmationModal
+          title="Confirm modification"
+          confirmButtonLabel="Confirm changes"
+          confirmButtonAppearance="positive"
+          onConfirm={handleSaveGroups}
+          close={closeGroupsConfirmModal}
+          confirmButtonLoading={savingGroups}
+          className="permission-confirm-modal"
+        >
+          <GroupsOrIdentityChangesTable
+            identityGroupsChangeSummary={identityGroupsChangeSummary}
+            groupIdentitiesChangeSummary={groupIdentitiesChangeSummary}
+            identities={[identity]}
+            initialGroupBy="identity"
+          />
+        </ConfirmationModal>
+      )}
+    </>
+  );
+};
+
+export default EditIdentityPanel;

--- a/src/pages/permissions/panels/EditIdentityPanelContent.tsx
+++ b/src/pages/permissions/panels/EditIdentityPanelContent.tsx
@@ -1,0 +1,70 @@
+import { OutputField } from "@canonical/react-components";
+import type { FC } from "react";
+import {
+  getIdentityName,
+  isBearerIdentityType,
+} from "util/permissionIdentities";
+import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
+import EditIdentityGroupsSection, {
+  type IdentityGroupChanges,
+} from "./EditIdentityGroupsSection";
+import IssueNewTokenSection from "./IssueNewTokenSection";
+import { isoTimeToString } from "util/helpers";
+
+interface Props {
+  canEdit: boolean;
+  groups: LxdAuthGroup[];
+  identity: LxdIdentity;
+  onGroupChanges: (
+    changes: IdentityGroupChanges,
+    nextModifiedGroups: Set<string>,
+  ) => void;
+}
+
+const EditIdentityPanelContent: FC<Props> = ({
+  canEdit,
+  groups,
+  identity,
+  onGroupChanges,
+}) => {
+  const isBearer = isBearerIdentityType(identity.type);
+
+  return (
+    <>
+      <OutputField
+        id="identity-name"
+        label="Name"
+        value={getIdentityName(identity)}
+      />
+      <OutputField id="identity-id" label="ID" value={identity.id} />
+      <OutputField
+        id="identity-auth-method-type"
+        label="Auth method"
+        value={`${identity.authentication_method.toUpperCase()} - ${identity.type}`}
+      />
+      {isBearer && (
+        <div className="u-flex u-gap--small">
+          <OutputField
+            id="identity-expires-at"
+            label="Expires at"
+            value={
+              isoTimeToString(identity.expires_at ?? "") || "No active token"
+            }
+          />
+
+          <div className="issue-token-button-wrapper">
+            <IssueNewTokenSection identity={identity} canEdit={canEdit} />
+          </div>
+        </div>
+      )}
+      <EditIdentityGroupsSection
+        identity={identity}
+        groups={groups}
+        canEdit={canEdit}
+        onChange={onGroupChanges}
+      />
+    </>
+  );
+};
+
+export default EditIdentityPanelContent;

--- a/src/pages/permissions/panels/GroupSelection.tsx
+++ b/src/pages/permissions/panels/GroupSelection.tsx
@@ -1,6 +1,4 @@
 import { useState, type DependencyList, type FC } from "react";
-import PermissionGroupsFilter from "../PermissionGroupsFilter";
-import type { LxdAuthGroup } from "types/permissions";
 import {
   EmptyState,
   Icon,
@@ -8,11 +6,13 @@ import {
   ScrollableTable,
 } from "@canonical/react-components";
 import SelectableMainTable from "components/SelectableMainTable";
+import PermissionGroupsFilter from "../PermissionGroupsFilter";
 import { Link } from "react-router-dom";
 import { pluralize } from "util/helpers";
 import useSortTableData from "util/useSortTableData";
 import { ROOT_PATH } from "util/rootPath";
 import classnames from "classnames";
+import type { LxdAuthGroup } from "types/permissions";
 
 interface Props {
   groups: LxdAuthGroup[];
@@ -27,6 +27,7 @@ interface Props {
   preselectedGroups?: Set<string>;
   belowIds?: string[];
   disabled?: boolean;
+  hasScrollableTable?: boolean;
 }
 
 const GroupSelection: FC<Props> = ({
@@ -42,6 +43,7 @@ const GroupSelection: FC<Props> = ({
   preselectedGroups,
   belowIds = [],
   disabled = false,
+  hasScrollableTable = true,
 }) => {
   const [search, setSearch] = useState("");
 
@@ -138,40 +140,49 @@ const GroupSelection: FC<Props> = ({
     defaultSortDirection: preselectedGroups ? "descending" : "ascending",
   });
 
+  const table = (
+    <SelectableMainTable
+      id="group-selection-table"
+      className="group-selection-table"
+      headers={headers}
+      rows={sortedRows}
+      sortable
+      emptyStateMsg="No groups found"
+      itemName="group"
+      parentName=""
+      selectedNames={Array.from(selectedGroups)}
+      setSelectedNames={setSelectedGroups}
+      disabledNames={[]}
+      filteredNames={groups.map((group) => group.name)}
+      indeterminateNames={Array.from(indeterminateGroups ?? new Set())}
+      onToggleRow={toggleGroup}
+      hideContextualMenu
+      disableSelect={disabled}
+    />
+  );
+
   return (
-    <ScrollableContainer
-      dependencies={scrollDependencies}
-      belowIds={["panel-footer", ...belowIds]}
-      className="group-selection"
-    >
+    <div className="group-selection">
       {groups.length > 5 && (
         <PermissionGroupsFilter onChange={setSearch} value={search} />
       )}
       {groups.length ? (
-        <ScrollableTable
-          dependencies={[...scrollDependencies, search]}
-          tableId="group-selection-table"
-          belowIds={["panel-footer", ...belowIds]}
-        >
-          <SelectableMainTable
-            id="group-selection-table"
-            className="group-selection-table"
-            headers={headers}
-            rows={sortedRows}
-            sortable
-            emptyStateMsg="No groups found"
-            itemName="group"
-            parentName=""
-            selectedNames={Array.from(selectedGroups)}
-            setSelectedNames={setSelectedGroups}
-            disabledNames={[]}
-            filteredNames={groups.map((group) => group.name)}
-            indeterminateNames={Array.from(indeterminateGroups ?? new Set())}
-            onToggleRow={toggleGroup}
-            hideContextualMenu
-            disableSelect={disabled}
-          />
-        </ScrollableTable>
+        hasScrollableTable ? (
+          <ScrollableContainer
+            dependencies={scrollDependencies}
+            belowIds={["panel-footer", ...belowIds]}
+          >
+            <ScrollableTable
+              dependencies={[...scrollDependencies, search]}
+              tableId="group-selection-table"
+              belowIds={["panel-footer", ...belowIds]}
+            >
+              {table}
+            </ScrollableTable>
+          </ScrollableContainer>
+        ) : (
+          table
+        )
       ) : (
         <EmptyState
           className="empty-state empty-state__full-width"
@@ -188,7 +199,7 @@ const GroupSelection: FC<Props> = ({
           </Link>
         </EmptyState>
       )}
-    </ScrollableContainer>
+    </div>
   );
 };
 

--- a/src/pages/permissions/panels/IssueNewTokenButton.tsx
+++ b/src/pages/permissions/panels/IssueNewTokenButton.tsx
@@ -1,0 +1,30 @@
+import { type FC } from "react";
+import { Button, Icon } from "@canonical/react-components";
+
+interface Props {
+  canEdit: boolean;
+  onClick: () => void;
+}
+
+const IssueNewTokenButton: FC<Props> = ({ canEdit, onClick }) => {
+  return (
+    <Button
+      type="button"
+      appearance="base"
+      disabled={!canEdit}
+      title={
+        canEdit
+          ? undefined
+          : "You do not have permission to issue a new token for this identity"
+      }
+      className="u-no-margin--bottom"
+      onClick={onClick}
+      hasIcon
+    >
+      <Icon name="restart" />
+      <span>Issue new token</span>
+    </Button>
+  );
+};
+
+export default IssueNewTokenButton;

--- a/src/pages/permissions/panels/IssueNewTokenSection.tsx
+++ b/src/pages/permissions/panels/IssueNewTokenSection.tsx
@@ -1,0 +1,167 @@
+import { useState, type FC } from "react";
+import { ConfirmationModal, useNotify } from "@canonical/react-components";
+import { useQueryClient } from "@tanstack/react-query";
+import IdentityTokenModal from "pages/permissions/IdentityTokenModal";
+import type { LxdIdentity } from "types/permissions";
+import IdentityResource from "components/IdentityResource";
+import TokenExpirySelector from "pages/permissions/panels/TokenExpirySelector";
+import {
+  BEARER_EXPIRY_PATTERN,
+  BEARER_EXPIRY_VALIDATION_TEXT,
+  IDENTITY_MODAL_TEXT,
+  getIdentityName,
+  type IdentityType,
+} from "util/permissionIdentities";
+import { issueBearerToken } from "api/auth-identities";
+import { queryKeys } from "util/queryKeys";
+import type { IdentityFormValues } from "types/forms/identity";
+import IssueNewTokenButton from "./IssueNewTokenButton";
+
+interface Props {
+  identity: LxdIdentity;
+  canEdit: boolean;
+}
+
+const IssueNewTokenSection: FC<Props> = ({ identity, canEdit }) => {
+  const notify = useNotify();
+  const queryClient = useQueryClient();
+  const [isCustomExpiry, setIsCustomExpiry] = useState(false);
+  const [expiry, setExpiry] = useState("");
+  const [expiryError, setExpiryError] = useState<string | undefined>();
+  const [confirmingReissue, setConfirmingReissue] = useState(false);
+  const [reissuingToken, setReissuingToken] = useState(false);
+  const [reissuedToken, setReissuedToken] = useState("");
+
+  const identityFormValues: IdentityFormValues = {
+    name: getIdentityName(identity),
+    groups: identity.groups ?? [],
+    identityType: identity.type as IdentityType,
+    expiry: identity.expires_at || "",
+  };
+  const identityModalCaptions =
+    IDENTITY_MODAL_TEXT[identityFormValues.identityType];
+
+  const trimmedExpiry = expiry.trim();
+  const isCustomExpiryValid =
+    !isCustomExpiry ||
+    (!!trimmedExpiry && BEARER_EXPIRY_PATTERN.test(trimmedExpiry));
+
+  const handleIsCustomExpiryChange = (isCustom: boolean) => {
+    setIsCustomExpiry(isCustom);
+    if (!isCustom) {
+      setExpiry("");
+    }
+    setExpiryError(undefined);
+  };
+
+  const handleExpiryBlur = () => {
+    if (isCustomExpiry && !isCustomExpiryValid) {
+      setExpiryError(BEARER_EXPIRY_VALIDATION_TEXT);
+    } else {
+      setExpiryError(undefined);
+    }
+  };
+
+  const closeReissueConfirmModal = () => {
+    setConfirmingReissue(false);
+    setIsCustomExpiry(false);
+    setExpiry("");
+    setExpiryError(undefined);
+  };
+
+  const handleConfirmReissue = () => {
+    if (!isCustomExpiryValid) {
+      setExpiryError(BEARER_EXPIRY_VALIDATION_TEXT);
+      return;
+    }
+
+    setReissuingToken(true);
+    issueBearerToken(
+      getIdentityName(identity),
+      isCustomExpiry ? trimmedExpiry : "",
+    )
+      .then((response) => {
+        queryClient.invalidateQueries({ queryKey: [queryKeys.identities] });
+        setConfirmingReissue(false);
+        setReissuedToken(response.token);
+        setIsCustomExpiry(false);
+        setExpiry("");
+        setExpiryError(undefined);
+      })
+      .catch((e) => {
+        notify.failure("Token issue failed", e);
+      })
+      .finally(() => {
+        setReissuingToken(false);
+      });
+  };
+
+  const closeTokenDisplayModal = () => {
+    setReissuedToken("");
+  };
+
+  return (
+    <>
+      <IssueNewTokenButton
+        canEdit={canEdit}
+        onClick={() => {
+          setConfirmingReissue(true);
+        }}
+      />
+
+      {confirmingReissue && (
+        <ConfirmationModal
+          title="Issue new token"
+          confirmButtonLabel="Issue new token"
+          confirmButtonAppearance="positive"
+          onConfirm={handleConfirmReissue}
+          close={closeReissueConfirmModal}
+          confirmButtonLoading={reissuingToken}
+          className="permission-confirm-modal"
+          confirmButtonDisabled={isCustomExpiry && !expiry}
+          confirmButtonProps={{
+            title:
+              isCustomExpiry && !expiry
+                ? "Please provide a valid expiry date"
+                : undefined,
+          }}
+        >
+          <p>
+            This will invalidate the current token for{" "}
+            <IdentityResource identity={identity} variant="label" /> and issue a
+            new one. Existing integrations using the previous token will stop
+            working until they are updated with the new token.
+          </p>
+          <TokenExpirySelector
+            isCustomExpiry={isCustomExpiry}
+            expiry={expiry}
+            error={expiryError}
+            onIsCustomExpiryChange={handleIsCustomExpiryChange}
+            onExpiryChange={(value) => {
+              setExpiry(value);
+              if (expiryError) {
+                setExpiryError(undefined);
+              }
+            }}
+            onExpiryBlur={handleExpiryBlur}
+          />
+        </ConfirmationModal>
+      )}
+
+      {reissuedToken && identityModalCaptions && (
+        <IdentityTokenModal
+          onClose={closeTokenDisplayModal}
+          token={reissuedToken}
+          identity={identityFormValues}
+          title={identityModalCaptions.codeSnippetTitle}
+          notification={identityModalCaptions.notification}
+          howToUseCli={identityModalCaptions.howToUseCli?.(reissuedToken)}
+          howToUseUi={identityModalCaptions.howToUseUi}
+          titleSuffix="token issued successfully"
+        />
+      )}
+    </>
+  );
+};
+
+export default IssueNewTokenSection;

--- a/src/pages/permissions/panels/TokenExpirySelector.tsx
+++ b/src/pages/permissions/panels/TokenExpirySelector.tsx
@@ -1,0 +1,71 @@
+import { Input, RadioInput } from "@canonical/react-components";
+import { type FC, useId } from "react";
+
+interface Props {
+  isCustomExpiry: boolean;
+  expiry: string;
+  disabled?: boolean;
+  error?: string;
+  onIsCustomExpiryChange: (isCustom: boolean) => void;
+  onExpiryChange: (value: string) => void;
+  onExpiryBlur?: () => void;
+}
+
+const TokenExpirySelector: FC<Props> = ({
+  isCustomExpiry,
+  expiry,
+  disabled = false,
+  error,
+  onIsCustomExpiryChange,
+  onExpiryChange,
+  onExpiryBlur,
+}) => {
+  const inputId = useId();
+
+  return (
+    <div className="token-expiry-selector u-sv1">
+      <label id={`${inputId}-label`}>Token expiry</label>
+      <RadioInput
+        label="Default (10 years)"
+        checked={!isCustomExpiry}
+        disabled={disabled}
+        onChange={() => {
+          onIsCustomExpiryChange(false);
+        }}
+      />
+      <div className="token-expiry-custom">
+        <RadioInput
+          label="Custom"
+          checked={isCustomExpiry}
+          disabled={disabled}
+          onChange={() => {
+            onIsCustomExpiryChange(true);
+          }}
+        />
+        <Input
+          type="text"
+          id={inputId}
+          value={isCustomExpiry ? expiry : ""}
+          error={isCustomExpiry ? error : undefined}
+          onChange={(e) => {
+            onExpiryChange(e.target.value);
+          }}
+          onBlur={onExpiryBlur}
+          placeholder="e.g. 1d 3H 5M"
+          disabled={disabled || !isCustomExpiry}
+          help={
+            <>
+              Space-separated durations: {"<number><unit>"} <br />
+              Units are case-sensitive: y, m, w, d, H, M, S
+            </>
+          }
+        />
+        <label htmlFor={inputId} className="u-off-screen">
+          Token expiry value
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default TokenExpirySelector;

--- a/src/sass/_permission_identities.scss
+++ b/src/sass/_permission_identities.scss
@@ -1,3 +1,9 @@
+.issue-token-button-wrapper {
+  align-self: flex-end;
+  margin-bottom: 0.7rem;
+  margin-left: 0.8rem;
+}
+
 .permission-identities-list {
   .permission-identities-table {
     .auth-method {
@@ -71,12 +77,25 @@
   margin-top: $spv--large;
 }
 
-.create-identity-panel-token-expiry {
+.token-expiry-selector {
   padding-left: $spv--x-small;
 }
 
-.create-identity-panel-token-expiry-custom-container {
+.token-expiry-custom {
   align-items: flex-start;
   display: flex;
   gap: $sph--large;
+}
+
+.edit-identity-panel {
+  padding-top: 0 !important;
+
+  .p-panel__content {
+    margin-left: 0;
+    padding-top: 0;
+  }
+
+  tr:last-child {
+    border: 0;
+  }
 }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -439,8 +439,8 @@ body.is-dark .lxd-icon {
 }
 
 .host-path-device-modal,
-.create-tls-identity,
-.create-cluster-link {
+.create-cluster-link,
+.identity-token-modal {
   .p-modal__dialog {
     @include large {
       width: 40rem;
@@ -456,6 +456,16 @@ body.is-dark .lxd-icon {
           width: 1rem;
         }
       }
+    }
+  }
+}
+
+.identity-token-modal {
+  .p-modal__dialog {
+    // Keep snippet title glyphs uniform in identity token modals.
+    .p-code-snippet__title {
+      font-variant: normal;
+      font-variant-caps: normal;
     }
   }
 }

--- a/src/types/forms/identity.d.ts
+++ b/src/types/forms/identity.d.ts
@@ -5,5 +5,5 @@ export interface IdentityFormValues {
   groups?: string[];
   identityType: IdentityType;
   expiry: string;
-  isCustomExpiry: boolean;
+  isCustomExpiry?: boolean;
 }

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -235,6 +235,17 @@ export const getIdentityIconType = (
 
 export const BEARER_EXPIRY_PATTERN = /^(\d+[ymwdHMS])(?:\s+\d+[ymwdHMS])*$/;
 
+export const BEARER_EXPIRY_VALIDATION_TEXT =
+  "Use format like 1d 3H 5M with units y, m, w, d, H, M, or S";
+
+export const isBearerIdentityType = (
+  identityType: LxdIdentity["type"],
+): identityType is
+  | typeof IDENTITY_TYPE.BEARER_CLIENT
+  | typeof IDENTITY_TYPE.BEARER_DEVLXD => {
+  return identityType.toLowerCase().includes("token bearer");
+};
+
 export const IDENTITY_TYPE_HELP_TEXT: Record<
   IdentityType,
   { title: string; description: ReactNode }
@@ -270,7 +281,7 @@ export const IDENTITY_TYPE_HELP_TEXT: Record<
   },
 };
 
-export const CREATE_IDENTITY_MODAL_TEXT: Record<
+export const IDENTITY_MODAL_TEXT: Record<
   IdentityType,
   {
     codeSnippetTitle: string;

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -40,6 +40,7 @@ export interface PanelHelper {
   openEditStorageBucket: (bucket: string, pool: string, target: string) => void;
   openEditStorageBucketKey: (key: string) => void;
   openGroupIdentities: (group?: string) => void;
+  openEditIdentity: (identityId: string) => void;
   openIdentityGroups: (identity?: string) => void;
   openInstanceSummary: (instance: string, project: string) => void;
   openProfileSummary: (profile: string, project: string) => void;
@@ -80,6 +81,7 @@ export const panels = {
   editStorageBucketKey: "edit-bucket-key",
   groupIdentities: "group-identities",
   identityGroups: "identity-groups",
+  editIdentity: "edit-identity",
   instanceSummary: "instance-summary",
   profileSummary: "profile-summary",
   createImageRegistry: "create-image-registry",
@@ -290,6 +292,12 @@ const usePanelParams = (): PanelHelper => {
       const newParams = new URLSearchParams(params);
       newParams.append("identity", identity || "");
       setPanelParams(panels.identityGroups, Object.fromEntries(newParams));
+    },
+
+    openEditIdentity: (identityId) => {
+      const newParams = new URLSearchParams(params);
+      newParams.set("identity", identityId);
+      setPanelParams(panels.editIdentity, Object.fromEntries(newParams));
     },
 
     openInstanceSummary: (instance, project) => {

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -47,3 +47,40 @@ export const selectIdentitiesToModify = async (
       .click();
   }
 };
+
+export const getDisplayedToken = async (page: Page): Promise<string> => {
+  const token = page.locator(".command-wrapper .command").first();
+  await expect(token).toBeVisible();
+  const fullToken = await token.getAttribute("title");
+  expect(fullToken).toBeTruthy();
+  return fullToken ?? "";
+};
+
+export const closeTokenDisplayModal = async (page: Page) => {
+  const tokenModal = page.getByRole("dialog");
+  const copiedConfirmation = tokenModal.getByText("I have copied the token");
+
+  await expect(copiedConfirmation).toBeVisible();
+  await copiedConfirmation.click();
+  await tokenModal.getByRole("button", { name: "Done" }).click();
+};
+
+export const issueTokenFromEditPanel = async (
+  page: Page,
+  expiry?: string,
+): Promise<string> => {
+  await page.getByRole("button", { name: "Issue new token" }).click();
+  const tokenModal = page
+    .locator(".p-modal")
+    .filter({ hasText: "Issue new token" });
+
+  if (expiry) {
+    await tokenModal.getByLabel("Custom").click();
+    await tokenModal.getByLabel("Token expiry value").fill(expiry);
+  }
+
+  await tokenModal.getByRole("button", { name: "Issue new token" }).click();
+  await expect(page.getByText("token issued successfully")).toBeVisible();
+
+  return getDisplayedToken(page);
+};

--- a/tests/helpers/permissions.ts
+++ b/tests/helpers/permissions.ts
@@ -14,6 +14,13 @@ export const skipIfFineGrainedAuthorisationNotSupported = (
   );
 };
 
+export const skipIfBearerIdentitiesNotSupported = (lxdVersion: LxdVersions) => {
+  test.skip(
+    lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge",
+    "Bearer identities tests not supported for lxd 5.0 and 5.21",
+  );
+};
+
 export const assertTextVisible = async (
   page: Page,
   textValue: string,

--- a/tests/permission-identities.spec.ts
+++ b/tests/permission-identities.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "./fixtures/lxd-test";
+import { test, expect } from "./fixtures/lxd-test";
 import {
   createGroup,
   deleteGroup,
@@ -7,9 +7,13 @@ import {
 import {
   identityBar,
   identityFoo,
+  randomIdentityName,
   selectIdentitiesToModify,
   toggleGroupsForIdentities,
   visitIdentities,
+  getDisplayedToken,
+  closeTokenDisplayModal,
+  issueTokenFromEditPanel,
 } from "./helpers/permission-identities";
 import {
   assertTextVisible,
@@ -17,6 +21,7 @@ import {
   redoChange,
   undoChange,
   skipIfFineGrainedAuthorisationNotSupported,
+  skipIfBearerIdentitiesNotSupported,
 } from "./helpers/permissions";
 import { dismissNotification } from "./helpers/notification";
 
@@ -31,15 +36,11 @@ test("manage groups for single identity", async ({ page, lxdVersion }) => {
   await visitIdentities(page);
   await page
     .getByRole("row", { name: `Select ${identityBar} Name ID` })
-    .getByLabel("Manage groups")
+    .getByLabel("Edit identity")
     .click();
   await toggleGroupsForIdentities(page, [groupOne, groupTwo]);
-  await assertTextVisible(page, "2 groups will be modified");
-  await undoChange(page);
-  await assertTextVisible(page, "1 group will be modified");
-  await redoChange(page);
-  await assertTextVisible(page, "2 groups will be modified");
   await page.getByRole("button", { name: "Save 2 group changes" }).click();
+
   await confirmGroupsModifiedForIdentity(
     page,
     "bar",
@@ -53,10 +54,9 @@ test("manage groups for single identity", async ({ page, lxdVersion }) => {
   );
   await page
     .getByRole("row", { name: `Select ${identityBar} Name ID` })
-    .getByLabel("Manage groups")
+    .getByLabel("Edit identity")
     .click();
   await toggleGroupsForIdentities(page, [groupOne, groupTwo]);
-  await assertTextVisible(page, "2 groups will be modified");
   await page.getByRole("button", { name: "Save 2 group changes" }).click();
   await confirmGroupsModifiedForIdentity(
     page,
@@ -81,6 +81,10 @@ test("manage groups for many identities", async ({ page, lxdVersion }) => {
   await page.getByLabel("Modify groups").click();
   await toggleGroupsForIdentities(page, [groupOne, groupTwo]);
   await assertTextVisible(page, "2 groups will be modified");
+  await undoChange(page);
+  await assertTextVisible(page, "1 group will be modified");
+  await redoChange(page);
+  await assertTextVisible(page, "2 groups will be modified");
   await page.getByRole("button", { name: "Save 2 group changes" }).click();
   await confirmGroupsModifiedForIdentity(
     page,
@@ -99,6 +103,10 @@ test("manage groups for many identities", async ({ page, lxdVersion }) => {
   await page.getByLabel("Modify groups").click();
   await toggleGroupsForIdentities(page, [groupOne, groupTwo]);
   await assertTextVisible(page, "2 groups will be modified");
+  await undoChange(page);
+  await assertTextVisible(page, "1 group will be modified");
+  await redoChange(page);
+  await assertTextVisible(page, "2 groups will be modified");
   await page.getByRole("button", { name: "Save 2 group changes" }).click();
   await confirmGroupsModifiedForIdentity(
     page,
@@ -114,4 +122,56 @@ test("manage groups for many identities", async ({ page, lxdVersion }) => {
   );
   await deleteGroup(page, groupOne);
   await deleteGroup(page, groupTwo);
+});
+
+test("reissue a new token for bearer identity", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
+  skipIfBearerIdentitiesNotSupported(lxdVersion);
+
+  const identity = randomIdentityName();
+
+  // Create a bearer identity and capture its first token.
+  await visitIdentities(page);
+  await page.getByRole("button", { name: "Create identity" }).click();
+  await page.getByRole("button", { name: "Bearer token (Main API)" }).click();
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByPlaceholder("Enter name").fill(identity);
+  await sidePanel.getByRole("button", { name: "Create identity" }).click();
+
+  const initialToken = await getDisplayedToken(page);
+  await closeTokenDisplayModal(page);
+
+  const identityRow = page.getByRole("row").filter({ hasText: identity });
+  await expect(identityRow).toBeVisible();
+  const identityType = (
+    await identityRow
+      .getByRole("cell", { name: "Type", exact: true })
+      .textContent()
+  )?.trim();
+  const identityId = (
+    await identityRow
+      .getByRole("cell", { name: "ID", exact: true })
+      .textContent()
+  )?.trim();
+  await identityRow.getByLabel("Edit identity").click();
+
+  // Reissue and verify token rotation.
+  const reissuedToken = await issueTokenFromEditPanel(page);
+  await closeTokenDisplayModal(page);
+  expect(reissuedToken).not.toEqual(initialToken);
+
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await identityRow.getByLabel("Delete identity").click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+  await dismissNotification(
+    page,
+    `Identity ${identity} (${identityType}, ${identityId}) deleted.`,
+  );
+  await expect(identityRow).not.toBeVisible();
 });

--- a/tests/permissions-read-only.spec.ts
+++ b/tests/permissions-read-only.spec.ts
@@ -449,7 +449,7 @@ test.describe("Given a user with Viewer Server permissions...", () => {
     await page.getByPlaceholder("Filter").fill(identityName);
     await page.keyboard.press("Enter");
     await page.waitForTimeout(200); // wait for filter to apply
-    await expect(page.getByLabel("Manage groups")).toBeDisabled();
+    await expect(page.getByLabel("Edit identity")).toBeDisabled();
     await expect(page.getByLabel("Delete identity")).toBeDisabled();
   });
 


### PR DESCRIPTION
## Done

- add identity edit panel WD-37701
## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
   1. Edit an identity - view details and manage groups
      - Navigate to Permissions -> Identities.
      - Click the "Edit identity" (pencil) icon on a row, or click the groups count link for an identity.
      - Verify the Edit identity panel opens showing read-only Name, ID and Auth method.
      - Add/remove auth groups and save; verify a "Confirm modification" dialog lists the group changes, confirm it, and verify a success toast and updated group count in the list.
   2. Issue a new token for a bearer identity
      - Open the Edit identity panel for an existing Client or DevLXD bearer identity.
      - Verify "Issue new token" button are shown (not present for TLS identities).
      - Click "Issue new token", confirm the warning that the previous token will be invalidated, and confirm.
## Screenshots

<img width="1831" height="1083" alt="image" src="https://github.com/user-attachments/assets/184f0706-9e39-43b3-8af2-e3e520986a41" />
<img width="1831" height="1083" alt="image" src="https://github.com/user-attachments/assets/b0894dcc-2061-42c6-92c9-bad8502a6b58" />

