### PR TITLE
fix: Amends selector for network forwards description for test consis…

### DIFF
--- a/tests/helpers/network.ts
+++ b/tests/helpers/network.ts
@@ -202,7 +202,9 @@ export const createNetworkForward = async (page: Page, network: string) => {
   await expect(page.getByText("Edit a network forward")).toBeVisible();
   await expect(page.getByText("Same as listen port if empty")).toBeVisible(); // ensure the forward ports are loaded before continuing
   await page.waitForLoadState("networkidle"); // ensure network loaded
-  await page.getByLabel("Description").fill("My forward description");
+  await page
+    .getByRole("textbox", { name: "Description" })
+    .fill("My forward description");
   await page.getByRole("button", { name: "Update" }).click();
 
   await page.getByText(`Network forward ${listenAddress} updated.`).click();


### PR DESCRIPTION
…tency on firefox.

## Done

- Amends the description selector for Firefox for more consistency

Fixes:
- Based on the failing test [stack trace](https://github.com/canonical/lxd-ci/actions/runs/29725345230/job/88297043292#logs)

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - N/A

## Screenshots

N/A