### PR TITLE
feat(identities): explain identities types in the list page

### DIFF
--- a/src/pages/permissions/IdentityTypeChip.tsx
+++ b/src/pages/permissions/IdentityTypeChip.tsx
@@ -1,0 +1,67 @@
+import type { FC } from "react";
+import classnames from "classnames";
+import { Tooltip } from "@canonical/react-components";
+import type { LxdIdentity } from "types/permissions";
+import { IDENTITY_TYPE_HELP_TEXT } from "util/permissionIdentities";
+
+interface Props {
+  identity: LxdIdentity;
+  className?: string;
+}
+
+const getIdentityType = (identity: LxdIdentity): string => {
+  return `${identity.authentication_method.toUpperCase()} - ${identity.type}`;
+};
+
+// Identity types can carry a suffix (e.g. "(pending)"), match against the known base types
+const getHelpText = (type: LxdIdentity["type"]) => {
+  const baseType = (
+    Object.keys(IDENTITY_TYPE_HELP_TEXT) as Array<
+      keyof typeof IDENTITY_TYPE_HELP_TEXT
+    >
+  ).find((value) => type.startsWith(value));
+  return baseType ? IDENTITY_TYPE_HELP_TEXT[baseType] : undefined;
+};
+
+const IdentityTypeChip: FC<Props> = ({ identity, className }) => {
+  const helpText = getHelpText(identity.type);
+  const identityType = getIdentityType(identity);
+
+  const chip = (
+    <span
+      className={classnames("p-chip is-dense is-inline", className)}
+      tabIndex={helpText ? 0 : undefined}
+    >
+      <span className="p-chip__value u-truncate">{identity.type}</span>
+    </span>
+  );
+
+  if (!helpText) {
+    return chip;
+  }
+
+  return (
+    <Tooltip
+      zIndex={1000}
+      position="right"
+      positionElementClassName="identity-type-chip-tooltip-wrapper"
+      tooltipClassName="identity-type-chip-tooltip"
+      message={
+        <>
+          <div className="p-text--small-caps u-text--muted u-no-margin--bottom">
+            Type
+          </div>
+          <div className="identity-type-chip-tooltip-title u-no-margin--top">
+            {identityType}
+          </div>
+          <div className="p-text--small-caps u-text--muted">Description</div>
+          <div>{helpText.description}</div>
+        </>
+      }
+    >
+      {chip}
+    </Tooltip>
+  );
+};
+
+export default IdentityTypeChip;

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -43,6 +43,7 @@ import PermissionIdentitiesActions from "pages/permissions/PermissionIdentitiesA
 import ResourceLabel from "components/ResourceLabel";
 import IdentityExpiration from "pages/permissions/IdentityExpiration";
 import IdentityAdditionalIdpGroups from "pages/permissions/IdentityAdditionalIdpGroups";
+import IdentityTypeChip from "pages/permissions/IdentityTypeChip";
 
 const PermissionIdentities: FC = () => {
   const notify = useNotify();
@@ -72,9 +73,12 @@ const PermissionIdentities: FC = () => {
   const headers = [
     { content: "Name", className: "name", sortKey: "name" },
     { content: "ID", sortKey: "id", className: "identity-id" },
-    { content: "Auth method", sortKey: "authmethod", className: "auth-method" },
-    { content: "Type", sortKey: "type", className: "identity-type" },
     { content: "Expires", sortKey: "expires", className: "expires" },
+    {
+      content: "Type",
+      sortKey: "type",
+      className: "type",
+    },
     {
       content: "Groups",
       sortKey: "groups",
@@ -177,21 +181,16 @@ const PermissionIdentities: FC = () => {
           title: identity.id,
         },
         {
-          content: identity.authentication_method.toUpperCase(),
-          role: "cell",
-          "aria-label": "Auth method",
-          className: "auth-method",
-        },
-        {
-          content: identity.type,
-          role: "cell",
-          "aria-label": "Type",
-          className: "u-truncate identity-type",
-        },
-        {
           content: <IdentityExpiration identity={identity} />,
           role: "cell",
           "aria-label": "Expires",
+          className: "expires",
+        },
+        {
+          content: <IdentityTypeChip identity={identity} />,
+          role: "cell",
+          "aria-label": "Type",
+          className: "type",
         },
         {
           content: getGroupLink(),
@@ -222,7 +221,7 @@ const PermissionIdentities: FC = () => {
               <DeleteIdentityBtn identity={identity} />
             </>
           ),
-          className: "actions u-align--right",
+          className: "u-align--right actions",
           role: "cell",
           "aria-label": "Actions",
         },
@@ -230,8 +229,7 @@ const PermissionIdentities: FC = () => {
       sortData: {
         id: identity.id,
         name: name.toLowerCase(),
-        authentication_method: identity.authentication_method,
-        type: identity.type,
+        type: identity.type.toLowerCase(),
         expires: identity.expires_at ?? "",
         groups: identity.groups?.length || 0,
       },

--- a/src/pages/permissions/panels/EditIdentityPanelContent.tsx
+++ b/src/pages/permissions/panels/EditIdentityPanelContent.tsx
@@ -37,11 +37,7 @@ const EditIdentityPanelContent: FC<Props> = ({
         value={getIdentityName(identity)}
       />
       <OutputField id="identity-id" label="ID" value={identity.id} />
-      <OutputField
-        id="identity-auth-method-type"
-        label="Auth method"
-        value={`${identity.authentication_method.toUpperCase()} - ${identity.type}`}
-      />
+      <OutputField id="identity-type" label="Type" value={identity.type} />
       {isBearer && (
         <div className="u-flex u-gap--small">
           <OutputField

--- a/src/sass/_permission_identities.scss
+++ b/src/sass/_permission_identities.scss
@@ -4,24 +4,29 @@
   margin-left: 0.8rem;
 }
 
+.identity-type-chip-tooltip .p-tooltip__message {
+  white-space: normal;
+  width: 18rem;
+}
+
+.identity-type-chip-tooltip-title {
+  border-bottom: $border-thin;
+  margin-bottom: $spv--small;
+  padding-bottom: $spv--small;
+}
+
+.identity-type-chip-tooltip-wrapper {
+  width: 100%;
+}
+
 .permission-identities-list {
   .permission-identities-table {
-    .auth-method {
-      width: 8rem;
-    }
-
     .group-count {
       width: 6rem;
     }
 
     .actions {
       width: 8.5rem;
-    }
-
-    @media screen and (width < 1300px) {
-      .auth-method {
-        display: none;
-      }
     }
 
     @media screen and (width < 1000px) {
@@ -31,8 +36,7 @@
     }
 
     @media screen and (width < 900px) {
-      .select,
-      .identity-type {
+      .select {
         display: none;
       }
     }

--- a/src/types/permissions.d.ts
+++ b/src/types/permissions.d.ts
@@ -11,6 +11,7 @@ export interface LxdIdentity {
     | "Metrics certificate (unrestricted)"
     | "OIDC client"
     | "Client token bearer"
+    | "Initial UI token bearer"
     | "Server certificate"
     | "DevLXD token bearer";
   name: string;

--- a/src/util/permissionIdentities.tsx
+++ b/src/util/permissionIdentities.tsx
@@ -238,10 +238,14 @@ export const isBearerIdentityType = (
   return identityType.toLowerCase().includes("token bearer");
 };
 
-export const IDENTITY_TYPE_HELP_TEXT: Record<
-  IdentityType,
-  { title: string; description: ReactNode }
-> = {
+// Identity-type strings that can carry help text but are not part of IdentityType
+type AdditionalIdentityType =
+  | "Initial UI token bearer"
+  | "OIDC client"
+  | "Server certificate"
+  | "Metrics certificate";
+
+export const IDENTITY_TYPE_HELP_TEXT = {
   [IDENTITY_TYPE.TLS]: {
     title: "Client certificate",
     description:
@@ -251,6 +255,11 @@ export const IDENTITY_TYPE_HELP_TEXT: Record<
     title: "Client token bearer",
     description:
       "An API key for external automation tools, integrations, or remote scripts interacting with LXD over the network.",
+  },
+  "Initial UI token bearer": {
+    title: "Initial UI token bearer",
+    description:
+      "A short-lived bearer token that provides initial access to the LXD web UI.",
   },
   [IDENTITY_TYPE.BEARER_DEVLXD]: {
     title: "DevLXD token bearer",
@@ -271,7 +280,25 @@ export const IDENTITY_TYPE_HELP_TEXT: Record<
       </>
     ),
   },
-};
+  "OIDC client": {
+    title: "OIDC client",
+    description:
+      "An identity authenticated through the configured OpenID Connect identity provider.",
+  },
+  "Server certificate": {
+    title: "Server certificate",
+    description:
+      "A TLS certificate used to encrypt network traffic and verify a server's identity.",
+  },
+  "Metrics certificate": {
+    title: "Metrics certificate",
+    description:
+      "A certificate used by a monitoring system to access LXD metrics.",
+  },
+} satisfies Record<
+  IdentityType | AdditionalIdentityType,
+  { title: string; description: ReactNode }
+>;
 
 export const IDENTITY_MODAL_TEXT: Record<
   IdentityType,

--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -116,26 +116,34 @@ export const createIdentity = async (
   await expect(identityRow).toContainText(identityType);
 };
 
-export const deleteIdentity = async (page: Page, name: string) => {
+export const deleteIdentity = async (
+  page: Page,
+  name: string,
+  identityType: IdentityType,
+) => {
   await visitIdentities(page);
   const row = page.getByRole("row").filter({ hasText: name });
 
-  const identityType = (
-    await row.getByRole("cell", { name: "Type", exact: true }).textContent()
-  )?.trim();
   const identityId = (
     await row.getByRole("cell", { name: "ID", exact: true }).textContent()
   )?.trim();
 
-  expect(identityType).toBeTruthy();
   expect(identityId).toBeTruthy();
+
+  // Read the type as displayed in the row, since pending identities carry a
+  // "(pending)" suffix (e.g. "Client certificate (pending)") that must match
+  // the raw type rendered in the deletion toast.
+  const displayedType =
+    (
+      await row.getByRole("cell", { name: "Type", exact: true }).textContent()
+    )?.trim() || identityType;
 
   await row.getByRole("button", { name: "Delete identity" }).click();
   await page.getByRole("button", { name: "Delete", exact: true }).click();
 
   await dismissNotification(
     page,
-    `Identity ${name} (${identityType}, ${identityId}) deleted.`,
+    `Identity ${name} (${displayedType}, ${identityId}) deleted.`,
   );
   await expect(row).not.toBeVisible();
 };

--- a/tests/permission-identities.spec.ts
+++ b/tests/permission-identities.spec.ts
@@ -156,13 +156,13 @@ test("reissue a new token for bearer identity", async ({ page }) => {
   expect(reissuedToken).not.toEqual(initialToken);
 
   await page.getByRole("button", { name: "Cancel" }).click();
-  await deleteIdentity(page, identity);
+  await deleteIdentity(page, identity, IDENTITY_TYPE.BEARER_CLIENT);
 });
 
 test("create and delete TLS identity", async ({ page }) => {
   const tlsName = randomIdentityName();
   await createIdentity(page, tlsName, IDENTITY_TYPE.TLS);
-  await deleteIdentity(page, tlsName);
+  await deleteIdentity(page, tlsName, IDENTITY_TYPE.TLS);
 });
 
 test("create and delete token bearer identities", async ({
@@ -188,7 +188,7 @@ test("create and delete token bearer identities", async ({
   );
   await createIdentity(page, clusterLinkName, IDENTITY_TYPE.CLUSTER_LINK);
 
-  await deleteIdentity(page, bearerClientName);
-  await deleteIdentity(page, bearerDevlxdName);
-  await deleteIdentity(page, clusterLinkName);
+  await deleteIdentity(page, bearerClientName, IDENTITY_TYPE.BEARER_CLIENT);
+  await deleteIdentity(page, bearerDevlxdName, IDENTITY_TYPE.BEARER_DEVLXD);
+  await deleteIdentity(page, clusterLinkName, IDENTITY_TYPE.CLUSTER_LINK);
 });


### PR DESCRIPTION
## Done

- explain identities types in the list page WD-37735

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions -> Identities.
    - Hover over an identity type to see the explanations

## Screenshots
<img width="1904" height="990" alt="image" src="https://github.com/user-attachments/assets/a8e3003e-967d-4ce4-b410-4ec278766e54" />