### PR TITLE
feat(pragma): wrap pragma icon component

### DIFF
--- a/src/components/DsIcon.tsx
+++ b/src/components/DsIcon.tsx
@@ -1,0 +1,13 @@
+import { Icon, type IconProps } from "@canonical/react-ds-global";
+import type { FC } from "react";
+import { ROOT_PATH } from "util/rootPath";
+
+type Props = Omit<IconProps, "rootPath">;
+
+// Wraps the Pragma DsIcon component, presetting the rootPath so callers
+// don't need to repeat it at every call site.
+const DsIcon: FC<Props> = (props) => (
+  <Icon {...props} rootPath={`${ROOT_PATH}/ui/assets/icons`} />
+);
+
+export default DsIcon;

--- a/src/components/ResourceIcon.tsx
+++ b/src/components/ResourceIcon.tsx
@@ -1,8 +1,7 @@
 import { Icon as VanillaIcon } from "@canonical/react-components";
-import { Icon as DsIcon } from "@canonical/react-ds-global";
 import type { IconName } from "@canonical/ds-assets";
 import type { FC } from "react";
-import { ROOT_PATH } from "util/rootPath";
+import DsIcon from "components/DsIcon";
 
 export type ResourceIconType =
   | "bucket"
@@ -92,13 +91,7 @@ const isDsResourceIcon = (type: ResourceIconType): type is DsResourceIconType =>
 
 const ResourceIcon: FC<Props> = ({ type, className }) => {
   if (isDsResourceIcon(type)) {
-    return (
-      <DsIcon
-        icon={dsResourceIcons[type]}
-        className={className}
-        rootPath={`${ROOT_PATH}/ui/assets/icons`}
-      />
-    );
+    return <DsIcon icon={dsResourceIcons[type]} className={className} />;
   }
   return (
     <VanillaIcon name={vanillaResourceIcons[type]} className={className} />


### PR DESCRIPTION
## Done

- wrap pragma icon component so that `rootPath` is not defined everywhere the icon is used WD-38475

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Verify the pragma icons: project, network, and image registry icons render correctly in all locations forms, panels, pages, table rows, etc and in both dark and light themes.