### PR TITLE
fix(warnings) ensure side navigation activates on warning page

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -623,6 +623,7 @@ const Navigation: FC = () => {
                             to={`${ROOT_PATH}/ui/warnings?status=new`}
                             title="Warnings"
                             onClick={softToggleMenu}
+                            activeUrlMatches={[`${ROOT_PATH}/ui/warnings`]}
                           >
                             <Icon
                               className="is-light p-side-navigation__icon"


### PR DESCRIPTION
## Done

- fix(warnings) ensure side navigation activates on warning page

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open warnings page, ensure side navigation for it is active.
    - change filters on warnings page, ensure side nave stays active after and also on reload of the page with custom filters

## Screenshots

<img width="3840" height="1916" alt="image" src="https://github.com/user-attachments/assets/e5cb8257-d555-49b3-8c35-5bd14135ecc1" />