### PR TITLE
feat(pragma): use InlineCode

### DIFF
--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Row, Col, Notification } from "@canonical/react-components";
+import { InlineCode } from "@canonical/react-ds-global";
 import { capitalizeFirstLetter } from "util/helpers";
 import ResourceIcon, { type ResourceIconType } from "components/ResourceIcon";
 import { useIsScreenBelow } from "context/useIsScreenBelow";
@@ -47,7 +48,7 @@ const NotFound: FC<Props> = ({ entityType, entityName, errorMessage }) => {
         </p>
         <p>
           The {entityLabel} is missing or you do not have the{" "}
-          <code>viewer</code> permission for it.
+          <InlineCode>viewer</InlineCode> permission for it.
         </p>
         {errorMessage && (
           <Notification severity="negative" borderless>

--- a/src/pages/login/CertificateAddToken.tsx
+++ b/src/pages/login/CertificateAddToken.tsx
@@ -8,6 +8,7 @@ import {
   Spinner,
   CustomLayout,
 } from "@canonical/react-components";
+import { InlineCode } from "@canonical/react-ds-global";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "context/auth";
 import CertificateAddForm from "pages/login/CertificateAddForm";
@@ -62,9 +63,9 @@ const CertificateAddToken: FC = () => {
                       </p>
                       <div>
                         First, the command checks to see if there is an auth
-                        group <code>admins</code>. The{" "}
-                        <code>{`>/dev/null 2>&1`}</code> part ensures that if
-                        the group is missing, no error is shown.
+                        group <InlineCode>admins</InlineCode>. The{" "}
+                        <InlineCode>{`>/dev/null 2>&1`}</InlineCode> part
+                        ensures that if the group is missing, no error is shown.
                       </div>
                       <CodeSnippet
                         blocks={[
@@ -75,7 +76,8 @@ const CertificateAddToken: FC = () => {
                         ]}
                       />
                       <div>
-                        If there is no group <code>admins</code>, it is created.
+                        If there is no group <InlineCode>admins</InlineCode>, it
+                        is created.
                       </div>
                       <CodeSnippet
                         blocks={[
@@ -86,8 +88,8 @@ const CertificateAddToken: FC = () => {
                         ]}
                       />
                       <div>
-                        The new group <code>admins</code> is given server admin
-                        permissions.
+                        The new group <InlineCode>admins</InlineCode> is given
+                        server admin permissions.
                       </div>
                       <CodeSnippet
                         blocks={[
@@ -98,10 +100,10 @@ const CertificateAddToken: FC = () => {
                         ]}
                       />
                       <div>
-                        Finally, a new identity <code>lxd-ui</code> is created
-                        and added to the group <code>admins</code>. This command
-                        returns the identity trust token which should be pasted
-                        below.
+                        Finally, a new identity <InlineCode>lxd-ui</InlineCode>{" "}
+                        is created and added to the group{" "}
+                        <InlineCode>admins</InlineCode>. This command returns
+                        the identity trust token which should be pasted below.
                       </div>
                       <CodeSnippet
                         blocks={[

--- a/src/pages/networks/forms/NetworkDefaultACLRead.tsx
+++ b/src/pages/networks/forms/NetworkDefaultACLRead.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { Icon } from "@canonical/react-components";
+import { InlineCode } from "@canonical/react-ds-global";
 import { conjugateACLAction } from "util/helpers";
 import type { Direction } from "./NetworkDefaultACLSelector";
 
@@ -15,11 +16,11 @@ const NetworkDefaultACLRead: FC<{
       <br />
       <Icon name="arrow-left" className="network-default-acl-icon" />
       Egress traffic is:{" "}
-      <code>{conjugateACLAction(egressAction || "reject")}</code>
+      <InlineCode>{conjugateACLAction(egressAction || "reject")}</InlineCode>
       <br />
       <Icon name="arrow-right" className="network-default-acl-icon" />
       Ingress traffic is:{" "}
-      <code>{conjugateACLAction(ingressAction || "reject")}</code>
+      <InlineCode>{conjugateACLAction(ingressAction || "reject")}</InlineCode>
     </div>
   );
 };

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { List } from "@canonical/react-components";
+import { InlineCode } from "@canonical/react-ds-global";
 import CodeSnippetWithCopyButton from "components/CodeSnippetWithCopyButton";
 import type { ResourceIconType } from "components/ResourceIcon";
 import type { LxdAuthGroup, LxdIdentity } from "types/permissions";
@@ -336,11 +337,12 @@ export const IDENTITY_MODAL_TEXT: Record<
         className="u-no-margin--bottom"
         items={[
           <>
-            Set the bearer token in the <code>Authorization</code> header.
+            Set the bearer token in the <InlineCode>Authorization</InlineCode>{" "}
+            header.
           </>,
           <>
-            You can verify trust by checking the <code>auth</code> field in the
-            response metadata of <code>GET /1.0</code>:
+            You can verify trust by checking the <InlineCode>auth</InlineCode>{" "}
+            field in the response metadata of <InlineCode>GET /1.0</InlineCode>:
           </>,
           <CodeSnippetWithCopyButton
             code={`curl -k -H "Authorization: Bearer ${token}" ${location.origin}/1.0`}
@@ -369,15 +371,15 @@ export const IDENTITY_MODAL_TEXT: Record<
         items={[
           <>
             The token can be used to authenticate with LXD over the DevLXD
-            socket at <code>/dev/lxd/sock</code>.{" "}
+            socket at <InlineCode>/dev/lxd/sock</InlineCode>.{" "}
           </>,
           <>
-            It must be set as a bearer token in the <code>Authorization</code>{" "}
-            header.
+            It must be set as a bearer token in the{" "}
+            <InlineCode>Authorization</InlineCode> header.
           </>,
           <>
-            You can verify trust by checking the <code>auth</code> field in the
-            response of <code>GET /1.0</code>:
+            You can verify trust by checking the <InlineCode>auth</InlineCode>{" "}
+            field in the response of <InlineCode>GET /1.0</InlineCode>:
           </>,
           <CodeSnippetWithCopyButton
             code={`curl -H "Authorization: Bearer ${token}" -s --unix-socket /dev/lxd/sock http://custom.socket/1.0`}


### PR DESCRIPTION
## Done

- Replace `<code>` by `InlineCode` component from Pragma. Due to current limitations, I replaced occurrences where UI changes were minimal.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - **NotFound**  
        - Go to /ui/project/penguin-pen/replicator/replicator-alligator-2 (assuming you don't have a replicator called replicator-alligator-2 in a penguin-pen project). `InlineCode` is used for "viewer". Entity name not replaced because in `p-heading--4`.
    - **CertificateAddToken**  
        - Delete your TLS identity and go to /ui/login/certificate-add. Expand "What does this command do?". `InlineCode` is used for "admins" (x4), ">/dev/null 2>&1" and "lxd-ui" 
    - **NetworkDefaultACLRead**  
        - Go to a network detail page with an ACL. `InlineCode` is used in "When no ACL rule matches" paragraph (x2).
    - **util/permissionIdentities.tsx**  
        - Create a bearer token identity (main API and DevLXD). `InlineCode` is used in the success modal.


## Screenshots

NotFound - before
<img width="1857" height="1065" alt="NotFound - before" src="https://github.com/user-attachments/assets/e333ebde-a5ee-47e5-990f-61ecdcac680f" />

NotFound - after
<img width="1857" height="1065" alt="NotFound - after" src="https://github.com/user-attachments/assets/0b072446-b623-48ed-98d9-53cbfa96178b" />


CertificateAddToken - before
<img width="1861" height="1056" alt="CertificateAddToken - before" src="https://github.com/user-attachments/assets/ac86f955-f5d7-4b4d-9bbb-b3ae0fc5fe09" />

CertificateAddToken - after
<img width="1861" height="1056" alt="CertificateAddToken - after" src="https://github.com/user-attachments/assets/a5de572e-1ca0-4973-887d-a13ae5867870" />

NetworkDefaultACLRead - before
<img width="1861" height="1056" alt="NetworkDefaultACLRead - before" src="https://github.com/user-attachments/assets/3b577083-a82c-4e55-99aa-f3a1454709b2" />

NetworkDefaultACLRead - after
<img width="1861" height="1056" alt="NetworkDefaultACLRead - after" src="https://github.com/user-attachments/assets/bccf17be-6cca-4c34-9c10-b5058152f791" />

util/permissionIdentities.tsx - main API - before
<img width="1861" height="1056" alt="permissionIdentities - main API - before" src="https://github.com/user-attachments/assets/0caa3cf7-5d79-4469-bf43-06b1deccb1df" />

util/permissionIdentities.tsx - main API - after
<img width="1861" height="1056" alt="permissionIdentities - main API - after" src="https://github.com/user-attachments/assets/9eeb213e-3e61-4d15-a176-69cb6433153e" />

util/permissionIdentities.tsx - DevLXD - before
<img width="1861" height="1056" alt="permissionIdentities - devLxd - before" src="https://github.com/user-attachments/assets/b0d0481f-fde4-47a4-a5e7-40c3673f7675" />

util/permissionIdentities.tsx - DevLXD - after
<img width="1861" height="1056" alt="permissionIdentities - devLxd - after" src="https://github.com/user-attachments/assets/6ae93997-3804-4d03-9781-26e18f8c7a2c" />
