### PR TITLE
fix(bulk operations): improve e2e test to make it more robust

### DIFF
--- a/src/pages/operations/ChildOperationTrigger.tsx
+++ b/src/pages/operations/ChildOperationTrigger.tsx
@@ -49,7 +49,7 @@ const ChildOperationTrigger: FC<Props> = ({
           <List
             middot
             items={[
-              `${childCount} ${pluralize("child operation", childCount)}`,
+              `${childCount} child ${pluralize("operation", childCount)}`,
               ...childStatusItems,
             ]}
             className="u-no-margin--bottom"

--- a/tests/helpers/instances.ts
+++ b/tests/helpers/instances.ts
@@ -5,6 +5,8 @@ import { expect } from "../fixtures/lxd-test";
 import { visitLocalImages } from "./images";
 import { searchEntityListPage } from "./search";
 import { dismissNotification } from "./notification";
+import { runCommand } from "./shell";
+import { getLxcCmd } from "./auth";
 
 const DEFAULT_IMAGE = "alpine/3.23/cloud";
 
@@ -253,4 +255,13 @@ export const migrateInstanceRootStorage = async (
     page,
     `Instance ${instance} root storage successfully moved to pool ${pool}.`,
   );
+};
+
+export const getInstanceCount = (project: string): number => {
+  const lxc = getLxcCmd();
+  const instances = JSON.parse(
+    runCommand(`${lxc} list --project ${project} --format json`),
+  ) as Array<{ status: string }>;
+
+  return instances.length;
 };

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -3,6 +3,7 @@ import { getLxcCmd } from "./helpers/auth";
 import {
   createInstance,
   deleteInstance,
+  getInstanceCount,
   randomInstanceName,
   visitAndStartInstance,
   visitAndStopInstance,
@@ -50,28 +51,30 @@ test("bulk stop operation renders and expands child operations", async ({
   await visitAndStartInstance(page, secondInstance);
 
   const lxc = getLxcCmd();
+  const instanceCount = getInstanceCount("default");
   runCommand(`${lxc} stop --all --project default`);
 
   await visitOperations(page);
 
-  const childOperationsChip = page
-    .getByRole("button", { name: /2 child operations/i })
-    .first();
+  const childOperationsChip = page.getByRole("button", {
+    name: `${instanceCount} child operations`,
+  });
   await expect(childOperationsChip).toBeVisible();
-
   await childOperationsChip.click();
 
   const childRows = page.locator(
     "#operation-table tbody tr.child-operation-row",
   );
-  await expect(childRows).toHaveCount(2);
+  await expect(childRows).toHaveCount(instanceCount);
 
   const firstChildRow = childRows.filter({ hasText: firstInstance });
+  await expect(firstChildRow).toBeVisible();
   await expect(firstChildRow).toContainText("Stopping instance");
   await expect(firstChildRow).toContainText("Project: default");
   await expect(firstChildRow).toContainText("Success");
 
   const secondChildRow = childRows.filter({ hasText: secondInstance });
+  await expect(secondChildRow).toBeVisible();
   await expect(secondChildRow).toContainText("Stopping instance");
   await expect(secondChildRow).toContainText("Project: default");
   await expect(secondChildRow).toContainText("Success");


### PR DESCRIPTION
## Done

- bulk operations: make e2e test more robust

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Trust CI.

## Screenshots

<img width="1157" height="985" alt="image" src="https://github.com/user-attachments/assets/b6bc9b8b-375f-47df-9702-fe0b977817e4" />

