### PR TITLE
feat: [WD-38264] Address A11y navigation violations

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -507,11 +507,19 @@ const Navigation: FC = () => {
                           Configuration
                         </NavLink>
                       </SideNavigationItem>
-                      <hr
-                        className={classnames("navigation-hr", {
-                          "is-light": isLight,
-                        })}
-                      />
+                    </>
+                  )}
+                </ul>
+                {isAuthenticated && (
+                  <hr
+                    className={classnames("navigation-hr", {
+                      "is-light": isLight,
+                    })}
+                  />
+                )}
+                <ul className="p-side-navigation__list sidenav-top-ul">
+                  {isAuthenticated && (
+                    <>
                       <SideNavigationItem>
                         <NavAccordion
                           baseUrls={[
@@ -721,6 +729,11 @@ const Navigation: FC = () => {
                   { "is-light": isLight },
                 )}
               >
+                <hr
+                  className={classnames("navigation-hr", {
+                    "is-light": isLight,
+                  })}
+                />
                 <ul
                   className={classnames(
                     "p-side-navigation__list sidenav-bottom-ul",
@@ -729,11 +742,6 @@ const Navigation: FC = () => {
                     },
                   )}
                 >
-                  <hr
-                    className={classnames("navigation-hr", {
-                      "is-light": isLight,
-                    })}
-                  />
                   {isAuthenticated && (
                     <SideNavigationItem>
                       <div


### PR DESCRIPTION
## Done

- Addresses A11y violations in the Navigation which disproportionately affect most other violation occurences.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Ensure no other navigation related a11y errors occur.

## Screenshots

N/A