### PR TITLE
fix(identity) load current identity only once for the side navigation

### DIFF
--- a/src/api/auth-identities.tsx
+++ b/src/api/auth-identities.tsx
@@ -35,24 +35,6 @@ export const fetchCurrentIdentity = async (): Promise<LxdIdentity> => {
     });
 };
 
-export const fetchIdentity = async (
-  id: string,
-  authMethod: string,
-  isFineGrained: boolean | null,
-): Promise<LxdIdentity> => {
-  const params = new URLSearchParams();
-  params.set("recursion", "1");
-  addEntitlements(params, isFineGrained, identitiesEntitlements);
-
-  return fetch(
-    `${ROOT_PATH}/1.0/auth/identities/${encodeURIComponent(authMethod)}/${encodeURIComponent(id)}?${params.toString()}`,
-  )
-    .then(handleResponse)
-    .then((data: LxdApiResponse<LxdIdentity>) => {
-      return data.metadata;
-    });
-};
-
 export const updateIdentity = async (identity: LxdIdentity): Promise<void> => {
   await fetch(
     `${ROOT_PATH}/1.0/auth/identities/${encodeURIComponent(identity.authentication_method)}/${encodeURIComponent(identity.id)}`,

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -7,6 +7,7 @@ import { fetchCurrentIdentity } from "api/auth-identities";
 import { useSupportedFeatures } from "./useSupportedFeatures";
 import { getLoginProject } from "util/loginProject";
 import { AUTH_METHOD, type LXDAuthMethod } from "util/authentication";
+import type { LxdIdentity } from "types/permissions";
 
 interface ContextProps {
   isAuthenticated: boolean;
@@ -20,6 +21,7 @@ interface ContextProps {
   authMethod: LXDAuthMethod | null;
   authExpiresAt: string | null;
   effectiveGroups: string[] | null;
+  currentIdentity: LxdIdentity | null;
 }
 
 const initialState: ContextProps = {
@@ -34,6 +36,7 @@ const initialState: ContextProps = {
   authMethod: null,
   authExpiresAt: null,
   effectiveGroups: null,
+  currentIdentity: null,
 };
 
 export const AuthContext = createContext<ContextProps>(initialState);
@@ -116,6 +119,7 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
         authMethod,
         authExpiresAt: currentIdentity?.expires_at ?? null,
         effectiveGroups: currentIdentity?.effective_groups ?? null,
+        currentIdentity: currentIdentity ?? null,
       }}
     >
       {children}

--- a/src/context/useIdentities.tsx
+++ b/src/context/useIdentities.tsx
@@ -2,7 +2,7 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import { useAuth } from "./auth";
 import type { LxdIdentity } from "types/permissions";
-import { fetchIdentities, fetchIdentity } from "api/auth-identities";
+import { fetchIdentities } from "api/auth-identities";
 
 export const useIdentities = (): UseQueryResult<LxdIdentity[]> => {
   const { isFineGrained } = useAuth();
@@ -10,18 +10,5 @@ export const useIdentities = (): UseQueryResult<LxdIdentity[]> => {
     queryKey: [queryKeys.identities],
     queryFn: async () => fetchIdentities(isFineGrained),
     enabled: isFineGrained !== null,
-  });
-};
-
-export const useIdentity = (
-  id: string,
-  authMethod: string,
-  enabled?: boolean,
-): UseQueryResult<LxdIdentity> => {
-  const { isFineGrained } = useAuth();
-  return useQuery({
-    queryKey: [queryKeys.identities, authMethod, id],
-    queryFn: async () => fetchIdentity(id, authMethod, isFineGrained),
-    enabled: (enabled ?? true) && isFineGrained !== null,
   });
 };

--- a/src/context/useLoggedInUser.tsx
+++ b/src/context/useLoggedInUser.tsx
@@ -1,26 +1,19 @@
 import { useSettings } from "./useSettings";
-import { useIdentity } from "./useIdentities";
 import { getIdentityName } from "util/permissionIdentities";
 import { AUTH_METHOD } from "util/authentication";
 import { useAuth } from "context/auth";
 
 export const useLoggedInUser = () => {
   const { data: settings } = useSettings();
-  const { authMethod } = useAuth();
+  const { authMethod, currentIdentity } = useAuth();
 
   const id = settings?.auth_user_name || "";
 
-  const identityQueryEnabled =
-    !!id && !!authMethod && authMethod !== AUTH_METHOD.UNIX;
-  const { data: identity } = useIdentity(
-    id,
-    authMethod || "",
-    identityQueryEnabled,
-  );
-
   return {
     loggedInUserName:
-      authMethod === AUTH_METHOD.UNIX ? id : getIdentityName(identity),
+      authMethod === AUTH_METHOD.UNIX || !currentIdentity
+        ? id
+        : getIdentityName(currentIdentity),
     loggedInUserID: id,
   };
 };


### PR DESCRIPTION
## Done

- fix(identity) load current identity only once for the side navigation

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - load the ui, ensure the current identity is loaded via `1.0/auth/identities/current`, but not a second time via `/1.0/identies/:protocol/:name`. Check in the dev tools network tab