### PR TITLE
fix(replicators) url for replicators has been simplified and unified

### DIFF
--- a/src/pages/cluster/ClusterLinkRichChip.tsx
+++ b/src/pages/cluster/ClusterLinkRichChip.tsx
@@ -4,8 +4,7 @@ import { useIsScreenBelow } from "context/useIsScreenBelow";
 import ResourceLink from "components/ResourceLink";
 import { SMALL_TOOLTIP_BREAKPOINT } from "components/RichTooltipTable";
 import ClusterLinkRichTooltip from "./ClusterLinkRichTooltip";
-import { getClusterLinkListUrl } from "util/clusterLink";
-import { useIsClustered } from "context/useIsClustered";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   clusterLink: string;
@@ -19,13 +18,12 @@ const ClusterLinkRichChip: FC<Props> = ({
   disabled,
 }) => {
   const showTooltip = !useIsScreenBelow(SMALL_TOOLTIP_BREAKPOINT, "height");
-  const isClustered = useIsClustered();
 
   const resourceLink = (
     <ResourceLink
       type="cluster-link"
       value={clusterLink}
-      to={getClusterLinkListUrl(isClustered)}
+      to={`${ROOT_PATH}/ui/cluster/links`}
       hasTitle={!showTooltip}
       className={className}
       disabled={disabled}

--- a/src/pages/cluster/ClusterLinkRichTooltip.tsx
+++ b/src/pages/cluster/ClusterLinkRichTooltip.tsx
@@ -9,8 +9,8 @@ import ClusterLinkStatus from "./ClusterLinkStatus";
 import ResourceLabel from "components/ResourceLabel";
 import ClusterLinkAddresses from "./ClusterLinkAddresses";
 import { useIdentities } from "context/useIdentities";
-import { getClusterLinkListUrl, getLinkIdentity } from "util/clusterLink";
-import { useIsClustered } from "context/useIsClustered";
+import { getLinkIdentity } from "util/clusterLink";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   clusterLink: string;
@@ -19,7 +19,6 @@ interface Props {
 const ClusterLinkRichTooltip: FC<Props> = ({ clusterLink }) => {
   const { data: link, isLoading: isLinkLoading } = useClusterLink(clusterLink);
   const { data: identities = [] } = useIdentities();
-  const isClustered = useIsClustered();
 
   if (!link && !isLinkLoading) {
     return (
@@ -38,7 +37,7 @@ const ClusterLinkRichTooltip: FC<Props> = ({ clusterLink }) => {
       title: "Cluster link",
       value: link ? (
         <Link
-          to={getClusterLinkListUrl(isClustered)}
+          to={`${ROOT_PATH}/ui/cluster/links`}
           onClick={(e) => {
             e.stopPropagation();
           }}

--- a/src/pages/cluster/ClusterLinkSelector.tsx
+++ b/src/pages/cluster/ClusterLinkSelector.tsx
@@ -6,9 +6,8 @@ import {
   type CustomSelectProps,
 } from "@canonical/react-components";
 import { useClusterLinks } from "context/useClusterLinks";
-import { useIsClustered } from "context/useIsClustered";
 import ClusterLinkStatus from "pages/cluster/ClusterLinkStatus";
-import { getClusterLinkListUrl } from "util/clusterLink";
+import { ROOT_PATH } from "util/rootPath";
 
 interface ClusterLinkSelectorProps extends Omit<
   CustomSelectProps,
@@ -37,7 +36,6 @@ const ClusterLinkSelector: FC<ClusterLinkSelectorProps> = ({
 }) => {
   const { data: links = [], error: apiError, isLoading } = useClusterLinks();
   const notify = useNotify();
-  const isClustered = useIsClustered();
   const linkNames = links.map((link) => link.name);
 
   const hasNoLinks = links.length === 0 && !isLoading;
@@ -93,12 +91,12 @@ const ClusterLinkSelector: FC<ClusterLinkSelectorProps> = ({
       {hasNoLinks ? (
         <>
           Create your first{" "}
-          <Link to={getClusterLinkListUrl(isClustered)}>cluster link</Link>.
+          <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
         </>
       ) : (
         <>
           Manage your{" "}
-          <Link to={getClusterLinkListUrl(isClustered)}>cluster links</Link>.
+          <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>.
         </>
       )}
     </>

--- a/src/pages/cluster/ReplicatorDetailHeader.tsx
+++ b/src/pages/cluster/ReplicatorDetailHeader.tsx
@@ -11,8 +11,6 @@ import { checkDuplicateName } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 import * as Yup from "yup";
 import ReplicatorRichChip from "./ReplicatorRichChip";
-import { useIsClustered } from "context/useIsClustered";
-import { getReplicatorListUrl } from "util/replicator";
 
 interface Props {
   replicator: LxdReplicator;
@@ -24,7 +22,6 @@ const ReplicatorDetailHeader: FC<Props> = ({ replicator }) => {
   const toastNotify = useToastNotification();
   const { canEditReplicator } = useReplicatorEntitlements();
   const controllerState = useState<AbortController | null>(null);
-  const isClustered = useIsClustered();
 
   const RenameSchema = Yup.object().shape({
     name: Yup.string()
@@ -97,7 +94,7 @@ const ReplicatorDetailHeader: FC<Props> = ({ replicator }) => {
     <RenameHeader
       name={replicator.name}
       parentItems={[
-        <Link to={getReplicatorListUrl(isClustered)} key={1}>
+        <Link to={`${ROOT_PATH}/ui/cluster/replicators`} key={1}>
           Replicators
         </Link>,
       ]}

--- a/src/pages/cluster/ReplicatorList.tsx
+++ b/src/pages/cluster/ReplicatorList.tsx
@@ -14,7 +14,6 @@ import BaseLayout from "components/BaseLayout";
 import HelpLink from "components/HelpLink";
 import NotificationRow from "components/NotificationRow";
 import { useClusterLinks } from "context/useClusterLinks";
-import { useIsClustered } from "context/useIsClustered";
 import { useReplicators } from "context/useReplicators";
 import useSortTableData from "util/useSortTableData";
 import { CreateReplicatorButton } from "pages/cluster/actions/CreateReplicatorBtn";
@@ -45,7 +44,6 @@ const ReplicatorList: FC<Props> = ({ variant = "main", project, cluster }) => {
   const panelParams = usePanelParams();
   const { data: replicators = [], error, isLoading } = useReplicators(project);
   const { data: links = [], isLoading: linksLoading } = useClusterLinks();
-  const isClustered = useIsClustered();
 
   const isProjectConfiguration = variant === "project-configuration";
   const isEmptyState = replicators.length === 0 && !isLoading;
@@ -222,7 +220,6 @@ const ReplicatorList: FC<Props> = ({ variant = "main", project, cluster }) => {
             projectConfigurationInfoNotification
           }
           hasClusterLinks={hasClusterLinks}
-          isClustered={isClustered}
           docBaseLink={docBaseLink}
           project={project}
           cluster={cluster}

--- a/src/pages/cluster/ReplicatorListEmptyState.tsx
+++ b/src/pages/cluster/ReplicatorListEmptyState.tsx
@@ -3,13 +3,12 @@ import { Link } from "react-router-dom";
 import { EmptyState, Icon } from "@canonical/react-components";
 import { CreateReplicatorButton } from "pages/cluster/actions/CreateReplicatorBtn";
 import CreateClusterLinkBtn from "pages/cluster/actions/CreateClusterLinkBtn";
-import { getClusterLinkListUrl } from "util/clusterLink";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   isProjectConfiguration: boolean;
   projectConfigurationInfoNotification: React.ReactNode;
   hasClusterLinks: boolean;
-  isClustered: boolean;
   docBaseLink: string;
   project?: string;
   cluster?: string;
@@ -19,7 +18,6 @@ const ReplicatorListEmptyState: FC<Props> = ({
   isProjectConfiguration,
   projectConfigurationInfoNotification,
   hasClusterLinks,
-  isClustered,
   docBaseLink,
   project,
   cluster,
@@ -37,7 +35,7 @@ const ReplicatorListEmptyState: FC<Props> = ({
           {!hasClusterLinks && (
             <p>
               To create a replicator, first create a{" "}
-              <Link to={getClusterLinkListUrl(isClustered)}>cluster link</Link>.
+              <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
             </p>
           )}
           <p>
@@ -77,7 +75,7 @@ const ReplicatorListEmptyState: FC<Props> = ({
       {!hasClusterLinks && (
         <p>
           To create a replicator, first create a{" "}
-          <Link to={getClusterLinkListUrl(isClustered)}>cluster link</Link>.
+          <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster link</Link>.
         </p>
       )}
       <p>

--- a/src/pages/cluster/ReplicatorRichTooltip.tsx
+++ b/src/pages/cluster/ReplicatorRichTooltip.tsx
@@ -9,11 +9,9 @@ import { ROOT_PATH } from "util/rootPath";
 import { useReplicator } from "context/useReplicators";
 import ClusterLinkStatus from "./ClusterLinkStatus";
 import { useClusterLink } from "context/useClusterLinks";
-import { useIsClustered } from "context/useIsClustered";
 import ReplicatorRunTime from "./ReplicatorRunTime";
 import ReplicatorStatus from "./ReplicatorStatus";
 import ResourceLink from "components/ResourceLink";
-import { getClusterLinkListUrl } from "util/clusterLink";
 
 interface Props {
   replicatorName: string;
@@ -25,7 +23,6 @@ const ReplicatorRichTooltip: FC<Props> = ({ replicatorName, project }) => {
     replicatorName,
     project,
   );
-  const isClustered = useIsClustered();
 
   const isEnabled = !!replicator && !!replicator.config?.cluster;
   const { data: link } = useClusterLink(
@@ -84,7 +81,7 @@ const ReplicatorRichTooltip: FC<Props> = ({ replicatorName, project }) => {
         <ResourceLink
           type="cluster-link"
           value={replicator.config.cluster}
-          to={getClusterLinkListUrl(isClustered)}
+          to={`${ROOT_PATH}/ui/cluster/links`}
         />
       ) : (
         "-"

--- a/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
+++ b/src/pages/cluster/actions/DeleteReplicatorBtn.tsx
@@ -16,8 +16,6 @@ import { queryKeys } from "util/queryKeys";
 import { ROOT_PATH } from "util/rootPath";
 import classNames from "classnames";
 import ReplicatorRichChip from "../ReplicatorRichChip";
-import { useIsClustered } from "context/useIsClustered";
-import { getReplicatorListUrl } from "util/replicator";
 
 interface Props {
   replicator: LxdReplicator;
@@ -38,7 +36,6 @@ const DeleteReplicatorBtn: FC<Props> = ({
   const toastNotify = useToastNotification();
   const [isLoading, setLoading] = useState(false);
   const { canDeleteReplicator } = useReplicatorEntitlements();
-  const isClustered = useIsClustered();
   const isReplicatorRunning = replicator.last_run_status === "Running";
 
   const disabledReason = () => {
@@ -70,8 +67,7 @@ const DeleteReplicatorBtn: FC<Props> = ({
     // Only navigate to the replicators list if we are still on the deleted replicator's detail page
     const replicatorDetailPath = `${ROOT_PATH}/ui/project/${encodeURIComponent(replicator.project)}/replicator/${encodeURIComponent(replicator.name)}`;
     if (location.pathname.startsWith(replicatorDetailPath)) {
-      const replicatorListUrl = getReplicatorListUrl(isClustered);
-      navigate(replicatorListUrl);
+      navigate(`${ROOT_PATH}/ui/cluster/replicators`);
     }
 
     notifySuccess(replicator.name);

--- a/src/pages/images/ImageRegistryClusterLinkSelector.tsx
+++ b/src/pages/images/ImageRegistryClusterLinkSelector.tsx
@@ -4,8 +4,7 @@ import { useClusterLinks } from "context/useClusterLinks";
 import type { FormikProps } from "formik";
 import type { ImageRegistryFormValues } from "types/forms/image";
 import { Link } from "react-router-dom";
-import { useIsClustered } from "context/useIsClustered";
-import { getClusterLinkListUrl } from "util/clusterLink";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   formik: FormikProps<ImageRegistryFormValues>;
@@ -18,7 +17,6 @@ export const ImageRegistryClusterLinkSelector: FC<Props> = ({
 }) => {
   const { data: links = [], error } = useClusterLinks();
   const notify = useNotify();
-  const isClustered = useIsClustered();
   const hasNoLinks = links.length === 0;
 
   if (error) {
@@ -43,7 +41,7 @@ export const ImageRegistryClusterLinkSelector: FC<Props> = ({
   }));
 
   const helpLink = (
-    <Link to={getClusterLinkListUrl(isClustered)}>cluster links</Link>
+    <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>
   );
 
   const helpText = hasNoLinks ? (

--- a/src/pages/images/ImageRegistryRichTooltip.tsx
+++ b/src/pages/images/ImageRegistryRichTooltip.tsx
@@ -7,8 +7,7 @@ import { Link } from "react-router";
 import { useImageRegistry } from "context/useImageRegistries";
 import { isImageRegistryPublic } from "util/imageRegistries";
 import ItemName from "components/ItemName";
-import { getClusterLinkListUrl } from "util/clusterLink";
-import { useIsClustered } from "context/useIsClustered";
+import { ROOT_PATH } from "util/rootPath";
 
 interface Props {
   imageRegistryName: string;
@@ -21,7 +20,6 @@ const ImageRegistryRichTooltip: FC<Props> = ({
 }) => {
   const { data: imageRegistry, isLoading: isLoading } =
     useImageRegistry(imageRegistryName);
-  const isClustered = useIsClustered();
 
   if (!imageRegistry && !isLoading) {
     return (
@@ -85,7 +83,7 @@ const ImageRegistryRichTooltip: FC<Props> = ({
     rows.push({
       title: "Cluster",
       value: cluster ? (
-        <Link to={getClusterLinkListUrl(isClustered)}>{cluster}</Link>
+        <Link to={`${ROOT_PATH}/ui/cluster/links`}>{cluster}</Link>
       ) : (
         "-"
       ),

--- a/src/util/clusterLink.tsx
+++ b/src/util/clusterLink.tsx
@@ -1,6 +1,5 @@
 import type { LxdClusterLinkState, StatusCaption } from "types/cluster";
 import type { LxdIdentity } from "types/permissions";
-import { ROOT_PATH } from "util/rootPath";
 
 export const getClusterLinksStatus = (
   identity?: LxdIdentity,
@@ -28,10 +27,4 @@ export const getLinkIdentity = (
       identity.name === linkName &&
       identity.type.startsWith("Cluster link certificate"),
   );
-};
-
-export const getClusterLinkListUrl = (isClustered = false): string => {
-  return isClustered
-    ? `${ROOT_PATH}/ui/cluster/links`
-    : `${ROOT_PATH}/ui/server/cluster-links`;
 };

--- a/src/util/replicator.ts
+++ b/src/util/replicator.ts
@@ -1,7 +1,6 @@
 import type { FormikProps } from "formik";
 import type { ReplicatorFormValues } from "types/forms/replicator";
 import type { LxdReplicator } from "types/replicator";
-import { ROOT_PATH } from "./rootPath";
 
 export const getPayload = (
   formik: FormikProps<ReplicatorFormValues>,
@@ -14,10 +13,4 @@ export const getPayload = (
       schedule: formik.values.schedule,
     },
   };
-};
-
-export const getReplicatorListUrl = (isClustered = false): string => {
-  return isClustered
-    ? `${ROOT_PATH}/ui/cluster/replicators`
-    : `${ROOT_PATH}/ui/server/replicators`;
 };


### PR DESCRIPTION
## Done

- fix(replicators) url for replicators has been simplified and unified

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create replicator on unclustered server
    - delete replicator, see we go to the replicator list, not to a 404 page.