### PR TITLE
fix(Warnings): set severity chip as read only

### DIFF
--- a/src/util/warnings.tsx
+++ b/src/util/warnings.tsx
@@ -131,6 +131,7 @@ export const getWarningRows = (
           <Chip
             value={warning.severity}
             appearance={getSeverityChipAppearance(warning.severity)}
+            isReadOnly
           />
         ),
         role: "cell",


### PR DESCRIPTION
## Done

- Micro fix to set severity chip as read only in Warnings list and Overview's Warnings card. Since the chip doesn't do anything, the cursor should not be pointer when hover.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Warnings list page. Hover a severity chip, the cursor should be initial.
