### PR TITLE
fix(network) topology map should not wrap on responsive screens

### DIFF
--- a/src/sass/_network_form.scss
+++ b/src/sass/_network_form.scss
@@ -35,6 +35,10 @@
 
 .network-form {
   .contents {
+    .network-topology {
+      min-width: 54rem;
+    }
+
     .network-topology,
     .sections {
       max-width: 54rem;


### PR DESCRIPTION
## Done

- fix(network) topology map should not wrap on responsive screens

Fixes #2037

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - open network detail page
    - shrink screen, ensure topology view is responsively not breaking as in the linked issue, but starts scrolling on overflow

## Screenshots

[Screencast from 2026-09-08 09-33-28.webm](https://github.com/user-attachments/assets/36f04c59-3184-4a70-b621-5d2f331362b4)
