### PR TITLE
fix(network) in page navigation on network detail page should jump to the right section

### DIFF
--- a/src/pages/cluster/ClusterMemberHardware.tsx
+++ b/src/pages/cluster/ClusterMemberHardware.tsx
@@ -18,14 +18,17 @@ import ClusterMemberDetailPCI from "pages/cluster/ClusterMemberDetailPCI";
 import ClusterMemberDetailStorage from "pages/cluster/ClusterMemberDetailStorage";
 import ClusterMemberDetailUSB from "pages/cluster/ClusterMemberDetailUSB";
 import type { LxdClusterMember } from "types/cluster";
-import { getFirstVisibleSection } from "util/scroll";
+import { getFirstVisibleSection, scrollToSection } from "util/scroll";
+import { useLocation } from "react-router-dom";
 
 interface Props {
   member?: LxdClusterMember;
 }
 
 const ClusterMemberHardware: FC<Props> = ({ member }) => {
-  const [section, setSection] = useState("system");
+  const { hash } = useLocation();
+  const initialSection = hash ? hash.substring(1) : "system";
+  const [section, setSection] = useState(initialSection);
 
   const { data: resources, isLoading } = useClusterMemberResources(
     member?.server_name,
@@ -58,6 +61,15 @@ const ClusterMemberHardware: FC<Props> = ({ member }) => {
     wrapper?.addEventListener("scroll", scrollListener);
     return () => wrapper?.removeEventListener("scroll", scrollListener);
   }, [isLoading, sections]);
+
+  // the sections only exist once the resources are loaded, scroll after that
+  useEffect(() => {
+    if (!resources) {
+      return;
+    }
+    scrollToSection(initialSection);
+    setSection(initialSection);
+  }, [initialSection, resources]);
 
   if (isLoading || isStateLoading) {
     return <Spinner className="u-loader" text="Loading..." />;

--- a/src/pages/networks/CreateNetwork.tsx
+++ b/src/pages/networks/CreateNetwork.tsx
@@ -39,7 +39,6 @@ import { slugify } from "util/slugify";
 import FormFooterLayout from "components/forms/FormFooterLayout";
 import YamlSwitch from "components/forms/YamlSwitch";
 import { bridgeType, ovnType } from "util/networks";
-import { scrollToElement } from "util/scroll";
 import { useClusterMembers } from "context/useClusterMembers";
 import { useAuth } from "context/auth";
 import { useEventQueue } from "context/eventQueue";
@@ -194,7 +193,8 @@ const CreateNetwork: FC = () => {
   const updateSection = (newSection: string, source: "scroll" | "click") => {
     setSection(slugify(newSection));
     if (source === "click") {
-      scrollToElement(slugify(newSection));
+      const baseUrl = `${ROOT_PATH}/ui/project/${encodeURIComponent(project)}/networks/create`;
+      window.location.href = `${baseUrl}#${slugify(newSection)}`;
     }
   };
 

--- a/src/pages/networks/EditNetwork.tsx
+++ b/src/pages/networks/EditNetwork.tsx
@@ -32,7 +32,7 @@ import FormFooterLayout from "components/forms/FormFooterLayout";
 import YamlSwitch from "components/forms/YamlSwitch";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import { useNetworkEntitlements } from "util/entitlements/networks";
-import { scrollToElement } from "util/scroll";
+import { scrollToSection } from "util/scroll";
 import { useClusterMembers } from "context/useClusterMembers";
 import { useEventQueue } from "context/eventQueue";
 import { useNetworkFromClusterMembers } from "context/useNetworks";
@@ -205,7 +205,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
   };
 
   useEffect(() => {
-    scrollToElement(initialSection);
+    scrollToSection(initialSection);
     updateSection(initialSection);
   }, [initialSection]);
 
@@ -220,7 +220,7 @@ const EditNetwork: FC<Props> = ({ network, project }) => {
       if (newSection === GENERAL) {
         navigate(baseUrl);
       } else {
-        navigate(`${baseUrl}/#${slugify(newSection)}`);
+        window.location.href = `${baseUrl}#${slugify(newSection)}`;
       }
     }
     updateSection(slugify(newSection));

--- a/src/util/scroll.tsx
+++ b/src/util/scroll.tsx
@@ -6,6 +6,21 @@ export const scrollToElement = (id: string) => {
 };
 
 /**
+ * Scrolls the form content wrapper to the given section.
+ * Waits for one frame, so the sections are laid out before measuring.
+ */
+export const scrollToSection = (id: string) => {
+  requestAnimationFrame(() => {
+    const wrapper = document.getElementById("content-details");
+    const target = document.getElementById(id);
+    if (!wrapper || !target) {
+      return;
+    }
+    wrapper.scrollTop = target.offsetTop - wrapper.offsetTop;
+  });
+};
+
+/**
  * Returns the first section that is in the viewport.
  */
 export const getFirstVisibleSection = (


### PR DESCRIPTION
## Done

- fix(network) in page navigation on network detail page should jump to the right section

Fixes #2262

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create or edit a network
    - use in page navigation and ensure it work on the create and edit forms

## Screenshots

[Screencast from 2026-09-02 16-52-50.webm](https://github.com/user-attachments/assets/0f73d18c-16b9-43bc-baa7-10b8aab26fd8)
