### PR TITLE
feat: improve responsiveness of permission tables

### DIFF
--- a/src/pages/permissions/PermissionGroups.tsx
+++ b/src/pages/permissions/PermissionGroups.tsx
@@ -75,7 +75,11 @@ const PermissionGroups: FC = () => {
       sortKey: "permissions",
       className: "u-align--right permissions",
     },
-    { "aria-label": "Actions", className: "u-align--right actions" },
+    {
+      "aria-label": "Actions",
+      className: "u-align--right actions",
+      heading: "Actions",
+    },
   ];
 
   const filteredGroups = groups.filter(
@@ -208,6 +212,7 @@ const PermissionGroups: FC = () => {
           headers={headers}
           rows={sortedRows}
           sortable
+          responsive
           emptyStateMsg="No groups found matching this search"
           onUpdateSort={updateSort}
           itemName="group"

--- a/src/pages/permissions/PermissionIdentities.tsx
+++ b/src/pages/permissions/PermissionIdentities.tsx
@@ -84,7 +84,11 @@ const PermissionIdentities: FC = () => {
       sortKey: "groups",
       className: "u-align--right group-count",
     },
-    { "aria-label": "Actions", className: "u-align--right actions" },
+    {
+      "aria-label": "Actions",
+      className: "u-align--right actions",
+      heading: "Actions",
+    },
   ];
 
   const filters: PermissionIdentitiesFilterType = {
@@ -337,6 +341,7 @@ const PermissionIdentities: FC = () => {
                 headers={headers}
                 rows={sortedRows}
                 sortable
+                responsive
                 emptyStateMsg="No identities found matching this search"
                 onUpdateSort={updateSort}
                 itemName="identity"

--- a/src/pages/permissions/PermissionIdpGroups.tsx
+++ b/src/pages/permissions/PermissionIdpGroups.tsx
@@ -73,7 +73,11 @@ const PermissionIdpGroups: FC = () => {
       sortKey: "groups",
       className: "u-align--right mapped-groups",
     },
-    { "aria-label": "Actions", className: "u-align--right actions" },
+    {
+      "aria-label": "Actions",
+      className: "u-align--right actions",
+      heading: "Actions",
+    },
   ];
 
   const filteredGroups = groups.filter(
@@ -251,6 +255,7 @@ const PermissionIdpGroups: FC = () => {
             headers={headers}
             rows={sortedRows}
             sortable
+            responsive
             emptyStateMsg="No identity provider groups found matching this search"
             onUpdateSort={updateSort}
             itemName="IDP group"

--- a/src/sass/_permission_groups.scss
+++ b/src/sass/_permission_groups.scss
@@ -23,25 +23,6 @@
       .actions {
         width: 8.5rem;
       }
-
-      @media screen and (width < 1000px) {
-        .description {
-          display: none;
-        }
-      }
-
-      @media screen and (width < 900px) {
-        .identities,
-        .permissions {
-          display: none;
-        }
-      }
-
-      @media screen and (width < 600px) {
-        .select {
-          display: none;
-        }
-      }
     }
   }
 

--- a/src/sass/_permission_identities.scss
+++ b/src/sass/_permission_identities.scss
@@ -29,22 +29,10 @@
       width: 8.5rem;
     }
 
-    @media screen and (width < 1000px) {
-      .group-count {
-        display: none;
-      }
-    }
-
-    @media screen and (width < 900px) {
-      .select {
-        display: none;
-      }
-    }
-
-    @media screen and (width < 600px) {
-      .identity-id {
-        display: none;
-      }
+    // let the expiry warning icon wrap onto its own line instead of
+    // being clipped or overflowing the cell/card boundary on narrow screens
+    .expires {
+      white-space: normal;
     }
   }
 

--- a/src/sass/_permission_idp_groups.scss
+++ b/src/sass/_permission_idp_groups.scss
@@ -1,13 +1,4 @@
 .permission-idp-groups-list {
-  .permission-idp-group-table {
-    @media screen and (width < 650px) {
-      .select,
-      .mapped-groups {
-        display: none;
-      }
-    }
-  }
-
   @media screen and (width < 500px) {
     .page-header__search {
       display: none;


### PR DESCRIPTION
## Done

- Improve responsiveness of permission tables WD-38562

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Permissions -> Identites / Groups / IDP groups
    - Check the responsiveness of the table on different screen sizes
    - Ensure the warning label of an identity expiration is not cut off

## Screenshots

<img width="1011" height="630" alt="image" src="https://github.com/user-attachments/assets/8544948b-fac1-447b-9b4f-fbd10fe02bea" />