### PR TITLE
feat(WarningList): use Chip for severity

### DIFF
--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, type FC } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   Row,
   ScrollableTable,
   useNotify,
   Spinner,
   CustomLayout,
+  Chip,
 } from "@canonical/react-components";
 import { fetchWarnings } from "api/warnings";
 import { isoTimeToString } from "util/helpers";
@@ -12,13 +14,18 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import NotificationRow from "components/NotificationRow";
 import WarningExplanationTooltip from "pages/warnings/WarningExplanationTooltip";
-import BulkDeleteWarningBtn from "pages/warnings/actions/BulkDeleteWarningBtn";
 import SelectableMainTable from "components/SelectableMainTable";
 import PageHeader from "components/PageHeader";
-import WarningSearchFilter from "./WarningSearchFilter";
-import { useSearchParams } from "react-router-dom";
+import WarningSearchFilter from "pages/warnings/WarningSearchFilter";
+import BulkDeleteWarningBtn from "pages/warnings/actions/BulkDeleteWarningBtn";
 import type { LxdWarningSeverity, LxdWarningStatus } from "types/warning";
-import type { WarningFilters } from "util/warningFilter";
+import {
+  getSeverityChipAppearance,
+  QUERY,
+  SEVERITY,
+  STATUS,
+  type WarningFilters,
+} from "util/warningFilter";
 
 const WarningList: FC = () => {
   const notify = useNotify();
@@ -43,9 +50,9 @@ const WarningList: FC = () => {
   const hasWarnings = isLoading || warnings.length > 0;
 
   const filters: WarningFilters = {
-    queries: searchParams.getAll("query").map((value) => value.toLowerCase()),
-    statuses: searchParams.getAll("status") as LxdWarningStatus[],
-    severities: searchParams.getAll("severity") as LxdWarningSeverity[],
+    queries: searchParams.getAll(QUERY).map((value) => value.toLowerCase()),
+    statuses: searchParams.getAll(STATUS) as LxdWarningStatus[],
+    severities: searchParams.getAll(SEVERITY) as LxdWarningSeverity[],
   };
 
   const filteredWarnings = warnings.filter((item) => {
@@ -125,7 +132,12 @@ const WarningList: FC = () => {
           className: "status",
         },
         {
-          content: warning.severity,
+          content: (
+            <Chip
+              value={warning.severity}
+              appearance={getSeverityChipAppearance(warning.severity)}
+            />
+          ),
           role: "cell",
           "aria-label": "Severity",
           className: "severity",

--- a/src/pages/warnings/WarningSearchFilter.tsx
+++ b/src/pages/warnings/WarningSearchFilter.tsx
@@ -9,13 +9,15 @@ import {
   paramsFromSearchData,
   searchParamsToChips,
 } from "util/searchAndFilter";
-import { warningSeverities, warningStatuses } from "util/warningFilter";
-
-export const QUERY = "query";
-export const STATUS = "status";
-export const SEVERITY = "severity";
-
-const QUERY_PARAMS = [QUERY, STATUS, SEVERITY];
+import {
+  enhanceSeverityChipWithAppearance,
+  getSeverityChipAppearance,
+  warningSeverities,
+  SEVERITY,
+  STATUS,
+  WARNING_QUERY_PARAMS,
+  warningStatuses,
+} from "util/warningFilter";
 
 const WarningSearchFilter: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -32,7 +34,11 @@ const WarningSearchFilter: FC = () => {
       id: 2,
       heading: "Severity",
       chips: warningSeverities.map((severity) => {
-        return { lead: SEVERITY, value: severity };
+        return {
+          lead: SEVERITY,
+          value: severity,
+          appearance: getSeverityChipAppearance(severity),
+        };
       }),
     },
   ];
@@ -41,7 +47,7 @@ const WarningSearchFilter: FC = () => {
     const newParams = paramsFromSearchData(
       searchData,
       searchParams,
-      QUERY_PARAMS,
+      WARNING_QUERY_PARAMS,
     );
 
     if (newParams.toString() !== searchParams.toString()) {
@@ -53,7 +59,11 @@ const WarningSearchFilter: FC = () => {
     <>
       <h2 className="u-off-screen">Search and filter</h2>
       <SearchAndFilter
-        existingSearchData={searchParamsToChips(searchParams, QUERY_PARAMS)}
+        existingSearchData={searchParamsToChips(
+          searchParams,
+          WARNING_QUERY_PARAMS,
+          enhanceSeverityChipWithAppearance,
+        )}
         filterPanelData={searchAndFilterData}
         returnSearchData={onSearchDataChange}
         onExpandChange={() => {

--- a/src/util/searchAndFilter.spec.ts
+++ b/src/util/searchAndFilter.spec.ts
@@ -1,3 +1,4 @@
+import type { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import {
   paramsFromSearchData,
   searchChipBaseUrl,
@@ -66,6 +67,34 @@ describe("paramsFromSearchData, searchParamsToChips and searchChipBaseUrl", () =
     expect(results[1].value).toBe("simpson");
     expect(results[2].lead).toBe("foo");
     expect(results[2].value).toBe("foo1");
+  });
+
+  it("applies mapChip when translating url params to search chips", () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append("query", "homer");
+    searchParams.append("foo", "foo1");
+    const queryParams = ["query", "foo"];
+
+    const mapChip = (chip: SearchAndFilterChip): SearchAndFilterChip => {
+      if (chip.lead === "foo") {
+        return { ...chip, appearance: "information" };
+      }
+      return { ...chip, value: `${chip.value}-mapped` };
+    };
+
+    const results = searchParamsToChips(searchParams, queryParams, mapChip);
+
+    expect(results.length).toBe(2);
+
+    // Query chips keep query semantics and still pass through mapChip.
+    expect(results[0].quoteValue).toBe(true);
+    expect(results[0].value).toBe("homer-mapped");
+    expect(results[0].lead).toBeUndefined();
+
+    // Non-query chips can be enriched by mapChip.
+    expect(results[1].lead).toBe("foo");
+    expect(results[1].value).toBe("foo1");
+    expect(results[1].appearance).toBe("information");
   });
 
   it("searchChipBaseUrl preserves query params listed and drops those not listed", () => {

--- a/src/util/searchAndFilter.tsx
+++ b/src/util/searchAndFilter.tsx
@@ -30,17 +30,19 @@ const searchValuesByLead = (
 export const searchParamsToChips = (
   searchParams: URLSearchParams,
   queryParams: string[],
+  mapChip?: (chip: SearchAndFilterChip) => SearchAndFilterChip,
 ): SearchAndFilterChip[] => {
   const searchData: SearchAndFilterChip[] = [];
   queryParams.forEach((param) =>
     searchData.push(
-      ...searchParams
-        .getAll(param)
-        .map((value) =>
+      ...searchParams.getAll(param).map((value) => {
+        const chip: SearchAndFilterChip =
           param === "query"
             ? { quoteValue: true, value }
-            : { lead: param, value },
-        ),
+            : { lead: param, value };
+
+        return mapChip ? mapChip(chip) : chip;
+      }),
     ),
   );
   return searchData;

--- a/src/util/warningFilter.tsx
+++ b/src/util/warningFilter.tsx
@@ -1,4 +1,11 @@
+import type { SearchAndFilterChip } from "@canonical/react-components/dist/components/SearchAndFilter/types";
 import type { LxdWarningSeverity, LxdWarningStatus } from "types/warning";
+
+export const QUERY = "query";
+export const STATUS = "status";
+export const SEVERITY = "severity";
+
+export const WARNING_QUERY_PARAMS = [QUERY, STATUS, SEVERITY];
 
 export interface WarningFilters {
   queries: string[];
@@ -17,3 +24,32 @@ export const warningSeverities: LxdWarningSeverity[] = [
   "moderate",
   "high",
 ];
+
+export const getSeverityChipAppearance = (
+  severity: LxdWarningSeverity,
+): NonNullable<SearchAndFilterChip["appearance"]> => {
+  switch (severity) {
+    case "high":
+      return "negative";
+    case "moderate":
+      return "caution";
+    case "low":
+      return "information";
+    default:
+      return "caution";
+  }
+};
+
+export const enhanceSeverityChipWithAppearance = (
+  chip: SearchAndFilterChip,
+): SearchAndFilterChip => {
+  if (chip.lead !== SEVERITY) {
+    return chip;
+  }
+
+  const severity = warningSeverities.find((item) => item === chip.value);
+
+  return severity
+    ? { ...chip, appearance: getSeverityChipAppearance(severity) }
+    : chip;
+};


### PR DESCRIPTION
## Open question
What do we think of the appearance of the chips in SearchAndFilter ? It requires a dev in reac-components so it won't be available on the demo server, you need to trust my screenshots.

## Done

- feat(WarningList): use Chip for severity

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [Go to the Warnings list page.
    - Use the search and filter.

## Screenshots

<img width="1861" height="1056" alt="warning-list-severity-chip" src="https://github.com/user-attachments/assets/d5676aec-d375-4d29-b229-4ef738a160f2" />
<img width="1850" height="1054" alt="Screenshot from 2026-08-10 17-36-15" src="https://github.com/user-attachments/assets/6e7c8b80-7921-4113-b5df-e7ba77f60439" />
