### PR TITLE
test(file explorer): extend file explorer tests to symlinks resolving…

### DIFF
--- a/tests/helpers/instance-file-explorer.ts
+++ b/tests/helpers/instance-file-explorer.ts
@@ -1,9 +1,10 @@
 import type { Page } from "@playwright/test";
 import { expect, test, type LxdVersions } from "../fixtures/lxd-test";
+import { getLxcCmd } from "./auth";
 import { dismissNotification } from "./notification";
-import { assertTextVisible } from "./permissions";
 import { visitInstance } from "./instances";
 import { randomNameSuffix } from "./name";
+import { runCommand } from "./shell";
 
 export const skipIfFileExplorerNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
@@ -13,12 +14,23 @@ export const skipIfFileExplorerNotSupported = (lxdVersion: LxdVersions) => {
 };
 
 export const randomFileName = (): string => {
-  return `playwright-file-${randomNameSuffix()}`;
+  return `playwright-entry-${randomNameSuffix()}`;
 };
+
+export const randomDirectoryName = (): string => {
+  return `playwright-dir-${randomNameSuffix()}`;
+};
+
+export const randomSymlinkName = (): string => {
+  return `playwright-link-${randomNameSuffix()}`;
+};
+
+type FileExplorerEntryType = "file" | "directory" | "symlink";
+
 const getFileExplorerRow = (
   page: Page,
   name: string,
-  type: "file" | "directory",
+  type: FileExplorerEntryType,
 ) => {
   const table = page.getByRole("grid").first();
   return table
@@ -79,6 +91,30 @@ export const assertDirectoryExists = async (
   await expect(dirLink).toHaveCount(1);
 };
 
+export const createDirectory = async (
+  page: Page,
+  directoryName: string,
+  parentPath?: string,
+) => {
+  await page.getByRole("button", { name: "Create directory" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Create directory" });
+  await dialog.getByLabel("Directory name").fill(directoryName);
+  if (parentPath) {
+    await dialog.getByLabel("Parent path").fill(parentPath);
+  }
+  await dialog.getByRole("button", { name: "Create" }).click();
+
+  await dismissNotification(
+    page,
+    `Directory ${directoryName} created successfully.`,
+  );
+};
+
+const runCommandForInstance = (instance: string, command: string) => {
+  runCommand(`${getLxcCmd()} exec ${instance} -- ${command}`);
+};
+
 export const deleteFile = async (
   page: Page,
   fileName: string,
@@ -116,28 +152,41 @@ export const uploadFile = async (page: Page, filePath: string) => {
   await dismissNotification(page, " uploaded successfully");
 };
 
-export const createFile = async (page: Page, fileName: string) => {
-  // Use terminal to create files for now. Later we might add a file creation feature in the file explorer.
+export const createFile = async (
+  page: Page,
+  instance: string,
+  fileName: string,
+) => {
   const url = new URL(page.url());
   const currentPath = url.searchParams.get("path") ?? "/";
   const targetPath =
     currentPath === "/" ? `/${fileName}` : `${currentPath}/${fileName}`;
 
-  await page.getByTestId("tab-link-Terminal").click();
-  await assertTextVisible(page, "~#");
-  await page.waitForTimeout(1000); // ensure the terminal is ready
-  await page.locator(".xterm-rows").evaluate((e) => {
-    (e as HTMLElement).click();
-  });
-  await page.keyboard.type(`touch "${targetPath}"`, {
-    delay: 100,
-  });
-  await page.keyboard.press("Enter");
-
-  page.once("dialog", async (dialog) => {
-    await dialog.accept();
-  });
-  await page.getByRole("link", { name: "File Explorer" }).click();
-  await openDirectory(page, "tmp"); //hardcoded for now until file creation is implemented in the UI
+  runCommandForInstance(instance, `touch "${targetPath}"`);
+  await page.reload();
   await assertFileExists(page, fileName);
+};
+
+export const createSymlink = async (
+  page: Page,
+  instance: string,
+  symlinkName: string,
+  targetPath: string,
+) => {
+  const url = new URL(page.url());
+  const currentPath = url.searchParams.get("path") ?? "/";
+  const linkPath =
+    currentPath === "/" ? `/${symlinkName}` : `${currentPath}/${symlinkName}`;
+
+  runCommandForInstance(instance, `ln -s "${targetPath}" "${linkPath}"`);
+  await page.reload();
+  const symlinkRow = getFileExplorerRow(page, symlinkName, "symlink");
+  await expect(symlinkRow).toHaveCount(1);
+};
+
+export const openSymlink = async (page: Page, symlinkName: string) => {
+  const symlinkRow = getFileExplorerRow(page, symlinkName, "symlink");
+  await symlinkRow
+    .getByRole("button", { name: symlinkName, exact: true })
+    .click();
 };

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -169,7 +169,23 @@ export const createAndStartInstance = async (
 
 export const visitAndStartInstance = async (page: Page, instance: string) => {
   await visitInstance(page, instance);
-  await page.getByRole("button", { name: "Start", exact: true }).click();
+
+  const startButton = page.getByRole("button", { name: "Start", exact: true });
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+
+  // Wait for action buttons to settle: either instance can be started, or it is already running.
+  await expect(async () => {
+    const startEnabled = await startButton.isEnabled();
+    const stopEnabled = await stopButton.isEnabled();
+    expect(startEnabled || stopEnabled).toBe(true);
+  }).toPass();
+
+  // If Stop is enabled, the instance is already running and no start action is needed.
+  if (await stopButton.isEnabled()) {
+    return;
+  }
+
+  await startButton.click();
   await dismissNotification(page, `Instance ${instance} started.`);
 };
 

--- a/tests/instances.spec.ts
+++ b/tests/instances.spec.ts
@@ -17,6 +17,8 @@ import {
 import {
   visitFileExplorer,
   randomFileName,
+  randomDirectoryName,
+  randomSymlinkName,
   openDirectory,
   assertFileExists,
   assertFileNotExists,
@@ -25,6 +27,9 @@ import {
   downloadFile,
   uploadFile,
   createFile,
+  createDirectory,
+  createSymlink,
+  openSymlink,
   skipIfFileExplorerNotSupported,
 } from "./helpers/instance-file-explorer";
 import {
@@ -521,7 +526,7 @@ test("upload, download, and delete file from file explorer", async ({
   const stagedDownloadPath = testInfo.outputPath(targetFileName);
 
   // Create the source file inside the instance so the explorer has something to download.
-  await createFile(page, sourceFileName);
+  await createFile(page, instance, sourceFileName);
   await assertFileExists(page, sourceFileName);
 
   try {
@@ -551,6 +556,67 @@ test("upload, download, and delete file from file explorer", async ({
     // Keep the test-results artifact directory clean for the post-test steps.
     rmSync(stagedDownloadPath, { force: true });
   }
+});
+
+test("create directory from file explorer", async ({ page, lxdVersion }) => {
+  skipIfFileExplorerNotSupported(lxdVersion);
+
+  await visitAndStartInstance(page, instance);
+  await visitFileExplorer(page, instance);
+  await openDirectory(page, "tmp");
+
+  const directory = randomDirectoryName();
+  const directory2 = randomDirectoryName();
+
+  // Create a directory in tmp, then put another directory inside it.
+  await createDirectory(page, directory);
+  await assertDirectoryExists(page, directory);
+  await createDirectory(page, directory2, `/tmp/${directory}`);
+
+  // After creation the UI navigates to the parent path used for creation.
+  await expect(page).toHaveURL(new RegExp(`path=%2Ftmp%2F${directory}`));
+  await assertDirectoryExists(page, directory2);
+});
+
+test("file explorer follows symlinks to directories", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfFileExplorerNotSupported(lxdVersion);
+
+  // Create a directory and add a file that should still be visible after resolving the symlink.
+  await visitAndStartInstance(page, instance);
+  await visitFileExplorer(page, instance);
+  await openDirectory(page, "tmp");
+  const targetDirectoryName = randomDirectoryName();
+  const targetFileName = randomFileName();
+  const symlinkName = randomSymlinkName();
+  await createDirectory(page, targetDirectoryName);
+  await assertDirectoryExists(page, targetDirectoryName);
+  await openDirectory(page, targetDirectoryName);
+  await createFile(page, instance, targetFileName);
+  await assertFileExists(page, targetFileName);
+
+  // Go back to tmp and create the symlink that points at the new directory.
+  await page
+    .getByRole("navigation", { name: "File Explorer Path" })
+    .getByRole("link", { name: "tmp", exact: true })
+    .click();
+  await createSymlink(page, instance, symlinkName, targetDirectoryName);
+
+  // Open the symlink and let the file explorer resolve it to the target directory.
+  await openSymlink(page, symlinkName);
+
+  // The browser stays on the symlink path, but the target file should be visible.
+  await expect(page).toHaveURL(new RegExp(`path=%2Ftmp%2F${symlinkName}`));
+  await assertFileExists(page, targetFileName);
+
+  const breadcrumb = page.getByRole("navigation", {
+    name: "File Explorer Path",
+  });
+  await expect(
+    breadcrumb.getByText(symlinkName, { exact: true }),
+  ).toBeVisible();
 });
 
 test("file explorer shows empty state for a stopped virtual machine", async ({


### PR DESCRIPTION
… and directory creation

## Done

- extend file explorer tests to symlinks resolving and directory creation WD-37689

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure CI passes
