### PR TITLE
feat(identities) show effective groups for all identities

### DIFF
--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -16,7 +16,7 @@ export const fetchIdentities = async (
   isFineGrained: boolean | null,
 ): Promise<LxdIdentity[]> => {
   const params = new URLSearchParams();
-  params.set("recursion", "1");
+  params.set("recursion", "2");
   addEntitlements(params, isFineGrained, identitiesEntitlements);
 
   return fetch(`${ROOT_PATH}/1.0/auth/identities?${params.toString()}`)

--- a/src/pages/permissions/IdentityAdditionalIdpGroups.tsx
+++ b/src/pages/permissions/IdentityAdditionalIdpGroups.tsx
@@ -1,7 +1,5 @@
 import { List, Tooltip } from "@canonical/react-components";
 import { type FC } from "react";
-import { useSettings } from "context/useSettings";
-import { useAuth } from "context/auth";
 import type { LxdIdentity } from "types/permissions";
 import { pluralize } from "util/helpers";
 
@@ -10,16 +8,12 @@ interface Props {
 }
 
 const IdentityAdditionalIdpGroups: FC<Props> = ({ identity }) => {
-  const { effectiveGroups: loggedInIdentityEffectiveGroups } = useAuth();
-  const { data: settings } = useSettings();
-  const isLoggedInIdentity = settings?.auth_user_name === identity.id;
-
-  if (!isLoggedInIdentity || !loggedInIdentityEffectiveGroups) {
+  if (!identity.effective_groups) {
     return null;
   }
 
   const existingGroups = new Set(identity.groups ?? []);
-  const additionalIdpGroups = loggedInIdentityEffectiveGroups.filter(
+  const additionalIdpGroups = identity.effective_groups.filter(
     (g) => !existingGroups.has(g),
   );
 


### PR DESCRIPTION
## Done

- feat(identities) show effective groups for all identities

**Draft as it is pending on https://github.com/canonical/lxd/pull/18855 to land first**

Enabled by https://github.com/canonical/lxd/pull/18855
Fixes https://github.com/canonical/lxd-ui/issues/2191
Fixes https://warthogs.atlassian.net/browse/WD-38468

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Have an OIDC setup with IDP group mapping in place, login with an identity that receives permission via IDP group mapping
    - Open identity list with another identity
    - Ensure the OIDC identity is showing +n in the identity list and reveals the mapped groups correctly.

## Screenshots

<img width="3834" height="1922" alt="image" src="https://github.com/user-attachments/assets/dfc7b955-3f57-4da5-838e-c79a461b7c6a" />
