### PR TITLE
feat(Overview): fixed height when pagination on Warnings & Clustering

### DIFF
--- a/src/pages/overview/ClusteringCard.tsx
+++ b/src/pages/overview/ClusteringCard.tsx
@@ -132,7 +132,7 @@ const ClusteringCard: FC = () => {
 
   const clusterMembersTable = (
     <MainTable
-      className="cluster-members-table"
+      className="overview-table"
       aria-label="Cluster members"
       headers={headers}
       rows={members.length > ITEMS_PER_PAGE ? undefined : rows}

--- a/src/pages/overview/WarningsCard.tsx
+++ b/src/pages/overview/WarningsCard.tsx
@@ -61,7 +61,7 @@ const WarningsCard: FC = () => {
       sortable={true}
       defaultSort="severity"
       defaultSortDirection="descending"
-      className="warnings-table warnings-table--overview"
+      className="warnings-table overview-table"
       emptyStateMsg="No warnings found"
       responsive
     />

--- a/src/sass/_overview.scss
+++ b/src/sass/_overview.scss
@@ -86,6 +86,10 @@
 
     &.clustering {
       .p-card__content {
+        .overview-table {
+          margin-top: $spv--large;
+        }
+
         .total-resources {
           display: flex;
           gap: $sph--large;
@@ -99,9 +103,13 @@
             flex: 1;
           }
         }
+      }
 
-        .cluster-members-table {
-          margin-top: $spv--large;
+      &:has(.pagination) {
+        .p-card__content {
+          .overview-table {
+            min-height: 14rem;
+          }
         }
       }
     }
@@ -211,7 +219,15 @@
     }
 
     &.warnings {
-      .warnings-table--overview {
+      &:has(.pagination) {
+        .p-card__content {
+          .overview-table {
+            min-height: 19.2rem;
+          }
+        }
+      }
+
+      .overview-table {
         thead th {
           background-color: var(--vf-color-background-default);
           position: sticky;


### PR DESCRIPTION
## Done

- feat(Overview): fixed height when pagination on Warnings & Clustering

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Overview page. Make sure that Warnings and Clustering cards don't jump when pagination is displayed and page has less than 4 items.

## Screenshots


https://github.com/user-attachments/assets/2e43c184-c914-462c-b411-a5a3c0b9ed9a


https://github.com/user-attachments/assets/91797286-1cb4-4736-9b2a-04130fdb1e41

