### PR TITLE
fix(instance) select image on click of card when in mobile size

### DIFF
--- a/src/pages/images/ImageSelector.tsx
+++ b/src/pages/images/ImageSelector.tsx
@@ -1,4 +1,9 @@
-import { useState, type FC, type OptionHTMLAttributes } from "react";
+import {
+  useState,
+  type FC,
+  type OptionHTMLAttributes,
+  type MouseEvent,
+} from "react";
 import {
   Button,
   CheckboxInput,
@@ -169,11 +174,10 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
       };
       const itemType = figureType();
 
-      const selectImage = () => {
+      const selectImage = (e: MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
         onSelect(item, item.type ?? type);
       };
-
-      const onCellClick = isCardView ? undefined : selectImage;
 
       const displayRelease =
         item.os === "Ubuntu" &&
@@ -233,44 +237,44 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             content: item.os,
             role: "rowheader",
             "aria-label": "Distribution",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: displayRelease,
             role: "cell",
             "aria-label": "Release",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: displayVariant,
             role: "cell",
             "aria-label": "Variant",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: itemType,
             role: "cell",
             "aria-label": "Type",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: item.aliases.split(",").pop(),
             title: item.aliases.split(",").pop(),
             role: "cell",
             "aria-label": "Alias",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: getSource(),
             role: "cell",
             "aria-label": "Source",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: item.cached ? "Cached" : "Remote",
             role: "cell",
             "aria-label": "Cached",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
           {
             content: (
@@ -290,7 +294,7 @@ const ImageSelector: FC<Props> = ({ onSelect, onClose }) => {
             ),
             role: "cell",
             "aria-label": "Action",
-            onClick: onCellClick,
+            onClick: selectImage,
           },
         ],
         sortData: {


### PR DESCRIPTION
## Done

- select image on click of card when in mobile size

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instance, when selecting image, use a mobile view. ensure clicking the card also selects the image.

follow up to https://github.com/canonical/lxd-ui/pull/2106