### PR TITLE
feat(DeleteClusterLinkBtn): display list of used by items

### DIFF
--- a/src/pages/cluster/ClusterLinkList.tsx
+++ b/src/pages/cluster/ClusterLinkList.tsx
@@ -58,11 +58,17 @@ const ClusterLinkList: FC = () => {
       sortKey: "description",
     },
     {
+      content: "Used by",
+      sortKey: "usedBy",
+      className: "u-align--right",
+    },
+    {
       content: "Addresses",
     },
     {
       content: "Auth groups",
       sortKey: "groups",
+      className: "u-align--right",
     },
     { "aria-label": "Actions", className: "actions" },
   ];
@@ -101,6 +107,12 @@ const ClusterLinkList: FC = () => {
           "aria-label": "Description",
         },
         {
+          content: clusterLink.used_by?.length ?? 0,
+          role: "cell",
+          "aria-label": "Used by",
+          className: "u-align--right",
+        },
+        {
           content: <ClusterLinkAddresses clusterLink={clusterLink} />,
           role: "cell",
           "aria-label": "Addresses",
@@ -113,6 +125,7 @@ const ClusterLinkList: FC = () => {
           ),
           role: "cell",
           "aria-label": "Auth groups",
+          className: "u-align--right",
         },
         {
           content: (

--- a/src/pages/cluster/ClusterLinkUsedBy.tsx
+++ b/src/pages/cluster/ClusterLinkUsedBy.tsx
@@ -1,0 +1,45 @@
+import { type FC } from "react";
+import { Icon } from "@canonical/react-components";
+import type { LxdClusterLink } from "types/cluster";
+import UsedByRow from "components/UsedByRow";
+import ExpandableList from "components/ExpandableList";
+import { pluralize } from "util/helpers";
+
+interface Props {
+  clusterLink: LxdClusterLink;
+}
+
+const ClusterLinkUsedBy: FC<Props> = ({ clusterLink }) => {
+  if (!clusterLink.used_by?.length) {
+    return null;
+  }
+
+  const otherPaths = clusterLink.used_by.filter(
+    (path) => !path.includes("/1.0/replicators/"),
+  );
+
+  return (
+    <table className="p-main-table delete-cluster-link-table">
+      <tbody>
+        <UsedByRow entityType="replicator" usedBy={clusterLink.used_by} />
+        {otherPaths.length > 0 && (
+          <tr className="used-by-row">
+            <th className="u-text--muted used-by-row-header">
+              <Icon name="units" className="icon" />
+              {pluralize("Other", otherPaths.length)} ({otherPaths.length})
+            </th>
+            <td>
+              <ExpandableList
+                items={otherPaths.map((path) => (
+                  <div key={path}>{path}</div>
+                ))}
+              />
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
+export default ClusterLinkUsedBy;

--- a/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
+++ b/src/pages/cluster/actions/DeleteClusterLinkBtn.tsx
@@ -12,6 +12,7 @@ import type { LxdClusterLink } from "types/cluster";
 import ResourceLabel from "components/ResourceLabel";
 import { useClusterLinkEntitlements } from "util/entitlements/cluster-links";
 import ClusterLinkRichChip from "pages/cluster/ClusterLinkRichChip";
+import ClusterLinkUsedBy from "pages/cluster/ClusterLinkUsedBy";
 
 interface Props {
   clusterLink: LxdClusterLink;
@@ -25,6 +26,7 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
   const queryClient = useQueryClient();
 
   const canDelete = canDeleteClusterLink(clusterLink);
+  const isInUse = Boolean(clusterLink.used_by?.length);
 
   const handleDelete = () => {
     setLoading(true);
@@ -49,36 +51,41 @@ const DeleteClusterLinkBtn: FC<Props> = ({ clusterLink }) => {
       });
   };
 
-  const disabledReason = () => {
-    if (clusterLink.used_by?.length) {
-      return `Cannot delete this cluster link as it is currently in use.`;
-    }
-    if (!canDelete) {
-      return "You do not have permission to delete this cluster link";
-    }
-    return undefined;
-  };
+  const disabledReason = !canDelete
+    ? "You do not have permission to delete this cluster link"
+    : undefined;
 
   return (
     <ConfirmationButton
       appearance="base"
       className="has-icon"
-      onHoverText={disabledReason()}
-      disabled={Boolean(disabledReason())}
+      onHoverText={disabledReason}
+      disabled={!canDelete || isLoading}
       loading={isLoading}
       confirmationModalProps={{
-        title: "Confirm delete",
+        title: isInUse ? "Cannot delete cluster link" : "Confirm delete",
         children: (
-          <p>
-            This will permanently delete cluster link{" "}
-            <ClusterLinkRichChip clusterLink={clusterLink.name} />.
-          </p>
+          <>
+            {isInUse ? (
+              <>
+                <p>This cluster link is used by:</p>
+                <ClusterLinkUsedBy clusterLink={clusterLink} />
+              </>
+            ) : (
+              <p>
+                This will permanently delete cluster link{" "}
+                <ClusterLinkRichChip clusterLink={clusterLink.name} />.
+              </p>
+            )}
+          </>
         ),
         confirmButtonLabel: "Delete cluster link",
+        confirmButtonDisabled: isInUse,
         onConfirm: handleDelete,
+        className: "delete-cluster-link-dialog",
       }}
-      shiftClickEnabled
-      showShiftClickHint
+      shiftClickEnabled={!isInUse}
+      showShiftClickHint={!isInUse}
     >
       <Icon name="delete" />
     </ConfirmationButton>

--- a/src/sass/_cluster_link.scss
+++ b/src/sass/_cluster_link.scss
@@ -7,3 +7,25 @@
     }
   }
 }
+
+.delete-cluster-link-dialog {
+  .p-modal__dialog {
+    @include large {
+      width: 40rem;
+    }
+
+    .delete-cluster-link-table {
+      tbody {
+        tr {
+          th:first-child {
+            width: 14rem;
+
+            @include mobile-and-tablet {
+              width: 9rem;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/util/resourceDetails.tsx
+++ b/src/util/resourceDetails.tsx
@@ -24,6 +24,7 @@ export type ResourceType =
   | "network"
   | "network-forward"
   | "bucket"
+  | "replicator"
   | "volume";
 
 // refer to api spec to see how the names can be extracted from resource url

--- a/src/util/usedBy.tsx
+++ b/src/util/usedBy.tsx
@@ -60,6 +60,10 @@ export const filterUsedByType = (
           return path.includes("/forwards/");
         }
 
+        if (type === "replicator") {
+          return path.includes("/1.0/replicators/");
+        }
+
         return path.startsWith(`/1.0/${type}`);
       })
       .map((path) => {

--- a/tests/cluster-links-clustered.spec.ts
+++ b/tests/cluster-links-clustered.spec.ts
@@ -10,6 +10,17 @@ import {
   visitClusterLinks,
 } from "./helpers/cluster-links";
 import { skipIfNotClustered } from "./helpers/cluster";
+import { randomInstanceName } from "./helpers/instances";
+import { randomProjectName } from "./helpers/projects";
+import {
+  createReplicator,
+  deleteAllAfterReplicatorTest,
+  deleteReplicatorFromDetailPage,
+  randomReplicatorName,
+  setupProjectsForReplicator,
+  skipIfReplicatorsNotSupported,
+  visitReplicators,
+} from "./helpers/replicators";
 
 test("cluster link create edit delete", async ({
   page,
@@ -83,4 +94,48 @@ test("consume token to create cluster link", async ({
 
   deleteClusterLinkOnRemoteCluster(link);
   await deleteClusterLink(page, link);
+});
+
+test("cluster link deletion is blocked while in use by a replicator", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfClusterLinksNotSupported(lxdVersion);
+  skipIfReplicatorsNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+
+  const project = randomProjectName();
+  const instance = randomInstanceName();
+  const clusterLink = randomLinkName();
+  const replicator = randomReplicatorName();
+
+  await setupProjectsForReplicator(page, project, instance, clusterLink);
+  await createReplicator(page, replicator, clusterLink, project);
+
+  await visitClusterLinks(page);
+  const linkRow = page.getByRole("row").filter({ hasText: clusterLink });
+  await linkRow.getByRole("button", { name: "Delete cluster link" }).click();
+
+  const dialog = page.getByRole("dialog", {
+    name: "Cannot delete cluster link",
+  });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("This cluster link is used by:")).toBeVisible();
+  await expect(dialog.getByText("Replicator (1)")).toBeVisible();
+  await expect(
+    dialog.getByRole("button", { name: "Delete cluster link" }),
+  ).toBeDisabled();
+
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+
+  // Remove the replicator so the cluster link is no longer in use
+  await visitReplicators(page);
+  const replicatorRow = page.getByRole("row").filter({ hasText: replicator });
+  await replicatorRow.getByRole("link", { name: replicator }).click();
+  await expect(page.getByRole("heading", { name: "General" })).toBeVisible();
+  await deleteReplicatorFromDetailPage(page, replicator);
+
+  // deleteAllAfterReplicatorTest navigates to cluster links and deletes via the
+  // normal "Confirm delete" dialog, implicitly verifying the link is unblocked.
+  await deleteAllAfterReplicatorTest(page, project, clusterLink);
 });

--- a/tests/helpers/replicators.ts
+++ b/tests/helpers/replicators.ts
@@ -22,6 +22,7 @@ import {
   deleteProject,
 } from "./projects";
 import { createInstance } from "./instances";
+import { gotoURL } from "./navigate";
 
 export const skipIfReplicatorsNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
@@ -330,4 +331,13 @@ export const deleteAllAfterReplicatorTest = async (
   await visitClusterLinks(page);
   await deleteClusterLink(page, clusterLink);
   await deleteProject(page, project);
+};
+
+export const visitReplicators = async (page: Page) => {
+  await gotoURL(page, "/ui/");
+  await page.getByRole("button", { name: "Clustering" }).click();
+  await page.getByRole("link", { name: "Replicators" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Replicators" }),
+  ).toBeVisible();
 };


### PR DESCRIPTION
## Done

- feat(DeleteClusterLinkBtn): when cluster link is in use, enable delete button and display the list of used by items in the confirmation modal. "Delete" button in the confirmation modal remains disabled.
For now, only replicators are included in the used by list of a cluster link. I added a "Others" row in case other entities get added without our knowledge.

- Add "Used by" column in cluster links table
- Align right Auth groups

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Clustering > Links
    - Make sure the delete button is enabled for cluster links that are in use.
    - Click on the delete button of a cluster link that is in use. Make sure the replicators that use this cluster link are correctly listed and that the delete button in the confirmation modal is disabled.

## Screenshots

<img width="805" height="364" alt="image" src="https://github.com/user-attachments/assets/23973c5f-ec7c-4892-ac93-8cd09262f8e3" />

<img width="1554" height="834" alt="image" src="https://github.com/user-attachments/assets/a828bf61-97cb-49d3-bcc9-67518b40d392" />


