### PR TITLE
feat(Overview clustering): add used in total memory

### DIFF
--- a/src/pages/cluster/ClusterMemberMemoryUsage.tsx
+++ b/src/pages/cluster/ClusterMemberMemoryUsage.tsx
@@ -36,6 +36,7 @@ const ClusterMemberMemoryUsage: FC<Props> = ({ member }) => {
     totalMemory - freeMemory,
     totalMemory,
     memoryPercentage + bufferedMemoryPercentage,
+    true,
   );
 
   return (

--- a/src/util/resourceDetails.spec.ts
+++ b/src/util/resourceDetails.spec.ts
@@ -6,8 +6,13 @@ import {
 } from "./resourceDetails";
 
 describe("getMemoryText", () => {
-  it("includes the rounded usage percentage", () => {
-    expect(getMemoryText(1_500, 4_000, 37.5)).toBe("1.5 KiB of 3.9 KiB (38%)");
+  it("returns short and long variants", () => {
+    expect(getMemoryText(1_500, 4_000, 37.5, true)).toBe(
+      "1.5 KiB of 3.9 KiB (38%)",
+    );
+    expect(getMemoryText(1_500, 4_000, 37.5)).toBe(
+      "1.5 KiB of 3.9 KiB used (38%)",
+    );
   });
 });
 

--- a/src/util/resourceDetails.tsx
+++ b/src/util/resourceDetails.tsx
@@ -107,6 +107,11 @@ export const getMemoryText = (
   used: number,
   total: number,
   percentage: number,
+  isShort?: boolean,
 ): string => {
-  return `${humanFileSize(used)} of ${humanFileSize(total)} (${percentage.toFixed(0)}%)`;
+  if (isShort) {
+    return `${humanFileSize(used)} of ${humanFileSize(total)} (${percentage.toFixed(0)}%)`;
+  }
+
+  return `${humanFileSize(used)} of ${humanFileSize(total)} used (${percentage.toFixed(0)}%)`;
 };


### PR DESCRIPTION
## Done

- feat(Overview clustering): add used in total memory meter's text


## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Go to Overview page in a clustered environment.

## Screenshots

<img width="936" height="717" alt="Screenshot from 2026-09-04 13-17-10" src="https://github.com/user-attachments/assets/8cb6bee3-3db4-4a6d-b334-0c1e8694592d" />
