### PR TITLE
feat: [WD-38192] Add ETs to Entity Forms

### DIFF
--- a/src/components/ExplanationTooltip.tsx
+++ b/src/components/ExplanationTooltip.tsx
@@ -22,7 +22,7 @@ const ExplanationTooltip: FC<Props> = ({
     <Tooltip
       zIndex={1000}
       tooltipClassName="explanation-tooltip-portal"
-      position="btm-center"
+      position="top-center"
       message={
         <span className="explanation-tooltip">
           <span>{explanation}</span>

--- a/src/components/forms/SshKeyExplanationTooltip.tsx
+++ b/src/components/forms/SshKeyExplanationTooltip.tsx
@@ -1,0 +1,19 @@
+import type { FC, ReactNode } from "react";
+import ExplanationTooltip from "components/ExplanationTooltip";
+
+const SshKeyExplanationTooltip: FC<{
+  children?: ReactNode;
+}> = ({ children }) => {
+  return (
+    <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
+      explanation="Cloud init must be enabled on the instance to apply the keys. Additional keys get applied on instance creation or restart. SSH keys are not removed automatically."
+      docPath="/reference/instance_options/#instance-cloud-init:cloud-init.ssh-keys.KEYNAME"
+      docLabel="Learn more about SSH keys"
+    >
+      {children}
+    </ExplanationTooltip>
+  );
+};
+
+export default SshKeyExplanationTooltip;

--- a/src/components/forms/SshKeyForm.tsx
+++ b/src/components/forms/SshKeyForm.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Icon,
   MainTable,
-  Tooltip,
   usePortal,
 } from "@canonical/react-components";
 import type { InstanceAndProfileFormikProps } from "types/forms/instanceAndProfileFormProps";
@@ -18,6 +17,7 @@ import { useProfiles } from "context/useProfiles";
 import type { LxdProfile } from "types/profile";
 import SshKeyAddModal from "components/forms/SshKeyAddModal";
 import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import SshKeyExplanationTooltip from "components/forms/SshKeyExplanationTooltip";
 import { useParams } from "react-router-dom";
 import { scrollToElement } from "util/scroll";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
@@ -274,12 +274,7 @@ const SshKeyForm: FC<Props> = ({ formik, disabledReason }) => {
   return (
     <div className="ssh-key-form">
       <p className="p-form__label u-sv-1">
-        SSH keys{" "}
-        <Tooltip
-          message={`Cloud init must be enabled on the instance to apply the keys.\nAdditional keys get applied on instance creation or restart.\nSSH Keys are not removed automatically.`}
-        >
-          <Icon name="information" />
-        </Tooltip>
+        <SshKeyExplanationTooltip>SSH keys</SshKeyExplanationTooltip>
       </p>
 
       {rows.length > 0 && (

--- a/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterGroupExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const ClusterGroupExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Cluster groups organize cluster members for instance placement."
       docPath="/explanation/clustering/#cluster-groups"
       docLabel="Learn more about cluster groups"

--- a/src/pages/cluster/ClusterMemberExplanationTooltip.tsx
+++ b/src/pages/cluster/ClusterMemberExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const ClusterMemberExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Cluster members are individual servers that make up an LXD cluster."
       docPath="/explanation/clustering/"
       docLabel="Learn more about clustering"

--- a/src/pages/cluster/ClusterMemberSelector.tsx
+++ b/src/pages/cluster/ClusterMemberSelector.tsx
@@ -2,6 +2,7 @@ import { Select, type SelectProps } from "@canonical/react-components";
 import type { FC } from "react";
 import { useIsClustered } from "context/useIsClustered";
 import { useClusterMembers } from "context/useClusterMembers";
+import ClusterMemberExplanationTooltip from "pages/cluster/ClusterMemberExplanationTooltip";
 
 interface Props {
   disableReason?: string;
@@ -19,7 +20,11 @@ const ClusterMemberSelector: FC<SelectProps & Props> = ({
   return isClustered ? (
     <Select
       {...props}
-      label={label ?? "Cluster member"}
+      label={
+        <ClusterMemberExplanationTooltip>
+          {label ?? "Cluster member"}
+        </ClusterMemberExplanationTooltip>
+      }
       options={clusterMembers.map((clusterMember) => {
         return {
           label: clusterMember.server_name,

--- a/src/pages/cluster/ReplicatorExplanationTooltip.tsx
+++ b/src/pages/cluster/ReplicatorExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const ReplicatorExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Replicators copy instances between clusters across cluster links."
       docPath="/explanation/replicators/"
       docLabel="Learn more about replicators"

--- a/src/pages/images/ImageRegistryExplanationTooltip.tsx
+++ b/src/pages/images/ImageRegistryExplanationTooltip.tsx
@@ -1,11 +1,12 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const ImageRegistryExplanationTooltip: FC<{ children?: ReactNode }> = ({
-  children,
-}) => {
+const ImageRegistryExplanationTooltip: FC<{
+  children?: ReactNode;
+}> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Image registries connect to other LXD clusters to use custom images."
       docPath="/image-handling/"
       docLabel="Learn more about image registries"

--- a/src/pages/instances/InstanceExplanationTooltip.tsx
+++ b/src/pages/instances/InstanceExplanationTooltip.tsx
@@ -7,6 +7,7 @@ const InstanceExplanationTooltip: FC<{
 }> = ({ children, isConfigVariant }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Instances are VMs or containers."
       docPath={
         isConfigVariant

--- a/src/pages/instances/forms/EditInstanceDetails.tsx
+++ b/src/pages/instances/forms/EditInstanceDetails.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { Col, Row, OutputField } from "@canonical/react-components";
+import { Col, Label, Row, OutputField } from "@canonical/react-components";
 import ProfileSelector from "pages/profiles/ProfileSelector";
 import type { FormikProps } from "formik/dist/types";
 import type { EditInstanceFormValues } from "types/forms/instanceAndProfile";
@@ -9,6 +9,7 @@ import { ensureEditMode } from "util/editMode";
 import SshKeyForm from "components/forms/SshKeyForm";
 import { useIsClustered } from "context/useIsClustered";
 import PlacementGroupSelect from "pages/instances/forms/PlacementGroupSelect";
+import ClusterMemberExplanationTooltip from "pages/cluster/ClusterMemberExplanationTooltip";
 
 interface Props {
   formik: FormikProps<EditInstanceFormValues>;
@@ -47,9 +48,14 @@ const EditInstanceDetails: FC<Props> = ({ formik, project }) => {
       {isClustered && (
         <Row>
           <Col size={12}>
+            <Label forId="target">
+              <ClusterMemberExplanationTooltip>
+                Cluster member
+              </ClusterMemberExplanationTooltip>
+            </Label>
             <OutputField
               id="target"
-              label="Cluster member"
+              label=""
               value={formik.values.location}
               help="Use the migrate button in the header to move the instance to another cluster member."
             />

--- a/src/pages/instances/forms/InstanceTargetSelect.tsx
+++ b/src/pages/instances/forms/InstanceTargetSelect.tsx
@@ -1,11 +1,9 @@
 import { useRef, type FC } from "react";
 import {
   CustomSelect,
-  Icon,
   Input,
   Select,
   Spinner,
-  Tooltip,
 } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
 import type { CreateInstanceFormValues } from "types/forms/instanceAndProfile";
@@ -20,6 +18,8 @@ import type { SelectRef } from "@canonical/react-components/dist/components/Cust
 import PlacementGroupSelect from "pages/instances/forms/PlacementGroupSelect";
 import { PLACEMENT_GROUP_POLICY_COMPACT } from "pages/placement-groups/PlacementGroupForm";
 import { CLUSTER_GROUP_PREFIX } from "util/instances";
+import ClusterMemberExplanationTooltip from "pages/cluster/ClusterMemberExplanationTooltip";
+import ClusterGroupExplanationTooltip from "pages/cluster/ClusterGroupExplanationTooltip";
 
 export const TARGET = {
   AUTO: "auto",
@@ -162,7 +162,11 @@ const InstanceTargetSelect: FC<Props> = ({ formik }) => {
     return (
       <Input
         id="clusterMember"
-        label="Cluster member"
+        label={
+          <ClusterMemberExplanationTooltip>
+            Cluster member
+          </ClusterMemberExplanationTooltip>
+        }
         value={formik.values.target}
         disabled
         help="Member is determined by the selected ISO volume and can't be changed."
@@ -176,134 +180,141 @@ const InstanceTargetSelect: FC<Props> = ({ formik }) => {
     : "Please select an image before adding a placement group";
 
   return (
-    <div className="instance-target-selector">
-      <Select
-        id="target"
-        label={
-          <>
-            Target{" "}
-            <Tooltip
-              message={`LXD automatically selects a cluster member for the instance.\nPlacement groups allow you to control how instances are distributed across cluster members.`}
-            >
-              <Icon name="information" />
-            </Tooltip>
-          </>
-        }
-        wrapperClassName="select-input"
-        value={type}
-        options={[
-          {
-            label: "Auto",
-            value: TARGET.AUTO,
-          },
-          {
-            label: "Cluster group",
-            value: TARGET.CLUSTER_GROUP,
-            disabled: clusterGroupOptions.length === 0,
-          },
-          {
-            label: "Cluster member",
-            value: TARGET.CLUSTER_MEMBER,
-            disabled:
-              clusterMemberOptions.length === 0 ||
-              isProjectBlockingClusterMemberTargeting,
-          },
-          {
-            label: "Placement group",
-            value: TARGET.PLACEMENT_GROUP,
-          },
-        ]}
-        onChange={(e) => {
-          const type = e.target.value;
-          if (type === TARGET.AUTO) {
-            setAuto();
-          }
-          if (type === TARGET.CLUSTER_GROUP) {
-            setClusterGroup(clusterGroupOptions[0].value);
-            setTimeout(() => clusterGroupRef.current?.open(), 100);
-          }
-          if (type === TARGET.CLUSTER_MEMBER) {
-            setClusterMember(clusterMemberOptions[0].value);
-            setTimeout(() => clusterMemberRef.current?.open(), 100);
-          }
-          if (type === TARGET.PLACEMENT_GROUP) {
-            setPlacementGroup(placementGroups[0]?.name ?? "-");
-            if (placementGroups.length > 0) {
-              setTimeout(() => placementGroupRef.current?.open(), 100);
+    <>
+      <div className="instance-target-selector">
+        <Select
+          id="target"
+          label="Target"
+          wrapperClassName="select-input"
+          value={type}
+          options={[
+            {
+              label: "Auto",
+              value: TARGET.AUTO,
+            },
+            {
+              label: "Cluster group",
+              value: TARGET.CLUSTER_GROUP,
+              disabled: clusterGroupOptions.length === 0,
+            },
+            {
+              label: "Cluster member",
+              value: TARGET.CLUSTER_MEMBER,
+              disabled:
+                clusterMemberOptions.length === 0 ||
+                isProjectBlockingClusterMemberTargeting,
+            },
+            {
+              label: "Placement group",
+              value: TARGET.PLACEMENT_GROUP,
+            },
+          ]}
+          onChange={(e) => {
+            const type = e.target.value;
+            if (type === TARGET.AUTO) {
+              setAuto();
             }
-          }
-        }}
-        disabled={!formik.values.image}
-        error={
-          type === TARGET.PLACEMENT_GROUP && placementGroups.length === 0
-            ? "No placement groups found for this project."
-            : ""
-        }
-        title={missingImageTitle}
-      />
-      {type === TARGET.CLUSTER_GROUP && (
-        <CustomSelect
-          id="clusterGroup"
-          label="Cluster group"
-          wrapperClassName="select-input"
-          dropdownClassName="instance-target-dropdown"
-          selectRef={clusterGroupRef as SelectRef}
-          onChange={setClusterGroup}
-          value={selectedClusterGroup(formik.values.target)}
-          options={clusterGroupOptions}
-          header={
-            <div className="header">
-              <span className="name">Name</span>
-              <span className="members">Members</span>
-            </div>
-          }
-          disabled={!formik.values.image}
-        />
-      )}
-      {type === TARGET.CLUSTER_MEMBER && (
-        <CustomSelect
-          id="clusterMember"
-          label="Cluster member"
-          wrapperClassName="select-input"
-          dropdownClassName="instance-target-dropdown"
-          selectRef={clusterMemberRef as SelectRef}
-          onChange={setClusterMember}
-          value={selectedClusterMember(formik.values.target)}
-          options={clusterMemberOptions}
-          disabled={!formik.values.image}
-        />
-      )}
-      {type === TARGET.PLACEMENT_GROUP && (
-        <PlacementGroupSelect
-          value={formik.values.placementGroup}
-          setValue={setPlacementGroup}
-          project={project?.name ?? "default"}
-          ref={placementGroupRef as SelectRef}
-          disabled={!formik.values.image}
-          profileNames={formik.values.profiles}
-          isCreateInstance
-        />
-      )}
-      {canAnchorPlacementGroup && (
-        <CustomSelect
-          id="clusterMember"
-          label="Anchor"
-          wrapperClassName="select-input"
-          dropdownClassName="instance-target-dropdown"
-          selectRef={clusterMemberRef as SelectRef}
-          onChange={(value) => {
-            const target = value ?? undefined;
-            formik.setFieldValue("target", target);
+            if (type === TARGET.CLUSTER_GROUP) {
+              setClusterGroup(clusterGroupOptions[0].value);
+              setTimeout(() => clusterGroupRef.current?.open(), 100);
+            }
+            if (type === TARGET.CLUSTER_MEMBER) {
+              setClusterMember(clusterMemberOptions[0].value);
+              setTimeout(() => clusterMemberRef.current?.open(), 100);
+            }
+            if (type === TARGET.PLACEMENT_GROUP) {
+              setPlacementGroup(placementGroups[0]?.name ?? "-");
+              if (placementGroups.length > 0) {
+                setTimeout(() => placementGroupRef.current?.open(), 100);
+              }
+            }
           }}
-          value={selectedClusterMember(formik.values.target)}
-          options={[{ label: "Auto", value: "" }].concat(
-            ...clusterMemberOptions,
-          )}
           disabled={!formik.values.image}
-          help="Cluster member to anchor the placement group"
+          error={
+            type === TARGET.PLACEMENT_GROUP && placementGroups.length === 0
+              ? "No placement groups found for this project."
+              : ""
+          }
+          title={missingImageTitle}
         />
+        {type === TARGET.CLUSTER_GROUP && (
+          <CustomSelect
+            id="clusterGroup"
+            label={
+              <ClusterGroupExplanationTooltip>
+                Cluster group
+              </ClusterGroupExplanationTooltip>
+            }
+            wrapperClassName="select-input"
+            dropdownClassName="instance-target-dropdown"
+            selectRef={clusterGroupRef as SelectRef}
+            onChange={setClusterGroup}
+            value={selectedClusterGroup(formik.values.target)}
+            options={clusterGroupOptions}
+            header={
+              <div className="header">
+                <span className="name">Name</span>
+                <span className="members">Members</span>
+              </div>
+            }
+            disabled={!formik.values.image}
+          />
+        )}
+        {type === TARGET.CLUSTER_MEMBER && (
+          <CustomSelect
+            id="clusterMember"
+            label={
+              <ClusterMemberExplanationTooltip>
+                Cluster member
+              </ClusterMemberExplanationTooltip>
+            }
+            wrapperClassName="select-input"
+            dropdownClassName="instance-target-dropdown"
+            selectRef={clusterMemberRef as SelectRef}
+            onChange={setClusterMember}
+            value={selectedClusterMember(formik.values.target)}
+            options={clusterMemberOptions}
+            disabled={!formik.values.image}
+          />
+        )}
+        {type === TARGET.PLACEMENT_GROUP && (
+          <PlacementGroupSelect
+            value={formik.values.placementGroup}
+            setValue={setPlacementGroup}
+            project={project?.name ?? "default"}
+            ref={placementGroupRef as SelectRef}
+            disabled={!formik.values.image}
+            profileNames={formik.values.profiles}
+            isCreateInstance
+          />
+        )}
+        {canAnchorPlacementGroup && (
+          <CustomSelect
+            id="clusterMember"
+            label="Anchor"
+            wrapperClassName="select-input"
+            dropdownClassName="instance-target-dropdown"
+            selectRef={clusterMemberRef as SelectRef}
+            onChange={(value) => {
+              const target = value ?? undefined;
+              formik.setFieldValue("target", target);
+            }}
+            value={selectedClusterMember(formik.values.target)}
+            options={[{ label: "Auto", value: "" }].concat(
+              ...clusterMemberOptions,
+            )}
+            disabled={!formik.values.image}
+            help="Cluster member to anchor the placement group"
+          />
+        )}
+      </div>
+      {type === TARGET.AUTO && (
+        <p className="p-form-help-text">
+          LXD automatically selects a cluster member for the instance, unless a
+          target is specified.
+        </p>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/pages/instances/forms/PlacementGroupSelect.tsx
+++ b/src/pages/instances/forms/PlacementGroupSelect.tsx
@@ -7,6 +7,7 @@ import { pluralize } from "util/helpers";
 import type { CustomSelectOption } from "@canonical/react-components/dist/components/CustomSelect/CustomSelectDropdown/CustomSelectDropdown";
 import { useProfiles } from "context/useProfiles";
 import { ROOT_PATH } from "util/rootPath";
+import PlacementGroupExplanationTooltip from "pages/placement-groups/PlacementGroupExplanationTooltip";
 
 interface Props {
   value?: string;
@@ -120,7 +121,11 @@ const PlacementGroupSelect: FC<Props> = ({
   return (
     <CustomSelect
       id="placementGroup"
-      label="Placement group"
+      label={
+        <PlacementGroupExplanationTooltip>
+          Placement group
+        </PlacementGroupExplanationTooltip>
+      }
       wrapperClassName="select-input"
       dropdownClassName="placement-group-dropdown"
       selectRef={ref}

--- a/src/pages/networks/NetworkAclExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkAclExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const NetworkAclExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="ACLs define network access control rules for traffic on your networks."
       docPath="/howto/network_acls/"
       docLabel="Learn more about network ACLs"

--- a/src/pages/networks/NetworkExplanationTooltip.tsx
+++ b/src/pages/networks/NetworkExplanationTooltip.tsx
@@ -1,11 +1,12 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const NetworkExplanationTooltip: FC<{
-  children?: ReactNode;
-}> = ({ children }) => {
+const NetworkExplanationTooltip: FC<{ children?: ReactNode }> = ({
+  children,
+}) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Networks can be virtual or physical, and connect instances."
       docPath="/explanation/networks/"
       docLabel="Learn more about networks"

--- a/src/pages/placement-groups/PlacementGroupExplanationTooltip.tsx
+++ b/src/pages/placement-groups/PlacementGroupExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const PlacementGroupExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Placement groups define rules for placing instances across cluster members."
       docPath="/howto/cluster_placement_groups/"
       docLabel="Learn more about placement groups"

--- a/src/pages/profiles/ProfileExplanationTooltip.tsx
+++ b/src/pages/profiles/ProfileExplanationTooltip.tsx
@@ -3,10 +3,16 @@ import ExplanationTooltip from "components/ExplanationTooltip";
 
 const ProfileExplanationTooltip: FC<{
   children?: ReactNode;
-}> = ({ children }) => {
+  additionalInformation?: string;
+}> = ({ children, additionalInformation }) => {
   return (
     <ExplanationTooltip
-      explanation="Profiles are configuration templates for instances."
+      className="explanation-tooltip-wrapper--inline"
+      explanation={
+        additionalInformation
+          ? additionalInformation
+          : "Profiles are configuration templates for instances."
+      }
       docPath="/profiles/"
       docLabel="Learn more about profiles"
     >

--- a/src/pages/profiles/ProfileSelector.tsx
+++ b/src/pages/profiles/ProfileSelector.tsx
@@ -6,11 +6,11 @@ import {
   Select,
   useNotify,
   Spinner,
-  Tooltip,
 } from "@canonical/react-components";
 import { defaultFirst } from "util/helpers";
 import { focusField } from "util/formFields";
 import { useProfiles } from "context/useProfiles";
+import ProfileExplanationTooltip from "pages/profiles/ProfileExplanationTooltip";
 
 interface Props {
   project: string;
@@ -67,20 +67,9 @@ const ProfileSelector: FC<Props> = ({
   return (
     <>
       <Label forId="profile-0">
-        Profiles{" "}
-        <Tooltip
-          message={
-            <>
-              A profile stores a set of configuration, such as instance and
-              device options.
-              <br />
-              Profiles lower in this list take precedence and override values
-              from profiles above.
-            </>
-          }
-        >
-          <Icon name="information" />
-        </Tooltip>
+        <ProfileExplanationTooltip additionalInformation="Profiles are configuration templates for instances. Profiles lower in this list take precedence and override values from profiles above.">
+          Profiles
+        </ProfileExplanationTooltip>
       </Label>
       {selected.map((value, index) => (
         <div className="profile-select" key={value}>

--- a/src/pages/projects/ProjectConfigurationHeader.tsx
+++ b/src/pages/projects/ProjectConfigurationHeader.tsx
@@ -12,7 +12,6 @@ import { useEventQueue } from "context/eventQueue";
 import ProjectRichChip from "pages/projects/ProjectRichChip";
 import { useProjectEntitlements } from "util/entitlements/projects";
 import { useToastNotification } from "@canonical/react-components";
-import ProjectExplanationTooltip from "./ProjectExplanationTooltip";
 
 interface Props {
   project: LxdProject;
@@ -123,11 +122,7 @@ const ProjectConfigurationHeader: FC<Props> = ({ project }) => {
   return (
     <RenameHeader
       name={project.name}
-      parentItems={[
-        <ProjectExplanationTooltip key="project-configuration">
-          Project configuration
-        </ProjectExplanationTooltip>,
-      ]}
+      parentItems={["Project configuration"]}
       renameDisabledReason={getRenameDisabledReason()}
       controls={<DeleteProjectBtn project={project} />}
       isLoaded={Boolean(project)}

--- a/src/pages/projects/ProjectExplanationTooltip.tsx
+++ b/src/pages/projects/ProjectExplanationTooltip.tsx
@@ -6,7 +6,7 @@ const ProjectExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
-      className="explanation-tooltip-wrapper--breadcrumb"
+      className="explanation-tooltip-wrapper--inline"
       explanation="Projects organize and isolate LXD resources into separate groups."
       docPath="/reference/projects/"
       docLabel="Learn more about projects"

--- a/src/pages/projects/forms/ProjectDetailsForm.tsx
+++ b/src/pages/projects/forms/ProjectDetailsForm.tsx
@@ -4,6 +4,7 @@ import {
   Col,
   Icon,
   Input,
+  Label,
   Row,
   Tooltip,
   OutputField,
@@ -21,6 +22,8 @@ import NetworkSelector from "./NetworkSelector";
 import { useNetworks } from "context/useNetworks";
 import type { ProjectDetailsFormValues } from "types/forms/project";
 import ProfileRichChip from "pages/profiles/ProfileRichChip";
+import StoragePoolExplanationTooltip from "pages/storage/StoragePoolExplanationTooltip";
+import NetworkExplanationTooltip from "pages/networks/NetworkExplanationTooltip";
 
 export const projectDetailPayload = (
   values: ProjectDetailsFormValues,
@@ -123,21 +126,28 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
             title={formik.values.editRestriction}
           />
           {isEdit ? (
-            <OutputField
-              id="default_instance_storage_pool"
-              label="Default instance storage pool"
-              value={formik.values.default_instance_storage_pool}
-              help={
-                <>
-                  Edit the storage pool in the{" "}
-                  <ProfileRichChip
-                    profileName="default"
-                    projectName={project?.name ?? ""}
-                  />{" "}
-                  {" profile"}
-                </>
-              }
-            />
+            <>
+              <Label forId="default_instance_storage_pool">
+                <StoragePoolExplanationTooltip>
+                  Default instance storage pool
+                </StoragePoolExplanationTooltip>
+              </Label>
+              <OutputField
+                id="default_instance_storage_pool"
+                label=""
+                value={formik.values.default_instance_storage_pool}
+                help={
+                  <>
+                    Edit the storage pool in the{" "}
+                    <ProfileRichChip
+                      profileName="default"
+                      projectName={project?.name ?? ""}
+                    />{" "}
+                    {" profile"}
+                  </>
+                }
+              />
+            </>
           ) : (
             <StoragePoolSelector
               value={formik.values.default_instance_storage_pool}
@@ -148,28 +158,39 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 )
               }
               selectProps={{
-                label: "Default instance storage pool",
+                label: (
+                  <StoragePoolExplanationTooltip>
+                    Default instance storage pool
+                  </StoragePoolExplanationTooltip>
+                ),
                 disabled: !formik.values.features_profiles,
               }}
             />
           )}
 
           {isEdit ? (
-            <OutputField
-              id="default_instance_network"
-              label="Default instance network"
-              value={formik.values.default_project_network}
-              help={
-                <>
-                  Configure networks in the{" "}
-                  <ProfileRichChip
-                    profileName="default"
-                    projectName={project?.name ?? ""}
-                  />{" "}
-                  profile
-                </>
-              }
-            />
+            <>
+              <Label forId="default_instance_network">
+                <NetworkExplanationTooltip>
+                  Default instance network
+                </NetworkExplanationTooltip>
+              </Label>
+              <OutputField
+                id="default_instance_network"
+                label=""
+                value={formik.values.default_project_network}
+                help={
+                  <>
+                    Configure networks in the{" "}
+                    <ProfileRichChip
+                      profileName="default"
+                      projectName={project?.name ?? ""}
+                    />{" "}
+                    profile
+                  </>
+                }
+              />
+            </>
           ) : (
             <NetworkSelector
               value={formik.values.default_project_network}
@@ -177,7 +198,11 @@ const ProjectDetailsForm: FC<Props> = ({ formik, project, isEdit }) => {
                 void formik.setFieldValue("default_project_network", value)
               }
               hasNoneOption
-              label="Default instance network"
+              label={
+                <NetworkExplanationTooltip>
+                  Default instance network
+                </NetworkExplanationTooltip>
+              }
               disabled={hasNoProfiles || hasIsolatedNetworks}
               networkList={managedNetworks}
             />

--- a/src/pages/projects/forms/ProjectReplicaForm.tsx
+++ b/src/pages/projects/forms/ProjectReplicaForm.tsx
@@ -19,6 +19,7 @@ import type {
 } from "types/forms/project";
 import type { LxdProject } from "types/project";
 import { ensureEditMode } from "util/editMode";
+import ReplicatorExplanationTooltip from "pages/cluster/ReplicatorExplanationTooltip";
 
 export const replicaPayload = (
   values: ProjectReplicaFormValues,
@@ -148,7 +149,11 @@ const ProjectReplicaForm: FC<Props> = ({ formik, project, isEdit }) => {
       </Row>
       <Row>
         <Col size={12}>
-          <h2 className="p-heading--4">Replicators for this project</h2>
+          <h2 className="p-heading--4">
+            <ReplicatorExplanationTooltip>
+              Replicators for this project
+            </ReplicatorExplanationTooltip>
+          </h2>
           {isEdit ? (
             <ReplicatorList
               variant="project-configuration"

--- a/src/pages/storage/StorageDriverExplanationTooltip.tsx
+++ b/src/pages/storage/StorageDriverExplanationTooltip.tsx
@@ -1,19 +1,19 @@
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
-const StorageBucketExplanationTooltip: FC<{
+const StorageDriverExplanationTooltip: FC<{
   children?: ReactNode;
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
       className="explanation-tooltip-wrapper--inline"
-      explanation="Storage buckets provide storage for unstructured data."
-      docPath="/explanation/storage/#storage-buckets"
-      docLabel="Learn more about storage buckets"
+      explanation="LXD supports several storage drivers for storing images, instances, and custom volumes."
+      docPath="/reference/storage_drivers/"
+      docLabel="Learn more about storage drivers"
     >
       {children}
     </ExplanationTooltip>
   );
 };
 
-export default StorageBucketExplanationTooltip;
+export default StorageDriverExplanationTooltip;

--- a/src/pages/storage/StoragePoolExplanationTooltip.tsx
+++ b/src/pages/storage/StoragePoolExplanationTooltip.tsx
@@ -1,13 +1,16 @@
+import classNames from "classnames";
 import type { FC, ReactNode } from "react";
 import ExplanationTooltip from "components/ExplanationTooltip";
 
 const StoragePoolExplanationTooltip: FC<{
   children?: ReactNode;
+  className?: string;
   isConfigVariant?: boolean;
-}> = ({ children, isConfigVariant }) => {
+}> = ({ children, className, isConfigVariant }) => {
   return (
     <ExplanationTooltip
-      explanation="Storage pools host instance and image data."
+      className={classNames("explanation-tooltip-wrapper--inline", className)}
+      explanation="Storage pools host data from instances, images and more."
       docPath={
         isConfigVariant
           ? "/reference/storage_drivers/"

--- a/src/pages/storage/StorageVolumeExplanationTooltip.tsx
+++ b/src/pages/storage/StorageVolumeExplanationTooltip.tsx
@@ -6,6 +6,7 @@ const StorageVolumeExplanationTooltip: FC<{
 }> = ({ children }) => {
   return (
     <ExplanationTooltip
+      className="explanation-tooltip-wrapper--inline"
       explanation="Storage volumes provide storage for instances."
       docPath="/explanation/storage/#storage-volumes"
       docLabel="Learn more about storage volumes"

--- a/src/pages/storage/UploadCustomIso.tsx
+++ b/src/pages/storage/UploadCustomIso.tsx
@@ -22,6 +22,7 @@ import type { LxdSyncResponse } from "types/apiResponse";
 import { isValidISOAlias, sanitizeISOAlias } from "util/customISO";
 import classnames from "classnames";
 import { createIsoStorageVolume } from "api/storage-volumes";
+import StoragePoolExplanationTooltip from "pages/storage/StoragePoolExplanationTooltip";
 
 interface Props {
   onFinish: (name: string, pool: string) => void;
@@ -155,7 +156,11 @@ const UploadCustomIso: FC<Props> = ({ onCancel, onFinish }) => {
           setValue={setPool}
           selectProps={{
             id: "storagePool",
-            label: "Storage pool",
+            label: (
+              <StoragePoolExplanationTooltip>
+                Storage pool
+              </StoragePoolExplanationTooltip>
+            ),
             disabled: file === null,
             stacked: true,
           }}

--- a/src/pages/storage/forms/StorageBucketForm.tsx
+++ b/src/pages/storage/forms/StorageBucketForm.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from "react";
-import { Form, Input, OutputField } from "@canonical/react-components";
+import { Form, Input, Label, OutputField } from "@canonical/react-components";
 import type { FormikProps } from "formik/dist/types";
 import AutoExpandingTextArea from "components/AutoExpandingTextArea";
 import StoragePoolSelector from "../StoragePoolSelector";
@@ -8,6 +8,7 @@ import { useStorageBucketEntitlements } from "util/entitlements/storage-buckets"
 import type { LxdStorageBucket } from "types/storage";
 import { cephObject, storageDriverLabels } from "util/storageOptions";
 import type { StorageBucketFormValues } from "types/forms/storageBucket";
+import StoragePoolExplanationTooltip from "pages/storage/StoragePoolExplanationTooltip";
 
 interface Props {
   formik: FormikProps<StorageBucketFormValues>;
@@ -41,12 +42,19 @@ const StorageBucketForm: FC<Props> = ({ formik, bucket }) => {
       <Input type="submit" hidden value="Hidden input" />
 
       {isEditing ? (
-        <OutputField
-          id="storage_bucket_pool"
-          label="Storage pool"
-          value={formik.values.pool}
-          help="Storage bucket pool can't be changed"
-        />
+        <>
+          <Label forId="storage_bucket_pool">
+            <StoragePoolExplanationTooltip>
+              Storage pool
+            </StoragePoolExplanationTooltip>
+          </Label>
+          <OutputField
+            id="storage_bucket_pool"
+            label=""
+            value={formik.values.pool}
+            help="Storage bucket pool can't be changed"
+          />
+        </>
       ) : (
         <StoragePoolSelector
           value={formik.values.pool}
@@ -56,7 +64,11 @@ const StorageBucketForm: FC<Props> = ({ formik, bucket }) => {
           })}
           selectProps={{
             id: "bucket-create-pool",
-            label: "Storage pool",
+            label: (
+              <StoragePoolExplanationTooltip>
+                Storage pool
+              </StoragePoolExplanationTooltip>
+            ),
             disabled: !!bucketEditRestriction,
             help: !formik.errors.pool && "Pool must have a Ceph Object driver",
             error: formik.errors.pool,

--- a/src/pages/storage/forms/StorageDriverSelect.tsx
+++ b/src/pages/storage/forms/StorageDriverSelect.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { CustomSelect, OutputField } from "@canonical/react-components";
+import { CustomSelect, Label, OutputField } from "@canonical/react-components";
 import {
   getAlletraStoragePoolFormFields,
   getCephObjectPoolFormFields,
@@ -28,6 +28,7 @@ import {
 } from "util/storagePoolForm";
 import { useSettings } from "context/useSettings";
 import DocLink from "components/DocLink";
+import StorageDriverExplanationTooltip from "pages/storage/StorageDriverExplanationTooltip";
 
 interface Props {
   formik: FormikProps<StoragePoolFormValues>;
@@ -136,17 +137,28 @@ const StorageDriverSelect: FC<Props> = ({ formik }) => {
   return (
     <>
       {!formik.values.isCreating ? (
-        <OutputField
-          id={"driver"}
-          label={"Driver"}
-          value={storageDriverLabels[formik.values.driver]}
-          help={getHelpText()}
-        />
+        <>
+          <Label forId="driver">
+            <StorageDriverExplanationTooltip>
+              Driver
+            </StorageDriverExplanationTooltip>
+          </Label>
+          <OutputField
+            id="driver"
+            label=""
+            value={storageDriverLabels[formik.values.driver]}
+            help={getHelpText()}
+          />
+        </>
       ) : (
         <CustomSelect
           id="driver"
           name="driver"
-          label="Driver"
+          label={
+            <StorageDriverExplanationTooltip>
+              Driver
+            </StorageDriverExplanationTooltip>
+          }
           wrapperClassName="select-input"
           dropdownClassName="storage-driver-dropdown"
           help={getHelpText()}

--- a/src/pages/storage/forms/StorageVolumeClusterMember.tsx
+++ b/src/pages/storage/forms/StorageVolumeClusterMember.tsx
@@ -2,7 +2,8 @@ import type { FC } from "react";
 import type { FormikProps } from "formik";
 import type { LxdClusterMember } from "types/cluster";
 import type { StorageVolumeFormValues } from "types/forms/storageVolume";
-import { OutputField, Select } from "@canonical/react-components";
+import { Label, OutputField, Select } from "@canonical/react-components";
+import ClusterMemberExplanationTooltip from "pages/cluster/ClusterMemberExplanationTooltip";
 
 interface Props {
   formik: FormikProps<StorageVolumeFormValues>;
@@ -19,19 +20,30 @@ const StorageVolumeClusterMember: FC<Props> = ({ formik, clusterMembers }) => {
 
   if (!formik.values.isCreating) {
     return (
-      <OutputField
-        id="clusterMember"
-        label="Cluster member"
-        value={formik.values.clusterMember}
-        help="Use the migrate button in the header to move the storage volume to a another cluster member."
-      />
+      <>
+        <Label forId="clusterMember">
+          <ClusterMemberExplanationTooltip>
+            Cluster member
+          </ClusterMemberExplanationTooltip>
+        </Label>
+        <OutputField
+          id="clusterMember"
+          label=""
+          value={formik.values.clusterMember}
+          help="Use the migrate button in the header to move the storage volume to another cluster member."
+        />
+      </>
     );
   }
 
   return (
     <Select
       id="clusterMember"
-      label="Cluster member"
+      label={
+        <ClusterMemberExplanationTooltip>
+          Cluster member
+        </ClusterMemberExplanationTooltip>
+      }
       onChange={(e) => {
         formik.setFieldValue("clusterMember", e.target.value);
       }}

--- a/src/pages/storage/forms/StorageVolumeFormMain.tsx
+++ b/src/pages/storage/forms/StorageVolumeFormMain.tsx
@@ -23,6 +23,7 @@ import type { LxdClusterMember } from "types/cluster";
 import DiskSizeQuotaLimitation from "components/forms/DiskSizeQuotaLimitation";
 import StoragePoolSizeAvailable from "components/forms/StoragePoolSizeAvailable";
 import { getStorageVolumeFormProps } from "util/storageVolume";
+import StoragePoolExplanationTooltip from "pages/storage/StoragePoolExplanationTooltip";
 import StorageVolumeClusterMember from "./StorageVolumeClusterMember";
 
 interface Props {
@@ -51,7 +52,9 @@ const StorageVolumeFormMain: FC<Props> = ({
           {isCreating ? (
             <>
               <Label forId="storage-pool-selector-volume" required={isCreating}>
-                Storage pool
+                <StoragePoolExplanationTooltip>
+                  Storage pool
+                </StoragePoolExplanationTooltip>
               </Label>
               <StoragePoolSelector
                 value={formik.values.pool}
@@ -76,12 +79,19 @@ const StorageVolumeFormMain: FC<Props> = ({
               />
             </>
           ) : (
-            <OutputField
-              id="storage-pool-selector-volume"
-              label="Storage pool"
-              value={formik.values.pool}
-              help="Use the migrate button in the header to move the volume to a different storage pool."
-            />
+            <>
+              <Label forId="storage-pool-selector-volume">
+                <StoragePoolExplanationTooltip>
+                  Storage pool
+                </StoragePoolExplanationTooltip>
+              </Label>
+              <OutputField
+                id="storage-pool-selector-volume"
+                label=""
+                value={formik.values.pool}
+                help="Use the migrate button in the header to move the volume to a different storage pool."
+              />
+            </>
           )}
           <StorageVolumeClusterMember
             formik={formik}

--- a/src/sass/_explanation_tooltip.scss
+++ b/src/sass/_explanation_tooltip.scss
@@ -9,7 +9,7 @@
   width: 1rem !important;
 }
 
-.explanation-tooltip-wrapper--breadcrumb {
+.explanation-tooltip-wrapper--inline {
   display: inline-flex;
 }
 
@@ -20,7 +20,7 @@
 }
 
 .explanation-tooltip-portal .p-tooltip__message {
-  max-width: calc(60vw - 2rem);
+  max-width: min(calc(60vw - 2rem), 30rem);
   white-space: normal;
   width: max-content;
 }


### PR DESCRIPTION
## Done
Creates new ETs:
- SSH Keys
- Adds Config variant to ProjectExplanationTooltip (Feedback from @sophiecarroll in https://github.com/canonical/lxd-ui/pull/2194)

Adds ETs to the following pages:
- Instance creation form (Profile, SSH ETs)
- Profile creation form (SSH ETs)
- Storage Volume creation form (Storage pool ET)
- Storage Buckets creation form (Storage pool ET)
- Custom ISO creation form (Storage pool ET)
- Project configuration form (default storage pool & instance network)
- Project -> Replication -> Replicators for this project (Replicators ET)
- Storage Driver ET for the Storage Pool creation form

Other:
- Minor copy change in profile ET in instance creation.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - [List the steps to QA the new feature(s) or prove that a bug has been resolved]

## Screenshots
<img width="1562" height="946" alt="image" src="https://github.com/user-attachments/assets/1592c5d9-bc30-40a3-b3bf-2461c36796d6" />

<img width="988" height="683" alt="image" src="https://github.com/user-attachments/assets/881c34e6-20a1-4161-b921-8fed49c2bcab" />