### PR TITLE
test(Identities): Create e2e test to create and delete identities

### DIFF
--- a/src/util/identityTypes.ts
+++ b/src/util/identityTypes.ts
@@ -1,0 +1,13 @@
+export const IDENTITY_TYPE = {
+  TLS: "Client certificate",
+  BEARER_CLIENT: "Client token bearer",
+  BEARER_DEVLXD: "DevLXD token bearer",
+  CLUSTER_LINK: "Cluster link certificate",
+} as const;
+
+export type IdentityType = (typeof IDENTITY_TYPE)[keyof typeof IDENTITY_TYPE];
+
+export type BearerIdentityType = Extract<
+  IdentityType,
+  typeof IDENTITY_TYPE.BEARER_CLIENT | typeof IDENTITY_TYPE.BEARER_DEVLXD
+>;

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -5,25 +5,17 @@ import CodeSnippetWithCopyButton from "components/CodeSnippetWithCopyButton";
 import type { ResourceIconType } from "components/ResourceIcon";
 import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
 import DocLink from "components/DocLink";
-
-export const IDENTITY_TYPE = {
-  TLS: "tls-certificate",
-  BEARER_CLIENT: "Client token bearer",
-  BEARER_DEVLXD: "DevLXD token bearer",
-  CLUSTER_LINK: "Cluster link certificate",
-} as const;
-
-export type IdentityType = (typeof IDENTITY_TYPE)[keyof typeof IDENTITY_TYPE];
+import {
+  IDENTITY_TYPE,
+  type IdentityType,
+  type BearerIdentityType,
+} from "util/identityTypes";
+export { IDENTITY_TYPE, type IdentityType, type BearerIdentityType };
 
 export const IDENTITY_TYPES_WITH_EXPIRY: IdentityType[] = [
   IDENTITY_TYPE.BEARER_CLIENT,
   IDENTITY_TYPE.BEARER_DEVLXD,
 ];
-
-export type BearerIdentityType = Extract<
-  IdentityType,
-  typeof IDENTITY_TYPE.BEARER_CLIENT | typeof IDENTITY_TYPE.BEARER_DEVLXD
->;
 
 export type ChangeSummary = Record<
   string,
@@ -251,17 +243,17 @@ export const IDENTITY_TYPE_HELP_TEXT: Record<
   { title: string; description: ReactNode }
 > = {
   [IDENTITY_TYPE.TLS]: {
-    title: "TLS Certificate",
+    title: "Client certificate",
     description:
       "A certificate-based identity for long-lived client authentication.",
   },
   [IDENTITY_TYPE.BEARER_CLIENT]: {
-    title: "Bearer token (Main API)",
+    title: "Client token bearer",
     description:
       "An API key for external automation tools, integrations, or remote scripts interacting with LXD over the network.",
   },
   [IDENTITY_TYPE.BEARER_DEVLXD]: {
-    title: "Bearer token (DevLXD)",
+    title: "DevLXD token bearer",
     description: (
       <>
         Strictly for applications or storage drivers running directly inside a

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -2,6 +2,8 @@ import type { Page } from "@playwright/test";
 import { expect } from "../fixtures/lxd-test";
 import { gotoURL } from "./navigate";
 import { randomNameSuffix } from "./name";
+import { dismissNotification } from "./notification";
+import type { IdentityType } from "util/identityTypes";
 
 // These identities are created by the setup_test script in tests/scripts
 export const identityBar = "bar@bar.com";
@@ -83,4 +85,59 @@ export const issueTokenFromEditPanel = async (
   await expect(page.getByText("token issued successfully")).toBeVisible();
 
   return getDisplayedToken(page);
+};
+
+export const createIdentity = async (
+  page: Page,
+  name: string,
+  identityType: IdentityType,
+  expiry?: string,
+) => {
+  await visitIdentities(page);
+  await page.getByRole("button", { name: "Create identity" }).click();
+  await page.getByRole("button", { name: identityType }).click();
+
+  const sidePanel = page.getByLabel("Side panel");
+  await sidePanel.getByRole("textbox", { name: "Name" }).fill(name);
+  if (expiry) {
+    await sidePanel.getByLabel("Custom").click({ force: true });
+    await sidePanel.getByLabel("Token expiry value").fill(expiry);
+  }
+  await sidePanel.getByRole("button", { name: "Create identity" }).click();
+
+  const modal = page.getByRole("dialog");
+  await expect(modal).toContainText(`Identity ${name} created successfully`);
+
+  await modal
+    .getByRole("checkbox", { name: "I have copied the token" })
+    .check({ force: true });
+  await modal.getByRole("button", { name: "Done" }).click();
+
+  const identityRow = page.getByRole("row").filter({ hasText: name });
+  await expect(identityRow).toBeVisible();
+  await expect(identityRow).toContainText(identityType);
+};
+
+export const deleteIdentity = async (page: Page, name: string) => {
+  await visitIdentities(page);
+  const row = page.getByRole("row").filter({ hasText: name });
+
+  const identityType = (
+    await row.getByRole("cell", { name: "Type", exact: true }).textContent()
+  )?.trim();
+  const identityId = (
+    await row.getByRole("cell", { name: "ID", exact: true }).textContent()
+  )?.trim();
+
+  expect(identityType).toBeTruthy();
+  expect(identityId).toBeTruthy();
+
+  await row.getByRole("button", { name: "Delete identity" }).click();
+  await page.getByRole("button", { name: "Delete", exact: true }).click();
+
+  await dismissNotification(
+    page,
+    `Identity ${name} (${identityType}, ${identityId}) deleted.`,
+  );
+  await expect(row).not.toBeVisible();
 };

--- a/tests/helpers/permissions.ts
+++ b/tests/helpers/permissions.ts
@@ -5,6 +5,10 @@ export const supportsFineGrainedAuthorisation = (lxdVersion: LxdVersions) => {
   return lxdVersion !== "5.0-edge";
 };
 
+const supportsBearerIdentities = (lxdVersion: LxdVersions) => {
+  return lxdVersion !== "5.0-edge" && lxdVersion !== "5.21-edge";
+};
+
 export const skipIfFineGrainedAuthorisationNotSupported = (
   lxdVersion: LxdVersions,
 ) => {
@@ -16,7 +20,7 @@ export const skipIfFineGrainedAuthorisationNotSupported = (
 
 export const skipIfBearerIdentitiesNotSupported = (lxdVersion: LxdVersions) => {
   test.skip(
-    lxdVersion === "5.0-edge" || lxdVersion === "5.21-edge",
+    !supportsBearerIdentities(lxdVersion),
     "Bearer identities tests not supported for lxd 5.0 and 5.21",
   );
 };

--- a/tests/permission-identities.spec.ts
+++ b/tests/permission-identities.spec.ts
@@ -5,6 +5,8 @@ import {
   randomGroupName,
 } from "./helpers/permission-groups";
 import {
+  createIdentity,
+  deleteIdentity,
   identityBar,
   identityFoo,
   randomIdentityName,
@@ -24,6 +26,7 @@ import {
   skipIfBearerIdentitiesNotSupported,
 } from "./helpers/permissions";
 import { dismissNotification } from "./helpers/notification";
+import { IDENTITY_TYPE } from "util/identityTypes";
 
 test("manage groups for single identity", async ({ page, lxdVersion }) => {
   skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
@@ -136,7 +139,7 @@ test("reissue a new token for bearer identity", async ({
   // Create a bearer identity and capture its first token.
   await visitIdentities(page);
   await page.getByRole("button", { name: "Create identity" }).click();
-  await page.getByRole("button", { name: "Bearer token (Main API)" }).click();
+  await page.getByRole("button", { name: "Client token bearer" }).click();
   const sidePanel = page.getByLabel("Side panel");
   await sidePanel.getByPlaceholder("Enter name").fill(identity);
   await sidePanel.getByRole("button", { name: "Create identity" }).click();
@@ -146,16 +149,6 @@ test("reissue a new token for bearer identity", async ({
 
   const identityRow = page.getByRole("row").filter({ hasText: identity });
   await expect(identityRow).toBeVisible();
-  const identityType = (
-    await identityRow
-      .getByRole("cell", { name: "Type", exact: true })
-      .textContent()
-  )?.trim();
-  const identityId = (
-    await identityRow
-      .getByRole("cell", { name: "ID", exact: true })
-      .textContent()
-  )?.trim();
   await identityRow.getByLabel("Edit identity").click();
 
   // Reissue and verify token rotation.
@@ -164,14 +157,43 @@ test("reissue a new token for bearer identity", async ({
   expect(reissuedToken).not.toEqual(initialToken);
 
   await page.getByRole("button", { name: "Cancel" }).click();
-  await identityRow.getByLabel("Delete identity").click();
-  await page
-    .getByRole("dialog", { name: "Confirm delete" })
-    .getByRole("button", { name: "Delete" })
-    .click();
-  await dismissNotification(
+  await deleteIdentity(page, identity);
+});
+
+test("create and delete TLS identity", async ({ page, lxdVersion }) => {
+  skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
+
+  const tlsName = randomIdentityName();
+  await createIdentity(page, tlsName, IDENTITY_TYPE.TLS);
+  await deleteIdentity(page, tlsName);
+});
+
+test("create and delete token bearer identities", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfFineGrainedAuthorisationNotSupported(lxdVersion);
+  skipIfBearerIdentitiesNotSupported(lxdVersion);
+
+  const bearerClientName = randomIdentityName();
+  const bearerDevlxdName = randomIdentityName();
+  const clusterLinkName = randomIdentityName();
+
+  await createIdentity(
     page,
-    `Identity ${identity} (${identityType}, ${identityId}) deleted.`,
+    bearerClientName,
+    IDENTITY_TYPE.BEARER_CLIENT,
+    "1d",
   );
-  await expect(identityRow).not.toBeVisible();
+  await createIdentity(
+    page,
+    bearerDevlxdName,
+    IDENTITY_TYPE.BEARER_DEVLXD,
+    "2H",
+  );
+  await createIdentity(page, clusterLinkName, IDENTITY_TYPE.CLUSTER_LINK);
+
+  await deleteIdentity(page, bearerClientName);
+  await deleteIdentity(page, bearerDevlxdName);
+  await deleteIdentity(page, clusterLinkName);
 });


### PR DESCRIPTION
## Done

- test(Identities): Create e2e test to create and delete identities
- Edit will come after #2150 is merged

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Trust CI

## Screenshots

