### PR TITLE
feat(identity) show additional idp groups in identity list. fixes #2191

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -19,6 +19,7 @@ interface ContextProps {
   serverEntitlements: string[];
   authMethod: LXDAuthMethod | null;
   authExpiresAt: string | null;
+  effectiveGroups: string[] | null;
 }
 
 const initialState: ContextProps = {
@@ -32,6 +33,7 @@ const initialState: ContextProps = {
   serverEntitlements: [],
   authMethod: null,
   authExpiresAt: null,
+  effectiveGroups: null,
 };
 
 export const AuthContext = createContext<ContextProps>(initialState);
@@ -122,6 +124,7 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
         serverEntitlements,
         authMethod,
         authExpiresAt: currentIdentity?.expires_at ?? null,
+        effectiveGroups: currentIdentity?.effective_groups ?? null,
       }}
     >
       {children}

--- a/src/pages/permissions/IdentityAdditionalIdpGroups.tsx
+++ b/src/pages/permissions/IdentityAdditionalIdpGroups.tsx
@@ -1,0 +1,52 @@
+import { List, Tooltip } from "@canonical/react-components";
+import { type FC } from "react";
+import { useSettings } from "context/useSettings";
+import { useAuth } from "context/auth";
+import type { LxdIdentity } from "types/permissions";
+import { pluralize } from "util/helpers";
+
+interface Props {
+  identity: LxdIdentity;
+}
+
+const IdentityAdditionalIdpGroups: FC<Props> = ({ identity }) => {
+  const { effectiveGroups: loggedInIdentityEffectiveGroups } = useAuth();
+  const { data: settings } = useSettings();
+  const isLoggedInIdentity = settings?.auth_user_name === identity.id;
+
+  if (!isLoggedInIdentity || !loggedInIdentityEffectiveGroups) {
+    return null;
+  }
+
+  const existingGroups = new Set(identity.groups ?? []);
+  const additionalIdpGroups = loggedInIdentityEffectiveGroups.filter(
+    (g) => !existingGroups.has(g),
+  );
+
+  if (additionalIdpGroups.length === 0) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      className="u-margin-left--small"
+      message={
+        <>
+          Additional LXD groups from Identity provider group mappings:
+          <List className="u-no-margin--bottom" items={additionalIdpGroups} />
+        </>
+      }
+    >
+      <span
+        tabIndex={0}
+        className="u-text--muted"
+        aria-label={`${additionalIdpGroups.length} additional identity provider ${pluralize("group", additionalIdpGroups.length)}`}
+      >
+        {" "}
+        +{additionalIdpGroups.length}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default IdentityAdditionalIdpGroups;

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -43,6 +43,7 @@ import CreateIdentity from "pages/permissions/CreateIdentity";
 import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesActions";
 import ResourceLabel from "components/ResourceLabel";
 import IdentityExpiration from "pages/permissions/IdentityExpiration";
+import IdentityAdditionalIdpGroups from "pages/permissions/IdentityAdditionalIdpGroups";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -129,9 +130,12 @@ const PermissionIdentities: FC = () => {
     const getGroupLink = () => {
       if (canEditIdentity(identity)) {
         return (
-          <Button appearance="link" dense onClick={openEditIdentityPanel}>
-            {identity.groups?.length || 0}
-          </Button>
+          <>
+            <Button appearance="link" dense onClick={openEditIdentityPanel}>
+              {identity.groups?.length || 0}
+            </Button>
+            <IdentityAdditionalIdpGroups identity={identity} />
+          </>
         );
       }
 
@@ -141,6 +145,7 @@ const PermissionIdentities: FC = () => {
       return (
         <div title={identity.groups?.length ? groupsTitle : ""}>
           {identity.groups?.length || 0}
+          <IdentityAdditionalIdpGroups identity={identity} />
         </div>
       );
     };


### PR DESCRIPTION
## Done

- feat(identity) show additional idp groups in identity list.

Fixes #2191

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - login with OIDC identity that has a idp group claim membership. You can use the OIDC settings from the pr.yaml file 
    - in the identity list ensure that the +1 appears in the groups column with a tooltip specifying which groups come in through the idp claim.

## Screenshots

<img width="3840" height="1918" alt="image" src="https://github.com/user-attachments/assets/fb9b3de9-8d6a-4d4b-b3f4-df5033ab1889" />
