### PR TITLE
fix(auth) surface auth errors to the user

### DIFF
--- a/src/context/appProviders.tsx
+++ b/src/context/appProviders.tsx
@@ -23,8 +23,13 @@ const queryClient = new QueryClient({
     queries: {
       retry: (failureCount, error: unknown) => {
         if (error instanceof LxdApiError) {
-          // Do not retry for 404 errors
-          if (error.status === 404) {
+          // Do not retry for most 4xx client errors (auth/validation), but allow retries for timeouts/rate limiting.
+          if (
+            error.status >= 400 &&
+            error.status < 500 &&
+            error.status !== 408 &&
+            error.status !== 429
+          ) {
             return false;
           }
         }

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -77,7 +77,11 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
     return currentIdentity?.fine_grained ?? null;
   };
 
-  const { data: projects = [], isLoading: isProjectsLoading } = useQuery({
+  const {
+    data: projects = [],
+    isLoading: isProjectsLoading,
+    error: projectError,
+  } = useQuery({
     queryKey: [queryKeys.projects],
     queryFn: async () => fetchProjects(isFineGrained()),
     enabled: settings?.auth === "trusted" && isFineGrained() !== null,
@@ -86,7 +90,11 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
   const defaultProject = getLoginProject(projects);
   const isTls = authMethod === AUTH_METHOD.TLS;
 
-  const { data: certificates = [] } = useQuery({
+  const {
+    data: certificates = [],
+    isLoading: isCertificatesLoading,
+    error: certificateError,
+  } = useQuery({
     queryKey: [queryKeys.certificates, 1],
     queryFn: fetchCertificates,
     enabled: isTls,
@@ -109,8 +117,12 @@ export const AuthProvider: FC<ProviderProps> = ({ children }) => {
       value={{
         isAuthenticated: (settings && settings.auth !== "untrusted") ?? false,
         isAuthLoading:
-          isSettingsLoading || isIdentityLoading || isProjectsLoading,
-        authError: settingsError ?? identityError,
+          isSettingsLoading ||
+          isIdentityLoading ||
+          isProjectsLoading ||
+          isCertificatesLoading,
+        authError:
+          settingsError ?? identityError ?? projectError ?? certificateError,
         isRestricted,
         defaultProject,
         hasNoProjects: projects.length === 0 && !isProjectsLoading,


### PR DESCRIPTION
## Done

- fix(auth) surface auth errors to the user

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - run the UI against a backend that is from the 5.21 branch, such as `snap install lxd --channel=5.21/edge`
    - Ensure the UI loads and surfaces the error as below and we do not end up in an endless retry cycle for long times, ending in a confusing "project not found" page as before.

## Screenshots

<img width="3842" height="1916" alt="image" src="https://github.com/user-attachments/assets/860c0271-4704-4b12-8978-57c690eb0f69" />