### PR TITLE
fix(instance) ensure long ip addresses are fully displayed in instance configuration

### DIFF
--- a/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
+++ b/src/components/forms/NetworkDevicesForm/read/NetworkDeviceRows.tsx
@@ -152,7 +152,7 @@ export const getNetworkDeviceRows = ({
             inherited: (
               <div>
                 <b
-                  className={classnames("mono-font", {
+                  className={classnames("mono-font ip-address", {
                     "u-text--line-through": isDetached,
                   })}
                 >

--- a/src/sass/_network_device_form.scss
+++ b/src/sass/_network_device_form.scss
@@ -32,6 +32,10 @@
           }
         }
 
+        tbody td:has(.ip-address) {
+          overflow: visible;
+        }
+
         .configuration {
           overflow: visible;
 


### PR DESCRIPTION
## Done

- fix(instance) ensure long ip addresses are fully displayed in instance configuration. fixes #2271

Fixes #2271

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create instance with static ip, long number such as `2001:db8:abcd:0494:216:3eff:1234`. Can also manually set the value with dev tools for easier testing
    - ensure in instance configuration the value is properly displayed and not truncated or hidden partially

## Screenshots

<img width="3844" height="1920" alt="image" src="https://github.com/user-attachments/assets/19099eb0-57e1-42ef-a3dd-316ab0260ec5" />