### PR TITLE
fix(cert-import) update firefox steps. fixes #2197

### DIFF
--- a/src/pages/login/BrowserImport.tsx
+++ b/src/pages/login/BrowserImport.tsx
@@ -80,16 +80,16 @@ const BrowserImport: FC<Props> = ({ isBearerToken = false }) => {
             <li className="p-list__item">
               Go to Firefox&rsquo;s privacy settings:
               <pre className="p-code-snippet__block u-no-margin--bottom">
-                <code>about:preferences#privacy</code>
+                <code>about:preferences#connectionSecurity</code>
               </pre>
             </li>
             <li className="p-list__item">
               Scroll down to the certificates section and click{" "}
-              <b>View Certificates</b>
+              <b>Manage Certificates</b>
             </li>
             <li className="p-list__item">
               In the modal that appears, go to <b>Your certificates</b> and
-              click Import
+              click <b>Import</b>
             </li>
             <li className="p-list__item">
               Select the .pfx file you just downloaded. If you created a


### PR DESCRIPTION
## Done

- fix(cert-import) update firefox steps.

Fixes fixes #2197

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open unauthenticated UI (i.e. delete your user under permission > identities)
    - select in the onboarding > set up TLS login > Firefox
    - ensure steps are correctly matching current Firefox.

## Screenshots

<img width="3836" height="1918" alt="image" src="https://github.com/user-attachments/assets/273fe45f-04b3-4d6f-aff2-78aa32ce76b9" />