### PR TITLE
fix(NotFound): override pragma style

### DIFF
--- a/src/sass/_not_found.scss
+++ b/src/sass/_not_found.scss
@@ -1,6 +1,7 @@
 .not-found {
   margin: min(5dvh, $spv--strip-regular) auto;
 
+  .ds.not-found-icon,
   .not-found-icon {
     height: 2.5rem;
     opacity: 0.25;


### PR DESCRIPTION
## Done

- fix(NotFound): override pragma style

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to a Not Found page, for example `https://localhost:8407/ui/project/default/instance/i-do-not-exist`. Make sure the icon size matches the surrounding text.

## Screenshots

BEFORE
<img width="952" height="443" alt="Screenshot from 2026-08-26 16-45-03" src="https://github.com/user-attachments/assets/0535996b-e4e7-4276-8f12-fa39f1df1dc6" />

AFTER
<img width="952" height="443" alt="Screenshot from 2026-08-26 17-07-12" src="https://github.com/user-attachments/assets/e17c8f89-f65a-4154-b868-e0016244ad0c" />
