### PR TITLE
fix(instance) ensure parent path is invalidated on deleting an item in file explorer

### DIFF
--- a/src/pages/instances/actions/FileExplorerDeleteBtn.tsx
+++ b/src/pages/instances/actions/FileExplorerDeleteBtn.tsx
@@ -26,6 +26,7 @@ const FileExplorerDeleteBtn: FC<Props> = ({ instance, fullPath, fileType }) => {
   const isDirectory = fileType === "directory";
   const pathType = isDirectory ? "Directory" : "File";
   const pathName = fullPath.split("/").slice(-1)[0];
+  const parentPath = fullPath.split("/").slice(0, -1).join("/") || "/";
 
   const instanceLink = (
     <InstanceRichChip
@@ -42,6 +43,15 @@ const FileExplorerDeleteBtn: FC<Props> = ({ instance, fullPath, fileType }) => {
         instance.project,
         queryKeys.files,
         fullPath,
+      ],
+    });
+    queryClient.invalidateQueries({
+      queryKey: [
+        queryKeys.instances,
+        instance.name,
+        instance.project,
+        queryKeys.files,
+        parentPath,
       ],
     });
   };


### PR DESCRIPTION
## Done

- fix(instance) ensure parent path is invalidated on deleting an item in file explorer

issue surfaced on failing test runs:
- https://github.com/canonical/lxd-ui/actions/runs/33537995470/job/99957242882?pr=2251
- https://github.com/canonical/lxd-ui/actions/runs/33537995470/job/99957243126?pr=2251