### PR TITLE
Close any panel on ESC key press

### DIFF
--- a/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
+++ b/src/components/forms/NetworkDevicesForm/edit/NetworkDevicePanel.tsx
@@ -45,6 +45,7 @@ import { useNetworkAcls } from "context/useNetworkAcls";
 import type { LxdNetwork } from "types/network";
 import { Link } from "react-router";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   project: string;
@@ -319,6 +320,8 @@ const NetworkDevicePanel: FC<Props> = ({
     notify.clear();
     panelParams.clear();
   };
+
+  useEscCallback(handleCancel);
 
   if (!isLoading && !isCreatingLocal && !device && !inheritedDevice) {
     return (

--- a/src/components/forms/SnapshotForm.tsx
+++ b/src/components/forms/SnapshotForm.tsx
@@ -1,4 +1,4 @@
-import type { FC, KeyboardEvent } from "react";
+import type { FC } from "react";
 import {
   ActionButton,
   Button,
@@ -21,11 +21,6 @@ interface Props {
 
 const SnapshotForm: FC<Props> = (props) => {
   const { isEdit, formik, close, additionalFormInput } = props;
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
 
   return (
     <Modal
@@ -47,7 +42,6 @@ const SnapshotForm: FC<Props> = (props) => {
           </ActionButton>
         </>
       }
-      onKeyDown={handleEscKey}
     >
       <Form onSubmit={formik.handleSubmit} className="snapshot-creation-form">
         <Input

--- a/src/context/useEscCallback.tsx
+++ b/src/context/useEscCallback.tsx
@@ -1,0 +1,11 @@
+import { useListener } from "@canonical/react-components";
+
+export const useEscCallback = (callback: () => void) => {
+  const handleKeyPress = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      callback();
+    }
+  };
+
+  useListener(window, handleKeyPress, "keydown", true);
+};

--- a/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
+++ b/src/pages/cluster/actions/RunReplicatorPreflightChecks.tsx
@@ -41,6 +41,11 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
   const projectMode = project?.replica_mode;
   const projectModeValid =
     projectMode === "leader" || projectMode === "standby";
+  const projectConfigurationUrl = `/ui/project/${encodeURIComponent(replicator.project)}/configuration/replication`;
+  const isOnProjectPage = window.location.pathname.includes(
+    projectConfigurationUrl,
+  );
+
   checks.push({
     id: "project-mode",
     label: projectMode ? (
@@ -73,14 +78,15 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
             </>
           ) : null}{" "}
           It must be either <strong>leader</strong> or <strong>standby</strong>{" "}
-          to run replicator.{" "}
-          <Link
-            to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration/replication`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            See project configuration
-          </Link>
+          to run replicator.
+          {!isOnProjectPage && (
+            <>
+              {" "}
+              <Link to={projectConfigurationUrl}>
+                See project configuration
+              </Link>
+            </>
+          )}
         </>
       ) : undefined,
   });
@@ -110,14 +116,15 @@ const RunReplicatorPreflightChecks: FC<Props> = ({
         <>
           Project replica cluster <strong>{projectCluster || "none"}</strong>{" "}
           does not equal replicator cluster{" "}
-          <strong>{replicatorCluster || "none"}</strong>.{" "}
-          <Link
-            to={`/ui/project/${encodeURIComponent(replicator.project)}/configuration/replication`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            See project configuration
-          </Link>
+          <strong>{replicatorCluster || "none"}</strong>.
+          {!isOnProjectPage && (
+            <>
+              {" "}
+              <Link to={projectConfigurationUrl}>
+                See project configuration
+              </Link>
+            </>
+          )}
         </>
       ) : undefined,
     });

--- a/src/pages/cluster/panels/CreateClusterGroupPanel.tsx
+++ b/src/pages/cluster/panels/CreateClusterGroupPanel.tsx
@@ -17,6 +17,7 @@ import ResourceLink from "components/ResourceLink";
 import type { ClusterGroupFormValues } from "types/forms/clusterGroup";
 import ClusterGroupForm from "pages/cluster/ClusterGroupForm";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 const CreateClusterGroupPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -28,6 +29,8 @@ const CreateClusterGroupPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const formik = useFormik<ClusterGroupFormValues>({
     initialValues: {

--- a/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
+++ b/src/pages/cluster/panels/CreateClusterLinkPanel.tsx
@@ -7,7 +7,6 @@ import {
   Row,
   ScrollableContainer,
   SidePanel,
-  useListener,
   useToastNotification,
 } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
@@ -23,6 +22,7 @@ import ClusterLinkRichChip from "../ClusterLinkRichChip";
 import ClusterLinkDirectionSelection from "pages/cluster/ClusterLinkDirectionSelection";
 import BackLink from "components/BackLink";
 import type { ClusterLinkFormValues } from "types/forms/clusterLink";
+import { useEscCallback } from "context/useEscCallback";
 
 type CreateLinkFlowStep = "direction-selection" | "details";
 
@@ -40,10 +40,7 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
 
-  const handleEscKey = (e: KeyboardEvent) => {
-    if (e.key !== "Escape") {
-      return;
-    }
+  const handleEscKey = () => {
     switch (currentStep) {
       case "direction-selection":
         closePanel();
@@ -54,7 +51,7 @@ const CreateClusterLinkPanel: FC<Props> = ({ onSuccess }) => {
     }
   };
 
-  useListener(window, handleEscKey, "keydown", true);
+  useEscCallback(handleEscKey);
 
   const closePanel = () => {
     panelParams.clear();

--- a/src/pages/cluster/panels/CreateReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/CreateReplicatorPanel.tsx
@@ -20,6 +20,7 @@ import { checkDuplicateName } from "util/helpers";
 import { useCurrentProject } from "context/useCurrentProject";
 import { getPayload } from "util/replicator";
 import ReplicatorRichChip from "../ReplicatorRichChip";
+import { useEscCallback } from "context/useEscCallback";
 
 const CreateReplicatorPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -35,6 +36,8 @@ const CreateReplicatorPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const schema = Yup.object().shape({
     name: Yup.string()

--- a/src/pages/cluster/panels/EditClusterGroupPanel.tsx
+++ b/src/pages/cluster/panels/EditClusterGroupPanel.tsx
@@ -18,19 +18,21 @@ import { useClusterGroup } from "context/useClusterGroups";
 import type { ClusterGroupFormValues } from "types/forms/clusterGroup";
 import ClusterGroupForm from "pages/cluster/ClusterGroupForm";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 const EditClusterGroupPanel: FC = () => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
   const queryClient = useQueryClient();
-
   const { data: group } = useClusterGroup(panelParams.group ?? "");
 
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const formik = useFormik<ClusterGroupFormValues>({
     initialValues: {

--- a/src/pages/cluster/panels/EditClusterLinkPanel.tsx
+++ b/src/pages/cluster/panels/EditClusterLinkPanel.tsx
@@ -21,6 +21,7 @@ import ClusterLinkForm from "pages/cluster/ClusterLinkForm";
 import ClusterLinkRichChip from "../ClusterLinkRichChip";
 import type { LxdClusterLink } from "types/cluster";
 import type { ClusterLinkFormValues } from "types/forms/clusterLink";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   identity?: LxdIdentity;
@@ -37,6 +38,8 @@ const EditClusterLinkPanel: FC<Props> = ({ identity, clusterLink }) => {
     panelParams.clear();
     setError(null);
   };
+
+  useEscCallback(closePanel);
 
   const formik = useFormik<ClusterLinkFormValues>({
     initialValues: {

--- a/src/pages/cluster/panels/EditClusterMemberPanel.tsx
+++ b/src/pages/cluster/panels/EditClusterMemberPanel.tsx
@@ -22,6 +22,7 @@ import { useClusterGroups } from "context/useClusterGroups";
 import ClusterMemberRichChip from "../ClusterMemberRichChip";
 import ClusterMemberRolesSelector from "./ClusterMemberRolesSelector";
 import DocLink from "components/DocLink";
+import { useEscCallback } from "context/useEscCallback";
 
 export interface EditClusterMemberForm {
   name: string;
@@ -48,6 +49,8 @@ const EditClusterMemberPanel: FC<Props> = ({ onClose }) => {
     notify.clear();
     onClose?.();
   };
+
+  useEscCallback(closePanel);
 
   const formik = useFormik<EditClusterMemberForm>({
     initialValues: {

--- a/src/pages/cluster/panels/EditReplicatorPanel.tsx
+++ b/src/pages/cluster/panels/EditReplicatorPanel.tsx
@@ -19,6 +19,7 @@ import ReplicatorRichChip from "pages/cluster/ReplicatorRichChip";
 import { useReplicator } from "context/useReplicators";
 import { getPayload } from "util/replicator";
 import * as Yup from "yup";
+import { useEscCallback } from "context/useEscCallback";
 
 const EditReplicatorPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -40,6 +41,8 @@ const EditReplicatorPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const formik = useFormik<ReplicatorFormValues>({
     initialValues: {

--- a/src/pages/images/panels/CreateImageRegistryPanel.tsx
+++ b/src/pages/images/panels/CreateImageRegistryPanel.tsx
@@ -19,6 +19,7 @@ import { ImageRegistryForm } from "../ImageRegistryForm";
 import { checkDuplicateName } from "util/helpers";
 import ImageRegistryRichChip from "../ImageRegistryRichChip";
 import type { LxdImageRegistry, LxdImageRegistryConfig } from "types/image";
+import { useEscCallback } from "context/useEscCallback";
 
 export const CreateImageRegistryPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -31,6 +32,8 @@ export const CreateImageRegistryPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const schema = Yup.object().shape({
     name: Yup.string()

--- a/src/pages/images/panels/EditImageRegistryPanel.tsx
+++ b/src/pages/images/panels/EditImageRegistryPanel.tsx
@@ -19,6 +19,7 @@ import { ImageRegistryForm } from "../ImageRegistryForm";
 import ImageRegistryRichChip from "../ImageRegistryRichChip";
 import type { LxdImageRegistry, LxdImageRegistryConfig } from "types/image";
 import { useImageRegistry } from "context/useImageRegistries";
+import { useEscCallback } from "context/useEscCallback";
 
 export const EditImageRegistryPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -35,6 +36,8 @@ export const EditImageRegistryPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const getPayload = () => {
     const isSimpleStreams = formik.values.protocol === "simplestreams";

--- a/src/pages/instances/InstanceDetailPanel.tsx
+++ b/src/pages/instances/InstanceDetailPanel.tsx
@@ -13,10 +13,13 @@ import InstanceStateActions from "pages/instances/actions/InstanceStateActions";
 import InstanceDetailPanelContent from "./InstanceDetailPanelContent";
 import { useInstance } from "context/useInstances";
 import DeleteInstanceBtn from "pages/instances/actions/DeleteInstanceBtn";
+import { useEscCallback } from "context/useEscCallback";
 
 const InstanceDetailPanel: FC = () => {
   const notify = useNotify();
   const panelParams = usePanelParams();
+
+  useEscCallback(panelParams.clear);
 
   const enable = panelParams.instance !== null;
   const {

--- a/src/pages/instances/MigrateInstanceModal.tsx
+++ b/src/pages/instances/MigrateInstanceModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC, type KeyboardEvent } from "react";
+import { useState, type FC } from "react";
 import { Modal } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
 import FormLink from "components/FormLink";
@@ -27,12 +27,6 @@ const MigrateInstanceModal: FC<Props> = ({ close, instance }) => {
     type,
     target,
   });
-
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
 
   const handleGoBack = () => {
     // if target is set, we are on the confirmation stage
@@ -68,7 +62,6 @@ const MigrateInstanceModal: FC<Props> = ({ close, instance }) => {
     <Modal
       close={close}
       className="migrate-instance-modal"
-      onKeyDown={handleEscKey}
       aria-labelledby="migrate-title"
     >
       <header className="p-modal__header">

--- a/src/pages/instances/TerminalPayloadForm.tsx
+++ b/src/pages/instances/TerminalPayloadForm.tsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useEffect,
-  useRef,
-  type FC,
-  type KeyboardEvent,
-} from "react";
+import { useState, useEffect, useRef, type FC } from "react";
 import {
   ActionButton,
   Button,
@@ -118,12 +112,6 @@ const TerminalPayloadForm: FC<Props> = ({
       });
   };
 
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
-
   const updateContentHeight = () => {
     updateMaxHeight("content-wrapper", "p-modal__footer", 64, "max-height");
   };
@@ -172,7 +160,6 @@ const TerminalPayloadForm: FC<Props> = ({
           </ActionButton>
         </>
       }
-      onKeyDown={handleEscKey}
     >
       {notification && (
         <Notification

--- a/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
+++ b/src/pages/instances/actions/snapshots/InstanceConfigureSnapshotModal.tsx
@@ -1,4 +1,4 @@
-import type { FC, KeyboardEvent, ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 import { ActionButton, Button, Modal } from "@canonical/react-components";
 import type { LxdInstance } from "types/instance";
 import { useFormik } from "formik";
@@ -65,12 +65,6 @@ const InstanceConfigureSnapshotModal: FC<Props> = ({
     },
   });
 
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
-
   return (
     <Modal
       close={close}
@@ -106,7 +100,6 @@ const InstanceConfigureSnapshotModal: FC<Props> = ({
           </>
         )
       }
-      onKeyDown={handleEscKey}
     >
       <InstanceSnapshotsForm formik={formik} />
     </Modal>

--- a/src/pages/networks/panels/CreateLoadBalancerPoolPanel.tsx
+++ b/src/pages/networks/panels/CreateLoadBalancerPoolPanel.tsx
@@ -20,6 +20,7 @@ import LoadBalancerPoolForm, {
   toLoadBalancerPool,
 } from "pages/networks/forms/LoadBalancerPoolForm";
 import { createLoadBalancerPool } from "api/load-balancer-pools";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   network: LxdNetwork;
@@ -47,6 +48,8 @@ const CreateLoadBalancerPoolPanel: FC<Props> = ({
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const handleSubmit = (values: LoadBalancerPoolFormValues) => {
     const pool = toLoadBalancerPool(values);

--- a/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/CreateLocalPeeringPanel.tsx
@@ -24,6 +24,7 @@ import NetworkRichChip from "../NetworkRichChip";
 import { ROOT_PATH } from "util/rootPath";
 import { useEventQueue } from "context/eventQueue";
 import ResourceLabel from "components/ResourceLabel";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   network: LxdNetwork;
@@ -37,10 +38,14 @@ const CreateLocalPeeringPanel: FC<Props> = ({ network }) => {
   const queryClient = useQueryClient();
   const controllerState = useState<AbortController | null>(null);
   const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
+
   const networkURL = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}`;
   const projectOtherLabel = "Manually enter project";
   const networkOtherLabel = "Manually enter network";

--- a/src/pages/networks/panels/EditLoadBalancerPoolPanel.tsx
+++ b/src/pages/networks/panels/EditLoadBalancerPoolPanel.tsx
@@ -24,6 +24,7 @@ import LoadBalancerPoolForm, {
 } from "pages/networks/forms/LoadBalancerPoolForm";
 import { useEventQueue } from "context/eventQueue";
 import { getHealthCheckType } from "util/loadBalancers";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   network: LxdNetwork;
@@ -51,6 +52,8 @@ const EditLoadBalancerPoolPanel: FC<Props> = ({ network }) => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const invalidateCache = () => {
     queryClient.invalidateQueries({

--- a/src/pages/networks/panels/EditLocalPeeringPanel.tsx
+++ b/src/pages/networks/panels/EditLocalPeeringPanel.tsx
@@ -22,6 +22,7 @@ import { useLocalPeering } from "context/useLocalPeerings";
 import { updateNetworkPeer } from "api/network-local-peering";
 import ResourceLink from "components/ResourceLink";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   network: LxdNetwork;
@@ -38,6 +39,9 @@ const EditLocalPeeringPanel: FC<Props> = ({ network }) => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
+
   const networkURL = `${ROOT_PATH}/ui/project/${encodeURIComponent(project ?? "")}/network/${encodeURIComponent(network.name)}`;
 
   const {

--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -19,8 +19,8 @@ import PageHeader from "components/PageHeader";
 import NotificationRow from "components/NotificationRow";
 import PermissionGroupExplanationTooltip from "pages/permissions/PermissionGroupExplanationTooltip";
 import GroupActions from "./actions/GroupActions";
-import CreateGroupPanel from "./panels/CreateGroupPanel";
-import EditGroupPanel from "./panels/EditGroupPanel";
+import CreateAuthGroupPanel from "./panels/CreateAuthGroupPanel";
+import EditAuthGroupPanel from "./panels/EditAuthGroupPanel";
 import PermissionGroupsFilter from "./PermissionGroupsFilter";
 import EditGroupIdentitiesBtn from "./actions/EditGroupIdentitiesBtn";
 import EditGroupIdentitiesPanel from "./panels/EditGroupIdentitiesPanel";
@@ -322,10 +322,10 @@ const PermissionGroups: FC = () => {
         <Row className="permission-groups">{content}</Row>
       </CustomLayout>
 
-      {panelParams.panel === panels.createGroup && <CreateGroupPanel />}
+      {panelParams.panel === panels.createGroup && <CreateAuthGroupPanel />}
 
       {panelParams.panel === panels.editGroup && panelGroup && (
-        <EditGroupPanel
+        <EditAuthGroupPanel
           group={panelGroup}
           onClose={() => {
             setSelectedGroupNames([]);

--- a/src/pages/permissions/panels/CreateAuthGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateAuthGroupPanel.tsx
@@ -30,8 +30,9 @@ import EditGroupPermissionsForm from "pages/permissions/panels/EditGroupPermissi
 import GroupHeaderTitle from "pages/permissions/panels/GroupHeaderTitle";
 import ResourceLink from "components/ResourceLink";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
-const CreateGroupPanel: FC = () => {
+const CreateAuthGroupPanel: FC = () => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -49,6 +50,16 @@ const CreateGroupPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  const handleEscKey = () => {
+    if (subForm) {
+      setSubForm(null);
+    } else {
+      closePanel();
+    }
+  };
+
+  useEscCallback(handleEscKey);
 
   const groupSchema = Yup.object().shape({
     name: Yup.string()
@@ -197,4 +208,4 @@ const CreateGroupPanel: FC = () => {
   );
 };
 
-export default CreateGroupPanel;
+export default CreateAuthGroupPanel;

--- a/src/pages/permissions/panels/CreateIdentityPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdentityPanel.tsx
@@ -33,6 +33,7 @@ import {
 } from "util/permissionIdentities";
 import type { IdentityFormValues } from "types/forms/identity";
 import { createClusterLink } from "api/cluster-links";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   onSuccess: (identity: IdentityFormValues, token: string) => void;
@@ -64,6 +65,16 @@ const CreateIdentityPanel: FC<Props> = ({ onSuccess }) => {
     panelParams.clear();
     notify.clear();
   };
+
+  const handleEscKey = () => {
+    if (currentStep === "typeSelection") {
+      closePanel();
+    } else {
+      setCurrentStep("typeSelection");
+    }
+  };
+
+  useEscCallback(handleEscKey);
 
   const onError = (e: unknown) => {
     formik.setSubmitting(false);

--- a/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/CreateIdpGroupPanel.tsx
@@ -21,6 +21,7 @@ import ResourceLink from "components/ResourceLink";
 import { useAuthGroups } from "context/useAuthGroups";
 import NameWithGroupForm from "../forms/NameWithGroupForm";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface GroupEditHistory {
   groupsAdded: Set<string>;
@@ -62,6 +63,8 @@ const CreateIdpGroupPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const saveIdpGroup = (values: IdpGroupFormValues) => {
     const newGroup = {

--- a/src/pages/permissions/panels/EditAuthGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditAuthGroupPanel.tsx
@@ -45,13 +45,14 @@ import { useImagesInAllProjects } from "context/useImages";
 import { useIdentities } from "context/useIdentities";
 import { useGroupEntitlements } from "util/entitlements/groups";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   group: LxdAuthGroup;
   onClose?: () => void;
 }
 
-const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
+const EditAuthGroupPanel: FC<Props> = ({ group, onClose }) => {
   const panelParams = usePanelParams();
   const notify = useNotify();
   const toastNotify = useToastNotification();
@@ -245,6 +246,16 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
     onClose?.();
   };
 
+  const handleEscKey = () => {
+    if (subForm) {
+      setSubForm(null);
+    } else {
+      closePanel();
+    }
+  };
+
+  useEscCallback(handleEscKey);
+
   const changeCount =
     identities.filter((i) => i.isAdded || i.isRemoved).length +
     permissions.filter((p) => p.isAdded || p.isRemoved).length +
@@ -355,4 +366,4 @@ const EditGroupPanel: FC<Props> = ({ group, onClose }) => {
   );
 };
 
-export default EditGroupPanel;
+export default EditAuthGroupPanel;

--- a/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
+++ b/src/pages/permissions/panels/EditGroupIdentitiesPanel.tsx
@@ -32,6 +32,7 @@ import {
   getIdentityIdsForGroup,
   getIdentityName,
 } from "util/permissionIdentities";
+import { useEscCallback } from "context/useEscCallback";
 
 interface IdentityEditHistory {
   identitiesAdded: Set<string>;
@@ -178,6 +179,8 @@ const EditGroupIdentitiesPanel: FC<Props> = ({ groups }) => {
     notify.clear();
     setConfirming(false);
   };
+
+  useEscCallback(closePanel);
 
   const closeModal = () => {
     notify.clear();

--- a/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
+++ b/src/pages/permissions/panels/EditIdentityGroupsPanel.tsx
@@ -9,6 +9,7 @@ import NotificationRow from "components/NotificationRow";
 import GroupSelection from "./GroupSelection";
 import GroupSelectionActions from "../actions/GroupSelectionActions";
 import { useAuthGroups } from "context/useAuthGroups";
+import { useEscCallback } from "context/useEscCallback";
 
 interface GroupEditHistory {
   groupsAdded: Set<string>;
@@ -142,6 +143,8 @@ const EditIdentityGroupsPanel: FC<Props> = ({ identities, onClose }) => {
     setConfirming(false);
     onClose();
   };
+
+  useEscCallback(closePanel);
 
   const closeModal = () => {
     notify.clear();

--- a/src/pages/permissions/panels/EditIdentityPanel.tsx
+++ b/src/pages/permissions/panels/EditIdentityPanel.tsx
@@ -23,6 +23,7 @@ import { type IdentityGroupChanges } from "./EditIdentityGroupsSection";
 import EditIdentityPanelContent from "./EditIdentityPanelContent";
 import GroupSelectionActions from "../actions/GroupSelectionActions";
 import type { LxdIdentity } from "types/permissions";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   identity: LxdIdentity;
@@ -64,6 +65,8 @@ const EditIdentityPanel: FC<Props> = ({ identity, onClose }) => {
     setModifiedGroups(new Set());
     onClose();
   };
+
+  useEscCallback(closePanel);
 
   const canEdit = canEditIdentity(identity);
   const addedGroups = pendingGroupChanges?.addedGroups ?? new Set<string>();

--- a/src/pages/permissions/panels/EditIdpGroupPanel.tsx
+++ b/src/pages/permissions/panels/EditIdpGroupPanel.tsx
@@ -21,6 +21,7 @@ import GroupSelectionActions from "../actions/GroupSelectionActions";
 import ResourceLink from "components/ResourceLink";
 import { useAuthGroups } from "context/useAuthGroups";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface GroupEditHistory {
   groupsAdded: Set<string>;
@@ -123,6 +124,8 @@ const EditIdpGroupPanel: FC<Props> = ({ idpGroup, onClose }) => {
     notify.clear();
     onClose?.();
   };
+
+  useEscCallback(closePanel);
 
   const saveIdpGroup = (values: IdpGroupFormValues) => {
     const newGroupMappings = new Set(idpGroup.groups);

--- a/src/pages/placement-groups/panels/CreatePlacementGroupPanel.tsx
+++ b/src/pages/placement-groups/panels/CreatePlacementGroupPanel.tsx
@@ -23,6 +23,7 @@ import PlacementGroupForm, {
 import ResourceLink from "components/ResourceLink";
 import { checkDuplicateName } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 const CreatePlacementGroupPanel: FC = () => {
   const controllerState = useState<AbortController | null>(null);
@@ -36,6 +37,8 @@ const CreatePlacementGroupPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const schema = Yup.object().shape({
     name: Yup.string()

--- a/src/pages/placement-groups/panels/EditPlacementGroupPanel.tsx
+++ b/src/pages/placement-groups/panels/EditPlacementGroupPanel.tsx
@@ -22,6 +22,7 @@ import type { LxdPlacementGroup } from "types/placementGroup";
 import ResourceLink from "components/ResourceLink";
 import PlacementGroupUsedBy from "pages/placement-groups/PlacementGroupUsedBy";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 const EditPlacementGroupPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -39,6 +40,8 @@ const EditPlacementGroupPanel: FC = () => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const schema = Yup.object().shape({
     name: Yup.string().required("Placement group name is required"),

--- a/src/pages/profiles/ProfileDetailPanel.tsx
+++ b/src/pages/profiles/ProfileDetailPanel.tsx
@@ -9,10 +9,13 @@ import {
 } from "@canonical/react-components";
 import ProfileDetailPanelContent from "./ProfileDetailPanelContent";
 import { useProfile } from "context/useProfiles";
+import { useEscCallback } from "context/useEscCallback";
 
 const ProfileDetailPanel: FC = () => {
   const notify = useNotify();
   const panelParams = usePanelParams();
+
+  useEscCallback(panelParams.clear);
 
   const profileName = panelParams.profile;
   const projectName = panelParams.project;

--- a/src/pages/storage/AttachDiskDeviceModal.tsx
+++ b/src/pages/storage/AttachDiskDeviceModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC, type KeyboardEvent } from "react";
+import { useState, type FC } from "react";
 import { Modal } from "@canonical/react-components";
 import FormLink from "components/FormLink";
 import BackLink from "components/BackLink";
@@ -29,12 +29,6 @@ const AttachDiskDeviceModal: FC<Props> = ({
   onFinish,
 }) => {
   const [type, setType] = useState<DiskDeviceType>("choose type");
-
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
 
   const handleGoBack = () => {
     setType("choose type");
@@ -96,7 +90,6 @@ const AttachDiskDeviceModal: FC<Props> = ({
           close={close}
           className="migrate-instance-modal"
           title={modalTitle}
-          onKeyDown={handleEscKey}
         >
           <div className="choose-migration-type">
             <FormLink

--- a/src/pages/storage/MigrateVolumeModal.tsx
+++ b/src/pages/storage/MigrateVolumeModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC, type KeyboardEvent, type ReactNode } from "react";
+import { useState, type FC, type ReactNode } from "react";
 import { Modal } from "@canonical/react-components";
 import type { LxdStorageVolume } from "types/storage";
 import FormLink from "components/FormLink";
@@ -30,12 +30,6 @@ const MigrateVolumeModal: FC<Props> = ({ close, volume }) => {
     type,
     target,
   });
-
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
 
   const handleGoBack = () => {
     // if target is set, we are on the confirmation stage
@@ -77,11 +71,7 @@ const MigrateVolumeModal: FC<Props> = ({ close, volume }) => {
   };
 
   return (
-    <Modal
-      close={close}
-      className="migrate-instance-modal"
-      onKeyDown={handleEscKey}
-    >
+    <Modal close={close} className="migrate-instance-modal">
       <header className="p-modal__header">
         <h2
           className="p-modal__title"

--- a/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
+++ b/src/pages/storage/actions/snapshots/VolumeConfigureSnapshotModal.tsx
@@ -1,4 +1,4 @@
-import type { FC, KeyboardEvent } from "react";
+import type { FC } from "react";
 import {
   ActionButton,
   Button,
@@ -80,12 +80,6 @@ const VolumeConfigureSnapshotModal: FC<Props> = ({ volume, close }) => {
     },
   });
 
-  const handleEscKey = (e: KeyboardEvent<HTMLElement>) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
-
   return (
     <Modal
       close={close}
@@ -121,7 +115,6 @@ const VolumeConfigureSnapshotModal: FC<Props> = ({ volume, close }) => {
           </>
         )
       }
-      onKeyDown={handleEscKey}
     >
       <StorageVolumeFormSnapshots formik={formik} />
     </Modal>

--- a/src/pages/storage/forms/StorageBucketKeyForm.tsx
+++ b/src/pages/storage/forms/StorageBucketKeyForm.tsx
@@ -82,12 +82,22 @@ const StorageBucketKeyForm: FC<Props> = ({ formik, bucket }) => {
         label="Access Key"
         disabled={!!bucketEditRestriction}
         title={bucketEditRestriction}
+        help={
+          isEditing
+            ? undefined
+            : "Leave empty to generate an access key automatically."
+        }
       />
       <PasswordToggle
         {...getFormProps("secret-key")}
         label="Secret Key"
         disabled={!!bucketEditRestriction}
         title={bucketEditRestriction}
+        help={
+          isEditing
+            ? undefined
+            : "Leave empty to generate a secret key automatically."
+        }
       />
     </Form>
   );

--- a/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketKeyPanel.tsx
@@ -25,6 +25,7 @@ import {
 } from "util/storageBucket";
 import { useCurrentProject } from "context/useCurrentProject";
 import ResourceLabel from "components/ResourceLabel";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -43,6 +44,9 @@ const CreateStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
+
   const bucketURL = getStorageBucketURL(
     bucket.name,
     bucket.pool,

--- a/src/pages/storage/panels/CreateStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/CreateStorageBucketPanel.tsx
@@ -23,6 +23,7 @@ import {
   getStorageBucketURL,
   testDuplicateStorageBucketName,
 } from "util/storageBucket";
+import { useEscCallback } from "context/useEscCallback";
 
 const CreateStorageBucketPanel: FC = () => {
   const panelParams = usePanelParams();
@@ -30,11 +31,14 @@ const CreateStorageBucketPanel: FC = () => {
   const toastNotify = useToastNotification();
   const controllerState = useState<AbortController | null>(null);
   const queryClient = useQueryClient();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
-  const eventQueue = useEventQueue();
+
+  useEscCallback(closePanel);
 
   const bucketSchema = Yup.object().shape({
     name: Yup.string()

--- a/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketKeyPanel.tsx
@@ -22,6 +22,7 @@ import { useEventQueue } from "context/eventQueue";
 import { useBucketKey } from "context/useBuckets";
 import StorageBucketKeyForm from "../forms/StorageBucketKeyForm";
 import { getStorageBucketURL } from "util/storageBucket";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -38,6 +39,8 @@ const EditStorageBucketKeyPanel: FC<Props> = ({ bucket }) => {
     panelParams.clear();
     notify.clear();
   };
+
+  useEscCallback(closePanel);
 
   const bucketURL = getStorageBucketURL(bucket.name, bucket.pool, project);
 

--- a/src/pages/storage/panels/EditStorageBucketPanel.tsx
+++ b/src/pages/storage/panels/EditStorageBucketPanel.tsx
@@ -21,6 +21,7 @@ import { pluralize } from "util/helpers";
 import { useEventQueue } from "context/eventQueue";
 import { useCurrentProject } from "context/useCurrentProject";
 import { ROOT_PATH } from "util/rootPath";
+import { useEscCallback } from "context/useEscCallback";
 
 interface Props {
   bucket: LxdStorageBucket;
@@ -31,11 +32,14 @@ const EditStorageBucketPanel: FC<Props> = ({ bucket }) => {
   const toastNotify = useToastNotification();
   const { project } = useCurrentProject();
   const queryClient = useQueryClient();
+  const eventQueue = useEventQueue();
+
   const closePanel = () => {
     panelParams.clear();
     notify.clear();
   };
-  const eventQueue = useEventQueue();
+
+  useEscCallback(closePanel);
 
   const invalidateCache = () => {
     queryClient.invalidateQueries({


### PR DESCRIPTION
## Done

- Close any panel on ESC key press
- Cleanup custom modal ESC handlers and rely on the one upstream in react-components

Fixes WD-38408

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
- Check ESC key press on any side panel and modal you can find. Ensure panels go back one step on nested panels and close on the first step. Modals should always close on ESC key press.