### PR TITLE
feat(storage bucket key): hide secret key

### DIFF
--- a/src/components/PasswordOutputToggle.tsx
+++ b/src/components/PasswordOutputToggle.tsx
@@ -1,0 +1,58 @@
+import { useState, type FC } from "react";
+import { Button, Icon, List } from "@canonical/react-components";
+import CopyToClipboard from "components/CopyToClipboard";
+
+interface Props {
+  password?: string;
+}
+
+const PasswordOutputToggle: FC<Props> = ({ password }) => {
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  if (!password) {
+    return null;
+  }
+
+  return (
+    <div className="password-output-toggle u-flex">
+      <span
+        title={isRevealed ? password : undefined}
+        className="password-output-toggle-value u-truncate"
+      >
+        <span aria-hidden={!isRevealed}>
+          {isRevealed ? password : "\u2022".repeat(35)}
+        </span>
+        <span className="u-off-screen">
+          {isRevealed ? "Password is revealed" : "Password is hidden"}
+        </span>
+      </span>
+      <List
+        inline
+        className="u-no-margin--bottom password-output-toggle-actions-list"
+        items={[
+          <Button
+            key="reveal"
+            appearance="base"
+            className="u-no-margin--bottom"
+            dense
+            hasIcon
+            onClick={() => {
+              setIsRevealed((prev) => !prev);
+            }}
+            aria-label={isRevealed ? "Hide password" : "Show password"}
+            type="button"
+          >
+            <Icon name={isRevealed ? "hide" : "show"} />
+          </Button>,
+          <CopyToClipboard
+            key="copy"
+            value={password}
+            tooltipMessage="Copy password"
+          />,
+        ]}
+      />
+    </div>
+  );
+};
+
+export default PasswordOutputToggle;

--- a/src/pages/storage/StorageBucketKeys.tsx
+++ b/src/pages/storage/StorageBucketKeys.tsx
@@ -8,18 +8,19 @@ import {
   useNotify,
 } from "@canonical/react-components";
 import ItemName from "components/ItemName";
+import PasswordOutputToggle from "components/PasswordOutputToggle";
 import SelectableMainTable from "components/SelectableMainTable";
 import { useCurrentProject } from "context/useCurrentProject";
+import DocLink from "components/DocLink";
 import SelectedTableNotification from "components/SelectedTableNotification";
 import useSortTableData from "util/useSortTableData";
 import NotificationRow from "components/NotificationRow";
-import CreateStorageBucketKeyBtn from "./actions/CreateStorageBucketKeyBtn";
-import type { LxdStorageBucket } from "types/storage";
 import { useBucketKeys } from "context/useBuckets";
-import StorageBucketKeyActions from "./actions/StorageBucketKeyActions";
-import StorageBucketKeyBulkDelete from "./actions/StorageBucketKeyBulkDelete";
+import CreateStorageBucketKeyBtn from "pages/storage/actions/CreateStorageBucketKeyBtn";
+import StorageBucketKeyActions from "pages/storage/actions/StorageBucketKeyActions";
+import StorageBucketKeyBulkDelete from "pages/storage/actions/StorageBucketKeyBulkDelete";
+import type { LxdStorageBucket } from "types/storage";
 import { capitalizeFirstLetter } from "util/helpers";
-import DocLink from "components/DocLink";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -77,8 +78,8 @@ const StorageBucketKeys: FC<Props> = ({ bucket }) => {
       sortKey: "description",
       className: "description",
     },
-    { content: "Access key", className: "key-field", sortKey: "access-key" },
-    { content: "Secret key", className: "key-field", sortKey: "secret-key" },
+    { content: "Access key", className: "access-key", sortKey: "access-key" },
+    { content: "Secret key", className: "secret-key", sortKey: "secret-key" },
     { "aria-label": "Actions", className: "actions" },
   ];
 
@@ -115,13 +116,13 @@ const StorageBucketKeys: FC<Props> = ({ bucket }) => {
           content: key["access-key"],
           role: "cell",
           "aria-label": "Access key",
-          className: "key-field",
+          className: "access-key",
         },
         {
-          content: key["secret-key"],
+          content: <PasswordOutputToggle password={key["secret-key"]} />,
           role: "cell",
           "aria-label": "Secret key",
-          className: "key-field",
+          className: "secret-key",
         },
         {
           content: <StorageBucketKeyActions bucketKey={key} bucket={bucket} />,

--- a/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
+++ b/src/pages/storage/actions/DeleteStorageBucketKeyBtn.tsx
@@ -123,7 +123,7 @@ const DeleteStorageBucketKeyBtn: FC<Props> = ({ bucket, bucketKey }) => {
       disabled={!canEditBucket(bucket)}
       onHoverText={
         canEditBucket(bucket)
-          ? "Delete key"
+          ? "Delete bucket key"
           : "You do not have permission to delete this key."
       }
     >

--- a/src/pages/storage/forms/StorageBucketKeyForm.tsx
+++ b/src/pages/storage/forms/StorageBucketKeyForm.tsx
@@ -1,5 +1,10 @@
-import type { FC, ReactNode } from "react";
-import { Form, Input, Select } from "@canonical/react-components";
+import { type FC, type ReactNode } from "react";
+import {
+  Form,
+  Input,
+  PasswordToggle,
+  Select,
+} from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets";
@@ -78,9 +83,8 @@ const StorageBucketKeyForm: FC<Props> = ({ formik, bucket }) => {
         disabled={!!bucketEditRestriction}
         title={bucketEditRestriction}
       />
-      <Input
+      <PasswordToggle
         {...getFormProps("secret-key")}
-        type="text"
         label="Secret Key"
         disabled={!!bucketEditRestriction}
         title={bucketEditRestriction}

--- a/src/sass/_password_output_toggle.scss
+++ b/src/sass/_password_output_toggle.scss
@@ -1,0 +1,24 @@
+.password-output-toggle {
+  @media (width < 1036px) {
+    width: calc(100% - $sph--small);
+  }
+
+  .password-output-toggle-value {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .password-output-toggle-actions-list {
+    .p-inline-list__item {
+      align-items: center;
+      display: inline-flex;
+      vertical-align: middle;
+
+      .copy-to-clipboard-container {
+        .copy-to-clipboard-button {
+          padding: 0 !important;
+        }
+      }
+    }
+  }
+}

--- a/src/sass/_storage.scss
+++ b/src/sass/_storage.scss
@@ -13,12 +13,12 @@
   }
 
   .description {
-    width: 15rem;
+    width: 10rem;
   }
 
   .name,
   .role {
-    width: 10rem;
+    width: 8rem;
   }
 
   .p-panel__controls {
@@ -29,8 +29,12 @@
     margin-top: 0;
   }
 
-  .key-field {
+  .access-key {
     min-width: 15rem;
+  }
+
+  .secret-key {
+    width: 18rem;
   }
 
   @media screen and (width > 1090px) and (width < 1400px) {

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -144,6 +144,7 @@ $border-thin: 1px solid $colors--theme--border-low-contrast !default;
 @import "operation_list";
 @import "overview";
 @import "page_header";
+@import "password_output_toggle";
 @import "pattern_navigation";
 @import "pattern_terminal";
 @import "permission_confirm_modal";

--- a/tests/helpers/storageBucket.ts
+++ b/tests/helpers/storageBucket.ts
@@ -74,7 +74,9 @@ export const deleteBucketKey = async (
   bucketKey: string,
 ) => {
   const row = page.getByRole("row").filter({ hasText: bucketKey });
-  await row.getByRole("button", { name: "Delete key", exact: true }).click();
+  await row
+    .getByRole("button", { name: "Delete bucket key", exact: true })
+    .click();
   await page
     .getByRole("dialog", { name: "Confirm delete" })
     .getByRole("button", { name: "Delete" })


### PR DESCRIPTION
## Done

- feat(storage bucket key): hide secret key

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Storage > Buckets > a bucket with at least one key detail page. The secret key should not be visible on landing.
    - Click on the eye icon to reveal the secret key.
    - Click on the copy to clipboard icon to copy the secret key.
    - Click on the pencil icon to edit the key. The secret key should not be visible when the side panel opens.
    - Click on the pencil icon to edit the secret key.

## Screenshots


<img width="1546" height="1054" alt="image" src="https://github.com/user-attachments/assets/2add5eb7-c2e9-47b4-b028-0bf834cbf6fc" />

<img width="1546" height="1054" alt="image" src="https://github.com/user-attachments/assets/073fdd75-3b52-447f-8f3e-5f17258f9acd" />

<img width="1546" height="1054" alt="image" src="https://github.com/user-attachments/assets/f2681e63-8979-4634-b5d9-b1746f08dc06" />

<img width="1546" height="1054" alt="image" src="https://github.com/user-attachments/assets/5e2bb744-1c38-4381-b389-a17b7065eeda" />
