### PR TITLE
feat(Overview): remove double scroll in WarningsCard

### DIFF
--- a/src/pages/overview/WarningsCard.tsx
+++ b/src/pages/overview/WarningsCard.tsx
@@ -1,8 +1,15 @@
 import { type FC } from "react";
-import { Card, Icon, MainTable, Spinner } from "@canonical/react-components";
 import { Link } from "react-router-dom";
+import {
+  Card,
+  Icon,
+  MainTable,
+  Spinner,
+  TablePagination,
+} from "@canonical/react-components";
 import { useCurrentProject } from "context/useCurrentProject";
 import { useWarnings } from "context/useWarnings";
+import { ITEMS_PER_PAGE } from "pages/overview/overviewConstants";
 import WarningExplanationTooltip from "pages/warnings/WarningExplanationTooltip";
 import { ROOT_PATH } from "util/rootPath";
 import { getWarningHeaders, getWarningRows } from "util/warnings";
@@ -45,21 +52,38 @@ const WarningsCard: FC = () => {
     );
   }
 
+  const rows = getWarningRows(newWarnings, "overview");
+  const warningsTable = (
+    <MainTable
+      id="warning-table"
+      headers={getWarningHeaders("overview")}
+      rows={newWarnings.length > ITEMS_PER_PAGE ? undefined : rows}
+      sortable={true}
+      defaultSort="severity"
+      defaultSortDirection="descending"
+      className="warnings-table warnings-table--overview"
+      emptyStateMsg="No warnings found"
+      responsive
+    />
+  );
+
   return (
     <Card className={cardClassName} title={cardTitle}>
-      <div className="warnings-table-overview-scroll">
-        <MainTable
-          id="warning-table"
-          headers={getWarningHeaders("overview")}
-          rows={getWarningRows(newWarnings, "overview")}
-          sortable={true}
-          defaultSort="severity"
-          defaultSortDirection="descending"
-          className="warnings-table warnings-table--overview"
-          emptyStateMsg="No warnings found"
-          responsive
-        />
-      </div>
+      {newWarnings.length > ITEMS_PER_PAGE ? (
+        <TablePagination
+          id="warnings-pagination"
+          data={rows}
+          pageLimits={[ITEMS_PER_PAGE]}
+          itemName="warning"
+          position="below"
+          className="u-no-margin--bottom"
+          aria-label="Warnings pagination control"
+        >
+          {warningsTable}
+        </TablePagination>
+      ) : (
+        warningsTable
+      )}
       <div className="card-footer">
         <Link to={`${ROOT_PATH}/ui/warnings?status=new`}>See more</Link>
       </div>

--- a/src/sass/_overview.scss
+++ b/src/sass/_overview.scss
@@ -175,32 +175,27 @@
     }
 
     &.warnings {
-      .warnings-table-overview-scroll {
-        max-height: 17.5rem;
-        overflow-y: auto;
+      .warnings-table--overview {
+        thead th {
+          background-color: var(--vf-color-background-default);
+          position: sticky;
+          top: 0;
+          z-index: 1;
+        }
 
-        .warnings-table--overview {
-          thead th {
-            background-color: var(--vf-color-background-default);
-            position: sticky;
-            top: 0;
-            z-index: 1;
-          }
+        thead .last_message {
+          display: table-cell;
+          overflow: visible;
+          white-space: nowrap;
+        }
 
-          thead .last_message {
-            display: table-cell;
-            overflow: visible;
-            white-space: nowrap;
-          }
+        tbody .last_message {
+          @include u-line-clamp-truncate(2);
 
-          tbody .last_message {
-            @include u-line-clamp-truncate(2);
-
-            /* Explicitly cap the height so overflow lines can't bleed through */
-            max-height: calc(
-              1.5rem * 2 + 0.5rem
-            ); // line-height * lines + padding
-          }
+          /* Explicitly cap the height so overflow lines can't bleed through */
+          max-height: calc(
+            1.5rem * 2 + 0.5rem
+          ); // line-height * lines + padding
         }
       }
     }


### PR DESCRIPTION
## Done

- feat(Overview): remove double scroll in WarningsCard

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Overview page. Warnings card should include pagination when there are more than 4 items.

## Screenshots

<img width="1502" height="626" alt="image" src="https://github.com/user-attachments/assets/ffd89672-95ff-450c-b283-9df1260709f5" />