### PR TITLE
unidirectional cluster link create, display and edit

### DIFF
--- a/src/components/FormLink.tsx
+++ b/src/components/FormLink.tsx
@@ -11,6 +11,7 @@ interface Props {
   subTextBelowTitle?: boolean;
   disabled?: boolean;
   onHoverText?: string;
+  className?: string;
 }
 
 const FormLink: FC<Props> = ({
@@ -22,13 +23,18 @@ const FormLink: FC<Props> = ({
   isModified,
   disabled,
   onHoverText,
+  className,
 }) => {
   return (
     <Button
       appearance="base"
-      className={classnames("form-link u-no-margin--bottom", {
-        "form-link--subtext-below": subTextBelowTitle,
-      })}
+      className={classnames(
+        "form-link u-no-margin--bottom",
+        {
+          "form-link--subtext-below": subTextBelowTitle,
+        },
+        className,
+      )}
       onClick={onClick}
       type="button"
       disabled={disabled}

--- a/src/pages/cluster/ClusterLinkDirectionSelection.tsx
+++ b/src/pages/cluster/ClusterLinkDirectionSelection.tsx
@@ -1,0 +1,35 @@
+import type { FC } from "react";
+import FormLink from "components/FormLink";
+import type { LxdClusterLinkType } from "types/cluster";
+
+interface Props {
+  onSelect: (type: LxdClusterLinkType) => void;
+}
+
+const ClusterLinkDirectionSelection: FC<Props> = ({ onSelect }) => {
+  return (
+    <>
+      <FormLink
+        icon="devtools"
+        title="Bidirectional"
+        subText="Connect two LXD clusters with access in both directions. Required for replication."
+        subTextBelowTitle
+        onClick={() => {
+          onSelect("bidirectional");
+        }}
+        className="u-no-margin--right"
+      />
+      <FormLink
+        icon="chevron-right"
+        title="Unidirectional"
+        subText="Access another LXD cluster to fetch images, without granting access in return."
+        subTextBelowTitle
+        onClick={() => {
+          onSelect("unidirectional");
+        }}
+      />
+    </>
+  );
+};
+
+export default ClusterLinkDirectionSelection;

--- a/src/pages/cluster/ClusterLinkForm.tsx
+++ b/src/pages/cluster/ClusterLinkForm.tsx
@@ -1,25 +1,19 @@
-import { Form, Input, Label, RadioInput } from "@canonical/react-components";
+import { Form, Input, Label, OutputField } from "@canonical/react-components";
 import type { FC } from "react";
 import GroupSelection from "pages/permissions/panels/GroupSelection";
 import { useAuthGroups } from "context/useAuthGroups";
 import type { FormikProps } from "formik/dist/types";
-
-export interface ClusterLinkFormValues {
-  name: string;
-  description?: string;
-  token?: string;
-  tokenType?: "generate" | "consume";
-  authGroups: string[];
-  isCreating: boolean;
-  initialAuthGroups?: string[];
-}
+import ClusterLinkTokenInput from "pages/cluster/ClusterLinkTokenInput";
+import type { ClusterLinkFormValues } from "types/forms/clusterLink";
 
 interface Props {
   formik: FormikProps<ClusterLinkFormValues>;
 }
 
 const ClusterLinkForm: FC<Props> = ({ formik }) => {
-  const { data: authGroups = [] } = useAuthGroups();
+  const { data: authGroups = [] } = useAuthGroups(
+    formik.values.type === "bidirectional",
+  );
 
   const selectedGroups = new Set(formik.values.authGroups);
   const initial = new Set(formik.values.initialAuthGroups);
@@ -29,19 +23,33 @@ const ClusterLinkForm: FC<Props> = ({ formik }) => {
   const hasName = formik.values.name !== "";
 
   return (
-    <Form onSubmit={formik.handleSubmit}>
+    <Form onSubmit={formik.handleSubmit} className="cluster-link-form">
       {/* hidden submit to enable enter key in inputs */}
       <Input type="submit" hidden value="Hidden input" />
       {formik.values.isCreating && (
-        <Input
-          {...formik.getFieldProps("name")}
-          type="text"
-          label="Name"
-          placeholder="Enter name"
-          required
-          autoFocus
-          error={formik.touched.name ? formik.errors.name : null}
-        />
+        <>
+          <OutputField
+            id="type"
+            label="Cluster link type"
+            value={formik.values.type}
+          />
+          <ClusterLinkTokenInput formik={formik} />
+          <Input
+            {...formik.getFieldProps("name")}
+            type="text"
+            label="Cluster link name"
+            placeholder="Enter name"
+            required
+            disabled={
+              (formik.values.token === "" &&
+                (formik.values.type === "unidirectional" ||
+                  formik.values.tokenType === "consume")) ||
+              (formik.values.type === "bidirectional" &&
+                !formik.values.tokenType)
+            }
+            error={formik.touched.name ? formik.errors.name : null}
+          />
+        </>
       )}
       <Input
         {...formik.getFieldProps("description")}
@@ -55,77 +63,41 @@ const ClusterLinkForm: FC<Props> = ({ formik }) => {
             : "Please enter a name before adding a description"
         }
       />
-      {formik.values.isCreating && (
+      {formik.values.type === "bidirectional" && (
         <>
-          <div
-            className="u-sv1"
-            title={
-              hasName
-                ? undefined
-                : "Please enter a name before selecting token options"
-            }
-          >
-            <RadioInput
-              inline
-              className="margin-right--large"
-              label="Generate token"
-              checked={formik.values.tokenType === "generate"}
-              onChange={() => {
-                formik.setFieldValue("tokenType", "generate");
-              }}
-              disabled={!hasName}
-            />
-            <RadioInput
-              inline
-              label="I have a token"
-              checked={formik.values.tokenType === "consume"}
-              onChange={() => {
-                formik.setFieldValue("tokenType", "consume");
-              }}
-              disabled={!hasName}
-            />
-          </div>
-          {formik.values.tokenType === "consume" && (
-            <Input
-              {...formik.getFieldProps("token")}
-              type="text"
-              label="Token"
-              placeholder="Enter token (e.g. eyJhbGciOiJIUzI1Ni...)"
-              help="Paste the token you have generated on the target cluster"
-            />
-          )}
+          <Label className="u-sv-2">Auth groups</Label>
+          <p className="u-text--muted u-sv-1 p-text--small">
+            Control access for incoming requests through this cluster link.
+          </p>
+          <GroupSelection
+            groups={authGroups}
+            modifiedGroups={modifiedGroups}
+            parentItemName="cluster link"
+            selectedGroups={selectedGroups}
+            setSelectedGroups={(val, isUnselectAll) => {
+              if (isUnselectAll) {
+                formik.setFieldValue("authGroups", []);
+              } else {
+                formik.setFieldValue("authGroups", val);
+              }
+            }}
+            toggleGroup={(group) => {
+              const currentGroups = formik.values.authGroups;
+              if (currentGroups.includes(group)) {
+                formik.setFieldValue(
+                  "authGroups",
+                  currentGroups.filter((g) => g !== group),
+                );
+              } else {
+                formik.setFieldValue("authGroups", [...currentGroups, group]);
+              }
+            }}
+            scrollDependencies={[formik]}
+            disabled={!hasName}
+            hasScrollableTable={false}
+          />
         </>
       )}
-      <Label className="u-sv-2">Auth groups</Label>
-      <p className="u-text--muted u-sv-1 p-text--small">
-        Control access for incoming requests through this cluster link.
-      </p>
-      <GroupSelection
-        groups={authGroups}
-        modifiedGroups={modifiedGroups}
-        parentItemName="cluster link"
-        selectedGroups={selectedGroups}
-        setSelectedGroups={(val, isUnselectAll) => {
-          if (isUnselectAll) {
-            formik.setFieldValue("authGroups", []);
-          } else {
-            formik.setFieldValue("authGroups", val);
-          }
-        }}
-        toggleGroup={(group) => {
-          const currentGroups = formik.values.authGroups;
-          if (currentGroups.includes(group)) {
-            formik.setFieldValue(
-              "authGroups",
-              currentGroups.filter((g) => g !== group),
-            );
-          } else {
-            formik.setFieldValue("authGroups", [...currentGroups, group]);
-          }
-        }}
-        scrollDependencies={[formik]}
-        disabled={!hasName}
-      />
     </Form>
   );
 };

--- a/src/pages/cluster/ClusterLinkList.tsx
+++ b/src/pages/cluster/ClusterLinkList.tsx
@@ -154,7 +154,10 @@ const ClusterLinkList: FC = () => {
 
   const { rows: sortedRows, updateSort } = useSortTableData({ rows });
   const isEmptyState = clusterLinks.length === 0 && !isLoading;
-  const panelIdentity = getLinkIdentity(identities, panelParams.identity);
+  const panelIdentity = getLinkIdentity(identities, panelParams.clusterLink);
+  const panelLink = clusterLinks.find(
+    (link) => link.name === panelParams.clusterLink,
+  );
 
   if (isLoading) {
     return <Spinner className="u-loader" text="Loading cluster links..." />;
@@ -223,8 +226,11 @@ const ClusterLinkList: FC = () => {
         </Row>
       </BaseLayout>
       <CreateClusterLink />
-      {panelParams.panel === panels.editClusterLink && panelIdentity && (
-        <EditClusterLinkPanel identity={panelIdentity} />
+      {panelParams.panel === panels.editClusterLink && panelLink && (
+        <EditClusterLinkPanel
+          identity={panelIdentity}
+          clusterLink={panelLink}
+        />
       )}
     </>
   );

--- a/src/pages/cluster/ClusterLinkTokenInput.tsx
+++ b/src/pages/cluster/ClusterLinkTokenInput.tsx
@@ -1,0 +1,102 @@
+import type { FC } from "react";
+import type { FormikProps } from "formik/dist/types";
+import type { ClusterLinkFormValues } from "types/forms/clusterLink";
+import { Input, Select } from "@canonical/react-components";
+
+interface Props {
+  formik: FormikProps<ClusterLinkFormValues>;
+}
+
+const ClusterLinkTokenInput: FC<Props> = ({ formik }) => {
+  const getTokenHelp = () => {
+    if (formik.values.type === "unidirectional") {
+      return (
+        <>
+          Paste the token you have generated on the target cluster.
+          <br />
+          To create one, open the LXD UI on the <b>target cluster</b>, then go
+          to{" "}
+          <b>
+            Permissions {">"} Identities {">"} Create identity
+          </b>{" "}
+          and select <b>Cluster link</b>.
+        </>
+      );
+    }
+
+    if (formik.values.tokenType === "generate") {
+      return "Token will be generated";
+    }
+
+    if (formik.values.tokenType === "consume") {
+      return (
+        <>
+          Paste the token you have generated on the target cluster.
+          <br />
+          To create one, open the LXD UI on the <b>target cluster</b>, then go
+          to{" "}
+          <b>
+            Clustering {">"} Links {">"} Create cluster link
+          </b>{" "}
+          and generate a token for the bidirectional link.
+        </>
+      );
+    }
+
+    return null;
+  };
+
+  const tokenInput = (
+    <Input
+      {...formik.getFieldProps("token")}
+      type="text"
+      label="Token"
+      placeholder="Enter token (e.g. eyJhbGciOiJIUzI1Ni...)"
+      autoFocus={formik.values.type === "unidirectional"}
+      disabled={
+        formik.values.tokenType !== "consume" &&
+        formik.values.type === "bidirectional"
+      }
+      required
+      help={getTokenHelp()}
+    />
+  );
+
+  if (formik.values.type === "unidirectional") {
+    return <>{tokenInput}</>;
+  } else {
+    return (
+      <>
+        <div className="u-sv1">
+          <Select
+            label="Token setup"
+            options={[
+              {
+                label: "Select an option...",
+              },
+              {
+                label: "Generate a token for the target LXD cluster",
+                value: "generate",
+              },
+              {
+                label: "I have a token",
+                value: "consume",
+              },
+            ]}
+            {...formik.getFieldProps("tokenType")}
+            autoFocus
+            onChange={(e) => {
+              formik.setFieldValue("tokenType", e.target.value);
+              if (e.target.value === "generate") {
+                formik.setFieldValue("token", "");
+              }
+            }}
+          />
+        </div>
+        {tokenInput}
+      </>
+    );
+  }
+};
+
+export default ClusterLinkTokenInput;

--- a/src/pages/cluster/modals/CreateClusterLinkModal.tsx
+++ b/src/pages/cluster/modals/CreateClusterLinkModal.tsx
@@ -11,6 +11,7 @@ import {
 import CodeSnippetWithCopyButton from "components/CodeSnippetWithCopyButton";
 import ConfirmationCheckbox from "components/ConfirmationCheckbox";
 import ClusterLinkRichChip from "../ClusterLinkRichChip";
+import ResourceLabel from "components/ResourceLabel";
 
 interface Props {
   onClose: () => void;
@@ -28,7 +29,8 @@ const CreateClusterLinkModal: FC<Props> = ({ onClose, token, linkName }) => {
       className="create-cluster-link"
       title={
         <>
-          Cluster link <ClusterLinkRichChip clusterLink={linkName} /> created
+          Cluster link <ResourceLabel type="cluster-link" value={linkName} />{" "}
+          created
         </>
       }
       buttonRow={[

--- a/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
+++ b/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
@@ -7,20 +7,24 @@ import {
   Row,
   ScrollableContainer,
   SidePanel,
+  useListener,
   useToastNotification,
 } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState, type FC } from "react";
+import { useState, type FC, type MouseEvent } from "react";
 import usePanelParams from "util/usePanelParams";
 import * as Yup from "yup";
 import { useFormik } from "formik";
 import { queryKeys } from "util/queryKeys";
 import { createClusterLink } from "api/cluster-links";
 import { base64EncodeObject, checkDuplicateName } from "util/helpers";
-import ClusterLinkForm, {
-  type ClusterLinkFormValues,
-} from "pages/cluster/ClusterLinkForm";
+import ClusterLinkForm from "pages/cluster/ClusterLinkForm";
 import ClusterLinkRichChip from "../ClusterLinkRichChip";
+import ClusterLinkDirectionSelection from "pages/cluster/ClusterLinkDirectionSelection";
+import BackLink from "components/BackLink";
+import type { ClusterLinkFormValues } from "types/forms/clusterLink";
+
+type CreateLinkFlowStep = "direction-selection" | "details";
 
 interface Props {
   onSuccess: (identityName: string, token: string) => void;
@@ -29,9 +33,28 @@ interface Props {
 const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
   const panelParams = usePanelParams();
   const [error, setError] = useState<NotificationType | null>(null);
+  const [currentStep, setCurrentStep] = useState<CreateLinkFlowStep>(
+    "direction-selection",
+  );
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
+
+  const handleEscKey = (e: KeyboardEvent) => {
+    if (e.key !== "Escape") {
+      return;
+    }
+    switch (currentStep) {
+      case "direction-selection":
+        closePanel();
+        break;
+      case "details":
+        goToDirectionSelection();
+        break;
+    }
+  };
+
+  useListener(window, handleEscKey, "keydown", true);
 
   const closePanel = () => {
     panelParams.clear();
@@ -47,10 +70,10 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
           checkDuplicateName(value, "", controllerState, "cluster/links"),
       )
       .required("Link name is required"),
-    token: Yup.string().when("tokenType", {
-      is: "consume",
-      then: (schema) =>
-        schema.required("Token is required when consuming a token"),
+    token: Yup.string().when(["tokenType", "type"], {
+      is: (tokenType: string, type: string) =>
+        tokenType === "consume" || type === "unidirectional",
+      then: (schema) => schema.required("Token is required"),
       otherwise: (schema) => schema.notRequired(),
     }),
   });
@@ -60,23 +83,31 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
       name: "",
       description: "",
       token: "",
-      tokenType: "generate",
+      tokenType: undefined,
       authGroups: [],
       isCreating: true,
+      type: "bidirectional",
     },
     validationSchema: clusterLinkSchema,
     onSubmit: (values) => {
+      const isBidirectional = values.type === "bidirectional";
+      const hasToken = values.tokenType === "consume" || !isBidirectional;
+
       const payload = {
         name: values.name,
         description: values.description,
-        trust_token: values.tokenType === "consume" ? values.token : undefined,
-        auth_groups: values.authGroups,
-        type: "bidirectional",
+        trust_token: hasToken ? values.token : undefined,
+        auth_groups: isBidirectional ? values.authGroups : undefined,
+        type: values.type,
       };
 
       createClusterLink(JSON.stringify(payload))
         .then((response) => {
-          if (formik.values.tokenType === "generate" && response) {
+          if (
+            formik.values.type === "bidirectional" &&
+            formik.values.tokenType === "generate" &&
+            response
+          ) {
             const encodedToken = base64EncodeObject(response);
             onSuccess(values.name, encodedToken);
           } else {
@@ -104,10 +135,30 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
     },
   });
 
+  const goToDirectionSelection = () => {
+    setCurrentStep("direction-selection");
+  };
+
+  const goToDetailsStep = () => {
+    setCurrentStep("details");
+  };
+
   return (
-    <SidePanel className="cluster-link-panel">
+    <SidePanel>
       <SidePanel.Header>
-        <SidePanel.HeaderTitle>Create cluster link</SidePanel.HeaderTitle>
+        <SidePanel.HeaderTitle>
+          {currentStep === "direction-selection" && "Choose cluster link type"}
+          {currentStep === "details" && (
+            <BackLink
+              linkText="Choose type"
+              title="Create cluster link"
+              onMouseDown={(e: MouseEvent<HTMLButtonElement>) => {
+                e.preventDefault();
+              }}
+              onClick={goToDirectionSelection}
+            />
+          )}
+        </SidePanel.HeaderTitle>
       </SidePanel.Header>
       <Row className="u-no-padding">
         {error && (
@@ -123,35 +174,59 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
         )}
       </Row>
       <SidePanel.Content className="u-no-padding">
-        <ScrollableContainer dependencies={[error]} belowIds={["panel-footer"]}>
-          <ClusterLinkForm formik={formik} />
+        <ScrollableContainer
+          dependencies={[currentStep, error]}
+          belowIds={["panel-footer"]}
+        >
+          {currentStep === "direction-selection" && (
+            <ClusterLinkDirectionSelection
+              onSelect={(type) => {
+                formik.setFieldValue("type", type);
+                goToDetailsStep();
+              }}
+            />
+          )}
+          {currentStep === "details" && <ClusterLinkForm formik={formik} />}
         </ScrollableContainer>
       </SidePanel.Content>
       <SidePanel.Footer className="u-align--right">
-        <Button
-          appearance="base"
-          onClick={closePanel}
-          className="u-no-margin--bottom"
-          disabled={formik.isSubmitting}
-        >
-          Cancel
-        </Button>
-        <ActionButton
-          appearance="positive"
-          loading={formik.isSubmitting}
-          onClick={() => void formik.submitForm()}
-          className="u-no-margin--bottom"
-          disabled={
-            !formik.isValid || formik.isSubmitting || !formik.values.name
-          }
-          title={
-            formik.values.name
-              ? undefined
-              : "Please enter a name before submitting the form"
-          }
-        >
-          Create link
-        </ActionButton>
+        {currentStep === "direction-selection" && (
+          <Button
+            appearance="base"
+            onClick={closePanel}
+            className="u-no-margin--bottom"
+          >
+            Cancel
+          </Button>
+        )}
+        {currentStep === "details" && (
+          <>
+            <Button
+              appearance="base"
+              onClick={goToDirectionSelection}
+              className="u-no-margin--bottom"
+              disabled={formik.isSubmitting}
+            >
+              Back
+            </Button>
+            <ActionButton
+              appearance="positive"
+              loading={formik.isSubmitting}
+              onClick={() => void formik.submitForm()}
+              className="u-no-margin--bottom"
+              disabled={
+                !formik.isValid || formik.isSubmitting || !formik.values.name
+              }
+              title={
+                formik.values.name
+                  ? undefined
+                  : "Please enter a name before submitting the form"
+              }
+            >
+              Create link
+            </ActionButton>
+          </>
+        )}
       </SidePanel.Footer>
     </SidePanel>
   );

--- a/src/pages/cluster/panels/EditClusterLinkPanel.tsx
+++ b/src/pages/cluster/panels/EditClusterLinkPanel.tsx
@@ -15,24 +15,23 @@ import usePanelParams from "util/usePanelParams";
 import { useFormik } from "formik";
 import { queryKeys } from "util/queryKeys";
 import { updateClusterLink } from "api/cluster-links";
-import { useClusterLink } from "context/useClusterLinks";
 import type { LxdIdentity } from "types/permissions";
 import { updateIdentity } from "api/auth-identities";
-import ClusterLinkForm, {
-  type ClusterLinkFormValues,
-} from "pages/cluster/ClusterLinkForm";
+import ClusterLinkForm from "pages/cluster/ClusterLinkForm";
 import ClusterLinkRichChip from "../ClusterLinkRichChip";
+import type { LxdClusterLink } from "types/cluster";
+import type { ClusterLinkFormValues } from "types/forms/clusterLink";
 
 interface Props {
-  identity: LxdIdentity;
+  identity?: LxdIdentity;
+  clusterLink: LxdClusterLink;
 }
 
-const EditClusterLinkPanel: FC<Props> = ({ identity }) => {
+const EditClusterLinkPanel: FC<Props> = ({ identity, clusterLink }) => {
   const panelParams = usePanelParams();
   const [error, setError] = useState<NotificationType | null>(null);
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
-  const { data: clusterLink } = useClusterLink(panelParams.identity ?? "");
 
   const closePanel = () => {
     panelParams.clear();
@@ -41,11 +40,12 @@ const EditClusterLinkPanel: FC<Props> = ({ identity }) => {
 
   const formik = useFormik<ClusterLinkFormValues>({
     initialValues: {
-      name: clusterLink?.name ?? "",
-      description: clusterLink?.description ?? "",
+      name: clusterLink.name,
+      description: clusterLink.description,
       authGroups: identity?.groups ?? [],
       isCreating: false,
       initialAuthGroups: identity?.groups ?? [],
+      type: clusterLink.type,
     },
     enableReinitialize: true,
     onSubmit: (values) => {
@@ -54,18 +54,31 @@ const EditClusterLinkPanel: FC<Props> = ({ identity }) => {
         description: values.description,
       };
 
-      updateClusterLink(clusterLink?.name ?? "", JSON.stringify(payload))
+      if (clusterLink.type === "bidirectional" && !identity) {
+        setError(
+          failure(
+            "Cluster link update failed",
+            new Error("Identity not found"),
+          ),
+        );
+        formik.setSubmitting(false);
+        return;
+      }
+
+      updateClusterLink(clusterLink.name ?? "", JSON.stringify(payload))
         .then(async () => {
-          const payloadIdentity = {
-            ...identity,
-            groups: values.authGroups,
-          };
-          await updateIdentity(payloadIdentity);
+          if (clusterLink.type === "bidirectional" && identity) {
+            const payloadIdentity = {
+              ...identity,
+              groups: values.authGroups,
+            };
+            await updateIdentity(payloadIdentity);
+          }
           closePanel();
           toastNotify.success(
             <>
               Cluster link{" "}
-              <ClusterLinkRichChip clusterLink={clusterLink?.name ?? ""} />{" "}
+              <ClusterLinkRichChip clusterLink={clusterLink.name ?? ""} />{" "}
               saved.
             </>,
           );
@@ -89,8 +102,8 @@ const EditClusterLinkPanel: FC<Props> = ({ identity }) => {
     <SidePanel>
       <SidePanel.Header>
         <SidePanel.HeaderTitle className="u-truncate">
-          <span title={`Edit cluster link ${clusterLink?.name}`}>
-            Edit cluster link {clusterLink?.name}
+          <span title={`Edit cluster link ${clusterLink.name}`}>
+            Edit cluster link {clusterLink.name}
           </span>
         </SidePanel.HeaderTitle>
       </SidePanel.Header>

--- a/src/sass/_cluster_link.scss
+++ b/src/sass/_cluster_link.scss
@@ -1,10 +1,13 @@
-.cluster-link-panel {
-  .p-panel__content {
-    overflow: visible;
+.cluster-link-form {
+  .token-output {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+  }
 
-    .content-details {
-      overflow: visible;
-    }
+  .modified-status,
+  .select {
+    max-width: 50px;
   }
 }
 

--- a/src/sass/_selectable_main_table.scss
+++ b/src/sass/_selectable_main_table.scss
@@ -11,6 +11,10 @@
     .p-checkbox__label {
       display: contents;
     }
+
+    &:has(input:disabled) {
+      opacity: 0.33;
+    }
   }
 
   &.no-menu {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -20,6 +20,7 @@
 @include vf-p-icon-connected;
 @include vf-p-icon-containers;
 @include vf-p-icon-copy-to-clipboard;
+@include vf-p-icon-devtools;
 @include vf-p-icon-disconnect;
 @include vf-p-icon-edit;
 @include vf-p-icon-export;

--- a/src/types/cluster.d.ts
+++ b/src/types/cluster.d.ts
@@ -44,11 +44,13 @@ export interface LxdClusterGroup {
 
 export type ClusterSpecificValues = Record<string, string>;
 
+export type LxdClusterLinkType = "bidirectional" | "unidirectional";
+
 export interface LxdClusterLink {
   config: Record<string, string>;
   description: string;
   name: string;
-  type: string;
+  type: LxdClusterLinkType;
   access_entitlements?: string[];
   used_by?: string[];
 }

--- a/src/types/forms/clusterLink.ts
+++ b/src/types/forms/clusterLink.ts
@@ -1,0 +1,12 @@
+import type { LxdClusterLinkType } from "types/cluster";
+
+export interface ClusterLinkFormValues {
+  name: string;
+  description?: string;
+  token?: string;
+  tokenType?: "generate" | "consume";
+  authGroups: string[];
+  isCreating: boolean;
+  initialAuthGroups?: string[];
+  type: LxdClusterLinkType;
+}

--- a/src/util/usePanelParams.tsx
+++ b/src/util/usePanelParams.tsx
@@ -31,7 +31,7 @@ export interface PanelHelper {
   openCreateStorageBucketKey: (project: string) => void;
   openCreateIdentity: () => void;
   openEditClusterGroup: (group: string) => void;
-  openEditClusterLink: (link: string) => void;
+  openEditClusterLink: (clusterLink: string) => void;
   openEditGroup: (group: string, subForm?: GroupSubForm) => void;
   openEditIdpGroup: (group: string) => void;
   openCreatePlacementGroup: () => void;
@@ -203,8 +203,8 @@ const usePanelParams = (): PanelHelper => {
       setPanelParams(panels.editClusterGroups, { group });
     },
 
-    openEditClusterLink: (identity) => {
-      setPanelParams(panels.editClusterLink, { identity });
+    openEditClusterLink: (clusterLink) => {
+      setPanelParams(panels.editClusterLink, { "cluster-link": clusterLink });
     },
 
     openEditGroup: (group, subForm) => {

--- a/tests/cluster-links-clustered.spec.ts
+++ b/tests/cluster-links-clustered.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "./fixtures/lxd-test";
 import {
-  createClusterLink,
   deleteClusterLink,
   editClusterLink,
   randomLinkName,
@@ -8,6 +7,10 @@ import {
   createClusterLinkOnRemoteCluster,
   deleteClusterLinkOnRemoteCluster,
   visitClusterLinks,
+  createIdentityOnRemoteCluster,
+  deleteIdentityOnRemoteCluster,
+  createClusterLinkUnidirectional,
+  createClusterLinkBidirectional,
 } from "./helpers/cluster-links";
 import { skipIfNotClustered } from "./helpers/cluster";
 import { randomInstanceName } from "./helpers/instances";
@@ -31,7 +34,7 @@ test("cluster link create edit delete", async ({
 
   const link = randomLinkName();
   await visitClusterLinks(page);
-  await createClusterLink(page, link);
+  await createClusterLinkBidirectional(page, link);
   const row = page.getByRole("row").filter({ hasText: link });
   await expect(row).toBeVisible();
   await expect(row.getByRole("cell", { name: "Type" })).toHaveText(
@@ -60,8 +63,8 @@ test("cluster link table displays all links", async ({
   const link1 = randomLinkName();
   const link2 = randomLinkName();
   await visitClusterLinks(page);
-  await createClusterLink(page, link1);
-  await createClusterLink(page, link2);
+  await createClusterLinkBidirectional(page, link1);
+  await createClusterLinkBidirectional(page, link2);
 
   const row1 = page.getByRole("row").filter({ hasText: link1 });
   const row2 = page.getByRole("row").filter({ hasText: link2 });
@@ -84,7 +87,7 @@ test("consume token to create cluster link", async ({
   await visitClusterLinks(page);
 
   const token = createClusterLinkOnRemoteCluster(link);
-  await createClusterLink(page, link, token);
+  await createClusterLinkBidirectional(page, link, token);
 
   const row = page.getByRole("row").filter({ hasText: link });
   await expect(row.getByRole("cell", { name: "Status" })).toHaveText(
@@ -138,4 +141,27 @@ test("cluster link deletion is blocked while in use by a replicator", async ({
   // deleteAllAfterReplicatorTest navigates to cluster links and deletes via the
   // normal "Confirm delete" dialog, implicitly verifying the link is unblocked.
   await deleteAllAfterReplicatorTest(page, project, clusterLink);
+});
+
+test("create unidirectional cluster link", async ({
+  page,
+  lxdVersion,
+}, testInfo) => {
+  skipIfClusterLinksNotSupported(lxdVersion);
+  skipIfNotClustered(testInfo.project.name);
+
+  const link = randomLinkName();
+  await visitClusterLinks(page);
+
+  const token = createIdentityOnRemoteCluster(link);
+  await createClusterLinkUnidirectional(page, link, token);
+
+  const row = page.getByRole("row").filter({ hasText: link });
+  await expect(row.getByRole("cell", { name: "Status" })).toHaveText(
+    "Reachable",
+  );
+  await expect(row.getByRole("cell", { name: "Auth groups" })).toHaveText("0");
+
+  deleteIdentityOnRemoteCluster(link);
+  await deleteClusterLink(page, link);
 });

--- a/tests/helpers/cluster-links.ts
+++ b/tests/helpers/cluster-links.ts
@@ -29,22 +29,29 @@ export const visitClusterLinks = async (page: Page) => {
   ).toBeVisible();
 };
 
-export const createClusterLink = async (
+export const createClusterLinkBidirectional = async (
   page: Page,
   link: string,
   token?: string,
 ) => {
   await page.getByRole("button", { name: "Create cluster link" }).click();
   await expect(
-    page.getByRole("heading", { name: "Create cluster link" }),
+    page.getByRole("heading", { name: "Choose cluster link type" }),
   ).toBeVisible();
+  await page.getByRole("button", { name: "Bidirectional" }).click();
+
+  if (token) {
+    await page.getByLabel("Token setup").selectOption("consume");
+    await page.getByPlaceholder("Enter token").fill(token);
+  } else {
+    await page.getByLabel("Token setup").selectOption("generate");
+  }
+
   await page.getByPlaceholder("Enter name").fill(link);
   const panel = page.getByLabel("Side panel");
-  if (token) {
-    await page.getByText("I have a token").click();
-    await page.getByPlaceholder("Enter token").fill(token);
-  }
+
   panel.getByRole("rowheader").filter({ hasText: "admins" }).click();
+
   await panel.getByRole("button", { name: "Create link" }).click();
 
   await expect(page.getByText(`Cluster link ${link} created`)).toBeVisible();
@@ -55,6 +62,26 @@ export const createClusterLink = async (
   } else {
     await dismissNotification(page, `Cluster link ${link} created.`);
   }
+};
+
+export const createClusterLinkUnidirectional = async (
+  page: Page,
+  link: string,
+  token: string,
+) => {
+  await page.getByRole("button", { name: "Create cluster link" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Choose cluster link type" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Unidirectional" }).click();
+
+  await page.getByPlaceholder("Enter token").fill(token);
+  await page.getByPlaceholder("Enter name").fill(link);
+  const panel = page.getByLabel("Side panel");
+  await panel.getByRole("button", { name: "Create link" }).click();
+
+  await dismissNotification(page, `Cluster link ${link} created.`);
 };
 
 export const editClusterLink = async (page: Page, link: string) => {
@@ -97,4 +124,24 @@ export const createClusterLinkOnRemoteCluster = (link: string) => {
 export const deleteClusterLinkOnRemoteCluster = (link: string) => {
   const remoteVm = getRemoteClusterVm();
   runCommand(`lxc exec ${remoteVm} -- sh -c 'lxc cluster link delete ${link}'`);
+};
+
+export const createIdentityOnRemoteCluster = (link: string) => {
+  const remoteVm = getRemoteClusterVm();
+  const generateIdentityCmd = `lxc auth identity create cluster-link/${link} --group admins`;
+  const output = runCommand(
+    `lxc exec ${remoteVm} -- sh -c '${generateIdentityCmd}'`,
+  )
+    .toString()
+    .trim();
+
+  // Extract token from the output (it's on the last line)
+  return output.split("\n").pop() || "";
+};
+
+export const deleteIdentityOnRemoteCluster = (link: string) => {
+  const remoteVm = getRemoteClusterVm();
+  runCommand(
+    `lxc exec ${remoteVm} -- sh -c 'lxc auth identity delete tls/${link}'`,
+  );
 };

--- a/tests/helpers/replicators.ts
+++ b/tests/helpers/replicators.ts
@@ -4,7 +4,7 @@ import { dismissNotification } from "./notification";
 import { randomNameSuffix } from "./name";
 import { runCommand } from "./shell";
 import {
-  createClusterLink,
+  createClusterLinkBidirectional,
   createClusterLinkOnRemoteCluster,
   DELETE_ALL_CLUSTER_LINKS_COMMAND,
   deleteClusterLink,
@@ -61,7 +61,7 @@ export const setupProjectsForReplicator = async (
 
   // Cluster link & replica cluster setup
   const token = createClusterLinkOnRemoteCluster(clusterLink);
-  await createClusterLink(page, clusterLink, token);
+  await createClusterLinkBidirectional(page, clusterLink, token);
   await setClusterForProject(page, clusterLink, project);
 
   // Create standby project & promote to leader

--- a/tests/image-registries-clustered.spec.ts
+++ b/tests/image-registries-clustered.spec.ts
@@ -1,7 +1,7 @@
 import { test } from "./fixtures/lxd-test";
 import { skipIfNotClustered } from "./helpers/cluster";
 import {
-  createClusterLink,
+  createClusterLinkBidirectional,
   randomLinkName,
   visitClusterLinks,
 } from "./helpers/cluster-links";
@@ -22,7 +22,7 @@ test("create private LXD image registry", async ({
 
   const clusterName = randomLinkName();
   await visitClusterLinks(page);
-  await createClusterLink(page, clusterName);
+  await createClusterLinkBidirectional(page, clusterName);
 
   const projectName = "default";
   const registryName = randomImageRegistryName();


### PR DESCRIPTION
## Done

- unidirectional cluster link create, display and edit

Fixes WD-38124

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - go to clustering > links and create cluster link
      - create a unidirectional link
      - create a bidirectional link
      - edit a unidirectional link
      - edit a bidirectional link
      - To create the token for a unidirectional link, create another VM in the same network as your LXD backend and run this command to generate the token: `lxc auth identity create cluster-link/foo`

## Screenshots

<img width="3846" height="1920" alt="Screenshot from 2026-08-10 12-30-24" src="https://github.com/user-attachments/assets/fd0347e9-c2ae-4b59-9155-41ed37e05121" />

<img width="3846" height="1920" alt="Screenshot from 2026-08-10 12-30-41" src="https://github.com/user-attachments/assets/38de7125-548d-488f-982e-406af9220457" />

<img width="3846" height="1920" alt="Screenshot from 2026-08-10 12-30-54" src="https://github.com/user-attachments/assets/d2883e8b-f6e0-4d3d-a175-a709446e62bf" />

<img width="3846" height="1920" alt="image" src="https://github.com/user-attachments/assets/aec82329-abcf-4f13-bf83-98bb64daca3e" />

<img width="3846" height="1920" alt="image" src="https://github.com/user-attachments/assets/1df55690-c1aa-44d6-bc25-0661ac62ba63" />

<img width="3846" height="1920" alt="image" src="https://github.com/user-attachments/assets/e9d9df55-075d-4a3a-a55f-7bbcb12ac804" />

