### PR TITLE
feat(Networking): Prioritize main interfaces on IP address sorting

### DIFF
--- a/src/pages/instances/InstanceIps.tsx
+++ b/src/pages/instances/InstanceIps.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { getIpAddresses, sortIpv6Addresses } from "util/networks";
+import { getIpAddresses } from "util/networks";
 import type { IpFamily, LxdInstance } from "types/instance";
 import ExpandableList from "components/ExpandableList";
 
@@ -10,11 +10,9 @@ interface Props {
 
 const InstanceIps: FC<Props> = ({ instance, family }) => {
   const addresses = getIpAddresses(instance, family);
-  const sortedAddresses =
-    family === "inet6" ? sortIpv6Addresses(addresses) : addresses;
   return addresses.length ? (
     <ExpandableList
-      items={sortedAddresses.map((item) => (
+      items={addresses.map((item) => (
         <div
           key={item.address}
           className="ip u-truncate"

--- a/src/pages/instances/InstanceList.tsx
+++ b/src/pages/instances/InstanceList.tsx
@@ -25,7 +25,7 @@ import { useInstanceLoading } from "context/instanceLoading";
 import InstanceLink from "pages/instances/InstanceLink";
 import SelectableMainTable from "components/SelectableMainTable";
 import InstanceBulkActions from "pages/instances/actions/InstanceBulkActions";
-import { getIpAddresses, sortIpv6Addresses } from "util/networks";
+import { getIpAddresses } from "util/networks";
 import InstanceBulkDelete from "pages/instances/actions/InstanceBulkDelete";
 import InstanceSearchFilter from "./InstanceSearchFilter";
 import { enrichStatuses, type InstanceFilters } from "util/instanceFilter";
@@ -434,7 +434,7 @@ const InstanceList: FC = () => {
       };
 
       const ipv4 = getIpAddresses(instance, "inet");
-      const ipv6 = sortIpv6Addresses(getIpAddresses(instance, "inet6"));
+      const ipv6 = getIpAddresses(instance, "inet6");
 
       const loadingType = instanceLoading.getType(instance);
 

--- a/src/pages/instances/InstanceRichTooltip.tsx
+++ b/src/pages/instances/InstanceRichTooltip.tsx
@@ -3,7 +3,7 @@ import InstanceLink from "pages/instances/InstanceLink";
 import InstanceStatusIcon from "pages/instances/InstanceStatusIcon";
 import { useInstance } from "context/useInstances";
 import { Spinner } from "@canonical/react-components";
-import { getIpAddresses, sortIpv6Addresses } from "util/networks";
+import { getIpAddresses } from "util/networks";
 import type { IpFamily, LxdInstance } from "types/instance";
 import { getInstanceMacAddresses, getInstanceType } from "util/instances";
 import { isoTimeToString } from "util/helpers";
@@ -22,10 +22,7 @@ export const InstanceRichTooltip: FC<Props> = ({
   projectName,
 }) => {
   const getAddresses = (instance: LxdInstance, family: IpFamily) => {
-    const addresses = getIpAddresses(instance, family);
-    const sortedAddresses =
-      family === "inet6" ? sortIpv6Addresses(addresses) : addresses;
-    return sortedAddresses.map((item) => item.address);
+    return getIpAddresses(instance, family).map((item) => item.address);
   };
 
   const { data: instance, isLoading } = useInstance(instanceName, projectName);

--- a/src/util/networks.spec.ts
+++ b/src/util/networks.spec.ts
@@ -1,11 +1,14 @@
-import type { IpAddress, IpFamily } from "types/instance";
+import type { IpAddress, IpFamily, LxdInstance } from "types/instance";
 import {
   areNetworksEqual,
+  getIpAddresses,
+  getManagedInterfaces,
   getNetworkAcls,
+  isLocalIPv4,
   isLocalIPv6,
   isTypeOvn,
   ovnType,
-  sortIpv6Addresses,
+  sortIpAddresses,
   supportsNicDeviceAcls,
   testValidIp,
   testValidPort,
@@ -125,6 +128,26 @@ describe("testValidPort", () => {
   });
 });
 
+describe("isLocalIPv4", () => {
+  it("accepts loopback ipv4", () => {
+    expect(isLocalIPv4("127.0.0.1")).toBe(true);
+  });
+
+  it("accepts link local ipv4", () => {
+    expect(isLocalIPv4("169.254.10.20")).toBe(true);
+  });
+
+  it("rejects private ipv4", () => {
+    expect(isLocalIPv4("172.22.0.5")).toBe(false);
+    expect(isLocalIPv4("10.0.1.127")).toBe(false);
+    expect(isLocalIPv4("192.168.1.1")).toBe(false);
+  });
+
+  it("rejects public ipv4", () => {
+    expect(isLocalIPv4("8.8.8.8")).toBe(false);
+  });
+});
+
 describe("isLocalIPv6", () => {
   it("accepts link local ipv6", () => {
     const result = isLocalIPv6("fe80::1234:5678:90ab:cdef");
@@ -147,10 +170,16 @@ describe("isLocalIPv6", () => {
   });
 });
 
-describe("sortIpv6Addresses", () => {
+describe("sortIpAddresses", () => {
   const defaultFieldsV6 = {
-    iface: "",
+    iface: "veth0",
     family: "inet6" as IpFamily,
+    netmask: "",
+    scope: "",
+  };
+  const defaultFieldsV4 = {
+    iface: "veth0",
+    family: "inet" as IpFamily,
     netmask: "",
     scope: "",
   };
@@ -238,7 +267,7 @@ describe("sortIpv6Addresses", () => {
   ];
 
   it("should set IPv6 local addresses at the end", () => {
-    const result = sortIpv6Addresses(ipv6Addresses);
+    const result = sortIpAddresses(ipv6Addresses, new Set());
 
     for (let i = 0; i < 17; i++) {
       expect(isLocalIPv6(result[i].address)).toBe(false);
@@ -246,6 +275,160 @@ describe("sortIpv6Addresses", () => {
     for (let i = 17; i < result.length; i++) {
       expect(isLocalIPv6(result[i].address)).toBe(true);
     }
+  });
+
+  it("should not mutate the input", () => {
+    const input = [...ipv6Addresses];
+    sortIpAddresses(input, new Set());
+
+    expect(input).toEqual(ipv6Addresses);
+  });
+
+  it("should set main interface addresses first within each locality group", () => {
+    const addresses: IpAddress[] = [
+      { ...defaultFieldsV6, iface: "docker0", address: "fe80::1" },
+      { ...defaultFieldsV6, iface: "docker0", address: "2001:db8::1" },
+      { ...defaultFieldsV6, iface: "eth0", address: "fe80::2" },
+      { ...defaultFieldsV6, iface: "eth0", address: "2001:db8::2" },
+    ];
+
+    const result = sortIpAddresses(addresses, new Set(["eth0"]));
+
+    expect(result.map((item) => item.address)).toEqual([
+      "2001:db8::2",
+      "2001:db8::1",
+      "fe80::2",
+      "fe80::1",
+    ]);
+  });
+
+  it("should keep the original order of equally ranked addresses", () => {
+    const addresses: IpAddress[] = [
+      { ...defaultFieldsV4, iface: "eth0", address: "172.22.0.201" },
+      { ...defaultFieldsV4, iface: "eth0", address: "172.22.0.5" },
+    ];
+
+    const result = sortIpAddresses(addresses, new Set(["eth0"]));
+
+    expect(result.map((item) => item.address)).toEqual([
+      "172.22.0.201",
+      "172.22.0.5",
+    ]);
+  });
+});
+
+const createInstance = (
+  config: Record<string, string>,
+  network?: Record<string, unknown>,
+): LxdInstance =>
+  ({
+    name: "kube1",
+    config,
+    state: network ? { network } : undefined,
+  }) as unknown as LxdInstance;
+
+const iface = (hwaddr: string, addresses: string[], type = "broadcast") => ({
+  hwaddr,
+  type,
+  state: "up",
+  addresses: addresses.map((address) => ({
+    address,
+    family: address.includes(":") ? "inet6" : "inet",
+    netmask: "",
+    scope: address.includes(":") ? "link" : "global",
+  })),
+});
+
+const kube1Network = {
+  cilium_host: iface("62:92:d8:02:ec:78", [
+    "10.0.1.127",
+    "fe80::6092:d8ff:fe02:ec78",
+  ]),
+  enp5s0: iface("00:16:3e:02:73:86", [
+    "172.22.0.201",
+    "172.22.0.5",
+    "2a02:a455:3cc4:400:216:3eff:fe02:7386",
+    "fe80::216:3eff:fe02:7386",
+  ]),
+  lo: iface("", ["127.0.0.1", "::1"], "loopback"),
+  lxc8995be0b0d68: iface("d2:d9:a5:06:6c:fb", ["fe80::d0d9:a5ff:fe06:6cfb"]),
+};
+
+const kube1Config = { "volatile.eth0.hwaddr": "00:16:3e:02:73:86" };
+
+describe("getManagedInterfaces", () => {
+  it("matches the interface by hwaddr, not by name", () => {
+    const instance = createInstance(kube1Config, kube1Network);
+
+    expect(getManagedInterfaces(instance)).toEqual(new Set(["enp5s0"]));
+  });
+
+  it("ignores casing differences in the hwaddr", () => {
+    const instance = createInstance(
+      { "volatile.eth0.hwaddr": "00:16:3E:02:73:86" },
+      kube1Network,
+    );
+
+    expect(getManagedInterfaces(instance)).toEqual(new Set(["enp5s0"]));
+  });
+
+  it("returns an empty set when no volatile hwaddr matches", () => {
+    const instance = createInstance(
+      { "volatile.eth0.hwaddr": "00:16:3e:ff:ff:ff" },
+      kube1Network,
+    );
+
+    expect(getManagedInterfaces(instance)).toEqual(new Set());
+  });
+
+  it("returns an empty set for an instance without state", () => {
+    expect(getManagedInterfaces(createInstance(kube1Config))).toEqual(
+      new Set(),
+    );
+  });
+});
+
+describe("getIpAddresses", () => {
+  it("returns an empty list for a stopped instance", () => {
+    expect(getIpAddresses(createInstance(kube1Config), "inet")).toEqual([]);
+    expect(getIpAddresses(createInstance(kube1Config), "inet6")).toEqual([]);
+  });
+
+  it("excludes loopback and lists the nic device addresses first", () => {
+    const instance = createInstance(kube1Config, kube1Network);
+
+    const result = getIpAddresses(instance, "inet");
+
+    expect(result.map((item) => item.address)).toEqual([
+      "172.22.0.201",
+      "172.22.0.5",
+      "10.0.1.127",
+    ]);
+    expect(result[0].iface).toBe("enp5s0");
+  });
+
+  it("ranks the global address first and the nic device link local next", () => {
+    const instance = createInstance(kube1Config, kube1Network);
+
+    const result = getIpAddresses(instance, "inet6");
+
+    expect(result.map((item) => item.address)).toEqual([
+      "2a02:a455:3cc4:400:216:3eff:fe02:7386",
+      "fe80::216:3eff:fe02:7386",
+      "fe80::6092:d8ff:fe02:ec78",
+      "fe80::d0d9:a5ff:fe06:6cfb",
+    ]);
+  });
+
+  it("falls back to local last ordering when no nic device matches", () => {
+    const instance = createInstance({}, kube1Network);
+
+    const result = getIpAddresses(instance, "inet6");
+
+    expect(result[0].address).toBe("2a02:a455:3cc4:400:216:3eff:fe02:7386");
+    expect(result.slice(1).every((item) => isLocalIPv6(item.address))).toBe(
+      true,
+    );
   });
 });
 

--- a/src/util/networks.tsx
+++ b/src/util/networks.tsx
@@ -15,6 +15,7 @@ import {
   constructMemberError,
   type AbortControllerState,
 } from "util/helpers";
+import { getInstanceMacAddresses } from "util/instances";
 import { ROOT_PATH } from "util/rootPath";
 import type { AnyObject, TestFunction } from "yup";
 
@@ -45,19 +46,8 @@ export const typesWithNicDeviceAcls = [ovnType];
 export const typesWithNicStaticIPSupport = [bridgeType, ovnType];
 export const typesWithLocalPeerings = [ovnType];
 
-export const getIpAddresses = (
-  instance: LxdInstance,
-  family: IpFamily,
-): IpAddress[] => {
-  if (!instance.state?.network) return [];
-  return Object.entries(instance.state.network)
-    .filter(([key, _value]) => key !== "lo")
-    .flatMap(([key, value]) =>
-      value.addresses.map((item) => {
-        return { ...item, iface: key };
-      }),
-    )
-    .filter((item) => item.family === family);
+export const isLocalIPv4 = (ipv4Address: string): boolean => {
+  return ipv4Address.startsWith("127.") || ipv4Address.startsWith("169.254.");
 };
 
 export const isLocalIPv6 = (ipv6Address: string): boolean => {
@@ -75,15 +65,65 @@ export const isLocalIPv6 = (ipv6Address: string): boolean => {
   return false;
 };
 
-export const sortIpv6Addresses = (ipv6Addresses: IpAddress[]): IpAddress[] => {
-  if (ipv6Addresses.length === 0) return [];
+export const isLocalIp = (address: IpAddress): boolean => {
+  return address.family === "inet6"
+    ? isLocalIPv6(address.address)
+    : isLocalIPv4(address.address);
+};
 
-  // Set local addresses at the end
-  return ipv6Addresses.sort((a, b) => {
-    const isA_local = isLocalIPv6(a.address);
-    const isB_local = isLocalIPv6(b.address);
-    return isA_local === isB_local ? 0 : isA_local ? 1 : -1;
-  });
+const getIpRank = (
+  address: IpAddress,
+  managedInterfaces: Set<string>,
+): number => {
+  const localityRank = isLocalIp(address) ? 2 : 0;
+  const interfaceRank = managedInterfaces.has(address.iface) ? 0 : 1;
+  return localityRank + interfaceRank;
+};
+
+export const sortIpAddresses = (
+  addresses: IpAddress[],
+  managedInterfaces: Set<string>,
+): IpAddress[] => {
+  return [...addresses].sort(
+    (a, b) => getIpRank(a, managedInterfaces) - getIpRank(b, managedInterfaces),
+  );
+};
+
+// Match reported hwaddr to instance's volatile.<device>.hwaddr
+export const getManagedInterfaces = (instance: LxdInstance): Set<string> => {
+  const network = instance.state?.network;
+  if (!network) return new Set();
+
+  const deviceMacs = new Set(
+    getInstanceMacAddresses(instance).map((mac) => mac.toLowerCase()),
+  );
+  if (deviceMacs.size === 0) return new Set();
+
+  return new Set(
+    Object.entries(network)
+      .filter(([_key, value]) =>
+        deviceMacs.has((value.hwaddr ?? "").toLowerCase()),
+      )
+      .map(([key, _value]) => key),
+  );
+};
+
+export const getIpAddresses = (
+  instance: LxdInstance,
+  family: IpFamily,
+): IpAddress[] => {
+  if (!instance.state?.network) return [];
+
+  const addresses = Object.entries(instance.state.network)
+    .filter(([key, value]) => key !== "lo" && value.type !== "loopback")
+    .flatMap(([key, value]) =>
+      value.addresses.map((item) => {
+        return { ...item, iface: key };
+      }),
+    )
+    .filter((item) => item.family === family);
+
+  return sortIpAddresses(addresses, getManagedInterfaces(instance));
 };
 
 export const networkFormFieldToPayloadName: Record<


### PR DESCRIPTION
This PR prioritizes instances' main interfaces over others (for example interfaces created by docker, kubernetes cni's or loadbalancer software)

It has annoyed me for quite some time, so here is a solution :)

## Done

- Added prioritization of IP addresses with a matching hwaddr configured on the instance to IP sorting.
- Put IPv4 local addresses (127.* and 169.254.*) at the bottom of the list, just like already happens with IPv6 fe80::

Fixes #2213

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Create instances with one or more network adapters
    - Add new network interfaces inside the guest, i.e. docker or kubernetes (or dummy interfaces)
    - Look at the listed IP addresses.

## Screenshots

Note the IPv4 and IPv6 of `verylonginstancename-1234567890`. `10.203.31.138` and `fd42:f409:293:999e:216:3eff:feb0:abe5` are its'  main IP addresses.
The main IPv4 address is 3rd in the list and not visible on the Instances list page.

A localhost addr and the docker0 interface (172.17.0.1) also takes the first two entries in the list for the `resolute` instance, causing a "real" IP address to not be visible.

side by side before & after:

<img width="1166" height="463" alt="image" src="https://github.com/user-attachments/assets/cf965600-7d2e-4fbd-bbce-ecd3840624af" />

`resolute` instance:
<img width="1168" height="291" alt="image" src="https://github.com/user-attachments/assets/f106a731-0377-482f-8fb9-dc692d92e9bc" />


`verylonginstancename-1234567890` instance:
<img width="1060" height="431" alt="image" src="https://github.com/user-attachments/assets/5ae1359e-8d9b-4542-8bdd-e9111eec6c54" />


"Real" IPs now take preference and are visible for the `resolute` instance and `verylonginstancename-1234567890` instance.

