### PR TITLE
feat: [WD-38112] Warnings page permissions

### DIFF
--- a/src/context/useWarnings.tsx
+++ b/src/context/useWarnings.tsx
@@ -3,10 +3,11 @@ import { fetchWarnings } from "api/warnings";
 import type { LxdWarning } from "types/warning";
 import { queryKeys } from "util/queryKeys";
 
-export const useWarnings = (): UseQueryResult<LxdWarning[]> => {
+export const useWarnings = (enabled = true): UseQueryResult<LxdWarning[]> => {
   return useQuery<LxdWarning[], Error>({
     queryKey: [queryKeys.warnings],
     queryFn: async () => fetchWarnings(),
-    retry: false, // the api returns a 403 for users with limited permissions, surface the error right away
+    retry: false,
+    enabled,
   });
 };

--- a/src/pages/warnings/WarningList.tsx
+++ b/src/pages/warnings/WarningList.tsx
@@ -3,8 +3,8 @@ import { useSearchParams } from "react-router-dom";
 import {
   Row,
   ScrollableTable,
-  useNotify,
   CustomLayout,
+  Notification,
   Spinner,
 } from "@canonical/react-components";
 import NotificationRow from "components/NotificationRow";
@@ -23,17 +23,14 @@ import {
   STATUS,
   type WarningFilters,
 } from "util/warnings";
+import { useServerEntitlements } from "util/entitlements/server";
 
 const WarningList: FC = () => {
-  const notify = useNotify();
   const [selectedNames, setSelectedNames] = useState<string[]>([]);
   const [processingNames, setProcessingNames] = useState<string[]>([]);
   const [searchParams] = useSearchParams();
-  const { data: warnings = [], error, isLoading } = useWarnings();
-
-  if (error) {
-    notify.failure("Loading warnings failed", error);
-  }
+  const { canViewWarnings } = useServerEntitlements();
+  const { data: warnings = [], isLoading } = useWarnings(canViewWarnings());
 
   const hasWarnings = isLoading || warnings.length > 0;
 
@@ -115,36 +112,44 @@ const WarningList: FC = () => {
       }
     >
       <NotificationRow />
-      <Row>
-        <ScrollableTable
-          dependencies={[filteredWarnings]}
-          tableId="warning-table"
-          belowIds={["status-bar"]}
-        >
-          <SelectableMainTable
-            id="warning-table"
-            headers={getWarningHeaders()}
-            rows={rows}
-            paginate={30}
-            sortable
-            className="warnings-table"
-            emptyStateMsg={
-              isLoading ? (
-                <Spinner className="u-loader" text="Loading warnings..." />
-              ) : (
-                "No warnings found matching this search"
-              )
-            }
-            itemName="warning"
-            parentName="server"
-            selectedNames={selectedNames}
-            setSelectedNames={setSelectedNames}
-            filteredNames={filteredWarnings.map((warning) => warning.uuid)}
-            disabledNames={processingNames}
-            responsive
-          />
-        </ScrollableTable>
-      </Row>
+      {canViewWarnings() ? (
+        <Row>
+          <ScrollableTable
+            dependencies={[filteredWarnings]}
+            tableId="warning-table"
+            belowIds={["status-bar"]}
+          >
+            <SelectableMainTable
+              id="warning-table"
+              headers={getWarningHeaders()}
+              rows={rows}
+              paginate={30}
+              sortable
+              className="warnings-table"
+              emptyStateMsg={
+                isLoading ? (
+                  <Spinner className="u-loader" text="Loading warnings..." />
+                ) : (
+                  "No warnings found matching this search"
+                )
+              }
+              itemName="warning"
+              parentName="server"
+              selectedNames={selectedNames}
+              setSelectedNames={setSelectedNames}
+              filteredNames={filteredWarnings.map((warning) => warning.uuid)}
+              disabledNames={processingNames}
+              responsive
+            />
+          </ScrollableTable>
+        </Row>
+      ) : (
+        <Row>
+          <Notification severity="caution" title="Restricted permissions">
+            You do not have permission to view warnings.
+          </Notification>
+        </Row>
+      )}
     </CustomLayout>
   );
 };

--- a/src/util/entitlements/server.tsx
+++ b/src/util/entitlements/server.tsx
@@ -74,6 +74,10 @@ export const useServerEntitlements = () => {
     hasEntitlement(isFineGrained, "admin", serverEntitlements) ||
     hasEntitlement(isFineGrained, "viewer", serverEntitlements);
 
+  const canViewWarnings = () =>
+    hasEntitlement(isFineGrained, "can_view_warnings", serverEntitlements) ||
+    hasEntitlement(isFineGrained, "admin", serverEntitlements);
+
   const canCreateImageRegistries = () =>
     hasEntitlement(
       isFineGrained,
@@ -94,5 +98,6 @@ export const useServerEntitlements = () => {
     canViewMetrics,
     canViewPermissions,
     canViewResources,
+    canViewWarnings,
   };
 };


### PR DESCRIPTION
## Done

- Protects the warnings page with the can_view_warnings permission in place of the loading warnings failed error.

**Note:** Unauthorized users still see the error in the Warnings card on the overview page rather than a permission-denied state. This state should be addressed in a follow up PR, with design involvement.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - With a user who does not have can_view_warnings permission, attempt to access the Warnings page and observe the changes.
    - Verify by accessing the page with a user with all or can_view_warnings permissions.

## Screenshots

<img width="1846" height="1046" alt="image" src="https://github.com/user-attachments/assets/61639d32-23a8-4249-8679-a80a15baed87" />