### PR TITLE
bugfix: [WD-37852] Project replicator actions not restricted by permissions

### DIFF
--- a/src/pages/projects/actions/ClearProjectReplicaModeBtn.tsx
+++ b/src/pages/projects/actions/ClearProjectReplicaModeBtn.tsx
@@ -8,9 +8,10 @@ import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { updateReplicaMode } from "util/projects";
+import type { LxdProject } from "types/project";
 
 interface Props {
-  project: string;
+  project: LxdProject;
   isEdit: boolean;
 }
 
@@ -22,7 +23,7 @@ const ClearProjectReplicaModeBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const { canEditProject } = useProjectEntitlements();
 
   const disabledReason = () => {
-    if (!canEditProject) {
+    if (!canEditProject(project)) {
       return "You do not have permission to edit this project";
     }
 
@@ -37,7 +38,7 @@ const ClearProjectReplicaModeBtn: FC<Props> = ({ project, isEdit }: Props) => {
     toastNotify.success(
       <>
         Replica mode cleared for project{" "}
-        <ProjectRichChip projectName={project} />.
+        <ProjectRichChip projectName={project.name} />.
       </>,
     );
   };
@@ -48,9 +49,11 @@ const ClearProjectReplicaModeBtn: FC<Props> = ({ project, isEdit }: Props) => {
 
   const clearReplicaMode = () => {
     setIsClearing(true);
-    updateReplicaMode(project, "", handleSuccess, handleFailure).finally(() => {
-      setIsClearing(false);
-    });
+    updateReplicaMode(project.name, "", handleSuccess, handleFailure).finally(
+      () => {
+        setIsClearing(false);
+      },
+    );
   };
 
   return (

--- a/src/pages/projects/actions/DemoteProjectBtn.tsx
+++ b/src/pages/projects/actions/DemoteProjectBtn.tsx
@@ -8,9 +8,10 @@ import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { updateReplicaMode } from "util/projects";
+import type { LxdProject } from "types/project";
 
 interface Props {
-  project: string;
+  project: LxdProject;
   isEdit: boolean;
 }
 
@@ -22,7 +23,7 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const [isForce, setForce] = useState(false);
 
   const disabledReason = () => {
-    if (!canEditProject) {
+    if (!canEditProject(project)) {
       return "You do not have permission to edit this project";
     }
 
@@ -36,7 +37,8 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const handleSuccess = () => {
     toastNotify.success(
       <>
-        Project <ProjectRichChip projectName={project} /> demoted to standby.
+        Project <ProjectRichChip projectName={project.name} /> demoted to
+        standby.
       </>,
     );
   };
@@ -48,7 +50,7 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const demoteToStandby = () => {
     setIsDemoting(true);
     updateReplicaMode(
-      project,
+      project.name,
       "standby",
       handleSuccess,
       handleFailure,
@@ -75,8 +77,8 @@ const DemoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
         title: "Confirm demote",
         children: (
           <p>
-            This will demote project <ProjectRichChip projectName={project} />{" "}
-            to standby.
+            This will demote project{" "}
+            <ProjectRichChip projectName={project.name} /> to standby.
           </p>
         ),
         confirmButtonLabel: "Demote",

--- a/src/pages/projects/actions/PromoteProjectBtn.tsx
+++ b/src/pages/projects/actions/PromoteProjectBtn.tsx
@@ -8,9 +8,10 @@ import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { updateReplicaMode } from "util/projects";
+import type { LxdProject } from "types/project";
 
 interface Props {
-  project: string;
+  project: LxdProject;
   isEdit: boolean;
 }
 
@@ -22,7 +23,7 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const [isForce, setForce] = useState(false);
 
   const disabledReason = () => {
-    if (!canEditProject) {
+    if (!canEditProject(project)) {
       return "You do not have permission to edit this project";
     }
 
@@ -36,7 +37,8 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const handleSuccess = () => {
     toastNotify.success(
       <>
-        Project <ProjectRichChip projectName={project} /> promoted to leader.
+        Project <ProjectRichChip projectName={project.name} /> promoted to
+        leader.
       </>,
     );
   };
@@ -48,7 +50,7 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
   const promoteToLeader = () => {
     setIsPromoting(true);
     updateReplicaMode(
-      project,
+      project.name,
       "leader",
       handleSuccess,
       handleFailure,
@@ -74,8 +76,8 @@ const PromoteProjectBtn: FC<Props> = ({ project, isEdit }: Props) => {
         title: "Confirm promote",
         children: (
           <p>
-            This will promote project <ProjectRichChip projectName={project} />{" "}
-            to leader.
+            This will promote project{" "}
+            <ProjectRichChip projectName={project.name} /> to leader.
           </p>
         ),
         confirmButtonLabel: "Promote",

--- a/src/pages/projects/forms/ProjectForm.tsx
+++ b/src/pages/projects/forms/ProjectForm.tsx
@@ -69,7 +69,11 @@ const ProjectForm: FC<Props> = ({
               <ProjectResourceLimitsForm formik={formik} />
             )}
             {section === slugify(REPLICATION) && (
-              <ProjectReplicaForm formik={formik} isEdit={isEdit} />
+              <ProjectReplicaForm
+                formik={formik}
+                project={project}
+                isEdit={isEdit}
+              />
             )}
             {section === slugify(CLUSTERS) && (
               <ClusterRestrictionForm formik={formik} />

--- a/src/pages/projects/forms/ProjectReplicaForm.tsx
+++ b/src/pages/projects/forms/ProjectReplicaForm.tsx
@@ -17,6 +17,7 @@ import type {
   ProjectFormValues,
   ProjectReplicaFormValues,
 } from "types/forms/project";
+import type { LxdProject } from "types/project";
 import { ensureEditMode } from "util/editMode";
 
 export const replicaPayload = (
@@ -32,10 +33,11 @@ export const replicaPayload = (
 
 interface Props {
   formik: FormikProps<ProjectFormValues>;
+  project?: LxdProject;
   isEdit: boolean;
 }
 
-const ProjectReplicaForm: FC<Props> = ({ formik, isEdit }) => {
+const ProjectReplicaForm: FC<Props> = ({ formik, project, isEdit }) => {
   const getClusterHelpText = (mode?: string) => {
     if (!mode) {
       return null;
@@ -73,11 +75,15 @@ const ProjectReplicaForm: FC<Props> = ({ formik, isEdit }) => {
   };
 
   const getModeActionButtons = (mode?: string) => {
+    if (!project) {
+      return [];
+    }
+
     const buttons = [];
     if (mode !== "leader") {
       buttons.push(
         <PromoteProjectBtn
-          project={formik.values.name}
+          project={project}
           isEdit={isEdit}
           key="promote-btn"
         />,
@@ -86,18 +92,14 @@ const ProjectReplicaForm: FC<Props> = ({ formik, isEdit }) => {
 
     if (mode !== "standby") {
       buttons.push(
-        <DemoteProjectBtn
-          project={formik.values.name}
-          isEdit={isEdit}
-          key="demote-btn"
-        />,
+        <DemoteProjectBtn project={project} isEdit={isEdit} key="demote-btn" />,
       );
     }
 
     if (mode) {
       buttons.push(
         <ClearProjectReplicaModeBtn
-          project={formik.values.name}
+          project={project}
           isEdit={isEdit}
           key="clear-btn"
         />,


### PR DESCRIPTION

## Done

- Fixes the usage fo the canEditProjects function in the button permission evaluation to actually take the project as a parameter. Other affected components included.

Fixes https://github.com/canonical/lxd-ui/issues/2156

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Verify that as a user with no permissions, or only view_project permissions, you cannot interact with the replicator/project promote/demote actions.

## Screenshots

<img width="1856" height="1049" alt="image" src="https://github.com/user-attachments/assets/23e5f0c2-4b3f-4485-8b12-2010dc16e6ff" />