### PR TITLE
chore(tests) fix permission test helpers

### DIFF
--- a/tests/helpers/permission-identities.ts
+++ b/tests/helpers/permission-identities.ts
@@ -116,27 +116,22 @@ export const createIdentity = async (
   await expect(identityRow).toContainText(identityType);
 };
 
-export const deleteIdentity = async (
-  page: Page,
-  name: string,
-  identityType: IdentityType,
-) => {
+export const deleteIdentity = async (page: Page, name: string) => {
   await visitIdentities(page);
   const row = page.getByRole("row").filter({ hasText: name });
 
   const identityId = (
     await row.getByRole("cell", { name: "ID", exact: true }).textContent()
   )?.trim();
-
   expect(identityId).toBeTruthy();
 
   // Read the type as displayed in the row, since pending identities carry a
   // "(pending)" suffix (e.g. "Client certificate (pending)") that must match
   // the raw type rendered in the deletion toast.
-  const displayedType =
-    (
-      await row.getByRole("cell", { name: "Type", exact: true }).textContent()
-    )?.trim() || identityType;
+  const displayedType = (
+    await row.getByRole("cell", { name: "Type", exact: true }).textContent()
+  )?.trim();
+  expect(displayedType).toBeTruthy();
 
   await row.getByRole("button", { name: "Delete identity" }).click();
   await page.getByRole("button", { name: "Delete", exact: true }).click();

--- a/tests/permission-identities.spec.ts
+++ b/tests/permission-identities.spec.ts
@@ -156,39 +156,41 @@ test("reissue a new token for bearer identity", async ({ page }) => {
   expect(reissuedToken).not.toEqual(initialToken);
 
   await page.getByRole("button", { name: "Cancel" }).click();
-  await deleteIdentity(page, identity, IDENTITY_TYPE.BEARER_CLIENT);
+  await deleteIdentity(page, identity);
 });
 
 test("create and delete TLS identity", async ({ page }) => {
-  const tlsName = randomIdentityName();
-  await createIdentity(page, tlsName, IDENTITY_TYPE.TLS);
-  await deleteIdentity(page, tlsName, IDENTITY_TYPE.TLS);
+  const identity = randomIdentityName();
+  await createIdentity(page, identity, IDENTITY_TYPE.TLS);
+  await deleteIdentity(page, identity);
 });
 
-test("create and delete token bearer identities", async ({
+test("create and delete bearer client identity", async ({
   page,
   lxdVersion,
 }) => {
   skipIfTokenBearerIdentitiesNotSupported(lxdVersion);
-  const bearerClientName = randomIdentityName();
-  const bearerDevlxdName = randomIdentityName();
-  const clusterLinkName = randomIdentityName();
+  const identity = randomIdentityName();
+  await createIdentity(page, identity, IDENTITY_TYPE.BEARER_CLIENT, "1d");
+  await deleteIdentity(page, identity);
+});
 
-  await createIdentity(
-    page,
-    bearerClientName,
-    IDENTITY_TYPE.BEARER_CLIENT,
-    "1d",
-  );
-  await createIdentity(
-    page,
-    bearerDevlxdName,
-    IDENTITY_TYPE.BEARER_DEVLXD,
-    "2H",
-  );
-  await createIdentity(page, clusterLinkName, IDENTITY_TYPE.CLUSTER_LINK);
+test("create and delete devlxd client identity", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfTokenBearerIdentitiesNotSupported(lxdVersion);
+  const identity = randomIdentityName();
+  await createIdentity(page, identity, IDENTITY_TYPE.BEARER_DEVLXD, "2H");
+  await deleteIdentity(page, identity);
+});
 
-  await deleteIdentity(page, bearerClientName, IDENTITY_TYPE.BEARER_CLIENT);
-  await deleteIdentity(page, bearerDevlxdName, IDENTITY_TYPE.BEARER_DEVLXD);
-  await deleteIdentity(page, clusterLinkName, IDENTITY_TYPE.CLUSTER_LINK);
+test("create and delete cluster link identity", async ({
+  page,
+  lxdVersion,
+}) => {
+  skipIfTokenBearerIdentitiesNotSupported(lxdVersion);
+  const identity = randomIdentityName();
+  await createIdentity(page, identity, IDENTITY_TYPE.CLUSTER_LINK);
+  await deleteIdentity(page, identity);
 });


### PR DESCRIPTION
## Done

- chore(tests) fix permission test helpers
-  to fix lint violation on a11y tests using the delete identity helper

Fixes [list issues/bugs if needed]

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure check lint is passing in CI
    - ensure identity and a11y tests are passing in CI