### PR TITLE
feat(a11y): [WD-38581] add instance detail tab a11y and ensure list page content

### DIFF
--- a/tests/a11y-audit.spec.ts
+++ b/tests/a11y-audit.spec.ts
@@ -19,7 +19,7 @@ import {
   visitImageRegistry,
 } from "./helpers/image-registries";
 import {
-  createInstance,
+  createAndStartInstance,
   deleteInstance,
   randomInstanceName,
   visitInstance,
@@ -33,8 +33,14 @@ import {
   visitNetwork,
 } from "./helpers/network";
 import {
+  createNetworkAcl,
+  deleteNetworkAcl,
+  randomNetworkAclName,
+} from "./helpers/network-acls";
+import {
   createVolume,
   deleteVolume,
+  randomIsoName,
   randomVolumeName,
   visitVolume,
 } from "./helpers/storageVolume";
@@ -67,6 +73,7 @@ import {
   randomIdpGroupName,
   visitIdpGroups,
 } from "./helpers/permission-idp-groups";
+import { createCustomISO, deleteCustomISO } from "./helpers/custom-isos";
 
 test.describe("instances", () => {
   const instance = randomInstanceName();
@@ -78,7 +85,7 @@ test.describe("instances", () => {
       return;
     }
     const page = await browser.newPage();
-    await createInstance(page, instance);
+    await createAndStartInstance(page, instance);
     await createPool(page, pool);
     await createProject(page, project);
     await page.close();
@@ -238,9 +245,67 @@ test.describe("instances", () => {
   test("configure snapshot modal", async ({ page }, testInfo) => {
     skipIfNotA11yProject(testInfo.project.name);
     await visitInstance(page, instance);
-    await page.getByTestId("tab-link-Snapshots").click();
+    await page.getByRole("tab", { name: "Snapshots" }).click();
     await page.getByRole("button", { name: "See configuration" }).click();
     await runA11yAuditForModal(page, testInfo);
+  });
+
+  test("configuration tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "Configuration" }).click();
+    await page
+      .locator('[role="tabpanel"][aria-labelledby="configuration"]')
+      .waitFor();
+    await runA11yAudit(page, testInfo);
+  });
+
+  test("snapshots tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "Snapshots" }).click();
+    await page
+      .locator('[role="tabpanel"][aria-labelledby="snapshots"]')
+      .waitFor();
+    await runA11yAudit(page, testInfo);
+  });
+
+  test("file explorer tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "File explorer" }).click();
+    await page
+      .locator('[role="tabpanel"][aria-labelledby="file-explorer"]')
+      .waitFor();
+    await runA11yAudit(page, testInfo);
+  });
+
+  test("terminal tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "Terminal" }).click();
+    await page
+      .locator('[role="tabpanel"][aria-labelledby="terminal"]')
+      .waitFor();
+    await runA11yAudit(page, testInfo);
+  });
+
+  test("console tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "Console" }).click();
+    await page
+      .locator('[role="tabpanel"][aria-labelledby="console"]')
+      .waitFor();
+    await runA11yAudit(page, testInfo);
+  });
+
+  test("logs tab", async ({ page }, testInfo) => {
+    skipIfNotA11yProject(testInfo.project.name);
+    await visitInstance(page, instance);
+    await page.getByRole("tab", { name: "Logs" }).click();
+    await page.locator('[role="tabpanel"][aria-labelledby="logs"]').waitFor();
+    await runA11yAudit(page, testInfo);
   });
 });
 
@@ -267,6 +332,7 @@ test.describe("profiles", () => {
 
 test.describe("networks", () => {
   const network = randomNetworkName();
+  const networkAcl = randomNetworkAclName();
 
   test.beforeAll(async ({ browser }, testInfo) => {
     if (!isA11yProject(testInfo.project.name)) {
@@ -274,6 +340,7 @@ test.describe("networks", () => {
     }
     const page = await browser.newPage();
     await createNetwork(page, network);
+    await createNetworkAcl(page, networkAcl);
     await page.close();
   });
 
@@ -282,6 +349,7 @@ test.describe("networks", () => {
       return;
     }
     const page = await browser.newPage();
+    await deleteNetworkAcl(page, networkAcl);
     await deleteNetwork(page, network);
     await page.close();
   });
@@ -329,6 +397,7 @@ test.describe("storage", () => {
   const volume = randomVolumeName();
   const pool = randomPoolName();
   const project = randomProjectName();
+  const isoName = randomIsoName();
 
   test.beforeAll(async ({ browser }, testInfo) => {
     if (!isA11yProject(testInfo.project.name)) {
@@ -338,6 +407,8 @@ test.describe("storage", () => {
     await createPool(page, pool);
     await createVolume(page, volume);
     await createProject(page, project);
+    await createCustomISO(page, isoName);
+
     await page.close();
   });
 
@@ -346,6 +417,8 @@ test.describe("storage", () => {
       return;
     }
     const page = await browser.newPage();
+
+    await deleteCustomISO(page, isoName);
     await deleteVolume(page, volume);
     await deletePool(page, pool);
     await deleteProject(page, project);

--- a/tests/helpers/custom-isos.ts
+++ b/tests/helpers/custom-isos.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test";
+import { gotoURL } from "./navigate";
+
+export const ISO_FILE = "./tests/fixtures/foo.iso";
+
+export const createCustomISO = async (page: Page, isoName: string) => {
+  await gotoURL(page, "/ui/");
+  await page.getByRole("button", { name: "Storage", exact: true }).click();
+  await page.getByRole("link", { name: "Custom ISOs" }).click();
+  await page.getByRole("button", { name: "Upload custom ISO" }).click();
+  await page.getByLabel("Local file").setInputFiles(ISO_FILE);
+  await page.getByLabel("Alias").fill(isoName);
+  await page.getByRole("button", { name: "Upload", exact: true }).click();
+  await page.getByText(`Custom ISO ${isoName} uploaded successfully`).waitFor();
+};
+
+export const deleteCustomISO = async (page: Page, isoName: string) => {
+  await gotoURL(page, "/ui/");
+  await page.getByRole("button", { name: "Storage", exact: true }).click();
+  await page.getByRole("link", { name: "Custom ISOs" }).click();
+  await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
+  const isoRow = page.getByRole("row").filter({ hasText: isoName });
+  await isoRow.waitFor();
+  await isoRow.getByRole("button", { name: "Delete" }).click();
+  await page
+    .getByRole("dialog", { name: "Confirm delete" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+  await page.getByText(`Custom ISO ${isoName} deleted.`).waitFor();
+};

--- a/tests/iso-volumes.spec.ts
+++ b/tests/iso-volumes.spec.ts
@@ -5,8 +5,8 @@ import { activateOverride } from "./helpers/configuration";
 import { gotoURL } from "./helpers/navigate";
 import { randomIsoName } from "./helpers/storageVolume";
 import { dismissNotification } from "./helpers/notification";
+import { deleteCustomISO, ISO_FILE } from "./helpers/custom-isos";
 
-const ISO_FILE = "./tests/fixtures/foo.iso";
 test("upload and delete custom iso", async ({ page }) => {
   const isoName = randomIsoName();
 
@@ -32,11 +32,7 @@ test("upload and delete custom iso", async ({ page }) => {
   await assertTextVisible(page, "type: disk", true);
   await page.getByRole("button", { name: "Cancel", exact: true }).click();
 
-  await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
-  await assertTextVisible(page, "3 B");
-  await page.getByRole("button", { name: "Delete" }).click();
-  await page.getByText("Delete", { exact: true }).click();
-  await assertTextVisible(page, `Custom iso ${isoName} deleted.`);
+  await deleteCustomISO(page, isoName);
 });
 
 test("use custom iso for instance launch", async ({ page }) => {
@@ -73,11 +69,5 @@ test("use custom iso for instance launch", async ({ page }) => {
   await dismissNotification(page, `Created instance ${instance}.`);
 
   await deleteInstance(page, instance);
-  await gotoURL(page, "/ui/");
-  await page.getByRole("button", { name: "Storage", exact: true }).click();
-  await page.getByRole("link", { name: "Custom ISOs" }).click();
-  await page.getByPlaceholder("Search for custom ISOs").fill(isoName);
-  await page.getByRole("button", { name: "Delete" }).click();
-  await page.getByText("Delete", { exact: true }).click();
-  await assertTextVisible(page, `Custom iso ${isoName} deleted.`);
+  await deleteCustomISO(page, isoName);
 });


### PR DESCRIPTION
## Done

~~**https://github.com/canonical/lxd-ui/pull/2216 must be merged before this PR**~~ Can now be merged

- Adds a11y-audit coverage for all 6 instance detail page tabs: Configuration, Snapshots, File explorer, Terminal, Console, and Logs.
- Uses createAndStartInstance to support interactive tabs.
- Ensures ACL & ISO list pages are audited with actual content rather than empty states by creating a network ACL and uploading a custom ISO in test setup.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Observe test suite or run tests locally

## Screenshots

N/A