### PR TITLE
fix(network) disable load balancers on custom projects without network isolation

### DIFF
--- a/src/pages/networks/LoadBalancers.tsx
+++ b/src/pages/networks/LoadBalancers.tsx
@@ -2,25 +2,46 @@ import type { FC } from "react";
 import type { LxdNetwork } from "types/network";
 import { useCurrentProject } from "context/useCurrentProject";
 import MenuItem from "components/forms/FormMenuItem";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { ROOT_PATH } from "util/rootPath";
 import LoadBalancersTab from "pages/networks/LoadBalancersTab";
 import LoadBalancerPoolsTab from "pages/networks/LoadBalancerPoolsTab";
 import usePanelParams, { panels } from "util/usePanelParams";
 import CreateLoadBalancerPoolPanel from "pages/networks/panels/CreateLoadBalancerPoolPanel";
 import EditLoadBalancerPoolPanel from "pages/networks/panels/EditLoadBalancerPoolPanel";
+import { Notification } from "@canonical/react-components";
+import ProjectRichChip from "pages/projects/ProjectRichChip";
 
 interface Props {
   network: LxdNetwork;
 }
 
 const LoadBalancers: FC<Props> = ({ network }) => {
-  const { projectName: project } = useCurrentProject();
+  const { projectName, project, isLoading } = useCurrentProject();
   const { section } = useParams<{
     section?: string;
   }>();
   const navigate = useNavigate();
   const panelParams = usePanelParams();
+
+  if (
+    projectName !== "default" &&
+    project?.config["features.networks"] !== "true" &&
+    !isLoading
+  ) {
+    return (
+      <Notification severity="caution" title="Network isolation is disabled">
+        The current project <ProjectRichChip projectName={projectName} /> has
+        disabled network isolation. Please enable network isolation in{" "}
+        <Link
+          to={`${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/configuration`}
+        >
+          project configuration
+        </Link>{" "}
+        to access load balancer features.
+      </Notification>
+    );
+  }
 
   return (
     <>
@@ -33,7 +54,7 @@ const LoadBalancers: FC<Props> = ({ network }) => {
                 active={section ?? "load-balancers"}
                 setActive={() => {
                   navigate(
-                    `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}/load-balancers`,
+                    `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network/${encodeURIComponent(network.name)}/load-balancers`,
                   );
                 }}
               />
@@ -42,7 +63,7 @@ const LoadBalancers: FC<Props> = ({ network }) => {
                 active={section ?? ""}
                 setActive={() => {
                   navigate(
-                    `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/network/${encodeURIComponent(network.name)}/load-balancers/pools`,
+                    `${ROOT_PATH}/ui/project/${encodeURIComponent(projectName)}/network/${encodeURIComponent(network.name)}/load-balancers/pools`,
                   );
                 }}
               />


### PR DESCRIPTION
## Done

- fix(network) disable load balancers on custom projects without network isolation

Fixes #2261

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create a VM with LXD latest/edge and microovn configured
    - create a custom project that has network isolation disabled
    - create an ovn network in the default project
    - browse ovn network on the default project > check load balancers work as expected
    - browse ovn network on the custom project > check load balancers are disabled with the warning as in the screenshot below
    - 

## Screenshots

<img width="3832" height="1904" alt="image" src="https://github.com/user-attachments/assets/c590e84a-56b5-45f0-9f17-9f019df4e671" />