### PR TITLE
fix(instance) allow clearing of cpu and memory limit inputs

### DIFF
--- a/src/components/forms/CpuLimitSelector.tsx
+++ b/src/components/forms/CpuLimitSelector.tsx
@@ -3,6 +3,7 @@ import { RadioInput } from "@canonical/react-components";
 import { CPU_LIMIT_TYPE, type CpuLimit } from "types/limits";
 import CpuLimitInput from "components/forms/CpuLimitInput";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
+import { valueAsNumber } from "util/valueAsNumber";
 
 interface Props {
   cpuLimit?: CpuLimit;
@@ -48,7 +49,10 @@ const CpuLimitSelector: FC<Props> = ({
           step="1"
           placeholder="Number of exposed cores"
           onChange={(e) => {
-            setCpuLimit({ ...cpuLimit, dynamicValue: +e.target.value });
+            setCpuLimit({
+              ...cpuLimit,
+              dynamicValue: valueAsNumber(e.target.value),
+            });
           }}
           value={cpuLimit.dynamicValue ?? ""}
           help={help}

--- a/src/components/forms/MemoryLimitSelector.tsx
+++ b/src/components/forms/MemoryLimitSelector.tsx
@@ -3,6 +3,7 @@ import { Input, RadioInput, Select } from "@canonical/react-components";
 import { BYTES_UNITS, MEM_LIMIT_TYPE, type MemoryLimit } from "types/limits";
 import MemoryLimitAvailable from "components/forms/MemoryLimitAvailable";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
+import { valueAsNumber } from "util/valueAsNumber";
 
 interface Props {
   formik: InstanceAndProfileFormikProps;
@@ -57,10 +58,14 @@ const MemoryLimitSelector: FC<Props> = ({
           step="Any"
           placeholder="Enter percentage"
           onChange={(e) => {
-            setMemoryLimit({ ...memoryLimit, value: +e.target.value });
+            setMemoryLimit({
+              ...memoryLimit,
+              value: valueAsNumber(e.target.value),
+            });
           }}
-          value={`${memoryLimit.value ? memoryLimit.value : ""}`}
+          value={memoryLimit.value ?? ""}
           help={<MemoryLimitAvailable formik={formik} />}
+          error={formik.errors.limits_memory}
         />
       )}
       {memoryLimit.selectedType === MEM_LIMIT_TYPE.FIXED && (
@@ -73,10 +78,14 @@ const MemoryLimitSelector: FC<Props> = ({
             step="Any"
             placeholder="Enter value"
             onChange={(e) => {
-              setMemoryLimit({ ...memoryLimit, value: +e.target.value });
+              setMemoryLimit({
+                ...memoryLimit,
+                value: valueAsNumber(e.target.value),
+              });
             }}
-            value={`${memoryLimit.value ? memoryLimit.value : ""}`}
+            value={memoryLimit.value ?? ""}
             help={<MemoryLimitAvailable formik={formik} />}
+            error={formik.errors.limits_memory}
           />
           <Select
             id="memUnitSelect"

--- a/src/pages/instances/CreateInstance.tsx
+++ b/src/pages/instances/CreateInstance.tsx
@@ -89,6 +89,7 @@ import { InstanceRichChip } from "./InstanceRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
 import { ISO_VOLUME_TYPE } from "util/devices";
+import type { MemoryLimit } from "types/limits";
 
 interface PresetFormState {
   retryFormValues?: CreateInstanceFormValues;
@@ -117,6 +118,11 @@ const CreateInstance: FC = () => {
   const InstanceSchema = Yup.object().shape({
     name: instanceNameValidation(project, controllerState).optional(),
     instanceType: Yup.string().required("Instance type is required"),
+    limits_memory: Yup.mixed<MemoryLimit>().test(
+      "non-zero",
+      "Limit must be greater than 0",
+      (memory) => memory?.value !== 0,
+    ),
   });
 
   const updateFormHeight = () => {

--- a/src/util/instanceAndProfilePayloads.tsx
+++ b/src/util/instanceAndProfilePayloads.tsx
@@ -150,7 +150,7 @@ export const memoryLimitToPayload = (
   if (typeof memoryLimit === "string") {
     return memoryLimit;
   }
-  if (!memoryLimit?.value) {
+  if (!memoryLimit?.value && memoryLimit?.value !== 0) {
     return undefined;
   }
   return `${memoryLimit.value}${memoryLimit.unit}`;

--- a/src/util/instanceEdit.tsx
+++ b/src/util/instanceEdit.tsx
@@ -3,6 +3,7 @@ import type { LxdInstance } from "types/instance";
 import type { SshKey } from "types/forms/instanceAndProfile";
 import * as Yup from "yup";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
+import type { MemoryLimit } from "types/limits";
 
 export const parseSshKeys = (item: LxdProfile | LxdInstance): SshKey[] => {
   const sshConfigKeys = Object.keys(item.config).filter((item) =>
@@ -27,6 +28,11 @@ export const InstanceEditSchema: Yup.ObjectSchema<{
 }> = Yup.object().shape({
   name: Yup.string().required("Instance name is required"),
   instanceType: Yup.string().required("Instance type is required"),
+  limits_memory: Yup.mixed<MemoryLimit>().test(
+    "non-zero",
+    "Limit must be greater than 0",
+    (memory) => memory?.value !== 0,
+  ),
 });
 
 export const isInstanceCreation = (

--- a/src/util/valueAsNumber.spec.ts
+++ b/src/util/valueAsNumber.spec.ts
@@ -1,0 +1,18 @@
+import { valueAsNumber } from "util/valueAsNumber";
+
+describe("valueAsNumber", () => {
+  it("returns undefined for an empty string", () => {
+    expect(valueAsNumber("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-numeric values", () => {
+    expect(valueAsNumber("abc")).toBeUndefined();
+  });
+
+  it("parses valid numeric strings", () => {
+    expect(valueAsNumber("0")).toBe(0);
+    expect(valueAsNumber("42")).toBe(42);
+    expect(valueAsNumber("3.14")).toBe(3.14);
+    expect(valueAsNumber("-7")).toBe(-7);
+  });
+});

--- a/src/util/valueAsNumber.ts
+++ b/src/util/valueAsNumber.ts
@@ -1,0 +1,10 @@
+export const valueAsNumber = (value: string): number | undefined => {
+  if (value === "") {
+    return undefined;
+  }
+  const numberValue = Number(value);
+  if (isNaN(numberValue)) {
+    return undefined;
+  }
+  return numberValue;
+};


### PR DESCRIPTION
## Done

- fix(instance) allow clearing of cpu and memory limit inputs

Fixes #2190

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - instance detail page > configuration > resource limits
    - edit exposed cpu limit
    - type number, clear number to type another number, ensure no 0 is introduced
    - repeat test for memory limit below.

## Screenshots

<img width="3838" height="1914" alt="image" src="https://github.com/user-attachments/assets/0e347b65-afac-4067-bdc7-fab11fa27fa8" />
