### PR TITLE
fix(pools) ceph and cephfs do not support the source config field anymore

### DIFF
--- a/src/util/storagePool.tsx
+++ b/src/util/storagePool.tsx
@@ -226,14 +226,7 @@ export const isCephFSDriver = (values: StoragePoolFormValues) => {
 };
 
 export const hasSource = (driver: string): boolean => {
-  const driversWithSource = [
-    btrfsDriver,
-    cephDriver,
-    cephFSDriver,
-    dirDriver,
-    lvmDriver,
-    zfsDriver,
-  ];
+  const driversWithSource = [btrfsDriver, dirDriver, lvmDriver, zfsDriver];
 
   return driversWithSource.includes(driver);
 };


### PR DESCRIPTION
## Done

- fix(pools) ceph and cephfs do not support the source config field anymore

Fixes #2276

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - create / edit a storage pool with driver `ceph` and ensure the source field in the configuration is removed

## Screenshots

<img width="2748" height="1492" alt="image" src="https://github.com/user-attachments/assets/a6e02fe2-cde6-4567-8fd3-784f3b54e919" />