### PR TITLE
feat(cluster-links) allow creation of cluster link identities

### DIFF
--- a/src/pages/permissions/CreateIdentity.tsx
+++ b/src/pages/permissions/CreateIdentity.tsx
@@ -38,7 +38,7 @@ const CreateIdentity: FC = () => {
             token={token}
             identity={identity}
             title={identityModalCaptions.codeSnippetTitle}
-            notification={`${identityModalCaptions.notificationTitle} ${identityModalCaptions.notificationBody}`}
+            notification={identityModalCaptions.notification}
             howToUseCli={identityModalCaptions.howToUseCli?.(token)}
             howToUseUi={identityModalCaptions.howToUseUi}
           />

--- a/src/pages/permissions/CreateIdentityModal.tsx
+++ b/src/pages/permissions/CreateIdentityModal.tsx
@@ -10,7 +10,8 @@ import {
 import CodeSnippetWithCopyButton from "components/CodeSnippetWithCopyButton";
 import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import type { IdentityFormValues } from "types/forms/identity";
-import { IDENTITY_TYPE } from "util/permissionIdentities";
+import { getIdentityIconType } from "util/permissionIdentities";
+import type { LxdIdentity } from "types/permissions";
 
 interface Props {
   onClose: () => void;
@@ -41,11 +42,9 @@ const CreateIdentityModal: FC<Props> = ({
         <>
           Identity{" "}
           <ResourceLabel
-            type={
-              identity.identityType === IDENTITY_TYPE.TLS
-                ? "certificate"
-                : "token-bearer"
-            }
+            type={getIdentityIconType(
+              identity.identityType as LxdIdentity["type"],
+            )}
             value={identity.name}
             bold
             truncate

--- a/src/pages/permissions/panels/CreateIdentityPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdentityPanel.tsx
@@ -27,10 +27,12 @@ import {
   BEARER_EXPIRY_PATTERN,
   IDENTITY_TYPE,
   IDENTITY_TYPE_HELP_TEXT,
+  IDENTITY_TYPES_WITH_EXPIRY,
   type BearerIdentityType,
   type IdentityType,
 } from "util/permissionIdentities";
 import type { IdentityFormValues } from "types/forms/identity";
+import { createClusterLink } from "api/cluster-links";
 
 interface Props {
   onSuccess: (identity: IdentityFormValues, token: string) => void;
@@ -96,6 +98,25 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
         .catch((e) => {
           onError(e);
         });
+    } else if (values.identityType === IDENTITY_TYPE.CLUSTER_LINK) {
+      const payload = {
+        name: values.name,
+        auth_groups: values.groups,
+        type: "unidirectional",
+      };
+
+      createClusterLink(JSON.stringify(payload))
+        .then((response) => {
+          if (!response) {
+            onError("Failed to create cluster link identity");
+            return;
+          }
+          const encodedToken = base64EncodeObject(response);
+          onSuccess(values, encodedToken);
+        })
+        .catch((e) => {
+          onError(e);
+        });
     } else {
       createAndIssueBearerToken(
         values.name,
@@ -128,8 +149,7 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
       ),
     expiry: Yup.string().when("identityType", {
       is: (identityType: IdentityType) =>
-        identityType === IDENTITY_TYPE.BEARER_CLIENT ||
-        identityType === IDENTITY_TYPE.BEARER_DEVLXD,
+        IDENTITY_TYPES_WITH_EXPIRY.includes(identityType),
       then: (schema) =>
         schema.test(
           "valid-expiry-format",
@@ -222,12 +242,28 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
                   selectType(IDENTITY_TYPE.BEARER_DEVLXD);
                 }}
               />
+              <FormLink
+                icon="applications"
+                title={
+                  IDENTITY_TYPE_HELP_TEXT[IDENTITY_TYPE.CLUSTER_LINK].title
+                }
+                subText={
+                  IDENTITY_TYPE_HELP_TEXT[IDENTITY_TYPE.CLUSTER_LINK]
+                    .description
+                }
+                subTextBelowTitle
+                onClick={() => {
+                  selectType(IDENTITY_TYPE.CLUSTER_LINK);
+                }}
+              />
             </div>
           </ScrollableContainer>
         ) : (
           <>
             <NameWithGroupForm formik={formik} />
-            {formik.values.identityType !== IDENTITY_TYPE.TLS && (
+            {IDENTITY_TYPES_WITH_EXPIRY.includes(
+              formik.values.identityType,
+            ) && (
               <div className="create-identity-panel-token-expiry u-sv1">
                 <label id="token-expiry-label" htmlFor="expiry">
                   Token expiry

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -10,9 +10,15 @@ export const IDENTITY_TYPE = {
   TLS: "tls-certificate",
   BEARER_CLIENT: "Client token bearer",
   BEARER_DEVLXD: "DevLXD token bearer",
+  CLUSTER_LINK: "Cluster link certificate",
 } as const;
 
 export type IdentityType = (typeof IDENTITY_TYPE)[keyof typeof IDENTITY_TYPE];
+
+export const IDENTITY_TYPES_WITH_EXPIRY: IdentityType[] = [
+  IDENTITY_TYPE.BEARER_CLIENT,
+  IDENTITY_TYPE.BEARER_DEVLXD,
+];
 
 export type BearerIdentityType = Extract<
   IdentityType,
@@ -253,22 +259,29 @@ export const IDENTITY_TYPE_HELP_TEXT: Record<
       </>
     ),
   },
+  [IDENTITY_TYPE.CLUSTER_LINK]: {
+    title: "Cluster link certificate",
+    description: (
+      <>
+        Allows another LXD cluster to establish a unidirectional cluster link to
+        this cluster.
+      </>
+    ),
+  },
 };
 
 export const CREATE_IDENTITY_MODAL_TEXT: Record<
   IdentityType,
   {
     codeSnippetTitle: string;
-    notificationTitle: string;
-    notificationBody: string;
+    notification: string;
     howToUseCli?: (token: string) => ReactNode;
     howToUseUi?: ReactNode;
   }
 > = {
   [IDENTITY_TYPE.TLS]: {
     codeSnippetTitle: "Your identity trust token",
-    notificationTitle: "Copy the identity trust token",
-    notificationBody: "to authenticate your client.",
+    notification: "Copy the identity trust token to authenticate your client.",
     howToUseCli: (token: string) => (
       <>
         For use with the LXC command-line tool, run:
@@ -305,8 +318,8 @@ export const CREATE_IDENTITY_MODAL_TEXT: Record<
   },
   [IDENTITY_TYPE.BEARER_CLIENT]: {
     codeSnippetTitle: "Your API bearer token",
-    notificationTitle: "Copy the API bearer token",
-    notificationBody: "to authenticate your clients and automated tools.",
+    notification:
+      "Copy the API bearer token to authenticate your clients and automated tools.",
     howToUseCli: (token: string) => (
       <List
         className="u-no-margin--bottom"
@@ -337,8 +350,8 @@ export const CREATE_IDENTITY_MODAL_TEXT: Record<
   },
   [IDENTITY_TYPE.BEARER_DEVLXD]: {
     codeSnippetTitle: "Your DevLXD bearer token",
-    notificationTitle: "Copy the DevLXD bearer token",
-    notificationBody: "to authenticate internal workloads.",
+    notification:
+      "Copy the DevLXD bearer token to authenticate internal workloads.",
     howToUseCli: (token: string) => (
       <List
         className="u-no-margin--bottom"
@@ -374,6 +387,55 @@ export const CREATE_IDENTITY_MODAL_TEXT: Record<
           >
             How to authenticate to the DevLXD API
           </DocLink>,
+        ]}
+      />
+    ),
+  },
+
+  [IDENTITY_TYPE.CLUSTER_LINK]: {
+    codeSnippetTitle: "Your cluster link token",
+    notification:
+      "Copy the token to continue the cluster link creation on the source cluster.",
+    howToUseCli: (token: string) => (
+      <List
+        className="u-no-margin--bottom"
+        items={[
+          <>Create the cluster link on the source LXD cluster.</>,
+          <CodeSnippetWithCopyButton
+            code={`lxc cluster link create ${location.hostname} --unidirectional --token ${token}`}
+            tooltipMessage="Copy command"
+            className="u-no-margin--bottom"
+            key="code-snippet"
+          />,
+          <span className="u-text--muted p-text--small u-sv3" key="hint">
+            You can replace <code>{location.hostname}</code> with a nickname for
+            the cluster link.
+          </span>,
+          <DocLink
+            docPath="/howto/cluster_links_create/"
+            key="learn-more-link"
+            hasExternalIcon
+          >
+            How to create cluster links
+          </DocLink>,
+        ]}
+      />
+    ),
+    howToUseUi: (
+      <List
+        className="u-no-margin--bottom"
+        items={[
+          <>
+            Open the UI of the <b>source</b> LXD cluster.
+          </>,
+          <>
+            Go to <b>Clustering</b>, <b>Links</b> and select{" "}
+            <b>Create cluster link</b>.
+          </>,
+          <>
+            Select <b>unidirectional</b>.
+          </>,
+          <>Paste the token from this cluster to create the link.</>,
         ]}
       />
     ),


### PR DESCRIPTION
## Done

- feat(cluster-links) allow creation of cluster link identities

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to permission > identities > create identity
    - use the new cluster link identity and create the token for it.

## Screenshots

<img width="3840" height="1904" alt="image" src="https://github.com/user-attachments/assets/024cc70c-43d3-4597-a188-69c7186f978c" />

<img width="3840" height="1904" alt="image" src="https://github.com/user-attachments/assets/2c76e05e-15e8-4236-ac60-3cefc3fe5c90" />

<img width="3840" height="1904" alt="image" src="https://github.com/user-attachments/assets/b0c72d32-3b53-481e-a4c0-e41fd291fc1f" />

<img width="3840" height="1904" alt="image" src="https://github.com/user-attachments/assets/fd4a8f8f-e76f-46af-8ad6-13ca0f02dfe3" />
