### PR TITLE
fix(registries) fix singular case for cluster links help text

### DIFF
--- a/src/pages/images/ImageRegistryClusterLinkSelector.tsx
+++ b/src/pages/images/ImageRegistryClusterLinkSelector.tsx
@@ -40,14 +40,17 @@ export const ImageRegistryClusterLinkSelector: FC<Props> = ({
     ),
   }));
 
-  const helpLink = (
-    <Link to={`${ROOT_PATH}/ui/cluster/links`}>cluster links</Link>
-  );
-
+  const clusterLinkURL = `${ROOT_PATH}/ui/cluster/links`;
   const helpText = hasNoLinks ? (
-    <>Cluster containing the images. Create your first {helpLink}.</>
+    <>
+      Cluster containing the images. Create your first{" "}
+      <Link to={clusterLinkURL}>cluster link</Link>.
+    </>
   ) : (
-    <>Cluster containing the images. Manage your {helpLink}.</>
+    <>
+      Cluster containing the images. Manage your{" "}
+      <Link to={clusterLinkURL}>cluster links</Link>.
+    </>
   );
 
   return (


### PR DESCRIPTION
## Done

- fix(registries) fix singular case for cluster links help text

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run with a LXD backend that supports image registries
    - go to images > Image registries > Create and check the help link when no cluster links are present

## Screenshots

<img width="3854" height="1916" alt="image" src="https://github.com/user-attachments/assets/edf98037-9386-4740-8e07-c49d00b6d015" />