### PR TITLE
fix(navigation) only expand or collapse the side navigation when crossing the breakpoint

### DIFF
--- a/src/context/menuCollapsed.tsx
+++ b/src/context/menuCollapsed.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { isDimensionBelow } from "util/helpers";
 import {
   mediumScreenBreakpoint,
@@ -13,6 +13,7 @@ const noCollapseEvents = new Set(["search-and-filter"]);
 
 export const useMenuCollapsed = () => {
   const [menuCollapsed, setMenuCollapsed] = useState(isMediumScreen());
+  const previousWidth = useRef(window.innerWidth);
 
   const updateMenuCollapsed = (isCollapsed: boolean) => {
     setMenuCollapsed(isCollapsed);
@@ -22,11 +23,32 @@ export const useMenuCollapsed = () => {
   };
 
   const collapseOnMediumScreen = (e: Event | CustomEvent<string>) => {
-    if (isSmallScreen()) {
+    const newWidth = window.innerWidth;
+    const oldWidth = previousWidth.current;
+    previousWidth.current = newWidth;
+
+    if ("detail" in e && noCollapseEvents.has(e.detail)) {
       return;
     }
-    if (!("detail" in e) || !noCollapseEvents.has(e.detail)) {
-      updateMenuCollapsed(isMediumScreen());
+
+    const isIncreasingLarge =
+      newWidth >= mediumScreenBreakpoint && oldWidth < mediumScreenBreakpoint;
+    if (isIncreasingLarge) {
+      updateMenuCollapsed(false);
+      return;
+    }
+
+    const isIncreasingSmall =
+      newWidth >= smallScreenBreakpoint && oldWidth < smallScreenBreakpoint;
+    if (isIncreasingSmall) {
+      updateMenuCollapsed(true);
+      return;
+    }
+
+    const isDecreasing =
+      newWidth < mediumScreenBreakpoint && oldWidth >= mediumScreenBreakpoint;
+    if (isDecreasing) {
+      updateMenuCollapsed(true);
     }
   };
 


### PR DESCRIPTION
## Done

- fix(navigation) only expand or collapse the side navigation when crossing the breakpoint to better match user intent

Fixes #1741

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - ensure side navigation opens/closes when crossing the breakpoint of 820 pixel width on resize
    - ensure if the side navigation is expanded and we increase, the side nav is never closed
    - ensur if the side nav is closed and we decrease, the side nav is never opened

## Screenshots

[Screencast from 2026-09-04 09-07-10.webm](https://github.com/user-attachments/assets/37414334-3fe5-445e-a097-45a77fd701fe)
