### PR TITLE
fix: [WD-38843] Instance Permissions handling

### DIFF
--- a/src/pages/instances/EditInstance.tsx
+++ b/src/pages/instances/EditInstance.tsx
@@ -60,7 +60,6 @@ import ProxyDeviceForm from "components/forms/ProxyDeviceForm";
 import FormSubmitBtn from "components/forms/FormSubmitBtn";
 import BootForm from "components/forms/BootForm";
 import { useInstanceEntitlements } from "util/entitlements/instances";
-import InstanceProfilesWarning from "./InstanceProfilesWarning";
 import { useProfiles } from "context/useProfiles";
 import usePanelParams, { panels } from "util/usePanelParams";
 import NetworkDevicePanel from "components/forms/NetworkDevicesForm/edit/NetworkDevicePanel";
@@ -212,12 +211,6 @@ const EditInstance: FC<Props> = ({ instance }) => {
         )}
         <Row className="form-contents" key={section}>
           <Col size={12}>
-            {section !== slugify(YAML_CONFIGURATION) && (
-              <InstanceProfilesWarning
-                instanceProfiles={instance.profiles}
-                profiles={profiles}
-              />
-            )}
             {(section === slugify(MAIN_CONFIGURATION) || !section) && (
               <EditInstanceDetails formik={formik} project={project} />
             )}

--- a/src/pages/instances/InstanceDetail.tsx
+++ b/src/pages/instances/InstanceDetail.tsx
@@ -16,6 +16,8 @@ import { buildGrafanaUrl } from "util/grafanaUrl";
 import NotFound from "components/NotFound";
 import { ROOT_PATH } from "util/rootPath";
 import InstanceFileExplorer from "./InstanceFileExplorer";
+import InstanceProfilesWarning from "./InstanceProfilesWarning";
+import { useProfiles } from "context/useProfiles";
 
 const tabs: string[] = [
   "Overview",
@@ -49,6 +51,8 @@ const InstanceDetail: FC = () => {
     refetch: refreshInstance,
     isLoading,
   } = useInstance(name, project);
+
+  const { data: profiles = [] } = useProfiles(project);
 
   const renderTabs: (string | TabLink)[] = [...tabs];
 
@@ -111,6 +115,10 @@ const InstanceDetail: FC = () => {
 
           {activeTab === "configuration" && (
             <div role="tabpanel" aria-labelledby="configuration">
+              <InstanceProfilesWarning
+                instanceProfiles={instance.profiles}
+                profiles={profiles}
+              />
               <EditInstance instance={instance} />
             </div>
           )}

--- a/src/pages/instances/InstanceFileExplorer.tsx
+++ b/src/pages/instances/InstanceFileExplorer.tsx
@@ -18,6 +18,7 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "util/queryKeys";
 import StartInstanceBtn from "./actions/StartInstanceBtn";
+import { useInstanceEntitlements } from "util/entitlements/instances";
 
 interface Props {
   instance: LxdInstance;
@@ -25,8 +26,10 @@ interface Props {
 
 const InstanceFileExplorer: FC<Props> = ({ instance }) => {
   const queryClient = useQueryClient();
+  const { canAccessInstanceFiles } = useInstanceEntitlements();
   const [searchParams] = useSearchParams();
   const currentPath = searchParams.get("path") || "/";
+
   const canServeFiles =
     isInstanceRunning(instance) || instance.type === "container";
 
@@ -44,7 +47,7 @@ const InstanceFileExplorer: FC<Props> = ({ instance }) => {
     ],
     queryFn: async () =>
       fetchInstanceDirectory(instance.name, instance.project, currentPath),
-    enabled: canServeFiles,
+    enabled: canServeFiles && canAccessInstanceFiles(instance),
   });
 
   const invalidateCache = () => {
@@ -58,6 +61,14 @@ const InstanceFileExplorer: FC<Props> = ({ instance }) => {
       ],
     });
   };
+
+  if (!canAccessInstanceFiles(instance)) {
+    return (
+      <Notification severity="caution" title="Restricted permissions">
+        You do not have permission to access the file system for this instance.
+      </Notification>
+    );
+  }
 
   if (!canServeFiles) {
     return (


### PR DESCRIPTION
## Done

- Fixes notification visibility for can_view_profiles across Instance configuration.
- Adds can_access_files gating to instance file explorer.

Permissions spec -> [Instances](https://docs.google.com/document/d/1w084rYc3t_4lawpWO9jy7Q4zjiHUuDbu485xQjppdRk/edit?tab=t.4flycefojlep#heading=h.yjm687iqwb1v).

Note:  InstanceProfilesWarning uses no entitlement. It's a data availability check: it compares the instance's profiles string array against the LxdProfile[] objects fetched via useProfiles(), and warns when some profiles are inaccessible (missing from the fetched list). Should it be guarded using an entitlement?

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Observe the Instance configuration with can_view and cannot_view profiles permissions
    - Observe the File explorer tab with can access files / cannot access files permissions

## Screenshots

<img width="1292" height="519" alt="image" src="https://github.com/user-attachments/assets/5b19bb0d-ff4a-4087-b411-f690ac04ffd5" />