### PR TITLE
fix(ImageRegistry): use HelpLink

### DIFF
--- a/src/pages/images/ImageRegistryProtocolSelector.tsx
+++ b/src/pages/images/ImageRegistryProtocolSelector.tsx
@@ -1,8 +1,8 @@
 import { type FC } from "react";
-import { RadioInput, Icon } from "@canonical/react-components";
+import { RadioInput } from "@canonical/react-components";
+import HelpLink from "components/HelpLink";
 import type { FormikProps } from "formik";
 import type { ImageRegistryFormValues } from "types/forms/image";
-import { Link } from "react-router-dom";
 
 interface Props {
   formik: FormikProps<ImageRegistryFormValues>;
@@ -10,18 +10,14 @@ interface Props {
 export const ImageRegistryProtocolSelector: FC<Props> = ({ formik }) => {
   return (
     <div className="image-registry-protocol-selector">
-      <div>
-        <label htmlFor="protocol">Protocol</label>
-        <Link
-          to="https://canonical.com/lxd/docs/v5/reference/remote_image_servers/#remote-server-types"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="help-text help-link"
-          title="Learn more about remote server types."
-        >
-          <Icon name="help" className="help-link-icon" />
-        </Link>
-      </div>
+      <HelpLink
+        docPath="/reference/remote_image_servers/#remote-server-types"
+        title="Learn more about remote server types."
+      >
+        <label htmlFor="protocol" className="u-no-margin--bottom">
+          Protocol
+        </label>
+      </HelpLink>
       <div id="protocol">
         <RadioInput
           inline

--- a/src/sass/_image_registry_protocol_selector.scss
+++ b/src/sass/_image_registry_protocol_selector.scss
@@ -1,6 +1,10 @@
 .image-registry-protocol-selector {
   margin-bottom: $spv--medium;
 
+  .help-link {
+    margin-bottom: $sp-small + $sp-xx-small;
+  }
+
   .lxd-protocol-input {
     margin-left: $sph--x-small;
     margin-right: $sph--large;


### PR DESCRIPTION
## Done

- Use HelpLink in ImageRegistryProtocolSelector

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to /ui/image-registries?panel=create-image-registry
    - Make sure the protocol's help link works.

## Screenshots

<img width="1860" height="1054" alt="image" src="https://github.com/user-attachments/assets/39483add-38d7-4313-a0a0-22c84cd4b333" />
