### PR TITLE
feat: [WD-37337] Adding NVME to Powerstore mode options

### DIFF
--- a/src/context/useSupportedFeatures.tsx
+++ b/src/context/useSupportedFeatures.tsx
@@ -65,5 +65,8 @@ export const useSupportedFeatures = () => {
     hasLoadBalancerHealthChecks: apiExtensions.has(
       "network_load_balancer_pool_health_checks",
     ),
+    hasStorageDriverPowerstoreNvme: apiExtensions.has(
+      "storage_driver_powerstore_nvme",
+    ),
   };
 };

--- a/src/pages/storage/forms/StoragePoolFormPowerStore.tsx
+++ b/src/pages/storage/forms/StoragePoolFormPowerStore.tsx
@@ -6,12 +6,15 @@ import { Select } from "@canonical/react-components";
 import { optionTrueFalse } from "util/options";
 import { optionPowerStoreMode } from "util/instanceOptions";
 import ScrollableConfigurationTable from "components/forms/ScrollableConfigurationTable";
+import { useSupportedFeatures } from "context/useSupportedFeatures";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
 }
 
 const StoragePoolFormPowerStore: FC<Props> = ({ formik }) => {
+  const { hasStorageDriverPowerstoreNvme } = useSupportedFeatures();
+
   return (
     <ScrollableConfigurationTable
       rows={[
@@ -20,7 +23,11 @@ const StoragePoolFormPowerStore: FC<Props> = ({ formik }) => {
           label: "Mode",
           name: "powerstore_mode",
           defaultValue: "",
-          children: <Select options={optionPowerStoreMode} />,
+          children: (
+            <Select
+              options={optionPowerStoreMode(hasStorageDriverPowerstoreNvme)}
+            />
+          ),
         }),
         getConfigurationRow({
           formik,

--- a/src/util/instanceOptions.tsx
+++ b/src/util/instanceOptions.tsx
@@ -77,7 +77,9 @@ export const optionIscsiNvme = (hasStorageNvmeTcp: boolean) => [
   },
 ];
 
-export const optionPowerStoreMode = [
+export const optionPowerStoreMode = (
+  hasStorageDriverPowerstoreNvme: boolean,
+) => [
   {
     label: "Select option",
     value: "",
@@ -91,6 +93,9 @@ export const optionPowerStoreMode = [
     label: "SCSI over FC",
     value: "scsi/fc",
   },
+  ...(hasStorageDriverPowerstoreNvme
+    ? [{ label: "NVMe over TCP", value: "nvme/tcp" }]
+    : []),
 ];
 
 export const optionNvmeSdc = (hasStorageNvmeTcp: boolean) => [


### PR DESCRIPTION
## Done

- Added nvme/tcp to Powerstore configuration list.
- Conditionally adds the above if the `storage_driver_powerstore_nvme` extension exists.

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - In a Powerstore compatible backend (or backend with an added line to test 
## Screenshots

N/A