### PR TITLE
fix(Overview): Do not display Permissions card when unrestricted

### DIFF
--- a/src/pages/overview/PermissionsCard.tsx
+++ b/src/pages/overview/PermissionsCard.tsx
@@ -2,14 +2,16 @@ import type { FC } from "react";
 import { Link } from "react-router-dom";
 import { Card, Icon, List } from "@canonical/react-components";
 import { useAuth } from "context/auth";
-import { pluralize } from "util/helpers";
+import { isUnrestricted, pluralize } from "util/helpers";
 import { ROOT_PATH } from "util/rootPath";
 
 const PermissionsCard: FC = () => {
-  const { effectiveGroups, isAuthLoading } = useAuth();
+  const { currentIdentity, effectiveGroups, isAuthLoading } = useAuth();
   const isAdmin = effectiveGroups?.includes("admins") ?? false;
+  const isUnrestrictedCert = currentIdentity && isUnrestricted(currentIdentity);
+  const hasFullPermissions = isAdmin || isUnrestrictedCert;
 
-  if (isAuthLoading || isAdmin) {
+  if (isAuthLoading || hasFullPermissions) {
     return null;
   }
 
@@ -23,7 +25,7 @@ const PermissionsCard: FC = () => {
   return (
     <Card className={cardClassName} title={cardTitle}>
       <p className="u-no-margin--bottom">
-        Overview information is filtered by your permission groups.
+        Overview information is filtered by your auth groups.
       </p>
       <div>
         <span>Your {pluralize("group", effectiveGroups?.length ?? 0)}: </span>


### PR DESCRIPTION
## Done

- fix(Overview): Do not display Permissions card when unrestricted
- Update copy to "auth groups"

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - On the demo server, you should not see the Permissions card

## Screenshots

<img width="1835" height="1110" alt="image" src="https://github.com/user-attachments/assets/20170ac6-750a-4b8b-9e9d-07a3f224d186" />

