### PR TITLE
feat(OperationList): handle child operations

### DIFF
--- a/src/api/operations.tsx
+++ b/src/api/operations.tsx
@@ -16,9 +16,10 @@ const sortOperationList = (operations: LxdOperationList) => {
 
 export const fetchOperations = async (
   project: string | null,
+  recursion: "1" | "2" = "1",
 ): Promise<LxdOperationList> => {
   const params = new URLSearchParams();
-  params.set("recursion", "1");
+  params.set("recursion", recursion);
   if (project) {
     params.append("project", project);
   } else {

--- a/src/context/operationsProvider.tsx
+++ b/src/context/operationsProvider.tsx
@@ -143,3 +143,30 @@ export default OperationsProvider;
 export const useOperations = () => {
   return useContext(OperationsContext);
 };
+
+export const useOperationsWithChildren = () => {
+  const { isAuthenticated } = useAuth();
+
+  const {
+    data: operationList,
+    error,
+    isLoading,
+    isFetching,
+  } = useQuery({
+    queryKey: [queryKeys.operations, "with-children"],
+    queryFn: async () => fetchOperations(null, "2"),
+    enabled: isAuthenticated,
+  });
+
+  const failure = operationList?.failure ?? [];
+  const running = operationList?.running ?? [];
+  const success = operationList?.success ?? [];
+  const operations = [...failure, ...running, ...success];
+
+  return {
+    operations,
+    error,
+    isLoading,
+    isFetching,
+  };
+};

--- a/src/pages/operations/ChildOperationTrigger.tsx
+++ b/src/pages/operations/ChildOperationTrigger.tsx
@@ -1,0 +1,63 @@
+import type { FC } from "react";
+import { Button, Icon, List } from "@canonical/react-components";
+import type { LxdOperation, LxdOperationStatus } from "types/operation";
+import { pluralize } from "util/helpers";
+import { countByStatus } from "util/operations";
+
+interface Props {
+  operation: LxdOperation;
+  isExpanded: boolean;
+  onToggleExpansion: (id: string) => void;
+}
+
+const ChildOperationTrigger: FC<Props> = ({
+  operation,
+  isExpanded,
+  onToggleExpansion,
+}) => {
+  const childOperations = operation.children ?? [];
+  const childCount = childOperations.length || 0;
+
+  if (childCount === 0) {
+    return null;
+  }
+
+  const statusCount = countByStatus(childOperations);
+  const childStatusItems = (
+    ["Running", "Failure", "Cancelled"] as LxdOperationStatus[]
+  )
+    .map((status) => {
+      const count = statusCount[status] ?? 0;
+      return count > 0 ? `${count} ${status.toLowerCase()}` : "";
+    })
+    .filter(Boolean);
+
+  return (
+    <div className="child-operations-trigger">
+      <Button
+        hasIcon
+        dense
+        appearance="base"
+        onClick={() => {
+          onToggleExpansion(operation.id);
+        }}
+        aria-expanded={isExpanded}
+        className="bulk-toggle-btn"
+      >
+        <span className="p-chip is-dense u-no-margin">
+          <Icon name={isExpanded ? "chevron-up" : "chevron-down"} />
+          <List
+            middot
+            items={[
+              `${childCount} ${pluralize("child operation", childCount)}`,
+              ...childStatusItems,
+            ]}
+            className="u-no-margin--bottom"
+          />
+        </span>
+      </Button>
+    </div>
+  );
+};
+
+export default ChildOperationTrigger;

--- a/src/pages/operations/OperationDescription.tsx
+++ b/src/pages/operations/OperationDescription.tsx
@@ -1,0 +1,24 @@
+import type { FC } from "react";
+import OperationInstanceName from "pages/operations/OperationInstanceName";
+import type { LxdOperation } from "types/operation";
+import { getProjectName } from "util/operations";
+
+interface Props {
+  operation: LxdOperation;
+}
+
+const OperationDescription: FC<Props> = ({ operation }) => {
+  const projectName = getProjectName(operation);
+
+  return (
+    <>
+      <div>{operation.description}</div>
+      <OperationInstanceName operation={operation} />
+      <div className="u-text--muted u-truncate" title={projectName}>
+        Project: {projectName}
+      </div>
+    </>
+  );
+};
+
+export default OperationDescription;

--- a/src/pages/operations/OperationList.tsx
+++ b/src/pages/operations/OperationList.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from "react";
+import { useState, type FC, type ReactNode } from "react";
 import {
   EmptyState,
   Icon,
@@ -11,42 +11,161 @@ import {
   Spinner,
   CustomLayout,
 } from "@canonical/react-components";
-import CancelOperationBtn from "pages/operations/actions/CancelOperationBtn";
-import { isoTimeToString, nonBreakingSpaces } from "util/helpers";
-import type { LxdOperationStatus } from "types/operation";
-import OperationInstanceName from "pages/operations/OperationInstanceName";
+import { useOperationsWithChildren } from "context/operationsProvider";
 import NotificationRow from "components/NotificationRow";
-import { getInstanceName, getProjectName } from "util/operations";
-import { useOperations } from "context/operationsProvider";
-import RefreshOperationsBtn from "pages/operations/actions/RefreshOperationsBtn";
-import useSortTableData from "util/useSortTableData";
 import PageHeader from "components/PageHeader";
+import ChildOperationTrigger from "pages/operations/ChildOperationTrigger";
+import OperationDescription from "pages/operations/OperationDescription";
+import OperationTimeDates from "pages/operations/OperationTimeDates";
+import CancelOperationBtn from "pages/operations/actions/CancelOperationBtn";
+import RefreshOperationsBtn from "pages/operations/actions/RefreshOperationsBtn";
+import type { LxdOperation } from "types/operation";
+import {
+  getIconNameForStatus,
+  getInstanceName,
+  getProjectName,
+} from "util/operations";
+import useSortTableData from "util/useSortTableData";
+
+const renderParentFirstColumnContent = ({
+  operation,
+  isExpanded,
+  onToggleExpansion,
+}: {
+  operation: LxdOperation;
+  isExpanded: boolean;
+  onToggleExpansion: (id: string) => void;
+}) => {
+  return (
+    <div className="time-cell-content">
+      <OperationTimeDates operation={operation} />
+      <ChildOperationTrigger
+        operation={operation}
+        isExpanded={isExpanded}
+        onToggleExpansion={onToggleExpansion}
+      />
+    </div>
+  );
+};
+
+const renderChildFirstColumnContent = (operation: LxdOperation) => {
+  return (
+    <>
+      <div className="child-tree-rail">
+        <span className="tree-connector" />
+      </div>
+      <div className="time-cell-content">
+        <OperationTimeDates operation={operation} />
+      </div>
+    </>
+  );
+};
+
+const buildOperationRow = ({
+  operation,
+  className,
+  timeContent,
+  sortData,
+}: {
+  operation: LxdOperation;
+  className: string;
+  timeContent: ReactNode;
+  sortData: Record<string, unknown>;
+}) => {
+  return {
+    key: operation.id,
+    className,
+    columns: [
+      {
+        content: timeContent,
+        role: "cell",
+        "aria-label": "Time",
+        className: "time",
+      },
+      {
+        content: <OperationDescription operation={operation} />,
+        role: "rowheader",
+        "aria-label": "Description",
+        className: "description",
+      },
+      {
+        content: (
+          <>
+            {operation.err && <div>{operation.err}</div>}
+            {Object.entries(operation.metadata ?? {}).map(
+              ([metaKey, value]) => (
+                <div key={metaKey}>
+                  <span title={JSON.stringify(value)}>
+                    {metaKey}: {JSON.stringify(value)}
+                  </span>
+                </div>
+              ),
+            )}
+          </>
+        ),
+        role: "cell",
+        "aria-label": "Details",
+        className: "details",
+      },
+      {
+        content: (
+          <>
+            <Icon
+              name={getIconNameForStatus(operation.status)}
+              className="status-icon"
+            />
+            {operation.status}
+          </>
+        ),
+        role: "cell",
+        "aria-label": "Status",
+        className: "status",
+      },
+      {
+        content: <CancelOperationBtn operation={operation} />,
+        role: "cell",
+        className: "u-align--right cancel",
+        "aria-label": "Actions",
+      },
+    ],
+    sortData,
+  };
+};
 
 const OperationList: FC = () => {
   const notify = useNotify();
-  const { operations, isLoading, error } = useOperations();
+  const { operations, isLoading, error } = useOperationsWithChildren();
+
   const [query, setQuery] = useState<string>("");
+  const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(new Set());
 
   if (error) {
     notify.failure("Loading operations failed", error);
   }
 
+  const toggleRowExpansion = (id: string) => {
+    setExpandedRowIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
   const headers = [
     { content: "Time", className: "time", sortKey: "created_at" },
-    { content: "Action", className: "action", sortKey: "action" },
-    { content: "Info", className: "info" },
+    {
+      content: "Description",
+      className: "description",
+      sortKey: "description",
+    },
+    { content: "Details", className: "details" },
     { content: "Status", className: "status status-header", sortKey: "status" },
     { "aria-label": "Actions", className: "cancel u-align--right" },
   ];
-
-  const getIconNameForStatus = (status: LxdOperationStatus) => {
-    return {
-      Cancelled: "status-failed-small",
-      Failure: "status-failed-small",
-      Running: "status-in-progress-small",
-      Success: "status-succeeded-small",
-    }[status];
-  };
 
   const filteredOperations = operations.filter((operation) => {
     const lowerCaseQuery = query.toLowerCase();
@@ -59,90 +178,50 @@ const OperationList: FC = () => {
     );
   });
 
-  const rows = filteredOperations.map((operation) => {
-    const projectName = getProjectName(operation);
-    return {
-      key: operation.id,
-      className: "u-row",
-      columns: [
-        {
-          content: (
-            <>
-              <div className="date-pair">
-                Initiated:{" "}
-                {nonBreakingSpaces(isoTimeToString(operation.created_at))}
-              </div>
-              <div className="date-pair u-text--muted">
-                Last update:{" "}
-                {nonBreakingSpaces(isoTimeToString(operation.updated_at))}
-              </div>
-            </>
-          ),
-          role: "cell",
-          "aria-label": "Time",
-          className: "time",
-        },
-        {
-          content: (
-            <>
-              <div>{operation.description}</div>
-              <OperationInstanceName operation={operation} />
-              <div className="u-text--muted u-truncate" title={projectName}>
-                Project: {projectName}
-              </div>
-            </>
-          ),
-          role: "rowheader",
-          "aria-label": "Action",
-          className: "action",
-        },
-        {
-          content: (
-            <>
-              {operation.err && <div>{operation.err}</div>}
-              {Object.entries(operation.metadata ?? {}).map(
-                ([key, value], index) => (
-                  <span key={index} title={JSON.stringify(value)}>
-                    {key}: {JSON.stringify(value)}
-                  </span>
-                ),
-              )}
-            </>
-          ),
-          role: "cell",
-          "aria-label": "Info",
-          className: "info",
-        },
-        {
-          content: (
-            <>
-              <Icon
-                name={getIconNameForStatus(operation.status)}
-                className="status-icon"
-              />
-              {operation.status}
-            </>
-          ),
-          role: "cell",
-          "aria-label": "Status",
-          className: "status",
-        },
-        {
-          content: <CancelOperationBtn operation={operation} />,
-          role: "cell",
-          className: "u-align--right cancel",
-          "aria-label": "Actions",
-        },
-      ],
-      sortData: {
-        created_at: operation.created_at,
-        action: operation.description,
-        status: operation.status,
-      },
+  const rows = filteredOperations.flatMap((operation) => {
+    const childOperations = operation.children ?? [];
+    const childCount = childOperations.length || operation.child_count || 0;
+    const hasChildOperations = childCount > 0;
+    const isExpanded = expandedRowIds.has(operation.id);
+
+    const parentRowSortData = {
+      created_at: operation.created_at,
+      description: operation.description,
+      status: operation.status,
     };
+
+    const parentRow = buildOperationRow({
+      operation,
+      className: "u-row",
+      timeContent: renderParentFirstColumnContent({
+        operation,
+        isExpanded,
+        onToggleExpansion: toggleRowExpansion,
+      }),
+      sortData: parentRowSortData,
+    });
+
+    if (!isExpanded || !hasChildOperations) {
+      return [parentRow];
+    }
+
+    const childRows = childOperations.map((child) => {
+      return buildOperationRow({
+        operation: child,
+        className: "u-row child-operation-row",
+        timeContent: renderChildFirstColumnContent(child),
+        sortData: parentRowSortData,
+      });
+    });
+
+    return [parentRow, ...childRows];
   });
 
-  const { rows: sortedRows, updateSort } = useSortTableData({ rows });
+  const { rows: sortedRows, updateSort } = useSortTableData({
+    rows,
+    defaultSort: "created_at",
+    defaultSortDirection: "descending",
+  });
 
   return (
     <>

--- a/src/pages/operations/OperationTimeDates.tsx
+++ b/src/pages/operations/OperationTimeDates.tsx
@@ -1,0 +1,22 @@
+import type { FC } from "react";
+import type { LxdOperation } from "types/operation";
+import { isoTimeToString, nonBreakingSpaces } from "util/helpers";
+
+interface Props {
+  operation: LxdOperation;
+}
+
+const OperationTimeDates: FC<Props> = ({ operation }) => {
+  return (
+    <>
+      <div className="date-pair">
+        Initiated: {nonBreakingSpaces(isoTimeToString(operation.created_at))}
+      </div>
+      <div className="date-pair u-text--muted">
+        Last update: {nonBreakingSpaces(isoTimeToString(operation.updated_at))}
+      </div>
+    </>
+  );
+};
+
+export default OperationTimeDates;

--- a/src/pages/operations/actions/RefreshOperationsBtn.tsx
+++ b/src/pages/operations/actions/RefreshOperationsBtn.tsx
@@ -1,18 +1,20 @@
 import { useEffect, type FC } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { queryKeys } from "util/queryKeys";
 import { ActionButton, Icon } from "@canonical/react-components";
-import { useOperations } from "context/operationsProvider";
 import classnames from "classnames";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
+import { useOperationsWithChildren } from "context/operationsProvider";
+import { queryKeys } from "util/queryKeys";
 
 const RefreshOperationsBtn: FC = () => {
-  const { isFetching } = useOperations();
+  const { isFetching } = useOperationsWithChildren();
   const queryClient = useQueryClient();
   const isSmallScreen = useIsScreenBelow();
 
   const handleRefresh = () => {
-    queryClient.invalidateQueries({ queryKey: [queryKeys.operations] });
+    queryClient.invalidateQueries({
+      predicate: (query) => query.queryKey[0] === queryKeys.operations,
+    });
   };
 
   // force a refresh on first render

--- a/src/sass/_operation_list.scss
+++ b/src/sass/_operation_list.scss
@@ -1,9 +1,11 @@
 .operation-list {
+  $tree-connector-offset: $spv--large + $spv--x-small;
+
   .status-header {
     padding-left: 1.8rem;
   }
 
-  @media screen and (min-width: $breakpoint-large) {
+  @include large {
     .time {
       width: 320px;
     }
@@ -17,18 +19,139 @@
     width: 120px;
   }
 
-  .action,
-  .info {
+  .description,
+  .details {
     white-space: break-spaces;
+  }
+
+  .time-cell-content {
+    display: flex;
+    flex-direction: column;
+    gap: $spv--x-small;
+  }
+
+  .child-operations-trigger {
+    margin-top: $spv--x-small;
+
+    .bulk-toggle-btn {
+      align-items: center;
+      border: none;
+      display: inline-flex;
+      gap: $sph--small;
+      padding: $spv--x-small $spv--x-small;
+
+      &[aria-expanded="true"] {
+        background-color: unset;
+      }
+
+      .p-chip {
+        height: auto;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+        white-space: normal;
+
+        .p-icon--chevron-up,
+        .p-icon--chevron-down {
+          align-self: flex-start;
+          flex-shrink: 0;
+          margin-left: 0;
+          margin-top: $spv--x-small;
+          min-width: 1rem; /* Reserve explicit width so it cannot be squished */
+        }
+
+        .p-inline-list--middot .p-inline-list__item:not(:first-child) {
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+
+  @include large {
+    .child-operation-row {
+      background-color: $colors--theme--background-active;
+
+      td {
+        border-top: none;
+        padding-bottom: $spv--small;
+        padding-top: $spv--small;
+
+        &.time {
+          padding-left: 0;
+          position: relative;
+
+          .time-cell-content {
+            padding-left: $spv--medium + $sph--x-large + $sph--small;
+          }
+        }
+      }
+
+      .child-tree-rail {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+
+        .tree-connector {
+          bottom: 0;
+          left: $spv--medium;
+          position: absolute;
+          top: 0;
+          width: $sph--x-large;
+
+          &::before,
+          &::after {
+            content: "";
+            position: absolute;
+          }
+
+          &::before {
+            border-left: 2px solid var(--color-border);
+            bottom: 0;
+            left: 0;
+            top: 0;
+          }
+
+          &::after {
+            border-top: 2px solid var(--color-border);
+            left: 0;
+            top: $tree-connector-offset;
+            width: 100%;
+          }
+        }
+      }
+    }
+
+    tr.child-operation-row:is(:has(+ tr:not(.child-operation-row)), :last-child)
+      .tree-connector::before {
+      bottom: auto;
+      height: $tree-connector-offset;
+    }
+  }
+
+  @include mobile-and-tablet {
+    .page-header__search {
+      display: none;
+    }
+
+    .p-table--mobile-card tbody td:last-child::after {
+      display: none;
+    }
+
+    .child-operation-row {
+      border-left: 3px solid var(--color-border);
+
+      .child-tree-rail {
+        display: none;
+      }
+
+      td.time .time-cell-content {
+        padding-left: 0;
+      }
+    }
   }
 
   .cancel {
     width: 110px;
-  }
-
-  @media screen and (width < $breakpoint-large) {
-    .page-header__search {
-      display: none;
-    }
   }
 }

--- a/src/types/operation.d.ts
+++ b/src/types/operation.d.ts
@@ -5,6 +5,8 @@ export type LxdOperationStatus =
   | "Success";
 
 export interface LxdOperation {
+  child_count?: number;
+  children?: LxdOperation[];
   class: string;
   created_at: string;
   description: string;

--- a/src/util/operations.tsx
+++ b/src/util/operations.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
-import type { LxdOperation, LxdOperationResponse } from "types/operation";
+import type {
+  LxdOperation,
+  LxdOperationResponse,
+  LxdOperationStatus,
+} from "types/operation";
 import type { LxdEvent } from "types/event";
 import { InstanceRichChip } from "pages/instances/InstanceRichChip";
 
@@ -138,4 +142,26 @@ export const instanceLinkFromOperation = (args: {
       projectName={project || "default"}
     />
   );
+};
+
+export const countByStatus = (
+  children: LxdOperation[],
+): Partial<Record<LxdOperationStatus, number>> => {
+  return children.reduce<Partial<Record<LxdOperationStatus, number>>>(
+    (statusCount, childOperation) => {
+      statusCount[childOperation.status] =
+        (statusCount[childOperation.status] ?? 0) + 1;
+      return statusCount;
+    },
+    {},
+  );
+};
+
+export const getIconNameForStatus = (status: LxdOperationStatus) => {
+  return {
+    Cancelled: "status-failed-small",
+    Failure: "status-failed-small",
+    Running: "status-in-progress-small",
+    Success: "status-succeeded-small",
+  }[status];
 };

--- a/tests/helpers/operations.ts
+++ b/tests/helpers/operations.ts
@@ -1,7 +1,23 @@
 import type { Page } from "@playwright/test";
-import { expect } from "../fixtures/lxd-test";
+import { type LxdVersions, test, expect } from "../fixtures/lxd-test";
+import { gotoURL } from "./navigate";
 
 export const validateOperation = async (page: Page, title: string) => {
   await page.getByText("Operations", { exact: true }).click();
   await expect(page.getByText(title)).toBeVisible();
+};
+
+export const visitOperations = async (page: Page) => {
+  await gotoURL(page, "/ui/");
+  await page.getByRole("link", { name: /^Operations/ }).click();
+  await expect(
+    page.getByRole("heading", { name: "Ongoing operations" }),
+  ).toBeVisible();
+};
+
+export const skipIfChildOperationsNotSupported = (lxdVersion: LxdVersions) => {
+  test.skip(
+    lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge",
+    "Child operations not supported for lxd 5.0 and 5.21",
+  );
 };

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -1,4 +1,5 @@
-import { test } from "./fixtures/lxd-test";
+import { expect, test } from "./fixtures/lxd-test";
+import { getLxcCmd } from "./helpers/auth";
 import {
   createInstance,
   deleteInstance,
@@ -6,7 +7,12 @@ import {
   visitAndStartInstance,
   visitAndStopInstance,
 } from "./helpers/instances";
-import { validateOperation } from "./helpers/operations";
+import {
+  skipIfChildOperationsNotSupported,
+  validateOperation,
+  visitOperations,
+} from "./helpers/operations";
+import { runCommand } from "./helpers/shell";
 
 test("instance operations are recognised on the Operations page", async ({
   page,
@@ -26,4 +32,49 @@ test("instance operations are recognised on the Operations page", async ({
   // delete instance and validate delete operation is in operation list
   await deleteInstance(page, instance);
   await validateOperation(page, `Deleting instance`);
+});
+
+test("bulk stop operation renders and expands child operations", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfChildOperationsNotSupported(lxdVersion);
+
+  const firstInstance = randomInstanceName();
+  const secondInstance = randomInstanceName();
+
+  await createInstance(page, firstInstance);
+  await createInstance(page, secondInstance);
+
+  await visitAndStartInstance(page, firstInstance);
+  await visitAndStartInstance(page, secondInstance);
+
+  const lxc = getLxcCmd();
+  runCommand(`${lxc} stop --all --project default`);
+
+  await visitOperations(page);
+
+  const childOperationsChip = page
+    .getByRole("button", { name: /2 child operations/i })
+    .first();
+  await expect(childOperationsChip).toBeVisible();
+
+  await childOperationsChip.click();
+
+  const childRows = page.locator(
+    "#operation-table tbody tr.child-operation-row",
+  );
+  await expect(childRows).toHaveCount(2);
+
+  const firstChildRow = childRows.filter({ hasText: firstInstance });
+  await expect(firstChildRow).toContainText("Stopping instance");
+  await expect(firstChildRow).toContainText("Project: default");
+  await expect(firstChildRow).toContainText("Success");
+
+  const secondChildRow = childRows.filter({ hasText: secondInstance });
+  await expect(secondChildRow).toContainText("Stopping instance");
+  await expect(secondChildRow).toContainText("Project: default");
+  await expect(secondChildRow).toContainText("Success");
+  await deleteInstance(page, firstInstance);
+  await deleteInstance(page, secondInstance);
 });


### PR DESCRIPTION
## Done

- In OperationList, display child operations

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Operations
    - To generate a bulk operation, you can stop all instances of the current project by running the command line `lxc stop --all` (or if you want to specify a project, run `lxc stop --all --project <project_name>`)
    - A bulk operation should have a chip with the count of child operations and a count for any statuses other than success
    - Click on the chevron or the chip to expand: extra rows for child operations should be displayed

## Screenshots

<img width="1571" height="1053" alt="image" src="https://github.com/user-attachments/assets/59078ab5-6607-4940-bff1-7ada35725753" />


