### PR TITLE
feat: [WD-38888] fix navigation responsivity

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -150,28 +150,30 @@ const Navigation: FC = () => {
 
   const adjustNavigationScrollForOverflow = () => {
     const navHeader = document.querySelector(".l-navigation .p-panel__header");
-    const navTop = document.querySelector(".l-navigation .p-panel__content");
+    const navContent = document.querySelector(
+      ".l-navigation .p-panel__content",
+    );
     const navBottom = document.querySelector(
       ".l-navigation .sidenav-bottom-container",
     );
     const navHeaderHeight = getElementAbsoluteHeight(navHeader as HTMLElement);
-    const navTopHeight = getElementAbsoluteHeight(navTop as HTMLElement);
+    const navContentHeight = navContent?.scrollHeight ?? 0;
     const navBottomHeight = getElementAbsoluteHeight(navBottom as HTMLElement);
 
-    const totalNavHeight = navHeaderHeight + navTopHeight + navBottomHeight;
+    const totalNavHeight = navHeaderHeight + navContentHeight + navBottomHeight;
 
     const isNavigationPanelOverflow = totalNavHeight >= window.innerHeight;
 
-    const targetNavTopHeight =
+    const targetNavContentHeight =
       window.innerHeight - navHeaderHeight - navBottomHeight;
 
     if (isNavigationPanelOverflow) {
-      const style = `height: ${targetNavTopHeight}px`;
-      navTop?.setAttribute("style", style);
+      const style = `height: ${targetNavContentHeight}px`;
+      navContent?.setAttribute("style", style);
       setScroll(true);
     } else {
       const style = `height: auto`;
-      navTop?.setAttribute("style", style);
+      navContent?.setAttribute("style", style);
       setScroll(false);
     }
   };

--- a/src/sass/_pattern_navigation.scss
+++ b/src/sass/_pattern_navigation.scss
@@ -116,14 +116,14 @@
 }
 
 .sidenav-top-ul {
-  height: 100%;
+  height: auto;
   margin-bottom: 0;
-  overflow: auto;
-  overflow-x: hidden;
+  overflow: visible;
 }
 
 .sidenav-top-container {
   height: 100%;
+  overflow: hidden auto;
 }
 
 .sidenav-bottom-ul {


### PR DESCRIPTION
## Done

- Stop nav from disappearing when opening configuration screen.

## QA

1. Run the LXD-UI:
    - On the demo server via the link posted by @webteam-app below. This is only available for PRs created by collaborators of the repo. Ask @Kxiru or @edlerd for access.
    - With a local copy of this branch, [build and run as described in the docs](https://github.com/canonical/lxd-ui/blob/main/CONTRIBUTING.md#setting-up-for-development).
2. Perform the following QA steps:
    - Login via any screen and test that oepning and closing configuration page doesn't have any unwanted effects.
    - Verify changes to not affect other navs either (login)

## Screenshots

N/A