### PR TITLE
feat(Network ETs): [WD-38183] Add Network ETs to tab pages.

### DIFF
--- a/src/components/InlineExplanation.tsx
+++ b/src/components/InlineExplanation.tsx
@@ -1,0 +1,23 @@
+import type { FC } from "react";
+import DocLink from "components/DocLink";
+
+interface Props {
+  explanation: string;
+  docPath: string;
+  docLabel: string;
+}
+
+const InlineExplanation: FC<Props> = ({ explanation, docPath, docLabel }) => {
+  return (
+    <>
+      <p className="p-text--small u-text--muted">{explanation}</p>
+      <p className="p-text--small">
+        <DocLink docPath={docPath} hasExternalIcon>
+          {docLabel}
+        </DocLink>
+      </p>
+    </>
+  );
+};
+
+export default InlineExplanation;

--- a/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
@@ -6,7 +6,7 @@ const ClusterGroupExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
-      explanation="Cluster groups organise cluster members for instance placement."
+      explanation="Cluster groups organize cluster members for instance placement."
       docPath="/explanation/clustering/#cluster-groups"
       docLabel="Learn more about cluster groups"
     >

--- a/src/pages/networks/LoadBalancerPoolExplanationTooltip.tsx
+++ b/src/pages/networks/LoadBalancerPoolExplanationTooltip.tsx
@@ -1,0 +1,18 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const LoadBalancerPoolExplanationTooltip: FC<{
+  children?: ReactNode;
+}> = ({ children }) => {
+  return (
+    <ExplanationTooltip
+      explanation="Load balancer pools group instances to process incoming traffic distributed by load balancers."
+      docPath="/howto/network_load_balancers/#configure-pools"
+      docLabel="Learn more about load balancer pools"
+    >
+      {children}
+    </ExplanationTooltip>
+  );
+};
+
+export default LoadBalancerPoolExplanationTooltip;

--- a/src/pages/networks/LoadBalancerPoolsTab.tsx
+++ b/src/pages/networks/LoadBalancerPoolsTab.tsx
@@ -7,6 +7,7 @@ import { useCurrentProject } from "context/useCurrentProject";
 import LoadBalancerPoolsTable from "pages/networks/LoadBalancerPoolsTable";
 import CreateLoadBalancerPoolBtn from "pages/networks/actions/CreateLoadBalancerPoolBtn";
 import LoadBalancerTableHeading from "pages/networks/LoadBalancerTableHeading";
+import LoadBalancerPoolExplanationTooltip from "pages/networks/LoadBalancerPoolExplanationTooltip";
 
 interface Props {
   network: LxdNetwork;
@@ -35,6 +36,10 @@ const LoadBalancerPoolsTab: FC<Props> = ({ network }) => {
         title="No load balancer pools found"
       >
         <p>There are no load balancer pools in this network.</p>
+        <p className="u-no-margin--bottom">
+          Load balancer pools group instances to process incoming traffic
+          distributed by load balancers.
+        </p>
         <p>
           <DocLink docPath="/howto/network_load_balancers/" hasExternalIcon>
             Learn more about load balancer pools
@@ -43,6 +48,7 @@ const LoadBalancerPoolsTab: FC<Props> = ({ network }) => {
         <CreateLoadBalancerPoolBtn
           network={network}
           className="empty-state-button"
+          isEmptyState
         />
       </EmptyState>
     );
@@ -50,7 +56,13 @@ const LoadBalancerPoolsTab: FC<Props> = ({ network }) => {
 
   return (
     <Row className="content">
-      <LoadBalancerTableHeading title="Load balancer pools">
+      <LoadBalancerTableHeading
+        title={
+          <LoadBalancerPoolExplanationTooltip>
+            Load balancer pools
+          </LoadBalancerPoolExplanationTooltip>
+        }
+      >
         <CreateLoadBalancerPoolBtn
           network={network}
           className="u-float-right"

--- a/src/pages/networks/LoadBalancerTableHeading.tsx
+++ b/src/pages/networks/LoadBalancerTableHeading.tsx
@@ -1,8 +1,8 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 
 interface Props {
-  title: string;
-  children: React.ReactNode;
+  title: ReactNode;
+  children: ReactNode;
 }
 
 const LoadBalancerTableHeading: FC<Props> = ({ title, children }) => {

--- a/src/pages/networks/LoadBalancersTab.tsx
+++ b/src/pages/networks/LoadBalancersTab.tsx
@@ -15,6 +15,7 @@ import LoadBalancersTable from "pages/networks/LoadBalancersTable";
 import LoadBalancerTableHeading from "pages/networks/LoadBalancerTableHeading";
 import CreateLoadBalancerPoolBtn from "pages/networks/actions/CreateLoadBalancerPoolBtn";
 import { useLoadBalancerPools } from "context/useLoadBalancerPools";
+import LoadBalancerExplanationTooltip from "pages/networks/LoadBalancerExplanationTooltip";
 
 interface Props {
   network: LxdNetwork;
@@ -59,6 +60,10 @@ const LoadBalancersTab: FC<Props> = ({ network }) => {
             </p>
           </>
         )}
+        <p className="u-no-margin--bottom">
+          Load balancers distribute services running on instances across
+          networks.
+        </p>
         <p>
           <DocLink docPath="/howto/network_load_balancers/" hasExternalIcon>
             Learn more about load balancers
@@ -68,31 +73,34 @@ const LoadBalancersTab: FC<Props> = ({ network }) => {
           network={network}
           appearance="positive"
           className="empty-state-button"
+          isEmptyState
         />
-        <CreateLoadBalancerPoolBtn network={network} appearance="" />
+        <CreateLoadBalancerPoolBtn
+          network={network}
+          appearance=""
+          isEmptyState
+        />
       </EmptyState>
     );
   }
 
   return (
-    <>
-      <p className="p-text--small u-text--muted u-no-margin--bottom">
-        Load balancers distribute services running on instances across networks.{" "}
-        <DocLink docPath="/howto/network_load_balancers/" hasExternalIcon>
-          Learn more about load balancers
-        </DocLink>
-      </p>
-      <Row className="content">
-        <LoadBalancerTableHeading title="Load balancers">
-          <CreateLoadBalancerBtn network={network} className="u-float-right" />
-        </LoadBalancerTableHeading>
-        <LoadBalancersTable
-          loadBalancers={loadBalancers}
-          network={network}
-          project={project}
-        />
-      </Row>
-    </>
+    <Row className="content">
+      <LoadBalancerTableHeading
+        title={
+          <LoadBalancerExplanationTooltip>
+            Load balancers
+          </LoadBalancerExplanationTooltip>
+        }
+      >
+        <CreateLoadBalancerBtn network={network} className="u-float-right" />
+      </LoadBalancerTableHeading>
+      <LoadBalancersTable
+        loadBalancers={loadBalancers}
+        network={network}
+        project={project}
+      />
+    </Row>
   );
 };
 

--- a/src/pages/networks/LoadBalancersTab.tsx
+++ b/src/pages/networks/LoadBalancersTab.tsx
@@ -75,16 +75,24 @@ const LoadBalancersTab: FC<Props> = ({ network }) => {
   }
 
   return (
-    <Row className="content">
-      <LoadBalancerTableHeading title="Load balancers">
-        <CreateLoadBalancerBtn network={network} className="u-float-right" />
-      </LoadBalancerTableHeading>
-      <LoadBalancersTable
-        loadBalancers={loadBalancers}
-        network={network}
-        project={project}
-      />
-    </Row>
+    <>
+      <p className="p-text--small u-text--muted u-no-margin--bottom">
+        Load balancers distribute services running on instances across networks.{" "}
+        <DocLink docPath="/howto/network_load_balancers/" hasExternalIcon>
+          Learn more about load balancers
+        </DocLink>
+      </p>
+      <Row className="content">
+        <LoadBalancerTableHeading title="Load balancers">
+          <CreateLoadBalancerBtn network={network} className="u-float-right" />
+        </LoadBalancerTableHeading>
+        <LoadBalancersTable
+          loadBalancers={loadBalancers}
+          network={network}
+          project={project}
+        />
+      </Row>
+    </>
   );
 };
 

--- a/src/pages/networks/LocalPeeringExplanationTooltip.tsx
+++ b/src/pages/networks/LocalPeeringExplanationTooltip.tsx
@@ -6,9 +6,9 @@ const LocalPeeringExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
-      explanation="Local peering connects two networks on the same LXD cluster."
-      docPath="/howto/network_peers/"
-      docLabel="Learn more about network peers"
+      explanation="Local peering connects two OVN networks on the same LXD cluster."
+      docPath="/howto/network_ovn_peers/"
+      docLabel="Learn more about local peering"
     >
       {children}
     </ExplanationTooltip>

--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -24,6 +24,7 @@ import DocLink from "components/DocLink";
 import CreateNetworkForwardBtn from "./actions/CreateNetworkForwardBtn";
 import ClusterMemberRichChip from "pages/cluster/ClusterMemberRichChip";
 import { ROOT_PATH } from "util/rootPath";
+import InlineExplanation from "components/InlineExplanation";
 
 interface Props {
   network: LxdNetwork;
@@ -181,16 +182,16 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
   return (
     <>
       {hasNetworkForwards && (
-        <CreateNetworkForwardBtn network={network} className="u-float-right" />
-      )}
-      {hasNetworkForwards && (
-        <p className="p-text--small u-text--muted u-no-margin--bottom">
-          Network forwards publish services running on instances across
-          networks.{" "}
-          <DocLink docPath="/howto/network_forwards/" hasExternalIcon>
-            Learn more about network forwards
-          </DocLink>
-        </p>
+        <div className="inline-explanation-bar">
+          <div>
+            <InlineExplanation
+              explanation="Network forwards publish services running on instances across networks."
+              docPath="/howto/network_forwards/"
+              docLabel="Learn more about network forwards"
+            />
+          </div>
+          <CreateNetworkForwardBtn network={network} />
+        </div>
       )}
       <Row>
         {hasNetworkForwards && (
@@ -220,6 +221,10 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
             title="No network forwards found"
           >
             <p>There are no network forwards in this project.</p>
+            <p className="u-no-margin--bottom">
+              Network forwards publish services running on instances across
+              networks.
+            </p>
             <p>
               <DocLink docPath="/howto/network_forwards/" hasExternalIcon>
                 Learn more about network forwards

--- a/src/pages/networks/NetworkForwards.tsx
+++ b/src/pages/networks/NetworkForwards.tsx
@@ -183,6 +183,15 @@ const NetworkForwards: FC<Props> = ({ network, project }) => {
       {hasNetworkForwards && (
         <CreateNetworkForwardBtn network={network} className="u-float-right" />
       )}
+      {hasNetworkForwards && (
+        <p className="p-text--small u-text--muted u-no-margin--bottom">
+          Network forwards publish services running on instances across
+          networks.{" "}
+          <DocLink docPath="/howto/network_forwards/" hasExternalIcon>
+            Learn more about network forwards
+          </DocLink>
+        </p>
+      )}
       <Row>
         {hasNetworkForwards && (
           <ScrollableTable

--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -144,6 +144,18 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
   return (
     <Row>
       {hasNetworkLeases && (
+        <p className="p-text--small u-text--muted u-no-margin--bottom">
+          Leases represent IP addresses allocated to instances by a
+          network&apos;s DHCP server.{" "}
+          <DocLink
+            docPath="/howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks"
+            hasExternalIcon
+          >
+            Learn more about network leases
+          </DocLink>
+        </p>
+      )}
+      {hasNetworkLeases && (
         <ScrollableTable
           dependencies={leases}
           tableId="network-lease-table"

--- a/src/pages/networks/NetworkLeases.tsx
+++ b/src/pages/networks/NetworkLeases.tsx
@@ -144,11 +144,14 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
   return (
     <Row>
       {hasNetworkLeases && (
-        <p className="p-text--small u-text--muted u-no-margin--bottom">
+        <p className="network-leases-explanation p-text--small u-text--muted">
           Leases represent IP addresses allocated to instances by a
           network&apos;s DHCP server.{" "}
           <DocLink
-            docPath="/howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks"
+            className="inline-explanation-wrap"
+            docPath={
+              "/howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks"
+            }
             hasExternalIcon
           >
             Learn more about network leases
@@ -182,6 +185,10 @@ const NetworkLeases: FC<Props> = ({ network, project }) => {
           title="No network leases found"
         >
           <p>There are no network leases in this project.</p>
+          <p className="u-no-margin--bottom">
+            Leases represent IP addresses allocated to instances by a
+            network&apos;s DHCP server.
+          </p>
           <p>
             <DocLink
               docPath="/howto/network_ipam/#view-dhcp-leases-for-fully-controlled-networks"

--- a/src/pages/networks/NetworkPeers.tsx
+++ b/src/pages/networks/NetworkPeers.tsx
@@ -132,6 +132,14 @@ const NetworkPeers: FC<Props> = ({ network, project }) => {
     <>
       <LocalPeeringWarning network={network} />
       {hasNetworkPeers && (
+        <p className="p-text--small u-text--muted u-no-margin--bottom">
+          Local peering connects two networks on the same LXD cluster.{" "}
+          <DocLink docPath="/howto/network_ovn_peers" hasExternalIcon>
+            Learn more about local peering
+          </DocLink>
+        </p>
+      )}
+      {hasNetworkPeers && (
         <CreateNetworkPeeringBtn network={network} className=" u-float-right" />
       )}
       <Row>

--- a/src/pages/networks/NetworkPeers.tsx
+++ b/src/pages/networks/NetworkPeers.tsx
@@ -21,6 +21,7 @@ import LocalPeeringWarning from "./LocalPeeringWarning";
 import NetworkRichChip from "./NetworkRichChip";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import LocalPeeringTargetWarning from "pages/networks/LocalPeeringTargetWarning";
+import InlineExplanation from "components/InlineExplanation";
 
 interface Props {
   network: LxdNetwork;
@@ -132,15 +133,16 @@ const NetworkPeers: FC<Props> = ({ network, project }) => {
     <>
       <LocalPeeringWarning network={network} />
       {hasNetworkPeers && (
-        <p className="p-text--small u-text--muted u-no-margin--bottom">
-          Local peering connects two networks on the same LXD cluster.{" "}
-          <DocLink docPath="/howto/network_ovn_peers" hasExternalIcon>
-            Learn more about local peering
-          </DocLink>
-        </p>
-      )}
-      {hasNetworkPeers && (
-        <CreateNetworkPeeringBtn network={network} className=" u-float-right" />
+        <div className="inline-explanation-bar">
+          <div>
+            <InlineExplanation
+              explanation="Local peering connects two OVN networks on the same LXD cluster."
+              docPath="/howto/network_ovn_peers/"
+              docLabel="Learn more about local peering"
+            />
+          </div>
+          <CreateNetworkPeeringBtn network={network} />
+        </div>
       )}
       <Row>
         {hasNetworkPeers && (
@@ -167,8 +169,11 @@ const NetworkPeers: FC<Props> = ({ network, project }) => {
             title="No local peerings found"
           >
             <p>There are no local peerings in this network and project.</p>
+            <p className="u-no-margin--bottom">
+              Local peering connects two OVN networks on the same LXD cluster.
+            </p>
             <p>
-              <DocLink docPath={`/howto/network_ovn_peers`}>
+              <DocLink docPath={`/howto/network_ovn_peers/`} hasExternalIcon>
                 Learn more about local peering
               </DocLink>
             </p>

--- a/src/pages/networks/actions/CreateLoadBalancerBtn.tsx
+++ b/src/pages/networks/actions/CreateLoadBalancerBtn.tsx
@@ -1,8 +1,12 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
+import {
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import type { LxdNetwork } from "types/network";
+import classnames from "classnames";
 import { useNavigate } from "react-router-dom";
 import { ROOT_PATH } from "util/rootPath";
 import { useLoadBalancerPools } from "context/useLoadBalancerPools";
@@ -13,6 +17,7 @@ interface Props {
   className?: string;
   appearance?: string;
   hasIcon?: boolean;
+  isEmptyState?: boolean;
 }
 
 const CreateLoadBalancerBtn: FC<Props> = ({
@@ -20,8 +25,9 @@ const CreateLoadBalancerBtn: FC<Props> = ({
   className,
   appearance = "positive",
   hasIcon = true,
+  isEmptyState = false,
 }) => {
-  const isSmallScreen = useIsScreenBelow();
+  const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
   const { canEditNetwork } = useNetworkEntitlements();
   const navigate = useNavigate();
   const { projectName: project } = useCurrentProject();
@@ -43,18 +49,20 @@ const CreateLoadBalancerBtn: FC<Props> = ({
   return (
     <Button
       appearance={appearance}
-      hasIcon={!isSmallScreen && hasIcon}
+      hasIcon={hasIcon}
       onClick={() => {
         navigate(
           `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}/load-balancers/create`,
         );
       }}
-      className={className}
+      className={classnames("network-create-action-btn", className)}
       disabled={!canEditNetwork(network) || !hasPools}
       title={getTitle()}
     >
-      {!isSmallScreen && hasIcon && <Icon name="plus" light />}
-      <span>Create load balancer</span>
+      {hasIcon && <Icon name="plus" light />}
+      <span>
+        {isEmptyState || !isMediumScreen ? "Create load balancer" : "Create"}
+      </span>
     </Button>
   );
 };

--- a/src/pages/networks/actions/CreateLoadBalancerPoolBtn.tsx
+++ b/src/pages/networks/actions/CreateLoadBalancerPoolBtn.tsx
@@ -1,31 +1,35 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
+import {
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import usePanelParams from "util/usePanelParams";
 import type { LxdNetwork } from "types/network";
+import classnames from "classnames";
 
 interface Props {
   network: LxdNetwork;
   className?: string;
   appearance?: string;
+  isEmptyState?: boolean;
 }
 
 const CreateLoadBalancerPoolBtn: FC<Props> = ({
   network,
   className,
   appearance = "positive",
+  isEmptyState = false,
 }) => {
-  const isSmallScreen = useIsScreenBelow();
+  const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
   const { canEditNetwork } = useNetworkEntitlements();
   const panelParams = usePanelParams();
-  const showIcon = !isSmallScreen;
-
   return (
     <Button
       appearance={appearance}
-      className={className}
-      hasIcon={showIcon}
+      className={classnames("network-create-action-btn", className)}
+      hasIcon
       onClick={panelParams.openCreateLoadBalancerPool}
       disabled={!canEditNetwork(network)}
       title={
@@ -34,8 +38,12 @@ const CreateLoadBalancerPoolBtn: FC<Props> = ({
           : "You do not have permission to create load balancer pools for this network"
       }
     >
-      {showIcon && <Icon name="plus" light={appearance === "positive"} />}
-      <span>Create load balancer pool</span>
+      <Icon name="plus" light={appearance === "positive"} />
+      <span>
+        {isEmptyState || !isMediumScreen
+          ? "Create load balancer pool"
+          : "Create"}
+      </span>
     </Button>
   );
 };

--- a/src/pages/networks/actions/CreateNetworkForwardBtn.tsx
+++ b/src/pages/networks/actions/CreateNetworkForwardBtn.tsx
@@ -1,6 +1,9 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
+import {
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import type { LxdNetwork } from "types/network";
 import classnames from "classnames";
@@ -14,7 +17,7 @@ interface Props {
 }
 
 const CreateNetworkForwardBtn: FC<Props> = ({ network, className }) => {
-  const isSmallScreen = useIsScreenBelow();
+  const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
   const { canEditNetwork } = useNetworkEntitlements();
   const { projectName: project } = useCurrentProject();
   const navigate = useNavigate();
@@ -22,14 +25,14 @@ const CreateNetworkForwardBtn: FC<Props> = ({ network, className }) => {
   return (
     <Button
       appearance="positive"
-      hasIcon={!isSmallScreen}
+      hasIcon
       onClick={() => {
         navigate(
           `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}/forwards/create`,
         );
       }}
       className={classnames(
-        "p-button--positive u-no-margin--bottom",
+        "p-button--positive u-no-margin--bottom network-create-action-btn",
         className,
       )}
       disabled={!canEditNetwork(network)}
@@ -39,8 +42,8 @@ const CreateNetworkForwardBtn: FC<Props> = ({ network, className }) => {
           : "You do not have permission to create network forwards for this network"
       }
     >
-      {!isSmallScreen && <Icon name="plus" light />}
-      <span>Create forward</span>
+      <Icon name="plus" light />
+      <span>{isMediumScreen ? "Create" : "Create forward"}</span>
     </Button>
   );
 };

--- a/src/pages/networks/actions/CreateNetworkPeeringBtn.tsx
+++ b/src/pages/networks/actions/CreateNetworkPeeringBtn.tsx
@@ -1,6 +1,9 @@
 import type { FC } from "react";
 import { Button, Icon } from "@canonical/react-components";
-import { useIsScreenBelow } from "context/useIsScreenBelow";
+import {
+  mediumScreenBreakpoint,
+  useIsScreenBelow,
+} from "context/useIsScreenBelow";
 import { useNetworkEntitlements } from "util/entitlements/networks";
 import usePanelParams from "util/usePanelParams";
 import type { LxdNetwork } from "types/network";
@@ -12,18 +15,21 @@ interface Props {
 }
 
 const CreateNetworkPeeringBtn: FC<Props> = ({ network, className }) => {
-  const isSmallScreen = useIsScreenBelow();
+  const isMediumScreen = useIsScreenBelow(mediumScreenBreakpoint);
   const { canEditNetwork } = useNetworkEntitlements();
   const panelParams = usePanelParams();
 
   return (
     <Button
       appearance="positive"
-      hasIcon={!isSmallScreen}
+      hasIcon
       onClick={() => {
         panelParams.openCreateLocalPeering();
       }}
-      className={classnames("p-button--positive", className)}
+      className={classnames(
+        "p-button--positive network-create-action-btn",
+        className,
+      )}
       disabled={!canEditNetwork(network)}
       title={
         canEditNetwork(network)
@@ -31,8 +37,8 @@ const CreateNetworkPeeringBtn: FC<Props> = ({ network, className }) => {
           : "You do not have permission to create local peerings for this network"
       }
     >
-      {!isSmallScreen && <Icon name="plus" light />}
-      <span>Create local peering</span>
+      <Icon name="plus" light />
+      <span>{isMediumScreen ? "Create" : "Create local peering"}</span>
     </Button>
   );
 };

--- a/src/pages/networks/panels/CreateLoadBalancerPoolPanel.tsx
+++ b/src/pages/networks/panels/CreateLoadBalancerPoolPanel.tsx
@@ -21,7 +21,7 @@ import LoadBalancerPoolForm, {
 } from "pages/networks/forms/LoadBalancerPoolForm";
 import { createLoadBalancerPool } from "api/load-balancer-pools";
 import { useEscCallback } from "context/useEscCallback";
-import LoadBalancerExplanationTooltip from "pages/networks/LoadBalancerExplanationTooltip";
+import LoadBalancerPoolExplanationTooltip from "pages/networks/LoadBalancerPoolExplanationTooltip";
 
 interface Props {
   network: LxdNetwork;
@@ -94,9 +94,9 @@ const CreateLoadBalancerPoolPanel: FC<Props> = ({
     <SidePanel>
       <SidePanel.Header>
         <SidePanel.HeaderTitle>
-          <LoadBalancerExplanationTooltip>
+          <LoadBalancerPoolExplanationTooltip>
             Create load balancer pool
-          </LoadBalancerExplanationTooltip>
+          </LoadBalancerPoolExplanationTooltip>
         </SidePanel.HeaderTitle>
       </SidePanel.Header>
       <NotificationRow className="u-no-padding" />

--- a/src/pages/networks/panels/EditLoadBalancerPoolPanel.tsx
+++ b/src/pages/networks/panels/EditLoadBalancerPoolPanel.tsx
@@ -25,7 +25,7 @@ import LoadBalancerPoolForm, {
 import { useEventQueue } from "context/eventQueue";
 import { getHealthCheckType } from "util/loadBalancers";
 import { useEscCallback } from "context/useEscCallback";
-import LoadBalancerExplanationTooltip from "pages/networks/LoadBalancerExplanationTooltip";
+import LoadBalancerPoolExplanationTooltip from "pages/networks/LoadBalancerPoolExplanationTooltip";
 
 interface Props {
   network: LxdNetwork;
@@ -123,9 +123,9 @@ const EditLoadBalancerPoolPanel: FC<Props> = ({ network }) => {
     <SidePanel>
       <SidePanel.Header>
         <SidePanel.HeaderTitle>
-          <LoadBalancerExplanationTooltip>
+          <LoadBalancerPoolExplanationTooltip>
             Edit load balancer pool
-          </LoadBalancerExplanationTooltip>
+          </LoadBalancerPoolExplanationTooltip>
         </SidePanel.HeaderTitle>
       </SidePanel.Header>
       <NotificationRow className="u-no-padding" />

--- a/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
+++ b/src/pages/permissions/PermissionGroupExplanationTooltip.tsx
@@ -6,7 +6,7 @@ const PermissionGroupExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
-      explanation="Auth groups organise identities for permission management."
+      explanation="Auth groups organize identities for permission management."
       docPath="/explanation/authorization"
       docLabel="Learn more about authorization"
     >

--- a/src/pages/projects/ProjectExplanationTooltip.tsx
+++ b/src/pages/projects/ProjectExplanationTooltip.tsx
@@ -7,7 +7,7 @@ const ProjectExplanationTooltip: FC<{
   return (
     <ExplanationTooltip
       className="explanation-tooltip-wrapper--breadcrumb"
-      explanation="Projects organise and isolate LXD resources into separate groups."
+      explanation="Projects organize and isolate LXD resources into separate groups."
       docPath="/reference/projects/"
       docLabel="Learn more about projects"
     >

--- a/src/sass/_explanation_tooltip.scss
+++ b/src/sass/_explanation_tooltip.scss
@@ -24,3 +24,22 @@
   white-space: normal;
   width: max-content;
 }
+
+.inline-explanation-bar {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  margin-right: $sph--x-large;
+
+  p:first-child {
+    margin-bottom: $spv--small;
+  }
+
+  .network-create-action-btn {
+    margin-left: $sph--large;
+  }
+}
+
+.inline-explanation-wrap {
+  white-space: nowrap;
+}

--- a/src/sass/_load_balancers.scss
+++ b/src/sass/_load_balancers.scss
@@ -27,6 +27,10 @@
   .left {
     flex-grow: 1;
   }
+
+  .network-create-action-btn {
+    margin-left: $sph--large;
+  }
 }
 
 .load-balancers-table {

--- a/src/sass/_network_leases.scss
+++ b/src/sass/_network_leases.scss
@@ -1,3 +1,9 @@
+.network-leases-explanation {
+  @include large {
+    white-space: nowrap;
+  }
+}
+
 .network-leases-table {
   .type,
   .hostname,

--- a/src/sass/_network_list.scss
+++ b/src/sass/_network_list.scss
@@ -38,3 +38,7 @@
     }
   }
 }
+
+.network-create-action-btn {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Done
Adds ExplanationTooltips or InlineExplanations to network tab pages:
- Network Forwards - IE
- Network Local Peering - IE
- Network Leases - IE (Custom)
- Network Load Balancers - ET
- Network Load Balancer Pools - ET

Also adds to create/edit LBs & LBPs

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Observe the Leases & Forwards tabs in the Demo server
    - Observe the load balancers and local peerings tabs in an OVN-compatible backend.

## Screenshots
<img width="1579" height="467" alt="image" src="https://github.com/user-attachments/assets/59eb1dd7-5f84-4156-bc22-1dd6cb1caa96" />
<img width="1331" height="341" alt="image" src="https://github.com/user-attachments/assets/26a6207f-e8fe-4d7f-a6b1-e41925cde81d" />
<img width="1577" height="341" alt="image" src="https://github.com/user-attachments/assets/6980f128-9d22-4b8b-a843-9dc56af05fb4" />
